### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -578,8 +578,17 @@ def rag_upload_endpoint(req: RagUploadRequest):
         ) or "file"
         safe_prefix = f"rag_{safe_prefix_core}_"
 
+        # Derive a safe suffix from the original filename extension.
+        raw_suffix = os.path.splitext(original_name)[1]
+        safe_suffix = "".join(
+            c for c in raw_suffix if c.isalnum() or c in ("-", "_", ".")
+        )
+        if not safe_suffix.startswith(".") or len(safe_suffix) > 10:
+            suffix = ".txt"
+        else:
+            suffix = safe_suffix
+
         # Write content to a temp file so _insert_document can stat() it
-        suffix = os.path.splitext(req.filename)[1] or ".txt"
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=suffix, prefix=safe_prefix, delete=False, encoding="utf-8"
         ) as tmp:

--- a/api/main.py
+++ b/api/main.py
@@ -576,6 +576,9 @@ def rag_upload_endpoint(req: RagUploadRequest):
         safe_prefix_core = "".join(
             c for c in original_name if c.isalnum() or c in ("-", "_", ".")
         ) or "file"
+        # Truncate to avoid exceeding filesystem limits for filename components
+        MAX_SAFE_PREFIX_CORE_LEN = 64
+        safe_prefix_core = safe_prefix_core[:MAX_SAFE_PREFIX_CORE_LEN]
         safe_prefix = f"rag_{safe_prefix_core}_"
 
         # Derive a safe suffix from the original filename extension.


### PR DESCRIPTION
Potential fix for [https://github.com/madara88645/Compiler/security/code-scanning/30](https://github.com/madara88645/Compiler/security/code-scanning/30)

In general, to fix uncontrolled data in path expressions, user input should be sanitized or validated before being incorporated into any filesystem path or filename. For simple filename-like values, a common approach is to strip directory components and undesirable characters, or to map the user-provided name into a safe tokenized form (e.g., hash or UUID). In more complex cases, normalization and checks against a trusted base directory are necessary.

For this specific endpoint in `api/main.py`, the minimum change that preserves existing behavior is to derive a safe prefix from `req.filename` instead of embedding it directly. We can: (1) extract just the basename of the filename, (2) restrict it to a small safe character set (e.g., letters, digits, dash, underscore, dot), (3) fall back to a generic name if nothing remains. Then we use this sanitized value in the temp file prefix. The original `req.filename` is still stored in the database unchanged for display, so functionality is preserved. Concretely:
- Inside `rag_upload_endpoint`, after importing `os` and `Path`, derive `safe_prefix` from `req.filename`, e.g. `os.path.basename(req.filename)`, filter characters with a simple comprehension, and default to `"file"` if empty.
- Replace `prefix=f"rag_{req.filename}_”` with `prefix=f"rag_{safe_prefix}_”`.
No new imports beyond `os` (already present in this function) are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
