### PR TITLE
Fix agent generator test assertions for multi_agent parameter

### DIFF
--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -40,7 +40,7 @@ def test_hybrid_compiler_generate_agent(mock_worker_client):
     # We can use ANY for the context content since it depends on the mock vector db
     from unittest.mock import ANY
 
-    mock_worker_client.generate_agent.assert_called_with("Test Agent", context=ANY)
+    mock_worker_client.generate_agent.assert_called_with("Test Agent", context=ANY, multi_agent=False)
 
 
 def test_api_generate_agent_endpoint():
@@ -55,4 +55,4 @@ def test_api_generate_agent_endpoint():
 
         assert response.status_code == 200
         assert response.json() == {"system_prompt": "# Mock API Agent"}
-        mock_compiler.generate_agent.assert_called_with("Test Agent Request")
+        mock_compiler.generate_agent.assert_called_with("Test Agent Request", multi_agent=False)

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -49,7 +49,7 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
     compiler.generate_agent("Test Agent")
     compiler.context_strategist.process.assert_called_with("Test Agent")
     mock_worker_client.generate_agent.assert_called_with(
-        "Test Agent", context={"file1.py": "content"}
+        "Test Agent", context={"file1.py": "content"}, multi_agent=False
     )
 
     # Test generate_skill with context


### PR DESCRIPTION
The `generate_agent` method in `HybridCompiler` and `WorkerClient` was updated to include a `multi_agent` parameter, but the corresponding tests were not updated to reflect this change in their mock assertions. This caused the CI pipeline to fail with `AssertionError: expected call not found`.

This PR updates the following tests to expect `multi_agent=False` in the call arguments:
- `tests/test_agent_generator.py::test_hybrid_compiler_generate_agent`
- `tests/test_agent_generator.py::test_api_generate_agent_endpoint`
- `tests/test_context_generation.py::test_hybrid_compiler_context_awareness`

---
*PR created automatically by Jules for task [3046468906860268483](https://jules.google.com/task/3046468906860268483) started by @madara88645*