### PR TITLE
🧹 Remove duplicate Console instantiation in app/export_import.py

### DIFF
--- a/app/export_import.py
+++ b/app/export_import.py
@@ -21,9 +21,6 @@ DataType = Literal["history", "favorites", "all"]
 console = Console()
 
 
-console = Console()
-
-
 class ExportImportManager:
     """Manages export and import operations for prompts, favorites, and history (LEGACY/STUB)."""
 


### PR DESCRIPTION
🎯 **What:** Removed a duplicate `console = Console()` line in `app/export_import.py`.

💡 **Why:** The variable `console` was being instantiated twice consecutively, which is redundant. Removing the duplicate line improves code clarity and maintainability.

✅ **Verification:** 
- Verified that the file `app/export_import.py` now contains only one instantiation of `console`.
- Ran `pytest tests/test_ui_export_import.py` and all tests passed.

✨ **Result:** The codebase is now cleaner and free of this specific redundancy.

---
*PR created automatically by Jules for task [4360109174098829068](https://jules.google.com/task/4360109174098829068) started by @madara88645*