### PR TITLE
Add edge case tests for cost estimator

### DIFF
--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -38,3 +38,80 @@ def test_estimate_run_cost_adversarial():
     result = estimate_run_cost(config, prompt)
 
     assert result["details"]["total_calls"] == 10
+
+
+def test_estimate_empty_prompt():
+    """Verify behavior with an empty string prompt."""
+    config = OptimizationConfig(
+        model="gpt-4o", max_generations=1, candidates_per_generation=1
+    )
+    prompt = ""
+    result = estimate_run_cost(config, prompt)
+
+    # Should not crash, cost should be low but cover system prompts
+    assert result["min_cost"] > 0
+    assert result["details"]["estimated_input_tokens"] > 0
+
+
+def test_estimate_zero_generations():
+    """Verify behavior when max_generations is 0."""
+    config = OptimizationConfig(
+        model="gpt-4o", max_generations=0, candidates_per_generation=5
+    )
+    prompt = "Test"
+    result = estimate_run_cost(config, prompt)
+
+    assert result["details"]["total_calls"] == 0
+    assert result["min_cost"] == 0.0
+
+
+def test_estimate_zero_candidates():
+    """Verify behavior when candidates_per_generation is 0."""
+    config = OptimizationConfig(
+        model="gpt-4o", max_generations=5, candidates_per_generation=0
+    )
+    prompt = "Test"
+    result = estimate_run_cost(config, prompt)
+
+    assert result["details"]["total_calls"] == 0
+    assert result["min_cost"] == 0.0
+
+
+def test_estimate_unknown_model():
+    """Verify fallback to default pricing for unknown models."""
+    config = OptimizationConfig(
+        model="unknown-model-123", max_generations=1, candidates_per_generation=1
+    )
+    prompt = "Test"
+    result = estimate_run_cost(config, prompt)
+
+    # Should use default pricing (GPT-4o equivalent in code)
+    assert result["min_cost"] > 0
+    assert "unknown-model-123" in result["message"]
+
+
+def test_estimate_adversarial_sparse():
+    """Verify behavior when adversarial_every is larger than max_generations."""
+    config = OptimizationConfig(
+        model="gpt-4o", max_generations=2, candidates_per_generation=1, adversarial_every=5
+    )
+    prompt = "Test"
+    result = estimate_run_cost(config, prompt)
+
+    # 2 gens * 1 cand = 2 calls
+    # adversarial_runs = 2 // 5 = 0
+    assert result["details"]["total_calls"] == 2
+
+
+def test_estimate_large_prompt():
+    """Verify behavior with a very large prompt."""
+    config = OptimizationConfig(
+        model="gpt-4o", max_generations=1, candidates_per_generation=1
+    )
+    # 10k characters
+    prompt = "a" * 10000
+    result = estimate_run_cost(config, prompt)
+
+    assert result["min_cost"] > 0
+    # Basic sanity check that tokens are accounted for
+    assert result["details"]["estimated_input_tokens"] > 2500  # > 10000/4


### PR DESCRIPTION
Add edge case tests for cost estimator

This commit adds a suite of edge case tests to `tests/test_estimator.py` to cover scenarios such as empty prompts, zero generations/candidates, unknown models, and large prompts. This improves the reliability and coverage of the cost estimation logic.

- Added `test_estimate_empty_prompt`
- Added `test_estimate_zero_generations`
- Added `test_estimate_zero_candidates`
- Added `test_estimate_unknown_model`
- Added `test_estimate_adversarial_sparse`
- Added `test_estimate_large_prompt`

---
*PR created automatically by Jules for task [14988520538641436506](https://jules.google.com/task/14988520538641436506) started by @madara88645*