### PR TITLE
test: Add cultural context tests for PsycholinguistHandler

### DIFF
--- a/tests/heuristics/test_psycholinguist.py
+++ b/tests/heuristics/test_psycholinguist.py
@@ -253,3 +253,247 @@ def test_neutral_sentiment(handler):
     # No extra constraints or role changes expected for neutral
     assert len(ir_v2.constraints) == 0
     assert ir_v2.role == "Assistant"
+
+
+def test_cultural_detection_currency_tr(handler):
+    text = "The price is 100 TL."
+    ir_v2 = IRv2(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        intents=[],
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+    ir_v1 = IR(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert ir_v2.metadata["cultural_context"] == "Turkish"
+    # TR context does not currently append to role
+    assert ir_v2.role == "Assistant"
+
+
+def test_cultural_detection_currency_eu(handler):
+    text = "It costs 50 Euro."
+    ir_v2 = IRv2(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        intents=[],
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+    ir_v1 = IR(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert ir_v2.metadata["cultural_context"] == "European"
+    # EU context does not currently append to role
+    assert ir_v2.role == "Assistant"
+
+
+def test_cultural_detection_currency_uk(handler):
+    text = "It costs 50 GBP."
+    ir_v2 = IRv2(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        intents=[],
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+    ir_v1 = IR(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert ir_v2.metadata["cultural_context"] == "British"
+    assert "(Use British English norms)" in ir_v2.role
+
+
+def test_cultural_detection_currency_us(handler):
+    text = "It costs 50 USD."
+    ir_v2 = IRv2(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        intents=[],
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+    ir_v1 = IR(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert ir_v2.metadata["cultural_context"] == "American"
+    assert "(Use American English norms)" in ir_v2.role
+
+
+def test_cultural_detection_tie_break(handler):
+    # 'color' (US) and 'colour' (UK) -> tie in spelling score (1 vs 1)
+    # 'GBP' -> currency tie-breaker should favor UK
+    text = "Check the color vs colour difference in GBP."
+    ir_v2 = IRv2(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        intents=[],
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+    ir_v1 = IR(
+        metadata={"original_text": text},
+        language="en",
+        persona="assistant",
+        role="Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=[],
+        style=[],
+        tone=[],
+        output_format="text",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+    )
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert ir_v2.metadata["cultural_context"] == "British"
+    assert "(Use British English norms)" in ir_v2.role


### PR DESCRIPTION
This PR adds comprehensive tests for the `detect_cultural_context` function within the `PsycholinguistHandler`.

Previously, tests only covered basic spelling-based detection for US and UK English. This PR expands coverage to include:
1.  **Currency-based detection:** Tests for Turkish (TR), European (EU), British (UK), and American (US) currencies when spelling cues are neutral.
2.  **Tie-breaking logic:** A test case ensuring that when spelling counts are equal (e.g., one US spelling, one UK spelling), the presence of a specific currency (e.g., GBP) correctly determines the cultural context.
3.  **Role and Metadata Verification:** Asserts that `cultural_context` metadata is set correctly and that the system role is updated with the appropriate norms for US/UK contexts (TR/EU contexts do not currently modify the role).

These tests ensure the robustness of the cultural context detection logic, particularly for edge cases involving mixed signals or purely currency-based cues.

---
*PR created automatically by Jules for task [16251892162415139515](https://jules.google.com/task/16251892162415139515) started by @madara88645*