### PR TITLE
Add GitHub Actions failure fixer script with automated diagnosis and rerun support

### DIFF
--- a/scripts/github_int_failure_fixer.py
+++ b/scripts/github_int_failure_fixer.py
@@ -1,0 +1,152 @@
+"""GitHub Actions failure fixer agent.
+
+Monitors failed workflow runs, analyzes log text for common causes,
+and can optionally trigger reruns for failed jobs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import re
+import zipfile
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+
+@dataclass(frozen=True)
+class FailureRecommendation:
+    pattern: re.Pattern[str]
+    root_cause: str
+    recommendation: str
+
+
+RECOMMENDATIONS = [
+    FailureRecommendation(
+        pattern=re.compile(r"unable to find package\.json|ENOENT.*package\.json", re.IGNORECASE),
+        root_cause="Node job executed in a directory without package.json.",
+        recommendation=(
+            "Set the correct working-directory for npm steps, or guard the Node job so it only runs "
+            "when package.json exists."
+        ),
+    ),
+    FailureRecommendation(
+        pattern=re.compile(r"No module named|ModuleNotFoundError", re.IGNORECASE),
+        root_cause="Python dependency missing in workflow environment.",
+        recommendation="Install required packages before tests/lint and verify requirements lockstep.",
+    ),
+    FailureRecommendation(
+        pattern=re.compile(r"permission denied|Resource not accessible by integration", re.IGNORECASE),
+        root_cause="Insufficient token or workflow permissions.",
+        recommendation="Update workflow permissions block and ensure required repo/token scopes are granted.",
+    ),
+]
+
+
+class GitHubIntFailureFixer:
+    def __init__(self, owner: str, repo: str, token: str, *, session: requests.Session | None = None) -> None:
+        self.owner = owner
+        self.repo = repo
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        )
+
+    def _url(self, path: str) -> str:
+        return f"https://api.github.com/repos/{self.owner}/{self.repo}{path}"
+
+    def list_failed_runs(self, *, per_page: int = 10) -> list[dict[str, Any]]:
+        response = self.session.get(
+            self._url("/actions/runs"),
+            params={"status": "completed", "conclusion": "failure", "per_page": per_page},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload.get("workflow_runs", [])
+
+    def download_run_logs(self, run_id: int) -> str:
+        response = self.session.get(self._url(f"/actions/runs/{run_id}/logs"), timeout=60)
+        response.raise_for_status()
+
+        zip_bytes = io.BytesIO(response.content)
+        with zipfile.ZipFile(zip_bytes) as log_archive:
+            collected: list[str] = []
+            for name in log_archive.namelist():
+                if not name.endswith(".txt"):
+                    continue
+                with log_archive.open(name) as file_obj:
+                    collected.append(file_obj.read().decode("utf-8", errors="replace"))
+            return "\n".join(collected)
+
+    def analyze_failure(self, log_text: str) -> tuple[str, str]:
+        for item in RECOMMENDATIONS:
+            if item.pattern.search(log_text):
+                return item.root_cause, item.recommendation
+        return (
+            "Unknown failure signature.",
+            "Inspect job logs for stack traces, then add a signature rule for automated diagnosis.",
+        )
+
+    def rerun_failed_jobs(self, run_id: int) -> None:
+        response = self.session.post(self._url(f"/actions/runs/{run_id}/rerun-failed-jobs"), timeout=30)
+        response.raise_for_status()
+
+    def process_failed_runs(self, *, auto_rerun: bool, dry_run: bool) -> list[dict[str, Any]]:
+        failed_runs = self.list_failed_runs()
+        reports: list[dict[str, Any]] = []
+
+        for run in failed_runs:
+            run_id = run["id"]
+            logs = self.download_run_logs(run_id)
+            root_cause, recommendation = self.analyze_failure(logs)
+            rerun_status = "skipped"
+
+            if auto_rerun and not dry_run:
+                self.rerun_failed_jobs(run_id)
+                rerun_status = "triggered"
+
+            reports.append(
+                {
+                    "run_id": run_id,
+                    "name": run.get("name"),
+                    "html_url": run.get("html_url"),
+                    "root_cause": root_cause,
+                    "recommendation": recommendation,
+                    "rerun_status": rerun_status,
+                }
+            )
+        return reports
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze and remediate failed GitHub Actions runs.")
+    parser.add_argument("--owner", required=True, help="Repository owner/org")
+    parser.add_argument("--repo", required=True, help="Repository name")
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN"), help="GitHub token (defaults to GITHUB_TOKEN)")
+    parser.add_argument("--auto-rerun", action="store_true", help="Trigger rerun-failed-jobs API for failed runs")
+    parser.add_argument("--dry-run", action="store_true", help="Analyze only; do not change workflow run state")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.token:
+        raise SystemExit("A GitHub token is required via --token or GITHUB_TOKEN.")
+
+    fixer = GitHubIntFailureFixer(args.owner, args.repo, args.token)
+    report = fixer.process_failed_runs(auto_rerun=args.auto_rerun, dry_run=args.dry_run)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_int_failure_fixer.py
+++ b/tests/test_github_int_failure_fixer.py
@@ -1,0 +1,64 @@
+import io
+import zipfile
+
+from scripts.github_int_failure_fixer import GitHubIntFailureFixer
+
+
+class FakeResponse:
+    def __init__(self, *, payload=None, content=b""):
+        self._payload = payload
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self):
+        self.headers = {}
+        self.post_calls = []
+
+    def get(self, url, params=None, timeout=None):
+        if url.endswith("/actions/runs"):
+            return FakeResponse(payload={"workflow_runs": [{"id": 123, "name": "CI", "html_url": "http://example/run"}]})
+        if url.endswith("/actions/runs/123/logs"):
+            stream = io.BytesIO()
+            with zipfile.ZipFile(stream, mode="w") as archive:
+                archive.writestr("job.txt", "Error: unable to find package.json")
+            return FakeResponse(content=stream.getvalue())
+        raise AssertionError(f"unexpected GET url: {url}")
+
+    def post(self, url, timeout=None):
+        self.post_calls.append(url)
+        return FakeResponse()
+
+
+def test_analyze_failure_package_json_signature():
+    fixer = GitHubIntFailureFixer("o", "r", "token", session=FakeSession())
+    cause, recommendation = fixer.analyze_failure("npm ERR! enoent Error: unable to find package.json")
+    assert "package.json" in cause
+    assert "working-directory" in recommendation
+
+
+def test_process_failed_runs_dry_run_skips_rerun():
+    session = FakeSession()
+    fixer = GitHubIntFailureFixer("o", "r", "token", session=session)
+
+    report = fixer.process_failed_runs(auto_rerun=True, dry_run=True)
+
+    assert len(report) == 1
+    assert report[0]["rerun_status"] == "skipped"
+    assert session.post_calls == []
+
+
+def test_process_failed_runs_can_trigger_rerun():
+    session = FakeSession()
+    fixer = GitHubIntFailureFixer("o", "r", "token", session=session)
+
+    report = fixer.process_failed_runs(auto_rerun=True, dry_run=False)
+
+    assert report[0]["rerun_status"] == "triggered"
+    assert any(call.endswith("/actions/runs/123/rerun-failed-jobs") for call in session.post_calls)


### PR DESCRIPTION
### Motivation
- Provide an automated utility to detect common failure signatures in GitHub Actions runs and produce actionable recommendations. 
- Allow safe remediation by optionally triggering `rerun-failed-jobs` while supporting a `--dry-run` mode to avoid accidental mutations.

### Description
- Add `scripts/github_int_failure_fixer.py`, which implements `GitHubIntFailureFixer` to list failed runs, download and unzip run logs, match logs against `RECOMMENDATIONS` signatures, and optionally call the `rerun-failed-jobs` API. 
- Implement signature-based diagnosis for common issues (missing `package.json`, missing Python modules, permission/token errors) and return root-cause plus recommendation strings. 
- Expose CLI flags `--owner`, `--repo`, `--token` (or `GITHUB_TOKEN`), `--auto-rerun`, and `--dry-run` for safe execution. 
- Add unit tests in `tests/test_github_int_failure_fixer.py` using a `FakeSession` to validate signature detection, dry-run behavior, and rerun triggering.

### Testing
- Ran `pytest -q tests/test_github_int_failure_fixer.py` which completed with `3 passed` tests. 
- Ran `python -m compileall scripts/github_int_failure_fixer.py tests/test_github_int_failure_fixer.py` which compiled the new files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17a36ba00832f8cf20f556c15fe2d)