### PR TITLE
Add GitHub Actions failure fixer prompt template

### DIFF
--- a/templates/github-int-failure-fixer.yaml
+++ b/templates/github-int-failure-fixer.yaml
@@ -1,0 +1,92 @@
+id: github-int-failure-fixer
+name: GitHub Int Failure Fixer Agent
+description: Diagnose failed GitHub Actions runs and recommend or automate safe fixes.
+category: development
+version: 1.0.0
+author: promptc
+tags:
+  - github-actions
+  - ci-cd
+  - automation
+  - troubleshooting
+  - devops
+
+template_text: |
+  You are a Senior GitHub Automation Specialist with expertise in CI/CD pipeline optimization and failure analysis.
+
+  Repository owner: {{repo_owner}}
+  Repository name: {{repo_name}}
+  Workflow identifier: {{workflow_id}}
+  Poll interval (seconds): {{poll_interval_seconds}}
+
+  Goals:
+  - Identify and diagnose failed GitHub Actions workflows.
+  - Analyze logs and error messages to pinpoint the root cause of failures.
+  - Provide actionable recommendations for fixing failed workflows.
+  - Automate safe fixes and retries for failed workflows.
+
+  Constraints:
+  - Integrate with the existing repository structure.
+  - Respect repository permissions and access controls.
+  - Do not introduce security vulnerabilities or expose secrets.
+  - Handle complex workflows with multiple stages and jobs.
+
+  Required workflow:
+  1. Monitor GitHub Actions runs for failures.
+  2. Analyze logs and extract the root cause.
+  3. Recommend the smallest safe fix.
+  4. Apply automation only when safe and explicit.
+
+  Failed run context:
+  {{failed_run_context}}
+
+  Error message:
+  {{error_message}}
+
+  Produce the following output sections:
+  1. Root cause
+  2. Evidence from logs
+  3. Recommended fix
+  4. Automation plan (API calls, retries, rollback)
+  5. Security and permission checks
+  6. Verification checklist
+
+variables:
+  - name: repo_owner
+    description: GitHub owner or organization name
+    required: true
+
+  - name: repo_name
+    description: GitHub repository name
+    required: true
+
+  - name: workflow_id
+    description: Numeric workflow ID or workflow file name
+    required: true
+
+  - name: poll_interval_seconds
+    description: Polling frequency in seconds
+    default: "60"
+    required: false
+
+  - name: failed_run_context
+    description: Relevant run metadata and job summary
+    default: ""
+    required: false
+
+  - name: error_message
+    description: Main error message extracted from logs
+    default: ""
+    required: false
+
+example_values:
+  repo_owner: octo-org
+  repo_name: compiler-platform
+  workflow_id: ci.yml
+  poll_interval_seconds: "60"
+  failed_run_context: |
+    run_id=123456789
+    branch=main
+    job=build-and-test
+    status=failed
+  error_message: "Error: unable to find package.json"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -93,11 +93,12 @@ def test_registry_load_builtin_templates(builtin_templates_path):
     templates = registry.list_templates()
 
     # Should have at least the templates we created
-    assert len(templates) >= 5
+    assert len(templates) >= 6
     template_ids = {t.id for t in templates}
     assert "code-review" in template_ids
     assert "tutorial-creator" in template_ids
     assert "tech-comparison" in template_ids
+    assert "github-int-failure-fixer" in template_ids
 
 
 def test_registry_filter_by_category(builtin_templates_path):
@@ -218,3 +219,24 @@ def test_tutorial_creator_template_render(builtin_templates_path):
     assert "beginner" in result
     assert "30 minutes" in result
     assert "tutorial" in result.lower()
+
+
+def test_github_int_failure_fixer_template_render(builtin_templates_path):
+    """Test rendering the GitHub Int Failure Fixer built-in template."""
+    registry = TemplateRegistry(builtin_path=builtin_templates_path)
+
+    template = registry.get_template("github-int-failure-fixer")
+    assert template is not None
+
+    result = template.render(
+        {
+            "repo_owner": "octo-org",
+            "repo_name": "compiler-platform",
+            "workflow_id": "ci.yml",
+        }
+    )
+
+    assert "octo-org" in result
+    assert "compiler-platform" in result
+    assert "ci.yml" in result
+    assert "Root cause" in result


### PR DESCRIPTION
### Motivation
- Provide a built-in prompt to help diagnose and safely remediate failed GitHub Actions runs and to standardize triage and automation guidance.
- Make this capability available as a reusable template so other components can render consistent remediation plans for CI/CD failures.

### Description
- Added a new built-in template at `templates/github-int-failure-fixer.yaml` that defines the agent role, goals, constraints, required workflow steps, output sections, variables, and example values for GitHub Actions failure triage.
- Updated `tests/test_templates.py` to expect the new template when loading built-ins and added `test_github_int_failure_fixer_template_render` to validate variable interpolation and core output content.

### Testing
- Ran `pytest -q tests/test_templates.py` which executed the template suite and the new render test.
- All tests passed: `14 passed in 0.39s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17a2d2b68832fb430e0581d1bc8e6)