### PR TITLE
Harden agent generator outputs to reduce hallucinated integrations

### DIFF
--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -285,9 +285,19 @@ class WorkerClient:
             {"role": "user", "content": user_text},
         ]
 
+        # Changed: add anti-hallucination guidance so generated examples stay honest when API/library details are unknown.
+        safety_note = (
+            "Reliability requirements for generated markdown:\n"
+            "- Do not invent dependencies, SDKs, or helper libraries that are not explicitly provided in context.\n"
+            "- Do not invent API fields, endpoints, or write operations unless their exact shape is known from context.\n"
+            "- If implementation details are unknown, use pseudo-code with TODO comments instead of pretending certainty.\n"
+            "- Keep the system prompt high-level and practical, and keep the example interaction short and natural."
+        )
+        messages.insert(1, {"role": "system", "content": safety_note})
+
         if context:
             ctx_str = "\n".join([f"{k}: {v}" for k, v in context.items()])
-            messages.insert(1, {"role": "system", "content": f"Context:\n{ctx_str}"})
+            messages.insert(2, {"role": "system", "content": f"Context:\n{ctx_str}"})
 
         with ThreadPoolExecutor(max_workers=3) as executor:
             # json_mode=False because we want Markdown text back

--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -8,6 +8,12 @@ You may be provided with a **Project Context** (snippets of code, file structure
 - Use specific filenames, class names, and architectural patterns found in the context.
 - The "Tech Stack" should reflect the actual technologies detected in the project context.
 
+## HONESTY & RELIABILITY RULES
+- Never invent dependencies, SDKs, utilities, or modules that are not present in the provided context.
+- Never invent API contracts (fields, request/response JSON keys, or privileged write operations) when the exact shape is unknown.
+- For uncertain implementation details, use pseudo-code and explicit `TODO` comments.
+- Do not present speculative integrations as production-ready code.
+
 ## INSTRUCTIONS
 1. Analyze the user's request (the "Vibe" or "Task") and any provided Project Context.
 2. Design a specialized AI Agent to fulfill this request, deeply integrated with the project structure.
@@ -46,12 +52,25 @@ The output must strictly follow this Markdown structure:
 [A brief example of a user input and the agent's expected high-quality response.]
 **User:** ...
 **Agent:** ...
+
+## Example Code (Pseudo-code Skeleton)
+[Provide a short, realistic skeleton only. Use comments and TODO markers where integration details are unknown.]
+```python
+# Pseudo-code only. Replace TODO items with real project APIs.
+
+def run_agent_task(payload):
+    # TODO: Parse validated input based on the actual schema.
+    # TODO: Call real project services or APIs confirmed in context.
+    # TODO: Handle errors, retries, and logging with existing project utilities.
+    return {"status": "not_implemented"}
+```
 ```
 
 ## TONE & STYLE
 - Professional, authoritative, and concise.
 - Use technical terminology appropriate for the domain.
 - The generated prompt should be ready to copy-paste into an LLM configuration.
+- Keep code examples explicitly non-final when key details are unknown.
 
 ## INPUT HANDLING
 - If the user input is vague (e.g., "make a coding bot"), infer the most likely high-value use case (e.g., "Full-Stack Web Development Assistant") and build that.


### PR DESCRIPTION
### Motivation
- Reduce hallucinations in generated agent markdown by preventing invented dependencies, APIs, or overconfident example code.
- Keep the existing UI/UX and API surface unchanged while making generated system prompts and example code more honest and safe.
- Prefer pseudo-code + explicit `TODO` markers when integration details are not verifiable from project context.

### Description
- Add a reliability-focused system message in `WorkerClient.generate_agent` to instruct the LLM not to invent dependencies, API fields, or write operations and to prefer pseudo-code when details are unknown. 
- Adjust message insertion ordering so the safety note is included before project `Context` when calling `_call_api`. 
- Update `app/llm_engine/prompts/agent_generator.md` with an explicit **Honesty & Reliability Rules** section that forbids invented SDKs/APIs and requires `TODO` comments for uncertain implementation details. 
- Extend the required output template with an `Example Code (Pseudo-code Skeleton)` section that demonstrates a short non-final skeleton using `TODO` markers and clarifying comments.

### Testing
- Ran `pytest -q tests/test_agent_generator.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17d2cb070832f99a149ea13502922)