### PR TITLE
Render markdown output and add history restore in Agent Generator

### DIFF
--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import ReactMarkdown from "react-markdown";
 import { API_BASE } from "@/config";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
@@ -11,6 +12,7 @@ export default function AgentGenerator() {
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [multiAgent, setMultiAgent] = useState(false);
+  const [history, setHistory] = useState<{ label: string; prompt: string }[]>([]);
 
   const handleGenerate = async () => {
     if (!description.trim()) return;
@@ -32,6 +34,13 @@ export default function AgentGenerator() {
 
       const data = await res.json();
       setResult(data.system_prompt);
+      setHistory((prev) => [
+        {
+          label: description.slice(0, 40) + (multiAgent ? " [swarm]" : " [single]"),
+          prompt: data.system_prompt,
+        },
+        ...prev,
+      ].slice(0, 5));
     } catch (e: any) {
       setError(e.message || "Failed to generate agent");
     } finally {
@@ -107,6 +116,31 @@ export default function AgentGenerator() {
               </div>
             </div>
 
+            {history.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <label className="text-xs font-medium text-zinc-300">Previous results</label>
+                <select
+                  className="w-full bg-black/20 border border-white/10 text-zinc-300 text-xs rounded-xl px-3 py-2 focus:outline-none focus:ring-1 focus:ring-green-500/50"
+                  defaultValue=""
+                  onChange={(e) => {
+                    const selected = history[Number(e.target.value)];
+                    if (selected) {
+                      setResult(selected.prompt);
+                    }
+                  }}
+                >
+                  <option value="" disabled>
+                    -- Restore previous result --
+                  </option>
+                  {history.map((entry, index) => (
+                    <option key={`${entry.label}-${index}`} value={index}>
+                      {entry.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
             <button
               onClick={handleGenerate}
               disabled={loading || !description.trim()}
@@ -141,12 +175,10 @@ export default function AgentGenerator() {
                   </button>
                 </div>
 
-                <div className="relative flex-1">
-                  <textarea
-                    className="w-full h-full bg-transparent p-6 font-mono text-sm text-zinc-300 resize-none focus:outline-none leading-relaxed selection:bg-green-500/30"
-                    readOnly
-                    value={result}
-                  />
+                <div className="relative flex-1 overflow-hidden">
+                  <div className="flex-1 overflow-y-auto p-6 prose prose-invert prose-sm max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-code:text-green-400 prose-pre:bg-zinc-900">
+                    <ReactMarkdown>{result}</ReactMarkdown>
+                  </div>
 
                   <button
                     onClick={copyToClipboard}


### PR DESCRIPTION
### Motivation
- Improve the output UX by rendering the generated system prompt as formatted markdown instead of showing raw markdown in a read-only textarea.
- Provide a lightweight, in-memory way to restore recently generated prompts so users can quickly revisit prior results.

### Description
- Import `ReactMarkdown` and replace the output panel's read-only `<textarea>` with a scrollable container that renders `<ReactMarkdown>{result}</ReactMarkdown>` and applies the requested Tailwind `prose` dark-theme classes.
- Add a `history` state to hold recent generated prompts (label + prompt), append new entries in `handleGenerate` with ` [swarm]` or ` [single]` labels, and cap the list to 5 entries.
- Render a `Previous results` `<select>` above the Generate button that restores a selected history entry by setting `result`, and keep `copyToClipboard` and the `result` state unchanged.
- No other behavior or UI changes were introduced.

### Testing
- Ran `rg -n "ReactMarkdown|textarea|Previous results|setHistory" web/app/agent-generator/page.tsx` to confirm the import, replacement of the output `<textarea>`, and added history code, which succeeded.
- Ran `npx eslint app/agent-generator/page.tsx` which reported pre-existing lint issues (`@typescript-eslint/no-explicit-any` and `react/no-unescaped-entities`) that are unrelated to this change.
- Started the dev server with `npm run dev` to smoke-test the app which started successfully, and attempted an automated Playwright screenshot test but Chromium crashed with a SIGSEGV in this container so no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6dba582b0832f93820e0fbd79ce80)