### PR TITLE
Add observability checks for multi-agent generation output

### DIFF
--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -304,6 +304,26 @@ class WorkerClient:
             future = executor.submit(self._call_api, messages, 3000, json_mode=False)
             try:
                 content = future.result(timeout=HARD_TIMEOUT_SECONDS)
+                if multi_agent:
+                    import logging
+                    import re
+
+                    # Count top-level agent headers: lines matching "# Agent N:" or "# Agent N "
+                    agent_headers = re.findall(
+                        r"^#\s+Agent\s+\d+", content, re.MULTILINE | re.IGNORECASE
+                    )
+                    agent_count = len(agent_headers)
+                    if agent_count > 4:
+                        logging.warning(
+                            f"[AgentGenerator] Multi-agent output exceeded limit: "
+                            f"{agent_count} agents detected (max 4). "
+                            f"Consider strengthening the multi_agent_planner prompt."
+                        )
+                    elif agent_count == 0:
+                        logging.warning(
+                            "[AgentGenerator] Multi-agent output contains no '# Agent N:' headers. "
+                            "Output may be malformed."
+                        )
                 return content
             except FuturesTimeoutError:
                 future.cancel()


### PR DESCRIPTION
### Motivation
- The multi-agent planner prompt is intended to produce 2–4 agents but the LLM can sometimes output more or malformed agent lists, so we need lightweight observability to detect those cases. 
- The goal is to log warnings for monitoring without rejecting or changing the generated content to avoid breaking user flows.

### Description
- Inserted a post-processing validation block inside `generate_agent()` immediately after `content = future.result(timeout=HARD_TIMEOUT_SECONDS)` and before `return content`, gated by `if multi_agent:`. 
- The block locally imports `logging` and `re`, counts top-level headers using the regex `r"^#\s+Agent\s+\d+"` with `re.MULTILINE | re.IGNORECASE`, and computes `agent_count`. 
- The code logs a warning when `agent_count > 4` or when `agent_count == 0` and otherwise leaves the returned `content` unchanged with no exceptions raised.

### Testing
- Ran `python -m py_compile app/llm_engine/client.py` and the file compiles successfully. 
- No unit tests were added; behavior was validated by static compilation and returning existing call flow unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6dbd31b78832fad8498c623231355)