### PR TITLE
Enhance multi-agent planner output template consistency

### DIFF
--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -25,9 +25,17 @@ The output must contain multiple agent definitions, separated by a horizontal ru
 - [Goal 1]
 - [Goal 2]
 
+## Constraints
+- [Constraint 1: what this agent must NOT do or boundaries it must respect]
+- [Constraint 2]
+
 ## Workflows
 1. [Step 1]
 2. [Step 2]
+
+## Tech Stack
+- [Tool/Library/Framework 1 used by this agent]
+- [Tool/Library/Framework 2 used by this agent]
 
 ---
 
@@ -40,9 +48,34 @@ The output must contain multiple agent definitions, separated by a horizontal ru
 - [Goal 1]
 - [Goal 2]
 
+## Constraints
+- [Constraint 1: what this agent must NOT do or boundaries it must respect]
+- [Constraint 2]
+
 ## Workflows
 1. [Step 1]
 2. [Step 2]
+
+## Tech Stack
+- [Tool/Library/Framework 1 used by this agent]
+- [Tool/Library/Framework 2 used by this agent]
+
+---
+
+## Swarm Example Code (Pseudo-code Skeleton)
+```python
+# Pseudo-code only. Replace TODO items with real project APIs.
+
+def run_swarm(mission_input):
+    agent_1_output = agent_1_execute(mission_input)
+    # TODO: Validate and transform Agent 1 output schema before handoff.
+
+    agent_2_output = agent_2_execute(agent_1_output)
+    # TODO: Add additional agent handoffs as needed (Agent 3/4).
+
+    # TODO: Merge outputs and return final deliverable.
+    return {"status": "not_implemented", "result": agent_2_output}
+```
 ```
 
 ## RULES


### PR DESCRIPTION
### Motivation
- Align the multi-agent planner prompt with the single-agent template so multi-agent outputs include the same essential per-agent metadata and produce higher-quality agent prompts.
- Add explicit boundaries and implementation guidance for each agent and a swarm-level handoff example to improve coordination and developer ergonomics.
- Keep all existing behavioral rules and swarm constraints unchanged to preserve current system expectations.

### Description
- Updated the `OUTPUT STRUCTURE` example in `app/llm_engine/prompts/multi_agent_planner.md` to include per-agent `## Constraints` and `## Tech Stack` sections alongside the existing `## Role`, `## Goals`, and `## Workflows` sections.
- Added a single swarm-level section `## Swarm Example Code (Pseudo-code Skeleton)` after the agent definitions containing a short pseudo-code handoff skeleton with `TODO` markers for unknown details.
- Preserved the existing `---` separation between agents and left the `RULES` block unchanged.
- Changes are limited to the example/template content used by the prompt generator and do not modify runtime logic.

### Testing
- No automated tests were added or executed for this documentation/template update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6db8c0d60832f90a492eeb538a2fc)