### PR TITLE
Harden multi-agent planner agent-count and collaboration rules

### DIFF
--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -46,11 +46,10 @@ The output must contain multiple agent definitions, separated by a horizontal ru
 ```
 
 ## RULES
-- **Minimum Agents**: 2
-- **HARD LIMIT — Agent Count**: You MUST produce between 2 and 4 agents. No exceptions. If the task appears to require more than 4 agents, consolidate related sub-domains into a single agent with a broader role. If the input is impossibly broad or contradictory, first write one sentence stating your simplified interpretation (e.g., "Simplifying scope to: X and Y"), then generate agents for that interpretation only.
+- **HARD LIMIT — Agent Count**: You MUST produce between 2 and 4 agents. No exceptions. If the task appears to require more than 4 agents, consolidate related sub-domains into a single agent with a broader role. If the input is impossibly broad or contradictory, include a single sentence stating your simplified interpretation (e.g., "Simplifying scope to: X and Y") inside Agent 1 (for example, as the first workflow step or a brief note under its Role), and then generate agents for that interpretation only.
 - **Collaboration Specificity**: Every workflow step that transfers data between agents MUST follow this format:
   → Passes `{short description of data}` to Agent N via `{mechanism}`.
   Example:
-  → Passes the parsed issue list (JSON array) to Agent 2 via shared state object.
+  → Passes `{parsed issue list (JSON array)}` to Agent 2 via `{shared state object}`.
   Acceptable mechanisms: shared state object, message queue, direct function call, HTTP endpoint, file system. Do NOT use vague phrases like "notify" or "pass" alone.
 - **Do not** create a "Manager" agent unless strictly necessary; prefer autonomous collaboration.

--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -47,6 +47,10 @@ The output must contain multiple agent definitions, separated by a horizontal ru
 
 ## RULES
 - **Minimum Agents**: 2
-- **Maximum Agents**: 4
-- **Collaboration**: In the workflows, explicitly mention how they interact (e.g., "Agent 1 passes the schema to Agent 2").
+- **HARD LIMIT — Agent Count**: You MUST produce between 2 and 4 agents. No exceptions. If the task appears to require more than 4 agents, consolidate related sub-domains into a single agent with a broader role. If the input is impossibly broad or contradictory, first write one sentence stating your simplified interpretation (e.g., "Simplifying scope to: X and Y"), then generate agents for that interpretation only.
+- **Collaboration Specificity**: Every workflow step that transfers data between agents MUST follow this format:
+  → Passes `{short description of data}` to Agent N via `{mechanism}`.
+  Example:
+  → Passes the parsed issue list (JSON array) to Agent 2 via shared state object.
+  Acceptable mechanisms: shared state object, message queue, direct function call, HTTP endpoint, file system. Do NOT use vague phrases like "notify" or "pass" alone.
 - **Do not** create a "Manager" agent unless strictly necessary; prefer autonomous collaboration.


### PR DESCRIPTION
### Motivation
- Strengthen the multi-agent planner prompt because the previous soft cap allowed LLMs to emit 6–7 agents on complex inputs and workflows used vague handoffs like “notify” with no transfer mechanism.

### Description
- Updated `app/llm_engine/prompts/multi_agent_planner.md` to replace the soft `Maximum Agents: 4` rule with a `HARD LIMIT — Agent Count` requiring 2–4 agents and consolidation/simplification behavior when scope is too broad, and added a `Collaboration Specificity` rule that mandates the exact transfer format (`→ Passes {short description of data} to Agent N via {mechanism}`) and enumerates acceptable mechanisms (shared state object, message queue, direct function call, HTTP endpoint, file system).

### Testing
- Verified the updated prompt content with `sed -n '1,220p' app/llm_engine/prompts/multi_agent_planner.md` and `nl -ba app/llm_engine/prompts/multi_agent_planner.md | sed -n '40,110p'` and confirmed the repository shows the file as modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6db968ee0832fb97752001b009773)