### PR TITLE
Fix structural prompt bugs in multi-agent planner template

### DIFF
--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -7,14 +7,13 @@ You are an Expert AI Systems Architect specializing in Multi-Agent Systems (MAS)
 2. Decompose the mission into distinct sub-domains (e.g., Frontend vs Backend, Research vs Writing, Coding vs Testing).
 3. Design 2 to 4 specialized agents to handle these sub-domains collaboratively.
 4. Output the result in **Markdown** format, separated by distinct headers.
-5. Do NOT include the title 'Multi-Agent Swarm Planner' or any meta-description of this prompt in your output. Start the output directly with `# Agent 1: [Name]`.
+5. Do NOT include the title 'Multi-Agent Swarm Planner' or any meta-description of this prompt in your output. Start the output directly with `# Agent 1: [Name/Role]`.
 
 ## CONTEXT AWARENESS
 - If Project Context is provided, assign specific files or architectural components to the most relevant agent.
 - Ensure agents share a common understanding of the tech stack.
 
 ## OUTPUT STRUCTURE
-The output must contain multiple agent definitions, separated by a horizontal rule `---`.
 Output each agent as a top-level Markdown section starting with `# Agent N: [Name/Role]`, followed by `## Role`, `## Goals`, and `## Workflows` subsections.
 Separate agents with `---`.
 

--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -7,6 +7,7 @@ You are an Expert AI Systems Architect specializing in Multi-Agent Systems (MAS)
 2. Decompose the mission into distinct sub-domains (e.g., Frontend vs Backend, Research vs Writing, Coding vs Testing).
 3. Design 2 to 4 specialized agents to handle these sub-domains collaboratively.
 4. Output the result in **Markdown** format, separated by distinct headers.
+5. Do NOT include the title 'Multi-Agent Swarm Planner' or any meta-description of this prompt in your output. Start the output directly with `# Agent 1: [Name]`.
 
 ## CONTEXT AWARENESS
 - If Project Context is provided, assign specific files or architectural components to the most relevant agent.
@@ -14,36 +15,8 @@ You are an Expert AI Systems Architect specializing in Multi-Agent Systems (MAS)
 
 ## OUTPUT STRUCTURE
 The output must contain multiple agent definitions, separated by a horizontal rule `---`.
-
-```markdown
-# Agent 1: [Name/Role]
-
-## Role
-[Specific persona, e.g., "Frontend Architect"]
-
-## Goals
-- [Goal 1]
-- [Goal 2]
-
-## Workflows
-1. [Step 1]
-2. [Step 2]
-
----
-
-# Agent 2: [Name/Role]
-
-## Role
-[Specific persona, e.g., "Backend API Specialist"]
-
-## Goals
-- [Goal 1]
-- [Goal 2]
-
-## Workflows
-1. [Step 1]
-2. [Step 2]
-```
+Output each agent as a top-level Markdown section starting with `# Agent N: [Name/Role]`, followed by `## Role`, `## Goals`, and `## Workflows` subsections.
+Separate agents with `---`.
 
 ## RULES
 - **Minimum Agents**: 2


### PR DESCRIPTION
### Motivation
- Prevent the model from duplicating agent definitions caused by an embedded fenced `markdown` example block in the `OUTPUT STRUCTURE` section.
- Prevent the prompt's file title from leaking into model outputs by adding an explicit instruction to omit the title and start output with the first agent header.

### Description
- Edited `app/llm_engine/prompts/multi_agent_planner.md` to remove the fenced ```markdown``` example block and replace it with a concise prose description of the expected output format: "Output each agent as a top-level Markdown section starting with `# Agent N: [Name/Role]`, followed by `## Role`, `## Goals`, and `## Workflows`, and separate agents with `---`."
- Added an explicit instruction in the `INSTRUCTIONS` section that states: `Do NOT include the title 'Multi-Agent Swarm Planner' or any meta-description of this prompt in your output. Start the output directly with # Agent 1: [Name]`.
- Retained the existing rules and context guidance while ensuring the output structure guidance no longer contains a fenced example that the model might reproduce verbatim.

### Testing
- Inspected the updated file with `sed -n '1,260p' app/llm_engine/prompts/multi_agent_planner.md` to review changes.
- Ran a Python assertion script to confirm the file contains no fenced `markdown` block and does contain the new explicit title-omission instruction with the checks passing.
- Verified the prompt text manually to ensure the `OUTPUT STRUCTURE` now describes the format in plain prose and that the `INSTRUCTIONS` include the new rule about omitting the title.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6db9156b0832fa49cef5495fc105c)