### PR TITLE
Refine agent generator input handling for short and ambiguous inputs

### DIFF
--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -73,7 +73,7 @@ def run_agent_task(payload):
 - Keep code examples explicitly non-final when key details are unknown.
 
 ## INPUT HANDLING
-- If the user input is 6 words or fewer, or contains no domain/technology hint:
+- If the user input is 6 words or fewer and contains no clear domain/technology hint:
   1. Choose the most likely high-value specialization.
   2. Begin the output with a blockquote: `> **Interpretation:** Treating this as a [specialization] agent. Re-run with a more specific description if needed.`
   3. Then output the full system prompt.

--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -73,4 +73,12 @@ def run_agent_task(payload):
 - Keep code examples explicitly non-final when key details are unknown.
 
 ## INPUT HANDLING
-- If the user input is vague (e.g., "make a coding bot"), infer the most likely high-value use case (e.g., "Full-Stack Web Development Assistant") and build that.
+- If the user input is 6 words or fewer, or contains no domain/technology hint:
+  1. Choose the most likely high-value specialization.
+  2. Begin the output with a blockquote: `> **Interpretation:** Treating this as a [specialization] agent. Re-run with a more specific description if needed.`
+  3. Then output the full system prompt.
+- If the user input is self-contradictory or covers more than 3 unrelated domains:
+  1. Pick the 1-2 most coherent domains.
+  2. Begin the output with: `> **Scope reduction:** Focusing on [domains] only.`
+  3. Then output the system prompt for that reduced scope.
+- Otherwise, generate the system prompt directly without any preamble.


### PR DESCRIPTION
### Motivation
- The generator silently picked specializations for short or vague inputs, causing biased or unexpected agent roles instead of surfacing the interpretation to the user. 
- The change aims to make disambiguation explicit by prepending a short `Interpretation` or `Scope reduction` note when inputs are too short, lack domain hints, or span many unrelated domains.

### Description
- Replaced the `INPUT HANDLING` section in `app/llm_engine/prompts/agent_generator.md` with decision rules that detect inputs of six words or fewer or those lacking domain/technology hints and require an `Interpretation` blockquote before the system prompt. 
- Added rules for self-contradictory or overly broad requests that cover more than three unrelated domains to emit a `Scope reduction` blockquote and focus the generated prompt on 1-2 coherent domains. 
- Left the behavior for well-scoped inputs unchanged so the system prompt is generated directly without any preamble.

### Testing
- Reviewed the updated file content with `sed -n '1,240p' app/llm_engine/prompts/agent_generator.md` and confirmed the new `INPUT HANDLING` text was present. 
- Inspected the targeted lines with `nl -ba app/llm_engine/prompts/agent_generator.md | sed -n '68,110p'` to verify formatting and numbering. 
- Verified the change delta using `git diff -- app/llm_engine/prompts/agent_generator.md` to confirm only the intended section was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6dba07804832fb6088e7c28971247)