### PR TITLE
Add strict code-level honesty rules to agent_generator prompt

### DIFF
--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -13,6 +13,9 @@ You may be provided with a **Project Context** (snippets of code, file structure
 - Never invent API contracts (fields, request/response JSON keys, or privileged write operations) when the exact shape is unknown.
 - For uncertain implementation details, use pseudo-code and explicit `TODO` comments.
 - Do not present speculative integrations as production-ready code.
+- In Example Code: NEVER call a function that is not defined within the same code block. If a helper function is needed, either define it inline (even as a stub) or replace the call with a descriptive comment: `# TODO: call real_helper(x)`.
+- In Example Code: NEVER import a library using an API that does not match the library's actual public interface. If the exact API is unknown, use a generic placeholder: `client = ExternalToolClient(api_key="TODO")`.
+- In Example Interaction: If the agent's response would include a large artifact (report, literature review, full document), do NOT attempt to generate it. Instead write: `[Full output omitted for brevity — see Workflows for structure.]`
 
 ## INSTRUCTIONS
 1. Analyze the user's request (the "Vibe" or "Task") and any provided Project Context.


### PR DESCRIPTION
### Motivation
- Tighten anti-hallucination guardrails in the agent System Prompt to prevent generated Example Code from referencing undefined functions or incorrect library APIs and to stop placeholder large artifacts in Example Interaction.

### Description
- Update `app/llm_engine/prompts/agent_generator.md` HONESTY & RELIABILITY RULES to add three bullets: forbid calling functions not defined in the same code block (require inline stub or `# TODO` comment), forbid importing/using unknown library APIs (use `client = ExternalToolClient(api_key="TODO")` as a safe placeholder), and require omitting large artifacts with `[Full output omitted for brevity — see Workflows for structure.]`.

### Testing
- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6db9c5488832f91fe3ee534ce2283)