### PR TITLE
feat: add export adapter layer for Agent and Skills generators

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
+
 import os
+
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
+
+from app.adapters.agent_ir import parse_agent_markdown
+from app.adapters.claude_sdk import to_python as _claude_python
+from app.adapters.claude_sdk import to_python_multi as _claude_python_multi
+from app.adapters.claude_sdk import to_yaml as _claude_yaml
+from app.adapters.langchain import to_langchain_python, to_langchain_yaml, to_langgraph_python
+from app.adapters.skill_adapter import to_claude_tool_use, to_langchain_tool
+from app.adapters.skill_ir import parse_skill_markdown
 from app.compiler import HEURISTIC_VERSION, HEURISTIC2_VERSION
 from app.llm_engine.schemas import QualityReport
 
@@ -1187,5 +1197,129 @@ async def generate_agent_endpoint(req: AgentGenRequest):
             include_example_code=req.include_example_code,
         )
         return AgentGenResponse(system_prompt=result)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ============================================================================
+# Export Endpoints — convert generated prompts to framework-compatible code
+# ============================================================================
+
+
+class AgentExportRequest(BaseModel):
+    system_prompt: str = Field(..., description="Generated agent system prompt markdown")
+    format: str = Field(
+        default="claude-sdk",
+        description="Target format: 'claude-sdk' | 'langchain' | 'langgraph'",
+    )
+    output_type: str = Field(
+        default="both",
+        description="Output type: 'python' | 'yaml' | 'both'",
+    )
+    is_multi_agent: bool = Field(default=False)
+
+
+class AgentExportResponse(BaseModel):
+    python_code: str | None = None
+    yaml_config: str | None = None
+
+
+@app.post("/agent-generator/export", response_model=AgentExportResponse)
+async def export_agent_endpoint(req: AgentExportRequest):
+    """Convert a generated agent system prompt into framework-compatible code."""
+    try:
+        ir = parse_agent_markdown(req.system_prompt)
+
+        python_code: str | None = None
+        yaml_config: str | None = None
+
+        fmt = req.format.lower()
+        want_python = req.output_type in ("python", "both")
+        want_yaml = req.output_type in ("yaml", "both")
+
+        if fmt == "claude-sdk":
+            if want_python:
+                python_code = _claude_python_multi(ir) if ir.is_multi_agent else _claude_python(ir)
+            if want_yaml:
+                yaml_config = _claude_yaml(ir)
+
+        elif fmt == "langchain":
+            if want_python:
+                python_code = to_langchain_python(ir)
+            if want_yaml:
+                yaml_config = to_langchain_yaml(ir)
+
+        elif fmt == "langgraph":
+            if want_python:
+                python_code = to_langgraph_python(ir)
+            if want_yaml:
+                yaml_config = to_langchain_yaml(ir)
+
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown format '{req.format}'. Use 'claude-sdk', 'langchain', or 'langgraph'.",
+            )
+
+        return AgentExportResponse(python_code=python_code, yaml_config=yaml_config)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+class SkillExportRequest(BaseModel):
+    skill_definition: str = Field(..., description="Generated skill definition markdown")
+    format: str = Field(
+        default="langchain-tool",
+        description="Target format: 'langchain-tool' | 'claude-tool-use'",
+    )
+    output_type: str = Field(
+        default="both",
+        description="Output type: 'python' | 'json' | 'both'",
+    )
+
+
+class SkillExportResponse(BaseModel):
+    python_code: str | None = None
+    json_config: str | None = None
+
+
+@app.post("/skills-generator/export", response_model=SkillExportResponse)
+async def export_skill_endpoint(req: SkillExportRequest):
+    """Convert a generated skill definition into framework-compatible code."""
+    try:
+        ir = parse_skill_markdown(req.skill_definition)
+
+        python_code: str | None = None
+        json_config: str | None = None
+
+        fmt = req.format.lower()
+        want_python = req.output_type in ("python", "both")
+        want_json = req.output_type in ("json", "both")
+
+        if fmt == "langchain-tool":
+            if want_python:
+                python_code = to_langchain_tool(ir)
+            if want_json:
+                json_config = to_claude_tool_use(ir)
+
+        elif fmt == "claude-tool-use":
+            if want_json:
+                json_config = to_claude_tool_use(ir)
+            if want_python:
+                python_code = to_langchain_tool(ir)
+
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown format '{req.format}'. Use 'langchain-tool' or 'claude-tool-use'.",
+            )
+
+        return SkillExportResponse(python_code=python_code, json_config=json_config)
+
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/adapters/__init__.py
+++ b/app/adapters/__init__.py
@@ -1,0 +1,19 @@
+from .agent_ir import AgentExportIR, parse_agent_markdown
+from .skill_ir import SkillExportIR, parse_skill_markdown
+from .claude_sdk import to_python as claude_sdk_python, to_yaml as claude_sdk_yaml
+from .langchain import to_langchain_python, to_langgraph_python, to_langchain_yaml
+from .skill_adapter import to_langchain_tool, to_claude_tool_use
+
+__all__ = [
+    "AgentExportIR",
+    "parse_agent_markdown",
+    "SkillExportIR",
+    "parse_skill_markdown",
+    "claude_sdk_python",
+    "claude_sdk_yaml",
+    "to_langchain_python",
+    "to_langgraph_python",
+    "to_langchain_yaml",
+    "to_langchain_tool",
+    "to_claude_tool_use",
+]

--- a/app/adapters/agent_ir.py
+++ b/app/adapters/agent_ir.py
@@ -83,7 +83,12 @@ def _extract_title(markdown: str) -> str:
         if stripped.startswith("# ") and not stripped.startswith("## "):
             title = stripped[2:].strip()
             # Strip common suffixes like " - System Prompt"
-            title = re.sub(r"\s*[-–]\s*(system\s+prompt|prompt)$", "", title, flags=re.IGNORECASE)
+            title = re.sub(
+                r"\s{0,50}[-–]\s{0,50}(system\s{1,50}prompt|prompt)$",
+                "",
+                title,
+                flags=re.IGNORECASE,
+            )
             return title.strip()
     return "AI Agent"
 

--- a/app/adapters/agent_ir.py
+++ b/app/adapters/agent_ir.py
@@ -1,0 +1,208 @@
+"""
+agent_ir.py — Parse Agent Generator markdown output into a structured IR.
+
+The Agent Generator produces consistent section headers (## Role, ## Goals, etc.).
+We exploit this to extract structured data without any LLM call.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+# Canonical section header aliases → IR field names
+_SECTION_ALIASES: dict[str, str] = {
+    "role": "role",
+    "persona": "role",
+    "goals": "goals",
+    "goal": "goals",
+    "objective": "goals",
+    "objectives": "goals",
+    "constraints": "constraints",
+    "constraint": "constraints",
+    "rules": "constraints",
+    "rule": "constraints",
+    "limitations": "constraints",
+    "workflows": "workflows",
+    "workflow": "workflows",
+    "steps": "workflows",
+    "tech stack": "tech_stack",
+    "tech": "tech_stack",
+    "technology stack": "tech_stack",
+    "tools": "tech_stack",
+    "tools & capabilities": "tech_stack",
+    "tools and capabilities": "tech_stack",
+    "capabilities": "tech_stack",
+}
+
+
+class AgentExportIR(BaseModel):
+    """Structured intermediate representation of a generated agent system prompt."""
+
+    name: str = "AI Agent"
+    role: str = ""
+    goals: list[str] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
+    workflows: list[str] = Field(default_factory=list)
+    tech_stack: list[str] = Field(default_factory=list)
+    model: str = "claude-opus-4-6"
+    is_multi_agent: bool = False
+    agents: list["AgentExportIR"] = Field(default_factory=list)
+    raw_system_prompt: str = ""  # always the full original markdown
+
+
+AgentExportIR.model_rebuild()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_bullets(text: str) -> list[str]:
+    """Extract bullet list items from a text block."""
+    items = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("- ", "* ", "• ")):
+            item = stripped[2:].strip()
+            if item:
+                items.append(item)
+        elif re.match(r"^\d+\.\s", stripped):
+            item = re.sub(r"^\d+\.\s+", "", stripped).strip()
+            if item:
+                items.append(item)
+    return items
+
+
+def _extract_title(markdown: str) -> str:
+    """Extract the agent name from the first # heading."""
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# ") and not stripped.startswith("## "):
+            title = stripped[2:].strip()
+            # Strip common suffixes like " - System Prompt"
+            title = re.sub(r"\s*[-–]\s*(system\s+prompt|prompt)$", "", title, flags=re.IGNORECASE)
+            return title.strip()
+    return "AI Agent"
+
+
+def _parse_sections(markdown: str) -> dict[str, str]:
+    """Split markdown into {section_key: content} using ## headers."""
+    sections: dict[str, str] = {}
+    current_key: Optional[str] = None
+    current_lines: list[str] = []
+
+    for line in markdown.splitlines():
+        if line.startswith("## "):
+            if current_key is not None:
+                sections[current_key] = "\n".join(current_lines).strip()
+            current_key = line[3:].strip().lower()
+            current_lines = []
+        elif line.startswith("# ") and not line.startswith("## "):
+            # Top-level title — save if we have a pending section
+            if current_key is not None:
+                sections[current_key] = "\n".join(current_lines).strip()
+                current_key = None
+                current_lines = []
+        else:
+            if current_key is not None:
+                current_lines.append(line)
+
+    if current_key is not None:
+        sections[current_key] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def _map_sections(sections: dict[str, str]) -> dict[str, str]:
+    """Normalise section keys using alias table."""
+    mapped: dict[str, str] = {}
+    for raw_key, content in sections.items():
+        canonical = _SECTION_ALIASES.get(raw_key)
+        if canonical and canonical not in mapped:
+            mapped[canonical] = content
+    return mapped
+
+
+def _build_ir(markdown: str, is_multi_agent: bool = False) -> AgentExportIR:
+    """Build a single AgentExportIR from one agent block."""
+    sections_raw = _parse_sections(markdown)
+    sections = _map_sections(sections_raw)
+
+    name = _extract_title(markdown)
+
+    return AgentExportIR(
+        name=name,
+        role=sections.get("role", "").strip(),
+        goals=_parse_bullets(sections.get("goals", "")),
+        constraints=_parse_bullets(sections.get("constraints", "")),
+        workflows=_parse_bullets(sections.get("workflows", "")),
+        tech_stack=_parse_bullets(sections.get("tech_stack", "")),
+        is_multi_agent=is_multi_agent,
+        raw_system_prompt=markdown.strip(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_agent_markdown(markdown: str) -> AgentExportIR:
+    """
+    Parse Agent Generator markdown output into AgentExportIR.
+
+    For multi-agent output (blocks separated by '---'), returns a parent IR
+    with individual agents in `.agents` and the full prompt in `.raw_system_prompt`.
+    """
+    markdown = markdown.strip()
+
+    # Detect multi-agent: look for agent-level `# Agent N:` headings after a `---`
+    # The multi-agent planner separates agents with a bare '---' line.
+    agent_blocks = _split_multi_agent_blocks(markdown)
+
+    if len(agent_blocks) > 1:
+        agents = [_build_ir(block, is_multi_agent=False) for block in agent_blocks]
+        # Use first agent's name as swarm name, or generic
+        swarm_name = "Multi-Agent Swarm"
+        return AgentExportIR(
+            name=swarm_name,
+            is_multi_agent=True,
+            agents=agents,
+            raw_system_prompt=markdown,
+        )
+
+    return _build_ir(markdown, is_multi_agent=False)
+
+
+def _split_multi_agent_blocks(markdown: str) -> list[str]:
+    """
+    Split multi-agent markdown on bare '---' separators that appear between agent
+    blocks (not inside fenced code or yaml front-matter).
+    """
+    blocks: list[str] = []
+    current: list[str] = []
+    in_fence = False
+
+    for line in markdown.splitlines():
+        stripped = line.strip()
+
+        # Track fenced code blocks so we don't split on --- inside them
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+
+        if not in_fence and stripped == "---":
+            block_text = "\n".join(current).strip()
+            if block_text:
+                blocks.append(block_text)
+            current = []
+        else:
+            current.append(line)
+
+    tail = "\n".join(current).strip()
+    if tail:
+        blocks.append(tail)
+
+    return blocks

--- a/app/adapters/claude_sdk.py
+++ b/app/adapters/claude_sdk.py
@@ -1,0 +1,110 @@
+"""
+claude_sdk.py — Generate Claude SDK-compatible Python code and YAML config from AgentExportIR.
+"""
+from __future__ import annotations
+
+import textwrap
+import yaml
+
+from .agent_ir import AgentExportIR
+
+
+def _escape_for_python_string(text: str) -> str:
+    """Escape triple-quotes so the prompt can safely be embedded in a \"\"\" string."""
+    return text.replace('"""', '\\"\\"\\"')
+
+
+def _indent_yaml_block(text: str, indent: int = 2) -> str:
+    """Indent every line of text for a YAML literal block scalar."""
+    prefix = " " * indent
+    return "\n".join(prefix + line for line in text.splitlines())
+
+
+# ---------------------------------------------------------------------------
+# Python code generation
+# ---------------------------------------------------------------------------
+
+
+def to_python(ir: AgentExportIR) -> str:
+    """Return ready-to-run Python code using the anthropic SDK."""
+    prompt = _escape_for_python_string(ir.raw_system_prompt)
+    return textwrap.dedent(
+        f'''\
+        from anthropic import Anthropic
+
+        client = Anthropic()
+
+        response = client.messages.create(
+            model="{ir.model}",
+            max_tokens=8096,
+            system="""{prompt}""",
+            messages=[
+                {{"role": "user", "content": "Your task here"}}
+            ]
+        )
+        print(response.content[0].text)
+    '''
+    )
+
+
+def to_python_multi(ir: AgentExportIR) -> str:
+    """
+    Return Python code for a multi-agent swarm using the anthropic SDK.
+    Each agent is represented as a separate system prompt; the user orchestrates
+    calls sequentially (simplest pattern for a middleware tool output).
+    """
+    if not ir.agents:
+        return to_python(ir)
+
+    lines = [
+        "from anthropic import Anthropic",
+        "",
+        "client = Anthropic()",
+        "",
+    ]
+
+    for i, agent in enumerate(ir.agents, start=1):
+        var_name = f"agent_{i}_prompt"
+        escaped = _escape_for_python_string(agent.raw_system_prompt)
+        lines.append(f"# Agent {i}: {agent.name}")
+        lines.append(f'{var_name} = """{escaped}"""')
+        lines.append("")
+
+    lines += [
+        "def call_agent(system_prompt: str, user_message: str) -> str:",
+        "    response = client.messages.create(",
+        f'        model="{ir.model}",',
+        "        max_tokens=8096,",
+        "        system=system_prompt,",
+        '        messages=[{"role": "user", "content": user_message}]',
+        "    )",
+        "    return response.content[0].text",
+        "",
+        "# Orchestrate: pipe output of one agent as input to the next",
+    ]
+
+    for i, agent in enumerate(ir.agents, start=1):
+        if i == 1:
+            lines.append(f'result_{i} = call_agent(agent_{i}_prompt, "Your initial task here")')
+        else:
+            lines.append(f"result_{i} = call_agent(agent_{i}_prompt, result_{i - 1})")
+
+    lines.append(f"print(result_{len(ir.agents)})")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# YAML config generation
+# ---------------------------------------------------------------------------
+
+
+def to_yaml(ir: AgentExportIR) -> str:
+    """Return YAML config suitable for anthropic messages.create()."""
+    config = {
+        "model": ir.model,
+        "max_tokens": 8096,
+        "system": ir.raw_system_prompt,
+        "messages": [{"role": "user", "content": "Your task here"}],
+    }
+    return yaml.dump(config, default_flow_style=False, allow_unicode=True, sort_keys=False)

--- a/app/adapters/langchain.py
+++ b/app/adapters/langchain.py
@@ -1,0 +1,169 @@
+"""
+langchain.py — Generate LangChain (LCEL) and LangGraph Python code from AgentExportIR.
+"""
+from __future__ import annotations
+
+import textwrap
+import yaml
+
+from .agent_ir import AgentExportIR
+
+
+def _escape_for_python_string(text: str) -> str:
+    return text.replace('"""', '\\"\\"\\"')
+
+
+# ---------------------------------------------------------------------------
+# LangChain LCEL chain
+# ---------------------------------------------------------------------------
+
+
+def to_langchain_python(ir: AgentExportIR) -> str:
+    """Return LangChain LCEL chain Python code."""
+    prompt = _escape_for_python_string(ir.raw_system_prompt)
+    return textwrap.dedent(
+        f'''\
+        from langchain_anthropic import ChatAnthropic
+        from langchain_core.prompts import ChatPromptTemplate
+        from langchain_core.output_parsers import StrOutputParser
+
+        llm = ChatAnthropic(model="{ir.model}")
+
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", """{prompt}"""),
+            ("human", "{{input}}")
+        ])
+
+        chain = prompt | llm | StrOutputParser()
+
+        # Usage
+        result = chain.invoke({{"input": "Your task here"}})
+        print(result)
+    '''
+    )
+
+
+# ---------------------------------------------------------------------------
+# LangGraph StateGraph agent
+# ---------------------------------------------------------------------------
+
+
+def to_langgraph_python(ir: AgentExportIR) -> str:
+    """Return LangGraph StateGraph Python code."""
+    if ir.is_multi_agent and ir.agents:
+        return _to_langgraph_multi(ir)
+    return _to_langgraph_single(ir)
+
+
+def _to_langgraph_single(ir: AgentExportIR) -> str:
+    prompt = _escape_for_python_string(ir.raw_system_prompt)
+    safe_name = _to_snake(ir.name)
+    return textwrap.dedent(
+        f'''\
+        from langgraph.graph import StateGraph, MessagesState, END
+        from langchain_anthropic import ChatAnthropic
+        from langchain_core.messages import SystemMessage
+
+        llm = ChatAnthropic(model="{ir.model}")
+
+        SYSTEM_PROMPT = """{prompt}"""
+
+
+        def {safe_name}_node(state: MessagesState):
+            messages = [SystemMessage(content=SYSTEM_PROMPT)] + state["messages"]
+            response = llm.invoke(messages)
+            return {{"messages": [response]}}
+
+
+        graph = StateGraph(MessagesState)
+        graph.add_node("{safe_name}", {safe_name}_node)
+        graph.set_entry_point("{safe_name}")
+        graph.add_edge("{safe_name}", END)
+
+        app = graph.compile()
+
+        # Usage
+        result = app.invoke({{
+            "messages": [{{"role": "user", "content": "Your task here"}}]
+        }})
+        print(result["messages"][-1].content)
+    '''
+    )
+
+
+def _to_langgraph_multi(ir: AgentExportIR) -> str:
+    """Multi-agent LangGraph with one node per agent connected sequentially."""
+    lines = [
+        "from langgraph.graph import StateGraph, MessagesState, END",
+        "from langchain_anthropic import ChatAnthropic",
+        "from langchain_core.messages import SystemMessage, HumanMessage",
+        "",
+        f'llm = ChatAnthropic(model="{ir.model}")',
+        "",
+    ]
+
+    node_names: list[str] = []
+    for i, agent in enumerate(ir.agents, start=1):
+        safe_name = _to_snake(agent.name) or f"agent_{i}"
+        escaped = _escape_for_python_string(agent.raw_system_prompt)
+        lines += [
+            f"# Agent {i}: {agent.name}",
+            f'SYSTEM_PROMPT_{i} = """{escaped}"""',
+            "",
+            f"def {safe_name}_node(state: MessagesState):",
+            f'    msgs = [SystemMessage(content=SYSTEM_PROMPT_{i})] + state["messages"]',
+            "    response = llm.invoke(msgs)",
+            '    return {"messages": [response]}',
+            "",
+        ]
+        node_names.append(safe_name)
+
+    lines += [
+        "graph = StateGraph(MessagesState)",
+    ]
+    for name in node_names:
+        lines.append(f'graph.add_node("{name}", {name}_node)')
+    lines.append(f'graph.set_entry_point("{node_names[0]}")')
+    for a, b in zip(node_names, node_names[1:]):
+        lines.append(f'graph.add_edge("{a}", "{b}")')
+    lines.append(f'graph.add_edge("{node_names[-1]}", END)')
+    lines += [
+        "",
+        "app = graph.compile()",
+        "",
+        "# Usage",
+        'result = app.invoke({"messages": [{"role": "user", "content": "Your task here"}]})',
+        'print(result["messages"][-1].content)',
+    ]
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# LangChain YAML config
+# ---------------------------------------------------------------------------
+
+
+def to_langchain_yaml(ir: AgentExportIR) -> str:
+    """Return a minimal YAML config for the LangChain prompt."""
+    config = {
+        "model": ir.model,
+        "system_prompt": ir.raw_system_prompt,
+        "input_variables": ["input"],
+        "template": "{input}",
+    }
+    return yaml.dump(config, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_snake(name: str) -> str:
+    """Convert an agent name to a safe Python snake_case identifier."""
+    import re
+
+    s = re.sub(r"[^a-zA-Z0-9\s]", "", name)
+    s = re.sub(r"\s+", "_", s.strip()).lower()
+    return s or "agent"

--- a/app/adapters/skill_adapter.py
+++ b/app/adapters/skill_adapter.py
@@ -1,0 +1,127 @@
+"""
+skill_adapter.py — Generate LangChain Tool and Claude tool_use JSON from SkillExportIR.
+"""
+from __future__ import annotations
+
+import json
+
+from .skill_ir import SkillExportIR, SkillParam
+
+
+def _to_pascal(snake: str) -> str:
+    return "".join(word.capitalize() for word in snake.split("_"))
+
+
+def _param_field_line(p: SkillParam) -> str:
+    desc = p.description.replace('"', '\\"')
+    if p.required:
+        return f'    {p.name}: {p.type} = Field(description="{desc}")'
+    return f'    {p.name}: {p.type} | None = Field(default=None, description="{desc}")'
+
+
+def _param_signature(p: SkillParam) -> str:
+    opt = " | None = None" if not p.required else ""
+    return f"{p.name}: {p.type}{opt}"
+
+
+# ---------------------------------------------------------------------------
+# LangChain Tool
+# ---------------------------------------------------------------------------
+
+
+def to_langchain_tool(ir: SkillExportIR) -> str:
+    """Return a LangChain @tool Python definition for this skill."""
+    pascal_name = _to_pascal(ir.name)
+    func_name = ir.name
+
+    # Build pydantic input model if there are params
+    if ir.params:
+        # Build each line with correct 4-space indent already applied — avoids
+        # the textwrap.dedent + multi-line f-string interpolation gotcha.
+        param_fields = "\n".join(_param_field_line(p) for p in ir.params)
+        input_model = f"class {pascal_name}Input(BaseModel):\n{param_fields}\n"
+        schema_arg = f"args_schema={pascal_name}Input"
+        sig_params = ", ".join(_param_signature(p) for p in ir.params)
+    else:
+        input_model = ""
+        schema_arg = ""
+        sig_params = ""
+
+    # Docstring for the tool
+    purpose = ir.purpose.replace('"""', '\\"\\"\\"') or f"Execute the {func_name} skill."
+
+    # Decorator
+    if schema_arg:
+        decorator = f"@tool({schema_arg})"
+    else:
+        decorator = "@tool"
+
+    # Build full output
+    parts = [
+        "from langchain.tools import tool",
+        "from pydantic import BaseModel, Field",
+    ]
+
+    # Add typing import if Any is used
+    if any(p.type == "Any" for p in ir.params) or ir.output_type == "Any":
+        parts.append("from typing import Any")
+
+    parts.append("")
+
+    if input_model:
+        parts.append(input_model)
+
+    parts.append(decorator)
+    if sig_params:
+        parts.append(f"def {func_name}({sig_params}) -> {ir.output_type}:")
+    else:
+        parts.append(f"def {func_name}() -> {ir.output_type}:")
+    parts.append(f'    """{purpose}"""')
+    parts.append("    # TODO: implement")
+    parts.append("    pass")
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Claude tool_use JSON
+# ---------------------------------------------------------------------------
+
+
+def to_claude_tool_use(ir: SkillExportIR) -> str:
+    """Return a Claude tool_use JSON block for this skill."""
+    properties: dict = {}
+    required: list[str] = []
+
+    for p in ir.params:
+        prop: dict = {"type": _py_to_json_type(p.type)}
+        if p.description:
+            prop["description"] = p.description
+        properties[p.name] = prop
+        if p.required:
+            required.append(p.name)
+
+    input_schema: dict = {"type": "object", "properties": properties}
+    if required:
+        input_schema["required"] = required
+
+    tool_def = {
+        "name": ir.name,
+        "description": ir.purpose or f"Execute the {ir.name} skill.",
+        "input_schema": input_schema,
+    }
+
+    return json.dumps(tool_def, indent=2)
+
+
+def _py_to_json_type(py_type: str) -> str:
+    mapping = {
+        "str": "string",
+        "int": "integer",
+        "float": "number",
+        "bool": "boolean",
+        "dict": "object",
+        "list": "array",
+        "Any": "string",
+    }
+    return mapping.get(py_type, "string")

--- a/app/adapters/skill_ir.py
+++ b/app/adapters/skill_ir.py
@@ -1,0 +1,227 @@
+"""
+skill_ir.py — Parse Skills Generator markdown output into a structured IR.
+
+Skills Generator output has sections: Name, Purpose, Input Schema, Output Schema,
+Implementation, Dependencies, Error Handling, Implementation Example (optional).
+"""
+from __future__ import annotations
+
+import re
+from pydantic import BaseModel, Field
+
+
+class SkillParam(BaseModel):
+    name: str
+    type: str = "str"
+    description: str = ""
+    required: bool = True
+
+
+class SkillExportIR(BaseModel):
+    name: str = "skill_name"  # snake_case from ## Name
+    purpose: str = ""  # from ## Purpose
+    params: list[SkillParam] = Field(default_factory=list)  # from ## Input Schema
+    output_type: str = "str"  # inferred from ## Output Schema
+    output_description: str = ""
+    dependencies: list[str] = Field(default_factory=list)  # from ## Dependencies
+    raw_definition: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_section(text: str) -> str:
+    return text.strip()
+
+
+def _extract_sections(markdown: str) -> dict[str, str]:
+    """Split markdown into {lower_header: content}."""
+    sections: dict[str, str] = {}
+    current_key = None
+    current_lines: list[str] = []
+
+    for line in markdown.splitlines():
+        if line.startswith("## "):
+            if current_key is not None:
+                sections[current_key] = "\n".join(current_lines).strip()
+            current_key = line[3:].strip().lower()
+            current_lines = []
+        elif line.startswith("# ") and not line.startswith("## "):
+            if current_key is not None:
+                sections[current_key] = "\n".join(current_lines).strip()
+                current_key = None
+                current_lines = []
+        else:
+            if current_key is not None:
+                current_lines.append(line)
+
+    if current_key is not None:
+        sections[current_key] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def _extract_title(markdown: str) -> str:
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# ") and not stripped.startswith("## "):
+            title = stripped[2:].strip()
+            title = re.sub(
+                r"\s*[-–]\s*(skill\s+definition|definition|skill)$",
+                "",
+                title,
+                flags=re.IGNORECASE,
+            )
+            return title.strip()
+    return "skill_name"
+
+
+def _to_snake(name: str) -> str:
+    # Preserve underscores — they are valid in snake_case identifiers
+    s = re.sub(r"[^a-zA-Z0-9_\s]", "", name)
+    s = re.sub(r"\s+", "_", s.strip()).lower()
+    return s or "skill_name"
+
+
+def _parse_name_section(text: str) -> str:
+    """Extract snake_case name from ## Name section."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            # Already snake_case most of the time
+            return _to_snake(stripped.split()[0])
+    return ""
+
+
+def _parse_params(text: str) -> list[SkillParam]:
+    """
+    Parse ## Input Schema into SkillParam list.
+    Handles both markdown table format and bullet list format.
+    """
+    params: list[SkillParam] = []
+
+    # Try table format: | Name | Type | Description | Required |
+    table_rows = re.findall(
+        r"^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|(?:\s*([^|]+?)\s*\|)?",
+        text,
+        re.MULTILINE,
+    )
+    if len(table_rows) > 1:  # >1 because first row is header
+        for row in table_rows[1:]:
+            name_cell = row[0].strip()
+            type_cell = row[1].strip()
+            desc_cell = row[2].strip()
+            req_cell = row[3].strip().lower() if len(row) > 3 else "yes"
+            if name_cell.lower() in ("name", "parameter", "param", "---", "-"):
+                continue
+            if re.match(r"^-+$", name_cell):
+                continue
+            params.append(
+                SkillParam(
+                    name=_to_snake(name_cell),
+                    type=_normalise_type(type_cell),
+                    description=desc_cell,
+                    required="no" not in req_cell and "false" not in req_cell,
+                )
+            )
+        if params:
+            return params
+
+    # Fallback: bullet list  "- param_name (type): description"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("- ", "* ")):
+            content = stripped[2:].strip()
+            # Pattern: name (type): description
+            m = re.match(r"^(\w+)\s*\(([^)]+)\)\s*:?\s*(.*)", content)
+            if m:
+                params.append(
+                    SkillParam(
+                        name=_to_snake(m.group(1)),
+                        type=_normalise_type(m.group(2)),
+                        description=m.group(3).strip(),
+                    )
+                )
+            else:
+                # Plain bullet: treat as str param
+                name = _to_snake(content.split(":")[0].split(" ")[0])
+                if name:
+                    params.append(SkillParam(name=name))
+
+    return params
+
+
+def _parse_output_type(text: str) -> tuple[str, str]:
+    """Infer output type from ## Output Schema text. Returns (type, description)."""
+    text_lower = text.lower()
+    type_map = [
+        (["dict", "json", "object", "map"], "dict"),
+        (["list", "array"], "list"),
+        (["bool", "boolean", "true/false"], "bool"),
+        (["int", "integer", "number", "count"], "int"),
+        (["float", "decimal"], "float"),
+    ]
+    for keywords, py_type in type_map:
+        if any(kw in text_lower for kw in keywords):
+            return py_type, text.strip()
+    return "str", text.strip()
+
+
+def _parse_dependencies(text: str) -> list[str]:
+    deps: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("- ", "* ")):
+            dep = stripped[2:].strip()
+            if dep:
+                deps.append(dep)
+    return deps
+
+
+def _normalise_type(raw: str) -> str:
+    """Map common type strings to Python type hints."""
+    mapping = {
+        "string": "str",
+        "text": "str",
+        "integer": "int",
+        "number": "int",
+        "float": "float",
+        "double": "float",
+        "boolean": "bool",
+        "bool": "bool",
+        "list": "list",
+        "array": "list",
+        "dict": "dict",
+        "object": "dict",
+        "json": "dict",
+        "any": "Any",
+    }
+    return mapping.get(raw.strip().lower(), raw.strip())
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_skill_markdown(markdown: str) -> SkillExportIR:
+    """Parse Skills Generator markdown output into SkillExportIR."""
+    markdown = markdown.strip()
+    sections = _extract_sections(markdown)
+
+    raw_name = sections.get("name", "")
+    parsed_name = _parse_name_section(raw_name) if raw_name else _to_snake(_extract_title(markdown))
+
+    output_type, output_desc = _parse_output_type(sections.get("output schema", ""))
+
+    return SkillExportIR(
+        name=parsed_name or "skill_name",
+        purpose=_clean_section(sections.get("purpose", "")),
+        params=_parse_params(sections.get("input schema", "")),
+        output_type=output_type,
+        output_description=output_desc,
+        dependencies=_parse_dependencies(sections.get("dependencies", "")),
+        raw_definition=markdown,
+    )

--- a/app/adapters/skill_ir.py
+++ b/app/adapters/skill_ir.py
@@ -69,7 +69,7 @@ def _extract_title(markdown: str) -> str:
         if stripped.startswith("# ") and not stripped.startswith("## "):
             title = stripped[2:].strip()
             title = re.sub(
-                r"\s*[-–]\s*(skill\s+definition|definition|skill)$",
+                r"\s{0,50}[-–]\s{0,50}(skill\s{1,50}definition|definition|skill)$",
                 "",
                 title,
                 flags=re.IGNORECASE,

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -1,0 +1,367 @@
+"""
+tests/test_export_adapters.py — Tests for the Export Adapter layer.
+
+Covers IR extraction, code generation, and API endpoints for both
+agent and skill exports.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from app.adapters.agent_ir import AgentExportIR, parse_agent_markdown
+from app.adapters.claude_sdk import to_python, to_yaml
+from app.adapters.langchain import to_langchain_python, to_langgraph_python
+from app.adapters.skill_adapter import to_claude_tool_use, to_langchain_tool
+from app.adapters.skill_ir import SkillExportIR, parse_skill_markdown
+
+
+# ---------------------------------------------------------------------------
+# Sample fixtures that mirror real agent_generator.md / skills_generator.md output
+# ---------------------------------------------------------------------------
+
+SINGLE_AGENT_MARKDOWN = """\
+# Data Analyst Agent - System Prompt
+
+## Role
+You are an expert data analyst specializing in business intelligence and statistical analysis.
+
+## Goals
+- Analyze datasets and extract actionable insights
+- Generate clear, concise reports for stakeholders
+- Identify trends, anomalies, and patterns in data
+
+## Constraints
+- Never fabricate or hallucinate data points
+- Always cite sources and confidence intervals
+- Limit analysis to provided datasets only
+
+## Workflows
+1. Receive dataset and analysis requirements
+2. Perform exploratory data analysis (EDA)
+3. Apply appropriate statistical methods
+4. Generate visual summaries where relevant
+5. Compile findings into a structured report
+
+## Tech Stack
+- Python (pandas, numpy, matplotlib, seaborn)
+- SQL for database queries
+- Jupyter notebooks for interactive analysis
+
+## Example Interaction
+User: Analyze sales data for Q3 2024.
+Agent: I'll begin with an EDA of the Q3 2024 sales dataset...
+"""
+
+MULTI_AGENT_MARKDOWN = """\
+# Agent 1: Researcher
+
+## Role
+You are a research specialist that gathers information from multiple sources.
+
+## Goals
+- Collect relevant information based on query
+- Summarise key findings concisely
+
+## Constraints
+- Only use verified information sources
+- Cite all references
+
+## Workflows
+1. Receive research query
+2. Identify relevant sources
+3. → Passes summarised findings to Agent 2 via structured JSON
+
+## Tech Stack
+- Web search APIs
+- Document parsing tools
+
+---
+
+# Agent 2: Writer
+
+## Role
+You are a professional technical writer who transforms research into polished documents.
+
+## Goals
+- Convert research findings into clear, readable prose
+- Maintain consistent tone and style
+
+## Constraints
+- Do not add information not present in source material
+- Keep output under 500 words unless instructed otherwise
+
+## Workflows
+1. Receive structured findings from Agent 1
+2. Draft document outline
+3. Write final document
+
+## Tech Stack
+- Markdown formatting
+- Grammar checking tools
+"""
+
+SKILL_MARKDOWN = """\
+# web_search - Skill Definition
+
+## Name
+web_search
+
+## Purpose
+Search the web for up-to-date information based on a user query and return relevant results.
+
+## Input Schema
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+| query | string | The search query string | Yes |
+| max_results | integer | Maximum number of results to return | No |
+
+## Output Schema
+Returns a list of search result objects, each containing title, url, and snippet fields.
+
+## Implementation
+1. Validate and sanitise the query string
+2. Call the search API with the query and max_results parameters
+3. Parse and normalise the response
+4. Return structured results
+
+## Dependencies
+- requests
+- beautifulsoup4
+
+## Error Handling
+- Return empty list if API is unavailable
+- Raise ValueError for empty or invalid query strings
+"""
+
+
+# ---------------------------------------------------------------------------
+# IR extraction tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_single_agent_ir():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+
+    assert isinstance(ir, AgentExportIR)
+    assert "Data Analyst" in ir.name
+    assert "expert data analyst" in ir.role
+    assert len(ir.goals) >= 3
+    assert any("insights" in g.lower() for g in ir.goals)
+    assert len(ir.constraints) >= 3
+    assert len(ir.workflows) >= 4
+    assert len(ir.tech_stack) >= 2
+    assert ir.is_multi_agent is False
+    assert ir.raw_system_prompt.strip() == SINGLE_AGENT_MARKDOWN.strip()
+
+
+def test_parse_multi_agent_ir():
+    ir = parse_agent_markdown(MULTI_AGENT_MARKDOWN)
+
+    assert ir.is_multi_agent is True
+    assert len(ir.agents) == 2
+    assert ir.raw_system_prompt.strip() == MULTI_AGENT_MARKDOWN.strip()
+
+    agent1, agent2 = ir.agents
+    assert "Researcher" in agent1.name or "researcher" in agent1.role.lower()
+    assert "Writer" in agent2.name or "writer" in agent2.role.lower()
+    assert len(agent1.goals) >= 1
+    assert len(agent2.goals) >= 1
+
+
+def test_parse_agent_raw_prompt_preserved():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    assert ir.raw_system_prompt.strip() == SINGLE_AGENT_MARKDOWN.strip()
+
+
+# ---------------------------------------------------------------------------
+# Claude SDK output tests
+# ---------------------------------------------------------------------------
+
+
+def test_claude_sdk_python_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    code = to_python(ir)
+
+    assert "from anthropic import Anthropic" in code
+    assert "client.messages.create(" in code
+    assert "claude-opus-4-6" in code
+    assert "max_tokens=8096" in code
+    assert "response.content[0].text" in code
+
+
+def test_claude_sdk_yaml_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    yml = to_yaml(ir)
+
+    parsed = yaml.safe_load(yml)
+    assert parsed["model"] == "claude-opus-4-6"
+    assert parsed["max_tokens"] == 8096
+    assert "system" in parsed
+    assert "Data Analyst" in parsed["system"]
+
+
+# ---------------------------------------------------------------------------
+# LangChain output tests
+# ---------------------------------------------------------------------------
+
+
+def test_langchain_python_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    code = to_langchain_python(ir)
+
+    assert "from langchain_anthropic import ChatAnthropic" in code
+    assert "from langchain_core.prompts import ChatPromptTemplate" in code
+    assert "StrOutputParser" in code
+    assert "chain.invoke" in code
+    assert "claude-opus-4-6" in code
+
+
+def test_langgraph_python_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    code = to_langgraph_python(ir)
+
+    assert "from langgraph.graph import StateGraph" in code
+    assert "MessagesState" in code
+    assert "SystemMessage" in code
+    assert "graph.compile()" in code
+    assert "app.invoke(" in code
+
+
+def test_langgraph_multi_agent_output():
+    ir = parse_agent_markdown(MULTI_AGENT_MARKDOWN)
+    code = to_langgraph_python(ir)
+
+    assert "StateGraph" in code
+    assert "SYSTEM_PROMPT_1" in code
+    assert "SYSTEM_PROMPT_2" in code
+    # Two nodes should be added
+    assert code.count("add_node(") == 2
+
+
+# ---------------------------------------------------------------------------
+# Skill IR extraction tests
+# ---------------------------------------------------------------------------
+
+
+def test_skill_ir_extraction():
+    ir = parse_skill_markdown(SKILL_MARKDOWN)
+
+    assert isinstance(ir, SkillExportIR)
+    assert ir.name == "web_search"
+    assert "search" in ir.purpose.lower()
+    assert len(ir.params) >= 1
+    query_param = next((p for p in ir.params if p.name == "query"), None)
+    assert query_param is not None
+    assert query_param.type == "str"
+    assert query_param.required is True
+
+
+# ---------------------------------------------------------------------------
+# Skill adapter output tests
+# ---------------------------------------------------------------------------
+
+
+def test_langchain_tool_output():
+    ir = parse_skill_markdown(SKILL_MARKDOWN)
+    code = to_langchain_tool(ir)
+
+    assert "@tool" in code
+    assert "from langchain.tools import tool" in code
+    assert "web_search" in code
+    # Should contain a pydantic model since we have params
+    assert "BaseModel" in code
+
+
+def test_claude_tool_use_json():
+    ir = parse_skill_markdown(SKILL_MARKDOWN)
+    json_str = to_claude_tool_use(ir)
+
+    parsed = json.loads(json_str)
+    assert parsed["name"] == "web_search"
+    assert "description" in parsed
+    assert parsed["input_schema"]["type"] == "object"
+    assert "query" in parsed["input_schema"]["properties"]
+    assert "query" in parsed["input_schema"].get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client():
+    from api.main import app
+
+    return TestClient(app)
+
+
+def test_export_api_endpoint_agent(client):
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": "claude-sdk",
+            "output_type": "both",
+            "is_multi_agent": False,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "python_code" in data
+    assert "yaml_config" in data
+    assert data["python_code"] is not None
+    assert "client.messages.create" in data["python_code"]
+    assert data["yaml_config"] is not None
+
+
+def test_export_api_endpoint_skill(client):
+    response = client.post(
+        "/skills-generator/export",
+        json={
+            "skill_definition": SKILL_MARKDOWN,
+            "format": "langchain-tool",
+            "output_type": "both",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "python_code" in data
+    assert "json_config" in data
+    assert data["python_code"] is not None
+    assert "@tool" in data["python_code"]
+    assert data["json_config"] is not None
+
+    parsed = json.loads(data["json_config"])
+    assert parsed["name"] == "web_search"
+
+
+def test_export_api_invalid_format(client):
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": "nonexistent-framework",
+            "output_type": "python",
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_export_api_python_only(client):
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": "langchain",
+            "output_type": "python",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["python_code"] is not None
+    assert data["yaml_config"] is None

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { API_BASE } from "@/config";
+
+type Framework = "claude-sdk" | "langchain" | "langgraph";
+type OutputTab = "python" | "yaml";
+
+interface ExportResult {
+  python_code: string | null;
+  yaml_config: string | null;
+}
+
+interface ExportPanelProps {
+  systemPrompt: string | null;
+  isMultiAgent: boolean;
+}
+
+const FRAMEWORKS: { id: Framework; label: string; color: string; activeColor: string }[] = [
+  {
+    id: "claude-sdk",
+    label: "Claude SDK",
+    color: "text-zinc-400 border-transparent hover:border-orange-500/40 hover:text-orange-300",
+    activeColor: "text-orange-300 border-orange-500/60 bg-orange-500/10",
+  },
+  {
+    id: "langchain",
+    label: "LangChain",
+    color: "text-zinc-400 border-transparent hover:border-green-500/40 hover:text-green-300",
+    activeColor: "text-green-300 border-green-500/60 bg-green-500/10",
+  },
+  {
+    id: "langgraph",
+    label: "LangGraph",
+    color: "text-zinc-400 border-transparent hover:border-blue-500/40 hover:text-blue-300",
+    activeColor: "text-blue-300 border-blue-500/60 bg-blue-500/10",
+  },
+];
+
+export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [framework, setFramework] = useState<Framework>("claude-sdk");
+  const [outputTab, setOutputTab] = useState<OutputTab>("python");
+  const [cache, setCache] = useState<Partial<Record<Framework, ExportResult>>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const prevPromptRef = useRef<string | null>(null);
+
+  // Reset cache when systemPrompt changes
+  useEffect(() => {
+    if (systemPrompt !== prevPromptRef.current) {
+      prevPromptRef.current = systemPrompt;
+      setCache({});
+      setError(null);
+    }
+  }, [systemPrompt]);
+
+  const currentResult = cache[framework] ?? null;
+
+  const fetchExport = async (fw: Framework) => {
+    if (!systemPrompt) return;
+    if (cache[fw]) return; // already fetched
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/agent-generator/export`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          system_prompt: systemPrompt,
+          format: fw,
+          output_type: "both",
+          is_multi_agent: isMultiAgent,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(body.detail ?? `Export failed (${res.status})`);
+      }
+
+      const data: ExportResult = await res.json();
+      setCache((prev) => ({ ...prev, [fw]: data }));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFrameworkClick = (fw: Framework) => {
+    setFramework(fw);
+    fetchExport(fw);
+  };
+
+  const handleToggle = () => {
+    const next = !isOpen;
+    setIsOpen(next);
+    if (next && !cache[framework]) {
+      fetchExport(framework);
+    }
+  };
+
+  const handleCopy = () => {
+    const text =
+      outputTab === "python" ? currentResult?.python_code : currentResult?.yaml_config;
+    if (text) {
+      navigator.clipboard.writeText(text).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+    }
+  };
+
+  const activeFramework = FRAMEWORKS.find((f) => f.id === framework)!;
+  const codeContent =
+    outputTab === "python" ? currentResult?.python_code : currentResult?.yaml_config;
+
+  if (!systemPrompt) return null;
+
+  return (
+    <div className="mt-6 border-t border-white/5 pt-4">
+      {/* Toggle header */}
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between px-2 py-1 group"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
+            Export
+          </span>
+          <span className="text-[10px] text-zinc-600 font-mono">
+            → framework code
+          </span>
+        </div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-zinc-500 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
+          {/* Framework tabs */}
+          <div className="flex gap-1 p-3 border-b border-white/5">
+            {FRAMEWORKS.map((fw) => (
+              <button
+                key={fw.id}
+                onClick={() => handleFrameworkClick(fw.id)}
+                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                  framework === fw.id ? fw.activeColor : fw.color
+                }`}
+              >
+                {fw.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Output type tabs */}
+          <div className="flex gap-1 px-3 pt-3">
+            {(["python", "yaml"] as OutputTab[]).map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setOutputTab(tab)}
+                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
+                  outputTab === tab
+                    ? "bg-white/10 text-zinc-100"
+                    : "text-zinc-500 hover:text-zinc-300"
+                }`}
+              >
+                {tab === "python" ? "Python Code" : "YAML Config"}
+              </button>
+            ))}
+          </div>
+
+          {/* Code area */}
+          <div className="relative p-3">
+            {loading ? (
+              <div className="flex items-center justify-center h-24 text-zinc-500 text-xs animate-pulse">
+                Generating {activeFramework.label} export...
+              </div>
+            ) : error ? (
+              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
+                {error}
+              </div>
+            ) : codeContent ? (
+              <div className="relative group/code">
+                <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
+                  <code>{codeContent}</code>
+                </pre>
+                <button
+                  onClick={handleCopy}
+                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                >
+                  {copied ? (
+                    <>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+                      Copy
+                    </>
+                  )}
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
+                Select a framework above to generate export code
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 import { API_BASE } from "@/config";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
+import ExportPanel from "./components/ExportPanel";
 
 export default function AgentGenerator() {
   const [description, setDescription] = useState("");
@@ -198,6 +199,7 @@ export default function AgentGenerator() {
                 <div className="relative flex-1 min-h-0 overflow-hidden">
                   <div className="absolute inset-0 overflow-y-auto p-6 pb-24 prose prose-invert prose-sm max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-code:text-green-400 prose-pre:bg-zinc-900">
                     <ReactMarkdown>{result}</ReactMarkdown>
+                    <ExportPanel systemPrompt={result} isMultiAgent={multiAgent} />
                   </div>
 
                   <button

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { API_BASE } from "@/config";
+
+type SkillFormat = "langchain-tool" | "claude-tool-use";
+type OutputTab = "python" | "json";
+
+interface SkillExportResult {
+  python_code: string | null;
+  json_config: string | null;
+}
+
+interface ExportPanelProps {
+  skillDefinition: string | null;
+}
+
+const FORMATS: { id: SkillFormat; label: string; color: string; activeColor: string }[] = [
+  {
+    id: "langchain-tool",
+    label: "LangChain Tool",
+    color: "text-zinc-400 border-transparent hover:border-green-500/40 hover:text-green-300",
+    activeColor: "text-green-300 border-green-500/60 bg-green-500/10",
+  },
+  {
+    id: "claude-tool-use",
+    label: "Claude tool_use",
+    color: "text-zinc-400 border-transparent hover:border-orange-500/40 hover:text-orange-300",
+    activeColor: "text-orange-300 border-orange-500/60 bg-orange-500/10",
+  },
+];
+
+export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [format, setFormat] = useState<SkillFormat>("langchain-tool");
+  const [outputTab, setOutputTab] = useState<OutputTab>("python");
+  const [cache, setCache] = useState<Partial<Record<SkillFormat, SkillExportResult>>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const prevDefRef = useRef<string | null>(null);
+
+  // Reset cache when skill definition changes
+  useEffect(() => {
+    if (skillDefinition !== prevDefRef.current) {
+      prevDefRef.current = skillDefinition;
+      setCache({});
+      setError(null);
+    }
+  }, [skillDefinition]);
+
+  const currentResult = cache[format] ?? null;
+
+  const fetchExport = async (fmt: SkillFormat) => {
+    if (!skillDefinition) return;
+    if (cache[fmt]) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/skills-generator/export`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          skill_definition: skillDefinition,
+          format: fmt,
+          output_type: "both",
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(body.detail ?? `Export failed (${res.status})`);
+      }
+
+      const data: SkillExportResult = await res.json();
+      setCache((prev) => ({ ...prev, [fmt]: data }));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFormatClick = (fmt: SkillFormat) => {
+    setFormat(fmt);
+    fetchExport(fmt);
+    // Reset output tab to a valid default for each format
+    if (fmt === "claude-tool-use") setOutputTab("json");
+    else setOutputTab("python");
+  };
+
+  const handleToggle = () => {
+    const next = !isOpen;
+    setIsOpen(next);
+    if (next && !cache[format]) {
+      fetchExport(format);
+    }
+  };
+
+  const handleCopy = () => {
+    const text =
+      outputTab === "python" ? currentResult?.python_code : currentResult?.json_config;
+    if (text) {
+      navigator.clipboard.writeText(text).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+    }
+  };
+
+  const outputTabs: { id: OutputTab; label: string }[] =
+    format === "claude-tool-use"
+      ? [{ id: "json", label: "JSON Config" }, { id: "python", label: "Python Tool" }]
+      : [{ id: "python", label: "Python Tool" }, { id: "json", label: "JSON Schema" }];
+
+  const codeContent =
+    outputTab === "python" ? currentResult?.python_code : currentResult?.json_config;
+
+  if (!skillDefinition) return null;
+
+  return (
+    <div className="mt-6 border-t border-white/5 pt-4">
+      {/* Toggle header */}
+      <button
+        onClick={handleToggle}
+        className="w-full flex items-center justify-between px-2 py-1 group"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
+            Export
+          </span>
+          <span className="text-[10px] text-zinc-600 font-mono">
+            → framework code
+          </span>
+        </div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-zinc-500 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
+          {/* Format tabs */}
+          <div className="flex gap-1 p-3 border-b border-white/5">
+            {FORMATS.map((f) => (
+              <button
+                key={f.id}
+                onClick={() => handleFormatClick(f.id)}
+                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                  format === f.id ? f.activeColor : f.color
+                }`}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Output type tabs */}
+          <div className="flex gap-1 px-3 pt-3">
+            {outputTabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setOutputTab(tab.id)}
+                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
+                  outputTab === tab.id
+                    ? "bg-white/10 text-zinc-100"
+                    : "text-zinc-500 hover:text-zinc-300"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Code area */}
+          <div className="relative p-3">
+            {loading ? (
+              <div className="flex items-center justify-center h-24 text-zinc-500 text-xs animate-pulse">
+                Generating export...
+              </div>
+            ) : error ? (
+              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
+                {error}
+              </div>
+            ) : codeContent ? (
+              <div className="relative group/code">
+                <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
+                  <code>{codeContent}</code>
+                </pre>
+                <button
+                  onClick={handleCopy}
+                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                >
+                  {copied ? (
+                    <>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+                      Copy
+                    </>
+                  )}
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
+                Select a format above to generate export code
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 import { API_BASE } from "@/config";
 import InfoButton from "../components/InfoButton";
 import ContextManager from "../components/ContextManager";
+import SkillExportPanel from "./components/ExportPanel";
 
 export default function SkillsGenerator() {
   const [description, setDescription] = useState("");
@@ -183,6 +184,7 @@ export default function SkillsGenerator() {
                 <div className="relative flex-1 min-h-0 overflow-hidden">
                   <div className="absolute inset-0 overflow-y-auto p-6 pb-24 prose prose-invert prose-sm max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-code:text-yellow-300 prose-pre:bg-zinc-900">
                     <ReactMarkdown>{result}</ReactMarkdown>
+                    <SkillExportPanel skillDefinition={result} />
                   </div>
 
                   <button


### PR DESCRIPTION
Adds framework-compatible code export (Claude SDK, LangChain, LangGraph) from generated agent/skill prompts without any extra LLM calls.

- app/adapters/: IR extraction (regex-based, deterministic) + adapters
  - agent_ir.py: parse agent markdown → AgentExportIR (single + multi-agent)
  - claude_sdk.py: generate Claude SDK Python code + YAML config
  - langchain.py: generate LangChain LCEL chain + LangGraph StateGraph Python
  - skill_ir.py: parse skill markdown → SkillExportIR (table + bullet schemas)
  - skill_adapter.py: generate LangChain @tool + Claude tool_use JSON
- api/main.py: POST /agent-generator/export and /skills-generator/export
- web: collapsible ExportPanel (framework tabs, Python/YAML sub-tabs, copy-to-clipboard) in both agent-generator and skills-generator pages
- tests/test_export_adapters.py: 15 tests covering IR, adapters, API endpoints