### PR TITLE
🧪 test: add coverage for emit_plan fallback behavior

### DIFF
--- a/tests/test_emitters.py
+++ b/tests/test_emitters.py
@@ -1,5 +1,6 @@
 from app.compiler import compile_text
 from app.emitters import emit_system_prompt, emit_user_prompt, emit_plan
+from app.models import IR
 
 
 def test_emitters_non_empty():
@@ -7,3 +8,55 @@ def test_emitters_non_empty():
     assert emit_system_prompt(ir)
     assert emit_user_prompt(ir)
     assert emit_plan(ir)
+
+
+def test_emit_plan_fallback():
+    ir = IR(
+        language="en",
+        persona="developer",
+        role="Senior software engineer",
+        domain="General",
+        output_format="markdown",
+        length_hint="short",
+        goals=["Test fallback"],
+        tasks=[],
+        steps=[]
+    )
+    plan_str = emit_plan(ir)
+    assert plan_str == "1. Analyze request\n   Rationale: establish understanding"
+
+
+def test_emit_plan_with_steps():
+    ir = IR(
+        language="en",
+        persona="developer",
+        role="Senior software engineer",
+        domain="General",
+        output_format="markdown",
+        length_hint="short",
+        goals=["Test steps"],
+        tasks=[],
+        steps=["First step", "Second step"]
+    )
+    plan_str = emit_plan(ir)
+    assert "1. First step" in plan_str
+    assert "2. Second step" in plan_str
+    assert "Rationale: execute task effectively" in plan_str
+
+
+def test_emit_plan_with_tasks_as_fallback():
+    ir = IR(
+        language="en",
+        persona="developer",
+        role="Senior software engineer",
+        domain="General",
+        output_format="markdown",
+        length_hint="short",
+        goals=["Test tasks"],
+        tasks=["First task", "Second task"],
+        steps=[]
+    )
+    plan_str = emit_plan(ir)
+    assert "1. First task" in plan_str
+    assert "2. Second task" in plan_str
+    assert "Rationale: execute task effectively" in plan_str

--- a/tests/test_emitters.py
+++ b/tests/test_emitters.py
@@ -20,7 +20,7 @@ def test_emit_plan_fallback():
         length_hint="short",
         goals=["Test fallback"],
         tasks=[],
-        steps=[]
+        steps=[],
     )
     plan_str = emit_plan(ir)
     assert plan_str == "1. Analyze request\n   Rationale: establish understanding"
@@ -36,7 +36,7 @@ def test_emit_plan_with_steps():
         length_hint="short",
         goals=["Test steps"],
         tasks=[],
-        steps=["First step", "Second step"]
+        steps=["First step", "Second step"],
     )
     plan_str = emit_plan(ir)
     assert "1. First step" in plan_str
@@ -54,7 +54,7 @@ def test_emit_plan_with_tasks_as_fallback():
         length_hint="short",
         goals=["Test tasks"],
         tasks=["First task", "Second task"],
-        steps=[]
+        steps=[],
     )
     plan_str = emit_plan(ir)
     assert "1. First task" in plan_str


### PR DESCRIPTION
🎯 **What:** The testing gap in `emit_plan` inside `app/emitters.py` specifically regarding execution plan generation and fallback cases has been addressed.
📊 **Coverage:** Added test cases cover `test_emit_plan_fallback` for when no tasks or steps exist, `test_emit_plan_with_steps` to test explicit step processing, and `test_emit_plan_with_tasks_as_fallback` to ensure task-based plans are parsed correctly when steps are missing. 
✨ **Result:** Enhanced test coverage that verifies the full execution logic of `emit_plan`.

---
*PR created automatically by Jules for task [14501153727834026529](https://jules.google.com/task/14501153727834026529) started by @madara88645*