### PR TITLE
🧪 Add test for ContextPresetStore saving

### DIFF
--- a/tests/test_context_presets.py
+++ b/tests/test_context_presets.py
@@ -24,3 +24,17 @@ def test_delete_and_rename(tmp_path: Path) -> None:
     assert store.delete("Beta") is True
     assert store.get("Beta") is None
     assert store.delete("Missing") is False
+
+
+def test_save_exception(tmp_path: Path, monkeypatch) -> None:
+    store = ContextPresetStore(path=tmp_path / "presets.json")
+    store.upsert("Test", "Data")
+
+    def mock_write_text(*args, **kwargs):
+        raise PermissionError("Permission denied")
+
+    monkeypatch.setattr(Path, "write_text", mock_write_text)
+
+    # Should not raise an exception
+    store.save()
+    store.upsert("Test2", "Data2")

--- a/tests/test_context_presets.py
+++ b/tests/test_context_presets.py
@@ -37,4 +37,10 @@ def test_save_exception(tmp_path: Path, monkeypatch) -> None:
 
     # Should not raise an exception
     store.save()
+    # Existing data should remain accessible in memory
+    assert store.get("Test").content == "Data"
+
+    # New presets should still be added to in-memory store despite save failure
     store.upsert("Test2", "Data2")
+    assert store.get("Test2").content == "Data2"
+    assert set(store.list_names()) == {"Test", "Test2"}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `save` method in `app/context_presets.py` was wrapping file writing operations in a broad `try-except-pass` block. While this intentionally prevents crashes during save failures, there were no tests to confirm or document this behavior, leading to a testing coverage gap.

📊 **Coverage:** What scenarios are now tested
A new test `test_save_exception` was added to `tests/test_context_presets.py`. This test mocks the `Path.write_text` method using `monkeypatch` to explicitly raise a `PermissionError` during the execution of `store.save()`.

✨ **Result:** The improvement in test coverage
The test successfully verifies that when file system errors occur during preset serialization and saving, the application silently catches the exception as intended, thereby increasing the reliability and robustness documentation of the codebase.

---
*PR created automatically by Jules for task [6656973546061556369](https://jules.google.com/task/6656973546061556369) started by @madara88645*