### PR TITLE
🎨 Palette: Improve InfoButton tooltip accessibility and UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-06 - Accessible Icon-Only Navigation
 **Learning:** Found an accessibility issue in the main Sidebar navigation (`web/app/components/Sidebar.tsx`) where icon-only links lacked proper labels, active state indicators (`aria-current`), and keyboard focus rings. Also, emoji icons were not hidden from screen readers.
 **Action:** Implemented a standard accessible pattern: added `aria-label` to the links, `aria-current="page"` to indicate active status, wrapped emojis in `<span aria-hidden="true">`, applied `focus-visible` classes for keyboard navigation, and added `aria-hidden="true"` to visual tooltips to prevent redundant announcements. This pattern should be applied to any future icon-only navigation components.
+
+## 2024-03-07 - Custom Tooltip Keyboard Accessibility
+**Learning:** Custom interactive tooltips (like in `InfoButton.tsx`) that rely only on `onMouseEnter` and `onMouseLeave` are completely invisible to keyboard users. Without explicit focus handling, they cannot access the information provided in the tooltip.
+**Action:** Always pair mouse hover events with explicit `onFocus` and `onBlur` handlers for custom tooltips. Additionally, add `focus-visible` classes to the trigger element to clearly indicate focus, and ensure proper ARIA attributes (`role="tooltip"` on the tooltip content and `aria-expanded` on the trigger).

--- a/web/app/components/InfoButton.tsx
+++ b/web/app/components/InfoButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, memo } from "react";
+import { useState, memo, useId } from "react";
 
 interface InfoButtonProps {
     title?: string;
@@ -12,26 +12,31 @@ interface InfoButtonProps {
 // this avoids re-rendering the button every time the parent layout or page state changes.
 const InfoButton = memo(function InfoButton({ title, description }: InfoButtonProps) {
     const [showTooltip, setShowTooltip] = useState(false);
+    const tooltipId = useId();
 
     return (
         <div className="relative inline-block ml-2 group">
             <button
                 type="button"
-                className="w-4 h-4 rounded-full bg-neutral-800 border border-neutral-700 text-neutral-400 text-[10px] font-bold flex items-center justify-center hover:bg-neutral-700 hover:text-white transition-colors cursor-help"
+                className="w-4 h-4 rounded-full bg-neutral-800 border border-neutral-700 text-neutral-400 text-[10px] font-bold flex items-center justify-center hover:bg-neutral-700 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors cursor-help"
                 onMouseEnter={() => setShowTooltip(true)}
                 onMouseLeave={() => setShowTooltip(false)}
+                onFocus={() => setShowTooltip(true)}
+                onBlur={() => setShowTooltip(false)}
                 onClick={(e) => {
                     e.preventDefault();
                     setShowTooltip(!showTooltip);
                 }}
                 aria-label="More information"
+                aria-describedby={showTooltip ? tooltipId : undefined}
             >
                 ?
             </button>
 
             {showTooltip && (
-                <div className="absolute z-50 w-64 p-3 mt-2 text-xs font-normal text-left text-neutral-300 bg-neutral-900 border border-neutral-700 rounded-md shadow-xl -left-2 top-full break-words">
+                <div id={tooltipId} role="tooltip" className="absolute z-50 w-64 p-3 mt-2 text-xs font-normal text-left text-neutral-300 bg-neutral-900 border border-neutral-700 rounded-md shadow-xl -left-2 top-full break-words animate-fade-in">
                     <div className="absolute w-2 h-2 bg-neutral-900 border-l border-t border-neutral-700 transform rotate-45 -top-1 left-3"></div>
+                    {title && <strong className="block text-white mb-1">{title}</strong>}
                     {description}
                 </div>
             )}


### PR DESCRIPTION
🎨 Palette: Improve InfoButton tooltip accessibility and UX

💡 What:
- Made the custom tooltip trigger fully keyboard accessible via `onFocus`/`onBlur` handlers.
- Added a `focus-visible` blue ring to the trigger button for keyboard navigation clarity.
- Updated ARIA semantics to use `aria-describedby` tied to a dynamically generated `useId()`, rather than `aria-expanded`.
- Updated the component to render the `title` prop in bold above the description (which also fixes the ESLint warning about unused props).
- Logged the learning regarding custom tooltip keyboard accessibility in `.Jules/palette.md`.

🎯 Why:
Custom tooltips relying only on `onMouseEnter` and `onMouseLeave` exclude keyboard-only and screen reader users from accessing contextual help.

♿ Accessibility:
Keyboard navigation is now supported, focus state is explicitly visible, and screen readers will correctly associate the tooltip description with the trigger button.

---
*PR created automatically by Jules for task [7460161967946982662](https://jules.google.com/task/7460161967946982662) started by @madara88645*