### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-07 - [Fix Path Traversal in File Upload Endpoint]
+**Vulnerability:** The `/rag/upload` endpoint `upload_file_endpoint` in `api/main.py` directly concatenated `req.filename` into a local path using `os.path.join(temp_dir, req.filename)` without any sanitization.
+**Learning:** This is a classic path traversal vulnerability where an attacker could upload files to an arbitrary location outside of the intended `temp_dir` by using sequences like `../` in `req.filename`.
+**Prevention:** Always sanitize user-provided filenames before using them in file system operations. `os.path.basename` is an effective way to extract just the filename from a given path, ignoring any directory traversal sequences. Added fallback logic for when the basename resolves to empty or relative current directory constructs (`.` or `..`).

--- a/api/main.py
+++ b/api/main.py
@@ -1060,7 +1060,13 @@ async def upload_file_endpoint(req: FileUploadRequest):
         # Create a temporary file with the content
         # This allows us to reuse the existing ingest_paths logic
         temp_dir = tempfile.mkdtemp(prefix="rag_upload_")
-        temp_path = os.path.join(temp_dir, req.filename)
+
+        # Sanitize filename to prevent path traversal
+        safe_filename = os.path.basename(req.filename)
+        if not safe_filename or safe_filename in (".", ".."):
+            safe_filename = "upload.txt"
+
+        temp_path = os.path.join(temp_dir, safe_filename)
 
         with open(temp_path, "w", encoding="utf-8") as f:
             f.write(req.content)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `/rag/upload` endpoint `upload_file_endpoint` in `api/main.py` directly concatenated `req.filename` into a local path using `os.path.join(temp_dir, req.filename)` without any sanitization.
🎯 Impact: This is a path traversal vulnerability where an attacker could upload files to an arbitrary location outside of the intended `temp_dir` by using sequences like `../` in `req.filename`. This could lead to arbitrary file overwrite, which might be leveraged for remote code execution or data destruction.
🔧 Fix: Sanitized the user-provided filename using `os.path.basename(req.filename)`. Added fallback logic to use a default `upload.txt` if the resulting string is empty or evaluates to a relative current directory construct (`.` or `..`).
✅ Verification: Tested against a local server instance with an exploit script attempting to write to `/tmp/pwned.txt`. The exploit succeeded before the patch and failed to write to `/tmp` after the patch. Ran all 499 backend tests via `pytest` to confirm no regressions. All tests passed.

---
*PR created automatically by Jules for task [1219162731086801088](https://jules.google.com/task/1219162731086801088) started by @madara88645*