### PR TITLE
🧪 Explicit assertion for reset_registry clearing global state

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -238,15 +238,20 @@ def test_get_registry_singleton():
 
 def test_reset_registry():
     """Test that reset_registry clears the global instance."""
+    import app.templates
+
     # Ensure clean state
     reset_registry()
+    assert app.templates._registry is None
 
     # Create an instance
     registry1 = get_registry()
     assert isinstance(registry1, TemplateRegistry)
+    assert app.templates._registry is not None
 
     # Reset it
     reset_registry()
+    assert app.templates._registry is None
 
     # Calling get_registry again should create a new instance
     registry2 = get_registry()


### PR DESCRIPTION
🎯 **What:** The existing `test_reset_registry` function lacked explicit verification of the internal module state. It only checked the return values of `get_registry()`.
📊 **Coverage:** Specifically testing the inner state of the `app.templates` module to confirm the singleton `_registry` object is effectively set to `None`.
✨ **Result:** Improved test reliability by verifying the core mechanism behind the `reset_registry` function directly.

---
*PR created automatically by Jules for task [1853490608654046125](https://jules.google.com/task/1853490608654046125) started by @madara88645*