### PR TITLE
🧪 test: add test for ContextPresetStore list_names method

### DIFF
--- a/tests/test_context_presets.py
+++ b/tests/test_context_presets.py
@@ -61,3 +61,22 @@ def test_rename_edge_cases(tmp_path: Path) -> None:
     # Test nonexistent old_name
     assert store.rename("Nonexistent", "Beta") is False
     assert store.get("Beta") is None
+
+
+def test_list_names(tmp_path: Path) -> None:
+    store = ContextPresetStore(path=tmp_path / "presets.json")
+
+    # Empty store
+    assert store.list_names() == []
+
+    # Store with presets
+    store.upsert("PresetA", "A")
+    store.upsert("PresetB", "B")
+    store.upsert("PresetC", "C")
+
+    names = store.list_names()
+    assert names == ["PresetA", "PresetB", "PresetC"]
+
+    # After deletion
+    store.delete("PresetB")
+    assert store.list_names() == ["PresetA", "PresetC"]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the testing gap for the `list_names` method inside `ContextPresetStore` class (`app/context_presets.py`).

📊 **Coverage:** What scenarios are now tested
The new unit test `test_list_names` in `tests/test_context_presets.py` comprehensively checks the list generation behavior against an empty preset store, a store populated with several elements (to ensure all are returned correctly as a list), and a store following an element deletion.

✨ **Result:** The improvement in test coverage
The coverage for `app/context_presets.py` now thoroughly includes `list_names` achieving 100% confidence for this method explicitly.

---
*PR created automatically by Jules for task [2255228843070592987](https://jules.google.com/task/2255228843070592987) started by @madara88645*