### PR TITLE
🧹 Remove unused import `annotations` in `cli/utils.py`

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import sys
 import json
 import time


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `cli/utils.py`.
💡 **Why:** This improves maintainability and cleans up the code without affecting its behavior since type hints requiring this import are not present in this file.
✅ **Verification:** Verified by running the Ruff linter, formatting checks, and targeted CLI tests (`tests/test_cli_console_refactor.py`, `tests/test_cli_extras.py`, `tests/test_cli_new_features.py`). All passed successfully.
✨ **Result:** Improved code health with fewer unused imports, ensuring the codebase adheres to cleaner practices.

---
*PR created automatically by Jules for task [9538533179898995086](https://jules.google.com/task/9538533179898995086) started by @madara88645*