### PR TITLE
⚡ Bolt: Optimize PricingModel.get_rate cache invalidation

### DIFF
--- a/app/optimizer/costs.py
+++ b/app/optimizer/costs.py
@@ -45,8 +45,9 @@ class PricingModel:
         "gpt-3.5-turbo": {"input": 0.5, "output": 1.5},
     }
 
-    # Track the tuple of known keys to catch all test mock changes (additions, removals, and swaps)
-    _KNOWN_KEYS_TUPLE: Tuple[str, ...] = tuple(RATES.keys())
+    # Track the set of known keys as a frozenset to catch all test mock changes (additions, removals, and swaps)
+    # without allocating a new tuple/set on every call
+    _KNOWN_KEYS_SET: frozenset[str] = frozenset(RATES.keys())
     # Cache sorted keys as a tuple to make it hashable for the lru_cache argument
     _SORTED_KEYS_TUPLE: Tuple[str, ...] = tuple(sorted(RATES.keys(), key=len, reverse=True))
 
@@ -64,12 +65,11 @@ class PricingModel:
         """Returns (input_rate, output_rate) per 1M tokens for the model."""
         # Performance optimization: get_rate is on the hot path.
         # Check if the dictionary keys have changed (e.g., due to test mocking).
-        # We use a tuple conversion of keys which correctly handles key swaps (unlike `len`)
-        # and is still much faster than the original `set()` instantiation logic.
-        current_keys = tuple(cls.RATES.keys())
-        if current_keys != cls._KNOWN_KEYS_TUPLE:
-            cls._KNOWN_KEYS_TUPLE = current_keys
-            cls._SORTED_KEYS_TUPLE = tuple(sorted(current_keys, key=len, reverse=True))
+        # We compare a frozenset directly against the dict_keys view, which handles key
+        # swaps correctly without allocating any new objects in the steady state.
+        if cls._KNOWN_KEYS_SET != cls.RATES.keys():
+            cls._KNOWN_KEYS_SET = frozenset(cls.RATES.keys())
+            cls._SORTED_KEYS_TUPLE = tuple(sorted(cls.RATES.keys(), key=len, reverse=True))
 
         # Dynamically fetch the matching key from the bounded LRU cache.
         # The cache key includes `cls._SORTED_KEYS_TUPLE`, so cache invalidation is automatic


### PR DESCRIPTION
💡 **What:** Optimized `PricingModel.get_rate` in `app/optimizer/costs.py` by tracking `cls.RATES.keys()` with a `frozenset` (`_KNOWN_KEYS_SET`) rather than recreating a `tuple` of keys on every invocation. 
🎯 **Why:** The previous approach, intended to catch cache invalidations when tests patch `RATES`, resulted in a fresh `tuple` object allocation on every function call in production. Since `get_rate` is on a hot path, this created unnecessary memory overhead. Comparing a `frozenset` to a `dict_keys` view works securely without any zero-state allocation because `dict_keys` inherently supports fast, C-level set operations.
📊 **Impact:** Entirely eliminates memory allocation (the transient tuple creation) during the steady-state cache check, resulting in a cleaner and tighter execution loop. 
🔬 **Measurement:** The optimization was verified by running `tests/optimizer/test_costs.py` and the full pytest suite. All 540 tests pass successfully.

---
*PR created automatically by Jules for task [2275252190997281311](https://jules.google.com/task/2275252190997281311) started by @madara88645*