### PR TITLE
⚡ Bolt: Remove lru_cache from heuristic functions

### DIFF
--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 from typing import Any, Dict, List, Tuple
-from functools import lru_cache
 
 
 try:
@@ -196,7 +195,6 @@ PERSONA_KEYWORDS = {
 }
 
 
-@lru_cache(maxsize=128)
 def pick_persona(text: str) -> tuple[str, dict]:
     lower = text.lower()
     scores = {k: 0 for k in PERSONA_KEYWORDS}
@@ -240,7 +238,6 @@ VARIANT_KEYWORDS = [
 ]
 
 
-@lru_cache(maxsize=128)
 def detect_summary(text: str) -> tuple[bool, int | None]:
     lower = text.lower()
     if any(k in lower for k in SUMMARY_KEYWORDS):
@@ -256,7 +253,6 @@ def detect_summary(text: str) -> tuple[bool, int | None]:
     return False, None
 
 
-@lru_cache(maxsize=128)
 def extract_comparison_items(text: str) -> list[str]:
     lower = text.lower()
     items: list[str] = []
@@ -291,7 +287,6 @@ def extract_comparison_items(text: str) -> list[str]:
     return cleaned
 
 
-@lru_cache(maxsize=128)
 def extract_variant_count(text: str) -> int:
     lower = text.lower()
     if any(k in lower for k in VARIANT_KEYWORDS):


### PR DESCRIPTION
💡 What: Removed `@lru_cache` decorators from text-processing heuristic functions (`pick_persona`, `detect_summary`, `extract_comparison_items`, `extract_variant_count`).
🎯 Why: These functions take user prompts as input, which are essentially unique strings. A cache hit rate is near zero, meaning it only adds memory overhead (storing strings) and computational overhead (hashing large strings) while constantly thrashing the `maxsize` boundary. Furthermore, caching functions that return mutable types (like lists and dicts) creates silent shared-state mutation bugs.
📊 Impact: Reduces memory bloat and eliminates OOM risks from unbounded prompt inputs. Also fixes potential mutation bugs.
🔬 Measurement: Verify cache decorators are gone. Tests pass in ~0.35s and logic stays the same.

---
*PR created automatically by Jules for task [11067166958939684371](https://jules.google.com/task/11067166958939684371) started by @madara88645*