### PR TITLE
🎨 Palette: Add aria-labels to Copy buttons

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -203,6 +203,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 <button
                   onClick={handleCopy}
                   className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                  aria-label="Copy code"
                 >
                   {copied ? (
                     <>

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -206,6 +206,7 @@ export default function AgentGenerator() {
                     onClick={copyToClipboard}
                     className="absolute bottom-6 right-6 bg-green-600 hover:bg-green-500 text-white p-3 rounded-xl shadow-lg shadow-green-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2"
                     title="Copy to Clipboard"
+                    aria-label="Copy Markdown"
                   >
                     <span className="text-xs font-bold">Copy Markdown</span>
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -181,6 +181,7 @@ export default function OfflinePage() {
                                                 )}
                                                 className="absolute bottom-6 right-6 bg-zinc-700 hover:bg-zinc-600 text-white p-3 rounded-xl shadow-lg transition-all hover:scale-105 active:scale-95 z-20"
                                                 title="Copy"
+                                                aria-label="Copy to Clipboard"
                                             >
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>
                                             </button>

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -202,6 +202,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 <button
                   onClick={handleCopy}
                   className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                  aria-label="Copy code"
                 >
                   {copied ? (
                     <>

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -191,6 +191,7 @@ export default function SkillsGenerator() {
                     onClick={copyToClipboard}
                     className="absolute bottom-6 right-6 bg-yellow-600 hover:bg-yellow-500 text-white p-3 rounded-xl shadow-lg shadow-yellow-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2"
                     title="Copy to Clipboard"
+                    aria-label="Copy Markdown"
                   >
                     <span className="text-xs font-bold">Copy Markdown</span>
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to various "Copy" buttons across the application, including the Agent Generator, Skills Generator, and Offline pages. Where the button contained visible text (e.g., "Copy Markdown"), the `aria-label` was made to exactly match that visible text to conform to WCAG 2.5.3 (Label in Name).
🎯 Why: To improve the accessibility of the application for users relying on screen readers or voice recognition software, ensuring that all interactive elements, especially icon-centric ones, have clear, programmatic descriptions.
♿ Accessibility: Ensures that screen readers will correctly announce the function of the copy buttons, making the application more inclusive and usable for people with disabilities.

---
*PR created automatically by Jules for task [16938081437688881909](https://jules.google.com/task/16938081437688881909) started by @madara88645*