### PR TITLE
🎨 Palette: Improve Sidebar navigation accessibility

### DIFF
--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -27,11 +27,12 @@ export default function Sidebar() {
                     <Link
                         key={item.path}
                         href={item.path}
-                        className={`w-10 h-10 rounded-xl flex items-center justify-center text-lg transition-all duration-300 relative group ${isActive
+                        className={`w-10 h-10 rounded-xl flex items-center justify-center text-lg transition-all duration-300 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${isActive
                             ? "bg-white/10 text-white shadow-lg shadow-white/5 ring-1 ring-white/20"
                             : "text-zinc-500 hover:text-white hover:bg-white/5"
                             }`}
-                        title={item.name}
+                        aria-label={item.name}
+                        aria-current={isActive ? "page" : undefined}
                     >
                         {item.icon}
                         {isActive && (


### PR DESCRIPTION
## 💡 What
This PR enhances the UX and accessibility of the main Sidebar navigation component. Specifically, it removes redundant native HTML `title` attributes, adds proper `aria-label` attributes to the icon-only navigation links, specifies the active page semantic state via `aria-current="page"`, and introduces visible focus rings for keyboard navigation users.

## 🎯 Why
Icon-only links without accessible names are invisible or confusing to screen reader users. Furthermore, relying on custom hover tooltips means keyboard-only users often miss the label information. Adding proper focus rings ensures keyboard users know exactly where their focus is on the page, and `aria-current` provides crucial context about which page is currently active. Removing the native `title` attribute resolves the visual noise of having both a custom and a native tooltip appear simultaneously.

## 📸 Before/After
Visually identical for mouse users (with native tooltips removed). Keyboard users will now see a clear blue focus ring when tabbing through the navigation links.

## ♿ Accessibility
- **Screen Readers**: Icon-only links now have explicit names (e.g., "Compiler", "Optimizer") via `aria-label`. The active state is explicitly communicated via `aria-current="page"`.
- **Keyboard Navigation**: Links now have a clear visual focus indicator (`focus-visible:ring-blue-500`) when tabbed into.

---
*PR created automatically by Jules for task [1108021957010914936](https://jules.google.com/task/1108021957010914936) started by @madara88645*