### PR TITLE
🧹 Code Health: Fix unused inline import of validate_prompt in CLI analytics

### DIFF
--- a/cli/commands/analytics.py
+++ b/cli/commands/analytics.py
@@ -13,6 +13,7 @@ from app.analytics import AnalyticsManager, create_record_from_ir
 
 # from app.history import get_history_manager
 from app.compiler import compile_text_v2
+from app.validator import validate_prompt
 
 
 def get_history_manager():
@@ -86,9 +87,7 @@ def analytics_record(
     validation_result = None
     if validate:
         with console.status("[cyan]Validating prompt..."):
-            from app.validator import validate_prompt as validator
-
-            validation_result = validator(ir, prompt_text)
+            validation_result = validate_prompt(ir, prompt_text)
 
     # Create record
     record = create_record_from_ir(


### PR DESCRIPTION
🎯 **What:** The code health issue "Unused import validate_prompt" in `cli/commands/analytics.py:89` has been addressed. The inline import using an alias has been moved to the top of the file without the alias.
💡 **Why:** Inline imports and unnecessary aliasing (`as validator`) can cause confusion, confuse static analysis tools (which flagged it as an unused import), and violate standard PEP 8 import grouping. Moving the import to the top of the file improves code readability, maintainability, and conforms to Python styling standards.
✅ **Verification:** 
- The linter (`ruff check cli/commands/analytics.py`) passed successfully, confirming the warning is resolved. 
- The full backend test suite involving CLI modules was executed via `pytest`, and all tests passed without regressions.
✨ **Result:** A cleaner module structure that fixes the reported code health issue while completely preserving original functionality.

---
*PR created automatically by Jules for task [8817815093171556137](https://jules.google.com/task/8817815093171556137) started by @madara88645*