### PR TITLE
🧹 [code health] Remove legacy importlib_metadata fallback

### DIFF
--- a/app/plugins.py
+++ b/app/plugins.py
@@ -6,10 +6,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
-try:  # Python 3.10+
-    from importlib import metadata
-except ImportError:  # pragma: no cover - fallback for older runtimes
-    import importlib_metadata as metadata  # type: ignore
+from importlib import metadata
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `importlib_metadata` fallback in `app/plugins.py`, conditionally importing `metadata` from `importlib`.
💡 **Why:** The project requires Python 3.10+ (as defined in `pyproject.toml`), meaning the `importlib.metadata` standard library module is always available. Removing this legacy fallback reduces code complexity, removes an unnecessary dependency check, and resolves linter warnings for unused imports.
✅ **Verification:** Ran `python -m pytest tests/test_plugins.py` to ensure plugin loading remains functional. Ran `pre-commit run --all-files` to format the code and run linters.
✨ **Result:** Cleaner code that relies on the standard library directly without a runtime fallback.

---
*PR created automatically by Jules for task [13203525238778639953](https://jules.google.com/task/13203525238778639953) started by @madara88645*