### PR TITLE
🧪 [testing improvement] Add test coverage for get_supported_extensions in app/rag/parsers.py

### DIFF
--- a/tests/test_rag_parsers.py
+++ b/tests/test_rag_parsers.py
@@ -1,9 +1,9 @@
-import json
+﻿import json
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
-from app.rag.parsers import parse_yaml, parse_yaml_file, ParseResult
-
+from app.rag.parsers import can_parse, get_supported_extensions, parse_yaml, parse_yaml_file, ParseResult
 
 def test_parse_yaml_str_success():
     yaml_str = "key: value\nnumber: 42"
@@ -60,3 +60,33 @@ def test_parse_yaml_file_error(tmp_path):
 
     assert result.content == ""
     assert "error" in result.metadata
+
+def test_get_supported_extensions():
+    """Test get_supported_extensions returns a list of extensions containing expected values."""
+    extensions = get_supported_extensions()
+
+    # Check that it returns a list
+    assert isinstance(extensions, list)
+
+    # Check that it has expected standard extensions
+    assert ".txt" in extensions
+    assert ".py" in extensions
+    assert ".md" in extensions
+    assert ".pdf" in extensions
+    assert ".docx" in extensions
+
+    # Check extensions are all strings starting with a dot
+    for ext in extensions:
+        assert isinstance(ext, str)
+        assert ext.startswith(".")
+
+def test_can_parse():
+    """Test can_parse logic for supported and unsupported extensions."""
+    # Create temp paths without needing them to exist on disk
+    assert can_parse(Path("test.py")) is True
+    assert can_parse(Path("test.txt")) is True
+    assert can_parse(Path("test.md")) is True
+    assert can_parse(Path("test.pdf")) is True
+    assert can_parse(Path("test.docx")) is True
+    assert can_parse(Path("test.unknown_extension")) is False
+    assert can_parse(Path("no_extension")) is False

--- a/tests/test_rag_parsers.py
+++ b/tests/test_rag_parsers.py
@@ -61,6 +61,7 @@ def test_parse_yaml_file_error(tmp_path):
     assert result.content == ""
     assert "error" in result.metadata
 
+
 def test_get_supported_extensions():
     """Test get_supported_extensions returns a list of extensions containing expected values."""
     extensions = get_supported_extensions()
@@ -79,6 +80,7 @@ def test_get_supported_extensions():
     for ext in extensions:
         assert isinstance(ext, str)
         assert ext.startswith(".")
+
 
 def test_can_parse():
     """Test can_parse logic for supported and unsupported extensions."""


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the untetested function `get_supported_extensions` in `app/rag/parsers.py`.
📊 **Coverage:** Two tests were added: `test_get_supported_extensions` to cover checking standard expected extensions and verifying their basic structure, and `test_can_parse` to add simple test coverage around the related capability check for file names.
✨ **Result:** The RAG parser module's core state validation mechanisms are now explicitly tested.

---
*PR created automatically by Jules for task [13910701139519200002](https://jules.google.com/task/13910701139519200002) started by @madara88645*