### PR TITLE
🧹 [code health] Implement missing JSON schema validation in TestRunner

### DIFF
--- a/app/testing/runner.py
+++ b/app/testing/runner.py
@@ -1,6 +1,7 @@
 import re
 import time
 import json
+import jsonschema
 from typing import Dict, Any, Optional
 from pathlib import Path
 from .models import TestSuite, TestCase, TestResult, SuiteResult, Assertion
@@ -202,8 +203,11 @@ class TestRunner:
         elif assertion.type == "json_schema":
             # Basic validation that it IS json
             try:
-                json.loads(output)
-                return True  # TODO: Validate against schema if value is a schema dict
+                parsed = json.loads(output)
+                # Validate against schema if value is provided and not a simple True boolean
+                if isinstance(assertion.value, dict) or assertion.value is False:
+                    jsonschema.validate(instance=parsed, schema=assertion.value)
+                return True
             except Exception:
                 return False
         elif assertion.type == "llm_judge":

--- a/tests/test_testing_schema.py
+++ b/tests/test_testing_schema.py
@@ -1,0 +1,50 @@
+from app.testing.models import TestSuite, TestCase, Assertion
+from app.testing.runner import TestRunner, Executor
+
+
+class SchemaMockExecutor(Executor):
+    def execute(self, prompt: str, config: dict) -> str:
+        if "invalid" in prompt.lower():
+            return '{"name": "Invalid", "price": "not_a_number"}'
+        return '{"name": "Valid Name", "price": 10.99}'
+
+
+def test_runner_schema_validation(tmp_path):
+    p_file = tmp_path / "test_prompt.txt"
+    p_file.write_text("Test prompt: {{type}}", encoding="utf-8")
+
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "price": {"type": "number"}},
+        "required": ["name", "price"],
+    }
+
+    suite = TestSuite(
+        name="Schema Suite",
+        prompt_file=str(p_file.name),
+        test_cases=[
+            TestCase(
+                id="c1",
+                input_variables={"type": "valid"},
+                assertions=[Assertion(type="json_schema", value=schema)],
+            ),
+            TestCase(
+                id="c2",
+                input_variables={"type": "invalid"},
+                assertions=[Assertion(type="json_schema", value=schema)],
+            ),
+        ],
+    )
+
+    runner = TestRunner(executor=SchemaMockExecutor())
+    result = runner.run_suite(suite, base_dir=tmp_path)
+
+    assert result.passed == 1
+    assert result.failed == 1
+
+    r1 = next(r for r in result.results if r.test_case_id == "c1")
+    assert r1.passed
+
+    r2 = next(r for r in result.results if r.test_case_id == "c2")
+    assert not r2.passed
+    assert "Assertion failed: json_schema" in r2.failures[0]


### PR DESCRIPTION
🎯 **What:** Implemented the missing `json_schema` validation logic in `app/testing/runner.py` to validate outputs against an optionally provided JSON schema dictionary using the `jsonschema` library.
💡 **Why:** A TODO comment indicated the assertion merely verified that the output was parseable JSON. By implementing the `jsonschema` validation, users can now precisely assert the structure and type of outputs expected from LLMs during testing, greatly increasing the utility and maintainability of the testing module.
✅ **Verification:** Added a targeted test `tests/test_testing_schema.py` which confirms a payload successfully passes and fails validation according to an object schema definition. Tests run appropriately, format passing via `pre-commit`.
✨ **Result:** Test assertions evaluating JSON schema fidelity are now fully functional and correctly enforced.

---
*PR created automatically by Jules for task [3454104680661650400](https://jules.google.com/task/3454104680661650400) started by @madara88645*