### PR TITLE
⚡ Bolt: Optimize redundant string lowering in `LogicAnalyzer`

### DIFF
--- a/app/heuristics/logic_analyzer.py
+++ b/app/heuristics/logic_analyzer.py
@@ -387,16 +387,17 @@ class LogicAnalyzer:
             matches = pattern.finditer(text)
             for match in matches:
                 entity = match.group(1) if match.lastindex else match.group(0)
+                entity_lower = entity.lower()
                 context = self._get_context(text, match.start(), match.end())
 
-                key = f"{info_type}:{entity.lower()}"
+                key = f"{info_type}:{entity_lower}"
                 if key in seen:
                     continue
                 seen.add(key)
 
                 # Determine severity based on context
                 severity = "warning"
-                if any(word in entity.lower() for word in ["database", "api", "schema", "config"]):
+                if any(word in entity_lower for word in ["database", "api", "schema", "config"]):
                     severity = "error"
 
                 missing.append(

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,13 @@
+import time
+from app.heuristics.logic_analyzer import LogicAnalyzer
+
+text = "the database " * 1000 + " the api " * 1000 + " the schema " * 1000 + " the config " * 1000
+
+analyzer = LogicAnalyzer()
+
+start_time = time.time()
+for _ in range(100):
+    analyzer.detect_missing_info(text)
+end_time = time.time()
+
+print(f"Time taken: {end_time - start_time:.4f} seconds")


### PR DESCRIPTION
💡 **What:** The optimization extracts the call to `entity.lower()` into a local variable (`entity_lower`) right after `entity` is initially extracted. It substitutes this cached variable inside the `key` generation string and inside the inner generator expression within `any(...)`.

🎯 **Why:** Previously, inside the loop `for match in matches:`, the value for `entity` was lowercased up to four additional times per matching iteration within the `any(word in entity.lower() for word in [...])` check. Caching the `.lower()` result saves CPU overhead and string allocations per match.

📊 **Measured Improvement:** On a heavily duplicated string with thousands of matching elements (benchmark execution time), performance measured ~3.58 seconds previously. Post-modification, results hover right around the same (3.61s locally) likely due to small sample variance, but mathematically the optimization successfully avoids redundant internal allocations on each iteration.

---
*PR created automatically by Jules for task [3596555924117229588](https://jules.google.com/task/3596555924117229588) started by @madara88645*