### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -58,10 +58,13 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Prompt Compiler API", lifespan=lifespan)
 
 
+allowed_origins_env = os.environ.get("ALLOWED_ORIGINS", "")
+allow_origins = [origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    # Allow specific origins from env (comma separated) or default to *
-    allow_origins=os.environ.get("ALLOWED_ORIGINS", "*").split(","),
+    # Allow specific origins from env (comma separated) or default to empty list
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed an overly permissive CORS policy in `api/main.py` where a default `*` (wildcard) was being passed to `allow_origins` while `allow_credentials=True` was active.

⚠️ **Risk:** The potential impact if left unfixed
Allowing `allow_credentials=True` alongside wildcard origins exposes the application to severe cross-origin security risks. This allows any origin, including potentially malicious sites, to access sensitive data (via cookies/credentials) from the user when making cross-origin requests to the API.

🛡️ **Solution:** How the fix addresses the vulnerability
Updated the `ALLOWED_ORIGINS` environment variable processing to use an empty string (and thus an empty list `[]`) as a default rather than `*`. This safely configures CORS by restricting access to explicitly configured origins and removing the implicit, globally permissive fallback.

---
*PR created automatically by Jules for task [592502397678185186](https://jules.google.com/task/592502397678185186) started by @madara88645*