### PR TITLE
🎨 Palette: Fix keyboard accessibility traps for hidden buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-14 - Fix Hidden Interactive Elements
+**Learning:** Hiding buttons with `opacity-0` and only showing them on hover (like `group-hover:opacity-100`) creates a keyboard accessibility trap. Screen reader and keyboard-only users can focus the element, but cannot see it because it remains invisible when focused.
+**Action:** Always pair `opacity-0 group-hover:opacity-100` with an explicit focus state like `focus-visible:opacity-100 focus-visible:ring-2` to ensure the element becomes visible when navigated to via keyboard.

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -202,7 +202,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 </pre>
                 <button
                   onClick={handleCopy}
-                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
                   aria-label="Copy code"
                 >
                   {copied ? (

--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -404,7 +404,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                             </div>
                             <button
                                 onClick={() => onInsertContext(r.content)}
-                                className="mt-1 text-[10px] text-blue-300 hover:text-blue-200 text-left opacity-0 group-hover:opacity-100 transition-all flex items-center gap-1 font-medium"
+                                className="mt-1 text-[10px] text-blue-300 hover:text-blue-200 text-left opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded transition-all flex items-center gap-1 font-medium"
                             >
                                 <span>+</span> Insert into Prompt
                             </button>

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -201,7 +201,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 </pre>
                 <button
                   onClick={handleCopy}
-                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
                   aria-label="Copy code"
                 >
                   {copied ? (


### PR DESCRIPTION
💡 **What:** Added `focus-visible:opacity-100` and `focus-visible:ring-*` classes to buttons that were previously hidden with `opacity-0` and only shown on hover. This affects the Context Manager ("Insert into Prompt") and Export Panels in both Agent Generator and Skills Generator.
🎯 **Why:** Hiding buttons with `opacity-0` creates a keyboard accessibility trap. A user pressing 'Tab' to navigate the interface could focus the button, but it would remain invisible, causing confusion and poor usability.
📸 **Before/After:**
- *Before:* Tabbing to the "Insert into Prompt" or "Copy code" buttons focused an invisible element.
- *After:* Tabbing correctly displays the button fully opaque, with a distinct blue focus ring to indicate current position.
♿ **Accessibility:** Fixes WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) by ensuring all interactive elements have a visible focus indicator when accessed via keyboard navigation.

---
*PR created automatically by Jules for task [12986201655899297460](https://jules.google.com/task/12986201655899297460) started by @madara88645*