### PR TITLE
🎨 Palette: Add aria-expanded to collapsible elements

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -125,6 +125,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
       {/* Toggle header */}
       <button
         onClick={handleToggle}
+        aria-expanded={isOpen}
         className="w-full flex items-center justify-between px-2 py-1 group"
       >
         <div className="flex items-center gap-2">

--- a/web/app/components/BenchmarkResults.tsx
+++ b/web/app/components/BenchmarkResults.tsx
@@ -80,6 +80,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
             <div className="border-b border-white/5">
                 <button
                     onClick={() => setPromptOpen(!promptOpen)}
+                    aria-expanded={promptOpen}
                     className="w-full px-5 py-3 flex items-center justify-between text-left hover:bg-white/[0.02] transition-colors group"
                 >
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
**What:**
Added `aria-expanded` attributes to the collapsible section buttons in `BenchmarkResults.tsx` and `ExportPanel.tsx`.

**Why:**
Screen reader users need to know if a collapsible section (like a code block or export panel) is currently open or closed. Without the `aria-expanded` attribute, the toggle button provides no context about its state.

**Before/After:**
- Before: `<button onClick={handleToggle}>...</button>`
- After: `<button onClick={handleToggle} aria-expanded={isOpen}>...</button>`
(No visual changes, purely an accessibility enhancement)

**Accessibility:**
This ensures that the state of collapsible panels is properly communicated to assistive technologies.

---
*PR created automatically by Jules for task [7209680326103745198](https://jules.google.com/task/7209680326103745198) started by @madara88645*