### PR TITLE
⚡ Bolt: Optimize N+1 query patterns during RAG document ingestion

### DIFF
--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -488,7 +488,10 @@ def ingest_paths(
         n_docs = 0
         n_chunks = 0
         # Bolt Optimization: pre-fetch existing document metadata to avoid N+1 queries during ingest
-        existing_docs = {row[0]: (row[1], row[2]) for row in conn.execute("SELECT path, mtime, size FROM docs").fetchall()}
+        existing_docs = {
+            row[0]: (row[1], row[2])
+            for row in conn.execute("SELECT path, mtime, size FROM docs").fetchall()
+        }
 
         # Use parser-supported extensions if available, else fallback
         if _HAS_PARSERS and exts is None:
@@ -526,6 +529,7 @@ def ingest_paths(
                                 embed_dim=embed_dim,
                                 chunking_strategy=chunking_strategy,
                             )
+                            existing_docs[str(fp)] = (stat_result.st_mtime, stat_result.st_size)
                             n_docs += 1
             else:
                 if pth.suffix.lower() not in allowed_exts:
@@ -551,6 +555,7 @@ def ingest_paths(
                         embed_dim=embed_dim,
                         chunking_strategy=chunking_strategy,
                     )
+                    existing_docs[str(pth)] = (stat_result.st_mtime, stat_result.st_size)
                     n_docs += 1
         # count chunks
         cur = conn.execute("SELECT COUNT(*) FROM chunks")

--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -120,11 +120,11 @@ def get_all_indexed_files(db_path: Optional[str] = None) -> List[str]:
         return []
 
 
-def _needs_ingest(conn: sqlite3.Connection, path: Path) -> bool:
+def _needs_ingest(existing_docs: dict, path: Path) -> Tuple[bool, os.stat_result]:
     stat = path.stat()
-    cur = conn.execute("SELECT mtime, size FROM docs WHERE path=?", (str(path),))
-    row = cur.fetchone()
-    return not row or row[0] != stat.st_mtime or row[1] != stat.st_size
+    row = existing_docs.get(str(path))
+    needs_ingest = not row or row[0] != stat.st_mtime or row[1] != stat.st_size
+    return needs_ingest, stat
 
 
 def _split_sentences(text: str) -> List[str]:
@@ -398,11 +398,11 @@ def _insert_document(
     path: Path,
     content: str,
     *,
+    stat: os.stat_result,
     embed: bool = False,
     embed_dim: int = 64,
     chunking_strategy: str = "paragraph",
 ) -> None:
-    stat = path.stat()
     cur = conn.execute(
         "INSERT INTO docs(path, mtime, size) VALUES(?, ?, ?)\n            ON CONFLICT(path) DO UPDATE SET mtime=excluded.mtime, size=excluded.size\n            RETURNING id",
         (str(path), stat.st_mtime, stat.st_size),
@@ -487,6 +487,9 @@ def ingest_paths(
         _init_schema(conn)
         n_docs = 0
         n_chunks = 0
+        # Bolt Optimization: pre-fetch existing document metadata to avoid N+1 queries during ingest
+        existing_docs = {row[0]: (row[1], row[2]) for row in conn.execute("SELECT path, mtime, size FROM docs").fetchall()}
+
         # Use parser-supported extensions if available, else fallback
         if _HAS_PARSERS and exts is None:
             allowed_exts = set(get_supported_extensions())
@@ -502,7 +505,8 @@ def ingest_paths(
                         fp = Path(root) / f
                         if fp.suffix.lower() not in allowed_exts:
                             continue
-                        if _needs_ingest(conn, fp):
+                        needs_ingest, stat_result = _needs_ingest(existing_docs, fp)
+                        if needs_ingest:
                             try:
                                 if _HAS_PARSERS and can_parse(fp):
                                     result = parse_file(fp)
@@ -517,6 +521,7 @@ def ingest_paths(
                                 conn,
                                 fp,
                                 content,
+                                stat=stat_result,
                                 embed=embed,
                                 embed_dim=embed_dim,
                                 chunking_strategy=chunking_strategy,
@@ -525,7 +530,8 @@ def ingest_paths(
             else:
                 if pth.suffix.lower() not in allowed_exts:
                     continue
-                if _needs_ingest(conn, pth):
+                needs_ingest, stat_result = _needs_ingest(existing_docs, pth)
+                if needs_ingest:
                     try:
                         if _HAS_PARSERS and can_parse(pth):
                             result = parse_file(pth)
@@ -540,6 +546,7 @@ def ingest_paths(
                         conn,
                         pth,
                         content,
+                        stat=stat_result,
                         embed=embed,
                         embed_dim=embed_dim,
                         chunking_strategy=chunking_strategy,


### PR DESCRIPTION
💡 **What:**
Pre-fetch existing document metadata (`path`, `mtime`, `size`) into a dictionary at the start of `ingest_paths` in `app/rag/simple_index.py`. The `_needs_ingest` function now performs an O(1) dictionary lookup instead of executing an individual SQLite `SELECT` query for every file. Additionally, the `path.stat()` result is now captured once and passed to `_insert_document` to avoid redundant system calls.

🎯 **Why:**
During bulk ingestion of directories or multiple files, the previous implementation executed a separate `SELECT` query for each file to check if it needed updating. This N+1 query pattern causes significant overhead, particularly on slower filesystems or networked databases. The redundant `stat()` calls also added unnecessary file system I/O.

📊 **Impact:**
Reduces database queries from O(N) to O(1) during the metadata check phase of document ingestion. Eliminates redundant `os.stat` system calls, leading to substantially faster ingestion times for large directories of documents.

🔬 **Measurement:**
Run `python -m pytest tests/test_rag.py tests/test_rag_pipeline.py tests/test_rag_upload.py` to ensure ingestion logic correctly inserts and updates documents exactly as before. Profile ingestion on a directory with thousands of small text files to see the reduced time.

---
*PR created automatically by Jules for task [6908666092125906104](https://jules.google.com/task/6908666092125906104) started by @madara88645*