### PR TITLE
🎨 Palette: Add `aria-expanded` to collapsible buttons

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -125,6 +125,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
       {/* Toggle header */}
       <button
         onClick={handleToggle}
+        aria-expanded={isOpen}
         className="w-full flex items-center justify-between px-2 py-1 group"
       >
         <div className="flex items-center gap-2">

--- a/web/app/components/BenchmarkResults.tsx
+++ b/web/app/components/BenchmarkResults.tsx
@@ -80,6 +80,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
             <div className="border-b border-white/5">
                 <button
                     onClick={() => setPromptOpen(!promptOpen)}
+                    aria-expanded={promptOpen}
                     className="w-full px-5 py-3 flex items-center justify-between text-left hover:bg-white/[0.02] transition-colors group"
                 >
                     <div className="flex items-center gap-2">

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -124,6 +124,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
       {/* Toggle header */}
       <button
         onClick={handleToggle}
+        aria-expanded={isOpen}
         className="w-full flex items-center justify-between px-2 py-1 group"
       >
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## 💡 What
Added the `aria-expanded` attribute to collapsible/accordion toggle buttons in `BenchmarkResults.tsx`, `agent-generator/components/ExportPanel.tsx`, and `skills-generator/components/ExportPanel.tsx`.

## 🎯 Why
When toggle buttons control the visibility of a section (like the Compiled Prompt or Export panels), screen readers need to know whether that section is currently visible or hidden. Without the `aria-expanded` attribute, screen reader users interact with a button that doesn't explicitly state what state it is controlling.

## 📸 Before/After
*(No visual changes, purely accessibility-focused attributes added)*

## ♿ Accessibility
This enhancement allows screen readers (like NVDA, VoiceOver, JAWS) to correctly announce the state (expanded or collapsed) of these dynamic sections to the user, making navigation and interaction much more predictable.

---
*PR created automatically by Jules for task [9634158429627417377](https://jules.google.com/task/9634158429627417377) started by @madara88645*