### PR TITLE
🎨 Palette: Fix Hidden Interactive Elements Accessibility

### DIFF
--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -40,7 +40,7 @@ export default function Sidebar() {
                         )}
 
                         {/* Tooltip */}
-                        <div className="absolute left-14 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                        <div className="absolute left-14 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
                             {item.name}
                         </div>
                     </Link>


### PR DESCRIPTION
💡 **What:** Added `group-focus-visible:opacity-100` to the hover tooltip inside the Sidebar navigation links.
🎯 **Why:** Hiding elements with `opacity-0` and revealing them only on hover (`group-hover:opacity-100`) creates a keyboard accessibility trap. Screen reader and keyboard-only users can navigate to the parent element, but the tooltip remains invisible because it lacks a focus state.
📸 **Before/After:** The tooltip for navigation items (like "Compiler") is now fully visible when navigating the sidebar using the `Tab` key.
♿ **Accessibility:** Fixes a keyboard navigation issue where focusable tooltip content was visually hidden for non-mouse users.

---
*PR created automatically by Jules for task [1954646182720722743](https://jules.google.com/task/1954646182720722743) started by @madara88645*