### PR TITLE
🧪 [testing improvement] Add error handling test for compile_fast endpoint

### DIFF
--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -56,6 +56,16 @@ def test_compile_fast_success(test_key):
         assert "processing_ms" in data
 
 
+def test_compile_fast_internal_error(test_key):
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.cache = {}
+        mock_compiler.worker.process.side_effect = Exception("Test Internal Error")
+
+        resp = client.post("/compile/fast", json={"text": "hello"}, headers={"x-api-key": test_key})
+        assert resp.status_code == 500
+        assert resp.json() == {"detail": "An internal error occurred."}
+
+
 def test_rate_limit(test_key):
     # Depending on how the rate limiter is implemented (in-memory global),
     # we might need to reset it or just spam enough requests.


### PR DESCRIPTION
🎯 **What:** The `compile_fast` endpoint in `api/main.py` lacked test coverage for its error handling block (`except Exception as e`).
📊 **Coverage:** A new test `test_compile_fast_internal_error` has been added to `tests/test_auth_fast_path.py` that mocks the compiler worker to raise an exception. It verifies that a `500 Internal Server Error` is returned with the correct `"An internal error occurred."` detail.
✨ **Result:** Increased test coverage for the fast compilation endpoint's error path, ensuring API reliability during internal failures.

---
*PR created automatically by Jules for task [5577713034702386214](https://jules.google.com/task/5577713034702386214) started by @madara88645*