### PR TITLE
Polish benchmark flow and extend popup preview

### DIFF
--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -87,7 +87,13 @@ class WorkerClient:
         # Conservative by default. If the conservative file is missing, fall back to worker_v1.md
         return self.system_prompt_conservative or self.system_prompt
 
-    def _call_api(self, messages: list, max_tokens: int = 1500, json_mode: bool = True) -> str:
+    def _call_api(
+        self,
+        messages: list,
+        max_tokens: int = 1500,
+        json_mode: bool = True,
+        model_override: Optional[str] = None,
+    ) -> str:
         """Internal: Makes the actual API call."""
         print(f"[DEBUG] Connecting to LLM Service (Base URL: {self.base_url})...", file=sys.stderr)
         print(
@@ -96,7 +102,7 @@ class WorkerClient:
         )
 
         kwargs = {
-            "model": self.model,
+            "model": model_override or self.model,
             "messages": messages,
             "temperature": 0.2,  # Low temp for deterministic structure
             "max_tokens": max_tokens,

--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -19,12 +19,23 @@ import time
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.compiler import compile_text_v2
 from app.emitters import emit_expanded_prompt_v2
 
 router = APIRouter(prefix="/benchmark", tags=["benchmark"])
+
+MAX_BENCHMARK_TEXT_LENGTH = 4000
+SUPPORTED_BENCHMARK_MODELS = {
+    "llama-3.1-8b-instant",
+    "openai/gpt-oss-20b",
+    "openai/gpt-oss-120b",
+    "llama-3.3-70b-versatile",
+    "mistral-saba-24b",
+    "meta-llama/llama-4-scout-17b-16e-instruct",
+    "qwen/qwen3-32b",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -35,11 +46,31 @@ router = APIRouter(prefix="/benchmark", tags=["benchmark"])
 class BenchmarkRequest(BaseModel):
     """Input for a benchmark run."""
 
-    text: str = Field(..., description="Raw user input prompt")
+    text: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_BENCHMARK_TEXT_LENGTH,
+        description="Raw user input prompt",
+    )
     model: str = Field(
         default="llama-3.1-8b-instant",
         description="LLM model identifier (e.g. 'llama-3.1-8b-instant')",
     )
+
+    @field_validator("text")
+    @classmethod
+    def validate_text(cls, value: str) -> str:
+        text = value.strip()
+        if not text:
+            raise ValueError("Prompt text must not be blank")
+        return text
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str) -> str:
+        if value not in SUPPORTED_BENCHMARK_MODELS:
+            raise ValueError("Unsupported benchmark model")
+        return value
 
 
 class MetricPair(BaseModel):
@@ -80,24 +111,25 @@ def _generate_llm_output(prompt: str, model: str) -> str:
     """
     Call the LLM with a simple user message and return the text response.
 
-    Falls back to a descriptive placeholder when the LLM is unavailable
-    so the endpoint remains testable in offline / CI environments.
+    Raises when the provider is unavailable so callers can return a safe
+    upstream error instead of silently benchmarking the wrong model.
     """
-    try:
-        from api.main import hybrid_compiler  # type: ignore[import]  # noqa: E402
+    from api.main import hybrid_compiler  # type: ignore[import]  # noqa: E402
 
-        if hybrid_compiler is None:
-            raise RuntimeError("HybridCompiler not initialised yet")
+    if hybrid_compiler is None:
+        raise RuntimeError("HybridCompiler not initialised yet")
 
-        worker = hybrid_compiler.worker
-        messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": prompt},
-        ]
-        return worker._call_api(messages, max_tokens=1500, json_mode=False)
-
-    except Exception as e:
-        return f"[LLM unavailable – mock output for: {prompt[:80]}] (error: {e})"
+    worker = hybrid_compiler.worker
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": prompt},
+    ]
+    return worker._call_api(
+        messages,
+        max_tokens=1500,
+        json_mode=False,
+        model_override=model,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -244,20 +276,20 @@ async def benchmark_run(req: BenchmarkRequest):
     try:
         raw_output = _generate_llm_output(req.text, req.model)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Step A failed: {e}")
+        raise HTTPException(status_code=502, detail="Benchmark model request failed") from e
 
     # --- Step B: Compile the prompt ---------------------------------------
     try:
         ir_v2 = compile_text_v2(req.text)
         compiled_prompt = emit_expanded_prompt_v2(ir_v2, diagnostics=True)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Step B (compile) failed: {e}")
+        raise HTTPException(status_code=500, detail="Benchmark compilation failed") from e
 
     # --- Step C: Generate with compiled prompt ----------------------------
     try:
         compiled_output = _generate_llm_output(compiled_prompt, req.model)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Step C failed: {e}")
+        raise HTTPException(status_code=502, detail="Benchmark model request failed") from e
 
     # --- Step D: Judge — LLM first, heuristic fallback --------------------
     judge_result = _judge_with_llm(req.text, raw_output, compiled_output)

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,68 +1,73 @@
-// Background Service Worker
+import { STORAGE_KEYS, loadRuntimeConfig } from "./config.mjs";
+import { buildPreviewEntry, mergePreviewHistory } from "./preview-history.mjs";
+
 console.log("MyCompiler Background Worker Loaded");
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.type === 'OPTIMIZE_PROMPT') {
-        handleOptimization(request, sendResponse);
-        return true; // Keep channel open for async response
-    }
+  if (request.type !== "OPTIMIZE_PROMPT") {
+    return false;
+  }
+
+  handleOptimization(request, sender)
+    .then(sendResponse)
+    .catch((error) => {
+      console.error("Optimization failed:", error);
+      sendResponse({
+        success: false,
+        error: error instanceof Error ? error.message : "Optimization failed.",
+      });
+    });
+
+  return true;
 });
 
-// Hardcoded Credentials (Public Mode)
-const _p1 = "gsk_TQV3OCCToZuQXSty0EB1WGdyb3FYgTCvx";
-const _p2 = "6jswSvrQjLV7tiFi6Ki";
-const CONFIG = {
-    apiKey: _p1 + _p2, // User's Groq Key (Split to avoid git scanning)
-    backendUrl: "https://compiler-production-626b.up.railway.app"     // Railway URL
-};
+async function handleOptimization(request, sender) {
+  const storage = await chrome.storage.local.get([STORAGE_KEYS.enabled]);
+  if (storage[STORAGE_KEYS.enabled] === false) {
+    return { success: false, error: "Extension is disabled." };
+  }
 
-async function handleOptimization(request, sendResponse) {
-    // Check if enabled
-    const storage = await chrome.storage.local.get(['enabled']);
-    if (storage.enabled === false) {
-        sendResponse({ success: false, error: "Extension is disabled." });
-        return;
-    }
+  const runtimeConfig = await loadRuntimeConfig(chrome.storage.local);
+  if (!runtimeConfig.ok) {
+    return { success: false, error: runtimeConfig.error };
+  }
 
-    const { text } = request;
-    const { apiKey, backendUrl } = CONFIG;
+  const text = typeof request.text === "string" ? request.text.trim() : "";
+  if (!text) {
+    return { success: false, error: "Prompt is empty." };
+  }
 
-    try {
-        // Ensure backendUrl doesn't have trailing slash
-        let baseUrl = backendUrl.replace(/\/$/, "");
-        if (!baseUrl.startsWith("http")) {
-            baseUrl = "https://" + baseUrl;
-        }
+  const response = await fetch(`${runtimeConfig.value.backendUrl}/compile/fast`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": runtimeConfig.value.apiKey,
+    },
+    body: JSON.stringify({
+      text,
+      v2: true,
+    }),
+  });
 
-        console.log(`Sending request to ${baseUrl}/compile/fast`);
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`API Error ${response.status}: ${errText}`);
+  }
 
-        const response = await fetch(`${baseUrl}/compile/fast`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'x-api-key': apiKey // Updated to match FastAPI 'name=x-api-key'
-            },
-            body: JSON.stringify({
-                text: text,
-                // Ensure we match the backend's expected schema
-                v2: true
-            })
-        });
+  const data = await response.json();
+  const result = data.expanded_prompt_v2 || data.expanded_prompt || data.system_prompt;
+  await persistPreviewHistory({
+    originalText: text,
+    optimizedText: result,
+    sourceUrl: sender?.tab?.url || sender?.url || "",
+  });
 
-        if (!response.ok) {
-            const errText = await response.text();
-            throw new Error(`API Error ${response.status}: ${errText}`);
-        }
+  return { success: true, data: result };
+}
 
-        const data = await response.json();
-
-        // Map response logic (matching API response model)
-        const result = data.expanded_prompt_v2 || data.expanded_prompt || data.system_prompt;
-
-        sendResponse({ success: true, data: result });
-
-    } catch (error) {
-        console.error("Optimization failed:", error);
-        sendResponse({ success: false, error: error.message });
-    }
+async function persistPreviewHistory({ originalText, optimizedText, sourceUrl }) {
+  const stored = await chrome.storage.local.get([STORAGE_KEYS.previewHistory]);
+  const entry = buildPreviewEntry({ originalText, optimizedText, sourceUrl });
+  const history = mergePreviewHistory(stored[STORAGE_KEYS.previewHistory], entry);
+  await chrome.storage.local.set({ [STORAGE_KEYS.previewHistory]: history });
 }

--- a/extension/config.mjs
+++ b/extension/config.mjs
@@ -1,0 +1,57 @@
+export const STORAGE_KEYS = {
+  enabled: "enabled",
+  conservativeMode: "promptc_conservative_mode",
+  backendUrl: "promptc_backend_url",
+  apiKey: "promptc_api_key",
+  previewHistory: "promptc_preview_history",
+};
+
+const CONFIGURATION_ERROR =
+  "Extension is not configured yet. Add your backend URL and API key in the popup.";
+
+export function normalizeBackendUrl(input) {
+  if (typeof input !== "string") {
+    return "";
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const prefixed = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  try {
+    const url = new URL(prefixed);
+    const pathname = url.pathname.replace(/\/+$/, "");
+    return `${url.origin}${pathname === "/" ? "" : pathname}`;
+  } catch {
+    return "";
+  }
+}
+
+export function resolveRuntimeConfig(rawConfig = {}) {
+  const backendUrl = normalizeBackendUrl(rawConfig.backendUrl);
+  const apiKey = typeof rawConfig.apiKey === "string" ? rawConfig.apiKey.trim() : "";
+
+  if (!backendUrl || !apiKey) {
+    return { ok: false, error: CONFIGURATION_ERROR };
+  }
+
+  return {
+    ok: true,
+    value: {
+      backendUrl,
+      apiKey,
+    },
+  };
+}
+
+export async function loadRuntimeConfig(storageArea) {
+  const stored = await storageArea.get([STORAGE_KEYS.backendUrl, STORAGE_KEYS.apiKey]);
+
+  return resolveRuntimeConfig({
+    backendUrl: stored[STORAGE_KEYS.backendUrl],
+    apiKey: stored[STORAGE_KEYS.apiKey],
+  });
+}

--- a/extension/config.test.mjs
+++ b/extension/config.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveRuntimeConfig } from "./config.mjs";
+
+test("resolveRuntimeConfig reports missing credentials without embedded defaults", () => {
+  const result = resolveRuntimeConfig({});
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "Extension is not configured yet. Add your backend URL and API key in the popup.");
+});
+
+test("resolveRuntimeConfig normalizes backend URLs and keeps secrets out of source", () => {
+  const result = resolveRuntimeConfig({
+    backendUrl: "compiler-production-626b.up.railway.app/",
+    apiKey: "pc_test_key",
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value?.backendUrl, "https://compiler-production-626b.up.railway.app");
+  assert.equal(result.value?.apiKey, "pc_test_key");
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,8 @@
         "storage"
     ],
     "background": {
-        "service_worker": "background.js"
+        "service_worker": "background.js",
+        "type": "module"
     },
     "action": {
         "default_popup": "popup.html",

--- a/extension/popup-preview.mjs
+++ b/extension/popup-preview.mjs
@@ -1,0 +1,16 @@
+export function getActivePreviewEntry(previewHistory, activePreviewId) {
+  const safeHistory = Array.isArray(previewHistory) ? previewHistory : [];
+  return safeHistory.find((entry) => entry.id === activePreviewId) ?? safeHistory[0] ?? null;
+}
+
+export function getRestoreText(entry) {
+  return typeof entry?.optimizedText === "string" ? entry.optimizedText : "";
+}
+
+export function formatPreviewDelta(entry) {
+  const originalText = typeof entry?.originalText === "string" ? entry.originalText : "";
+  const optimizedText = typeof entry?.optimizedText === "string" ? entry.optimizedText : "";
+  const delta = optimizedText.length - originalText.length;
+
+  return `${delta >= 0 ? "+" : ""}${delta} chars`;
+}

--- a/extension/popup-preview.test.mjs
+++ b/extension/popup-preview.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatPreviewDelta,
+  getActivePreviewEntry,
+  getRestoreText,
+} from "./popup-preview.mjs";
+
+const previewEntries = [
+  {
+    id: "latest",
+    originalText: "Short prompt",
+    optimizedText: "Expanded prompt",
+    siteLabel: "ChatGPT",
+    createdAt: 1700000000000,
+  },
+  {
+    id: "older",
+    originalText: "Another prompt",
+    optimizedText: "Another optimized prompt",
+    siteLabel: "Claude",
+    createdAt: 1690000000000,
+  },
+];
+
+test("getActivePreviewEntry returns the selected history item when available", () => {
+  const entry = getActivePreviewEntry(previewEntries, "older");
+
+  assert.equal(entry?.id, "older");
+});
+
+test("getActivePreviewEntry falls back to the latest item when selection is missing", () => {
+  const entry = getActivePreviewEntry(previewEntries, "missing");
+
+  assert.equal(entry?.id, "latest");
+});
+
+test("getRestoreText returns the optimized text for the selected preview", () => {
+  const text = getRestoreText(previewEntries[1]);
+
+  assert.equal(text, "Another optimized prompt");
+});
+
+test("formatPreviewDelta reports positive and negative char deltas", () => {
+  assert.equal(formatPreviewDelta(previewEntries[0]), "+3 chars");
+  assert.equal(
+    formatPreviewDelta({
+      originalText: "Longer original prompt",
+      optimizedText: "Short",
+    }),
+    "-17 chars",
+  );
+});

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -154,6 +154,10 @@ h1 {
     gap: var(--space-2);
 }
 
+.panel-row-start {
+    align-items: flex-start;
+}
+
 h2 {
     margin: 0;
     font-size: 15px;
@@ -162,6 +166,176 @@ h2 {
 .muted {
     margin: 2px 0 0;
     color: var(--text-muted);
+    font-size: 12px;
+}
+
+.field-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 14px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.field-label {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.input {
+    width: 100%;
+    min-height: 40px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-primary);
+    font-size: 13px;
+    transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
+}
+
+.input::placeholder {
+    color: #6f7891;
+}
+
+.input:focus-visible {
+    outline: none;
+    border-color: rgba(126, 213, 255, 0.6);
+    box-shadow: var(--focus-ring);
+}
+
+.panel-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.preview-panel {
+    gap: 12px;
+}
+
+.preview-empty {
+    margin-top: 12px;
+}
+
+.preview-content {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.preview-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.preview-meta-text {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.preview-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.preview-card {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.03);
+    padding: 12px;
+}
+
+.preview-card-optimized {
+    border-color: rgba(126, 213, 255, 0.32);
+    background: rgba(126, 213, 255, 0.08);
+}
+
+.preview-pre {
+    margin: 8px 0 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 96px;
+    overflow: auto;
+    color: var(--text-primary);
+    font-family: var(--font-mono, 'SFMono-Regular', Consolas, monospace);
+    font-size: 12px;
+    line-height: 1.45;
+}
+
+.preview-history {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.history-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.history-item {
+    width: 100%;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-primary);
+    text-align: left;
+    padding: 10px 12px;
+    cursor: pointer;
+    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+}
+
+.history-item:hover {
+    transform: translateY(-1px);
+    border-color: rgba(126, 213, 255, 0.35);
+}
+
+.history-item-active {
+    border-color: rgba(126, 213, 255, 0.55);
+    background: rgba(126, 213, 255, 0.08);
+}
+
+.history-item-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 4px;
+}
+
+.history-item-title {
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.history-item-time {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.history-item-snippet {
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.4;
+}
+
+.btn-small {
+    min-height: 32px;
+    padding: 8px 10px;
     font-size: 12px;
 }
 
@@ -185,6 +359,12 @@ h2 {
     color: #d0d4df;
     border-color: rgba(208, 212, 223, 0.36);
     background: rgba(208, 212, 223, 0.08);
+}
+
+.status-warning {
+    color: #fde68a;
+    border-color: rgba(251, 191, 36, 0.36);
+    background: rgba(251, 191, 36, 0.12);
 }
 
 .actions {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -41,12 +41,75 @@
             <p id="statusLabel" class="status status-enabled">Enabled</p>
         </section>
 
+        <section class="panel">
+            <div class="panel-row panel-row-start">
+                <div>
+                    <h2>Connection</h2>
+                    <p class="muted">Stored locally in this browser. No API key is bundled in the extension.</p>
+                </div>
+            </div>
+
+            <div class="field-stack">
+                <label class="field" for="backendUrlInput">
+                    <span class="field-label">Backend URL</span>
+                    <input id="backendUrlInput" class="input" type="url" placeholder="https://your-backend.example.com">
+                </label>
+
+                <label class="field" for="apiKeyInput">
+                    <span class="field-label">API Key</span>
+                    <input id="apiKeyInput" class="input" type="password" placeholder="pc_live_...">
+                </label>
+
+                <div class="panel-actions">
+                    <button id="saveConfig" class="btn btn-secondary" type="button">Save Config</button>
+                    <p id="configStatus" class="status status-disabled">Missing config</p>
+                </div>
+            </div>
+        </section>
+
         <section class="actions" aria-label="Actions">
             <button id="openPlayground" class="btn btn-primary" type="button">Open Playground</button>
             <button id="openDocs" class="btn btn-ghost" type="button">View Docs</button>
         </section>
+
+        <section class="panel preview-panel" aria-labelledby="previewHeading">
+            <div class="panel-row panel-row-start">
+                <div>
+                    <h2 id="previewHeading">Latest Preview</h2>
+                    <p class="muted">Extra visibility lives here. Select any recent result and restore it to your clipboard.</p>
+                </div>
+                <button id="restorePreview" class="btn btn-ghost btn-small" type="button">Restore</button>
+            </div>
+
+            <p id="previewEmpty" class="muted preview-empty">No optimized prompts yet. Run the chat-bar button once and the latest result will show up here.</p>
+
+            <div id="previewContent" class="preview-content" hidden>
+                <div class="preview-meta">
+                    <span id="previewSite" class="status status-enabled">ChatGPT</span>
+                    <span id="previewTime" class="preview-meta-text">Just now</span>
+                    <span id="previewDelta" class="preview-meta-text">-12 chars</span>
+                </div>
+
+                <div class="preview-stack">
+                    <article class="preview-card">
+                        <div class="field-label">Original</div>
+                        <pre id="previewOriginal" class="preview-pre"></pre>
+                    </article>
+
+                    <article class="preview-card preview-card-optimized">
+                        <div class="field-label">Optimized</div>
+                        <pre id="previewOptimized" class="preview-pre"></pre>
+                    </article>
+                </div>
+
+                <div class="preview-history">
+                    <div class="field-label">Recent</div>
+                    <div id="previewHistoryList" class="history-list"></div>
+                </div>
+            </div>
+        </section>
     </main>
-    <script src="popup.js"></script>
+    <script type="module" src="popup.js"></script>
 </body>
 
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,71 +1,230 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const enabledToggle = document.getElementById('enabledToggle');
-    const statusLabel = document.getElementById('statusLabel');
-    const playgroundButton = document.getElementById('openPlayground');
-    const docsButton = document.getElementById('openDocs');
-    const conservativeToggle = document.getElementById('pc-conservative-toggle');
-    const CONSERVATIVE_KEY = 'promptc_conservative_mode';
+import { STORAGE_KEYS, loadRuntimeConfig, normalizeBackendUrl } from "./config.mjs";
+import {
+  formatPreviewDelta,
+  getActivePreviewEntry,
+  getRestoreText,
+} from "./popup-preview.mjs";
 
-    chrome.storage.local.get(['enabled'], (result) => {
-        const isEnabled = result.enabled !== false;
-        enabledToggle.checked = isEnabled;
-        updateStatus(isEnabled);
-    });
+document.addEventListener("DOMContentLoaded", async () => {
+  const enabledToggle = document.getElementById("enabledToggle");
+  const statusLabel = document.getElementById("statusLabel");
+  const playgroundButton = document.getElementById("openPlayground");
+  const docsButton = document.getElementById("openDocs");
+  const conservativeToggle = document.getElementById("pc-conservative-toggle");
+  const backendUrlInput = document.getElementById("backendUrlInput");
+  const apiKeyInput = document.getElementById("apiKeyInput");
+  const saveConfigButton = document.getElementById("saveConfig");
+  const configStatus = document.getElementById("configStatus");
+  const restorePreviewButton = document.getElementById("restorePreview");
+  const previewEmpty = document.getElementById("previewEmpty");
+  const previewContent = document.getElementById("previewContent");
+  const previewSite = document.getElementById("previewSite");
+  const previewTime = document.getElementById("previewTime");
+  const previewDelta = document.getElementById("previewDelta");
+  const previewOriginal = document.getElementById("previewOriginal");
+  const previewOptimized = document.getElementById("previewOptimized");
+  const previewHistoryList = document.getElementById("previewHistoryList");
 
-    // Conservative mode initial state (default: ON)
-    chrome.storage.local.get([CONSERVATIVE_KEY], (result) => {
-        const on = result[CONSERVATIVE_KEY] !== false;
-        setConservativeUI(on);
-    });
+  const stored = await chrome.storage.local.get([
+    STORAGE_KEYS.enabled,
+    STORAGE_KEYS.conservativeMode,
+    STORAGE_KEYS.backendUrl,
+    STORAGE_KEYS.apiKey,
+    STORAGE_KEYS.previewHistory,
+  ]);
+  let previewHistory = Array.isArray(stored[STORAGE_KEYS.previewHistory])
+    ? stored[STORAGE_KEYS.previewHistory]
+    : [];
+  let activePreviewId = previewHistory[0]?.id ?? null;
+  let restoreFeedbackTimeout = null;
 
-    enabledToggle.addEventListener('change', () => {
-        const isEnabled = enabledToggle.checked;
-        chrome.storage.local.set({ enabled: isEnabled }, () => {
-            updateStatus(isEnabled);
-        });
-    });
+  const isEnabled = stored[STORAGE_KEYS.enabled] !== false;
+  enabledToggle.checked = isEnabled;
+  updateStatus(isEnabled);
 
-    if (conservativeToggle) {
-        conservativeToggle.addEventListener('click', () => {
-            chrome.storage.local.get([CONSERVATIVE_KEY], (result) => {
-                const current = result[CONSERVATIVE_KEY] !== false;
-                const next = !current;
-                chrome.storage.local.set({ [CONSERVATIVE_KEY]: next }, () => {
-                    setConservativeUI(next);
-                });
-            });
-        });
-    }
+  const conservativeModeOn = stored[STORAGE_KEYS.conservativeMode] !== false;
+  setConservativeUI(conservativeModeOn);
 
-    function updateStatus(enabled) {
-        statusLabel.textContent = enabled ? 'Enabled' : 'Disabled';
-        statusLabel.classList.toggle('status-enabled', enabled);
-        statusLabel.classList.toggle('status-disabled', !enabled);
-    }
+  backendUrlInput.value = stored[STORAGE_KEYS.backendUrl] || "";
+  apiKeyInput.value = stored[STORAGE_KEYS.apiKey] || "";
+  updateConfigStatus(await loadRuntimeConfig(chrome.storage.local));
+  renderPreview();
 
-    function setConservativeUI(on) {
-        if (!conservativeToggle) return;
-        conservativeToggle.classList.toggle('pc-conservative-on', on);
-        conservativeToggle.classList.toggle('pc-conservative-off', !on);
-        conservativeToggle.setAttribute('aria-pressed', on ? 'true' : 'false');
-        conservativeToggle.title = on
-            ? 'Conservative mode ON – keep prompts grounded and avoid hallucinations.'
-            : 'Conservative mode OFF – use more aggressive optimization.';
-    }
+  enabledToggle.addEventListener("change", async () => {
+    const nextEnabled = enabledToggle.checked;
+    await chrome.storage.local.set({ [STORAGE_KEYS.enabled]: nextEnabled });
+    updateStatus(nextEnabled);
+  });
 
-    playgroundButton.addEventListener('click', () => {
-        chrome.tabs.create({ url: 'http://localhost:3000' });
-    });
+  conservativeToggle?.addEventListener("click", async () => {
+    const result = await chrome.storage.local.get([STORAGE_KEYS.conservativeMode]);
+    const current = result[STORAGE_KEYS.conservativeMode] !== false;
+    const next = !current;
+    await chrome.storage.local.set({ [STORAGE_KEYS.conservativeMode]: next });
+    setConservativeUI(next);
+  });
 
-    docsButton.addEventListener('click', () => {
-        chrome.tabs.create({ url: 'https://github.com' });
-    });
-
-    // Helper: other scripts can query current mode
-    window.getPromptCompilerMode = function (cb) {
-        chrome.storage.local.get([CONSERVATIVE_KEY], (result) => {
-            const on = result[CONSERVATIVE_KEY] !== false;
-            cb(on ? 'conservative' : 'default');
-        });
+  saveConfigButton?.addEventListener("click", async () => {
+    const payload = {
+      [STORAGE_KEYS.backendUrl]: normalizeBackendUrl(backendUrlInput.value) || backendUrlInput.value.trim(),
+      [STORAGE_KEYS.apiKey]: apiKeyInput.value.trim(),
     };
+
+    await chrome.storage.local.set(payload);
+    updateConfigStatus(await loadRuntimeConfig(chrome.storage.local), true);
+  });
+
+  playgroundButton?.addEventListener("click", () => {
+    chrome.tabs.create({ url: "http://localhost:3000" });
+  });
+
+  docsButton?.addEventListener("click", () => {
+    chrome.tabs.create({ url: "https://github.com/madara88645/Compiler" });
+  });
+
+  restorePreviewButton?.addEventListener("click", async () => {
+    const restoreText = getRestoreText(getActivePreviewEntry(previewHistory, activePreviewId));
+    if (!restoreText) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(restoreText);
+    setRestoreButtonState(true);
+  });
+
+  previewHistoryList?.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-preview-id]");
+    if (!button) {
+      return;
+    }
+
+    activePreviewId = button.getAttribute("data-preview-id");
+    renderPreview();
+  });
+
+  function updateStatus(enabled) {
+    statusLabel.textContent = enabled ? "Enabled" : "Disabled";
+    statusLabel.classList.toggle("status-enabled", enabled);
+    statusLabel.classList.toggle("status-disabled", !enabled);
+  }
+
+  function setConservativeUI(on) {
+    if (!conservativeToggle) {
+      return;
+    }
+
+    conservativeToggle.classList.toggle("pc-conservative-on", on);
+    conservativeToggle.classList.toggle("pc-conservative-off", !on);
+    conservativeToggle.setAttribute("aria-pressed", on ? "true" : "false");
+    conservativeToggle.title = on
+      ? "Conservative mode ON - keep prompts grounded and avoid hallucinations."
+      : "Conservative mode OFF - use more aggressive optimization.";
+  }
+
+  function updateConfigStatus(result, justSaved = false) {
+    if (!configStatus) {
+      return;
+    }
+
+    configStatus.classList.remove("status-enabled", "status-disabled", "status-warning");
+
+    if (result.ok) {
+      configStatus.textContent = justSaved ? "Saved" : "Configured";
+      configStatus.classList.add("status-enabled");
+      return;
+    }
+
+    configStatus.textContent = justSaved ? "Check fields" : "Missing config";
+    configStatus.classList.add(justSaved ? "status-warning" : "status-disabled");
+  }
+
+  function renderPreview() {
+    const entry = getActivePreviewEntry(previewHistory, activePreviewId);
+
+    if (!entry) {
+      previewEmpty.hidden = false;
+      previewContent.hidden = true;
+      setRestoreButtonState(false);
+      restorePreviewButton.disabled = true;
+      return;
+    }
+
+    previewEmpty.hidden = true;
+    previewContent.hidden = false;
+    setRestoreButtonState(false);
+    restorePreviewButton.disabled = false;
+
+    previewSite.textContent = entry.siteLabel;
+    previewTime.textContent = formatRelativeTime(entry.createdAt);
+    previewDelta.textContent = formatPreviewDelta(entry);
+    previewOriginal.textContent = entry.originalText;
+    previewOptimized.textContent = entry.optimizedText;
+    previewHistoryList.innerHTML = previewHistory
+      .map((historyEntry) => {
+        const snippet = historyEntry.optimizedText.replace(/\s+/g, " ").trim().slice(0, 64);
+        const activeClass = historyEntry.id === entry.id ? " history-item-active" : "";
+        return `
+          <button class="history-item${activeClass}" type="button" data-preview-id="${historyEntry.id}">
+            <div class="history-item-top">
+              <span class="history-item-title">${historyEntry.siteLabel}</span>
+              <span class="history-item-time">${formatRelativeTime(historyEntry.createdAt)}</span>
+            </div>
+            <div class="history-item-snippet">${escapeHtml(snippet)}${historyEntry.optimizedText.length > 64 ? "..." : ""}</div>
+          </button>
+        `;
+      })
+      .join("");
+  }
+
+  function formatRelativeTime(timestamp) {
+    const diffMs = Date.now() - timestamp;
+    const diffMinutes = Math.max(1, Math.round(diffMs / 60000));
+
+    if (diffMinutes < 60) {
+      return `${diffMinutes}m ago`;
+    }
+
+    const diffHours = Math.round(diffMinutes / 60);
+    if (diffHours < 24) {
+      return `${diffHours}h ago`;
+    }
+
+    const diffDays = Math.round(diffHours / 24);
+    return `${diffDays}d ago`;
+  }
+
+  function escapeHtml(value) {
+    return value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;");
+  }
+
+  function setRestoreButtonState(restored) {
+    if (!restorePreviewButton) {
+      return;
+    }
+
+    if (restoreFeedbackTimeout) {
+      window.clearTimeout(restoreFeedbackTimeout);
+      restoreFeedbackTimeout = null;
+    }
+
+    restorePreviewButton.textContent = restored ? "Restored" : "Restore";
+    if (!restored) {
+      return;
+    }
+
+    restoreFeedbackTimeout = window.setTimeout(() => {
+      restorePreviewButton.textContent = "Restore";
+      restoreFeedbackTimeout = null;
+    }, 1400);
+  }
+
+  window.getPromptCompilerMode = function getPromptCompilerMode(callback) {
+    chrome.storage.local.get([STORAGE_KEYS.conservativeMode], (result) => {
+      const on = result[STORAGE_KEYS.conservativeMode] !== false;
+      callback(on ? "conservative" : "default");
+    });
+  };
 });

--- a/extension/preview-history.mjs
+++ b/extension/preview-history.mjs
@@ -1,0 +1,43 @@
+export const PREVIEW_HISTORY_LIMIT = 3;
+
+export function resolveSiteLabel(sourceUrl) {
+  if (typeof sourceUrl !== "string" || !sourceUrl.trim()) {
+    return "Unknown";
+  }
+
+  try {
+    const url = new URL(sourceUrl);
+    const host = url.hostname.toLowerCase();
+
+    if (host.includes("chatgpt.com")) {
+      return "ChatGPT";
+    }
+
+    if (host.includes("claude.ai")) {
+      return "Claude";
+    }
+
+    if (host.includes("gemini.google.com")) {
+      return "Gemini";
+    }
+
+    return url.hostname;
+  } catch {
+    return "Unknown";
+  }
+}
+
+export function buildPreviewEntry({ originalText, optimizedText, sourceUrl, now = Date.now() }) {
+  return {
+    id: `${now}-${Math.random().toString(36).slice(2, 8)}`,
+    originalText,
+    optimizedText,
+    siteLabel: resolveSiteLabel(sourceUrl),
+    createdAt: now,
+  };
+}
+
+export function mergePreviewHistory(existingEntries, nextEntry, limit = PREVIEW_HISTORY_LIMIT) {
+  const safeEntries = Array.isArray(existingEntries) ? existingEntries : [];
+  return [nextEntry, ...safeEntries].slice(0, limit);
+}

--- a/extension/preview-history.test.mjs
+++ b/extension/preview-history.test.mjs
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  PREVIEW_HISTORY_LIMIT,
+  buildPreviewEntry,
+  mergePreviewHistory,
+  resolveSiteLabel,
+} from "./preview-history.mjs";
+
+test("resolveSiteLabel maps supported chat domains to friendly names", () => {
+  assert.equal(resolveSiteLabel("https://chatgpt.com/c/123"), "ChatGPT");
+  assert.equal(resolveSiteLabel("https://claude.ai/new"), "Claude");
+  assert.equal(resolveSiteLabel("https://gemini.google.com/app"), "Gemini");
+});
+
+test("buildPreviewEntry keeps original and optimized text plus source metadata", () => {
+  const entry = buildPreviewEntry({
+    originalText: "Original prompt",
+    optimizedText: "Optimized prompt",
+    sourceUrl: "https://claude.ai/new",
+    now: 1700000000000,
+  });
+
+  assert.equal(entry.originalText, "Original prompt");
+  assert.equal(entry.optimizedText, "Optimized prompt");
+  assert.equal(entry.siteLabel, "Claude");
+  assert.equal(entry.createdAt, 1700000000000);
+});
+
+test("mergePreviewHistory prepends newest entry and keeps only recent items", () => {
+  const history = Array.from({ length: PREVIEW_HISTORY_LIMIT }, (_, index) =>
+    buildPreviewEntry({
+      originalText: `Original ${index}`,
+      optimizedText: `Optimized ${index}`,
+      sourceUrl: "https://chatgpt.com",
+      now: 1700000000000 + index,
+    }),
+  );
+
+  const latest = buildPreviewEntry({
+    originalText: "Newest original",
+    optimizedText: "Newest optimized",
+    sourceUrl: "https://gemini.google.com",
+    now: 1800000000000,
+  });
+
+  const merged = mergePreviewHistory(history, latest);
+
+  assert.equal(merged.length, PREVIEW_HISTORY_LIMIT);
+  assert.equal(merged[0].optimizedText, "Newest optimized");
+  assert.equal(merged.at(-1)?.optimizedText, "Optimized 1");
+});

--- a/tests/test_benchmark_api.py
+++ b/tests/test_benchmark_api.py
@@ -100,8 +100,28 @@ def test_benchmark_run_endpoint(client):
     assert data["compiled_output"] == mock_improved
 
 
-def test_benchmark_run_empty_prompt(client):
-    """Should handle empty prompt gracefully (compiler still works)."""
+def test_benchmark_run_uses_selected_model_for_both_generations(client):
+    """The requested benchmark model should be used for raw and compiled generations."""
+    selected_model = "openai/gpt-oss-20b"
+
+    with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
+        "app.routers.benchmark._judge_with_llm", return_value=None
+    ):
+        mock_llm.side_effect = ["raw output", "compiled output"]
+
+        response = client.post(
+            "/benchmark/run",
+            json={"text": "Explain Python", "model": selected_model},
+        )
+
+    assert response.status_code == 200
+    assert mock_llm.call_count == 2
+    assert mock_llm.call_args_list[0].args[1] == selected_model
+    assert mock_llm.call_args_list[1].args[1] == selected_model
+
+
+def test_benchmark_run_short_prompt_with_valid_model(client):
+    """A short prompt with a supported model should still succeed."""
     with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
         "app.routers.benchmark._judge_with_llm", return_value=None
     ):
@@ -109,7 +129,7 @@ def test_benchmark_run_empty_prompt(client):
 
         response = client.post(
             "/benchmark/run",
-            json={"text": "hello", "model": "test-model"},
+            json={"text": "hello", "model": "llama-3.1-8b-instant"},
         )
 
     assert response.status_code == 200
@@ -122,3 +142,38 @@ def test_benchmark_request_validation(client):
         json={"model": "some-model"},
     )
     assert response.status_code == 422
+
+
+def test_benchmark_request_rejects_invalid_model(client):
+    """Unsupported benchmark models should be rejected by validation."""
+    response = client.post(
+        "/benchmark/run",
+        json={"text": "Explain Python", "model": "not-a-real-model"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_benchmark_request_rejects_blank_text(client):
+    """Blank prompts should be rejected before any LLM work starts."""
+    response = client.post(
+        "/benchmark/run",
+        json={"text": "", "model": "llama-3.1-8b-instant"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_benchmark_provider_failure_returns_safe_error(client):
+    """Provider/model failures should return a safe upstream error instead of a mock result."""
+    with patch(
+        "app.routers.benchmark._generate_llm_output",
+        side_effect=RuntimeError("provider exploded"),
+    ), patch("app.routers.benchmark._judge_with_llm", return_value=None):
+        response = client.post(
+            "/benchmark/run",
+            json={"text": "Explain Python", "model": "llama-3.1-8b-instant"},
+        )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Benchmark model request failed"

--- a/web/app/benchmark/modelCatalog.test.mts
+++ b/web/app/benchmark/modelCatalog.test.mts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BENCHMARK_MODEL_GROUPS,
+  BENCHMARK_MODELS,
+  getBenchmarkModelById,
+} from "./modelCatalog.ts";
+
+test("benchmark catalog removes deprecated Maverick and includes production + preview targets", () => {
+  const ids = BENCHMARK_MODELS.map((model) => model.id);
+
+  assert.equal(ids.includes("meta-llama/llama-4-maverick-17b-128e-instruct"), false);
+  assert.equal(ids.includes("qwen/qwen3-32b"), true);
+  assert.equal(ids.includes("meta-llama/llama-4-scout-17b-16e-instruct"), true);
+});
+
+test("benchmark catalog exposes preview badges for scout and qwen", () => {
+  assert.equal(getBenchmarkModelById("meta-llama/llama-4-scout-17b-16e-instruct")?.availability, "preview");
+  assert.equal(getBenchmarkModelById("qwen/qwen3-32b")?.availability, "preview");
+});
+
+test("benchmark groups keep cheap and balanced models visible", () => {
+  const labels = BENCHMARK_MODEL_GROUPS.map((group) => group.label);
+
+  assert.equal(labels.includes("Cheap"), true);
+  assert.equal(labels.includes("Balanced"), true);
+});

--- a/web/app/benchmark/modelCatalog.ts
+++ b/web/app/benchmark/modelCatalog.ts
@@ -1,0 +1,80 @@
+export type BenchmarkModelBadge = "cheap" | "balanced" | "preview";
+export type BenchmarkModelAvailability = "production" | "preview";
+
+export type BenchmarkModelDefinition = {
+  id: string;
+  label: string;
+  badge: BenchmarkModelBadge;
+  availability: BenchmarkModelAvailability;
+  helperText: string;
+  group: "Cheap" | "Balanced" | "Preview";
+};
+
+export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
+  {
+    id: "llama-3.1-8b-instant",
+    label: "Llama 3.1 8B Instant",
+    badge: "cheap",
+    availability: "production",
+    helperText: "Lowest-cost baseline on Groq for fast A/B checks.",
+    group: "Cheap",
+  },
+  {
+    id: "openai/gpt-oss-20b",
+    label: "GPT-OSS 20B",
+    badge: "cheap",
+    availability: "production",
+    helperText: "Cheap open model with a strong quality-to-cost ratio.",
+    group: "Cheap",
+  },
+  {
+    id: "mistral-saba-24b",
+    label: "Mistral Saba 24B",
+    badge: "cheap",
+    availability: "production",
+    helperText: "Affordable multilingual option for broader prompt coverage.",
+    group: "Cheap",
+  },
+  {
+    id: "llama-3.3-70b-versatile",
+    label: "Llama 3.3 70B Versatile",
+    badge: "balanced",
+    availability: "production",
+    helperText: "Balanced quality model for richer benchmark comparisons.",
+    group: "Balanced",
+  },
+  {
+    id: "openai/gpt-oss-120b",
+    label: "GPT-OSS 120B",
+    badge: "balanced",
+    availability: "production",
+    helperText: "Stronger reference model when you want a higher-quality comparison.",
+    group: "Balanced",
+  },
+  {
+    id: "meta-llama/llama-4-scout-17b-16e-instruct",
+    label: "Llama 4 Scout 17B 16E",
+    badge: "preview",
+    availability: "preview",
+    helperText: "Preview Meta model with modern context handling and multimodal lineage.",
+    group: "Preview",
+  },
+  {
+    id: "qwen/qwen3-32b",
+    label: "Qwen 3 32B",
+    badge: "preview",
+    availability: "preview",
+    helperText: "Preview Qwen model for alternative reasoning and response style checks.",
+    group: "Preview",
+  },
+];
+
+export const BENCHMARK_MODEL_GROUPS = [
+  { label: "Cheap", options: BENCHMARK_MODELS.filter((model) => model.group === "Cheap") },
+  { label: "Balanced", options: BENCHMARK_MODELS.filter((model) => model.group === "Balanced") },
+  { label: "Preview", options: BENCHMARK_MODELS.filter((model) => model.group === "Preview") },
+] as const;
+
+export function getBenchmarkModelById(id: string): BenchmarkModelDefinition | undefined {
+  return BENCHMARK_MODELS.find((model) => model.id === id);
+}

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -176,10 +176,14 @@ export default function BenchmarkPage() {
 
           <div className="flex items-center gap-4">
             <div className="rounded-lg border border-white/5 bg-black/30 p-1">
-              <div className="px-2 pb-1 pt-1 font-mono text-[10px] uppercase tracking-wider text-zinc-500">
+              <label
+                htmlFor="benchmark-model"
+                className="block px-2 pb-1 pt-1 font-mono text-[10px] uppercase tracking-wider text-zinc-500"
+              >
                 Model
-              </div>
+              </label>
               <select
+                id="benchmark-model"
                 value={selectedModel}
                 onChange={(event) => setSelectedModel(event.target.value)}
                 className="min-w-[240px] cursor-pointer rounded border-none px-2 py-1.5 text-xs text-zinc-200 transition-colors focus:outline-none"
@@ -230,6 +234,8 @@ export default function BenchmarkPage() {
             <div className="group relative flex-1">
               <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-500/5 to-orange-500/5 opacity-0 transition-opacity duration-500 group-focus-within:opacity-100" />
               <textarea
+                id="benchmark-prompt"
+                aria-label="Benchmark prompt input"
                 className="h-full w-full resize-none rounded-xl border border-white/10 bg-black/30 p-4 font-mono text-sm leading-relaxed text-zinc-300 shadow-inner transition-all placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
                 placeholder={"Enter a prompt to start the battle...\n\ne.g. 'Write a Python script to scrape data'"}
                 value={prompt}

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -1,259 +1,328 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
-import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer, Legend } from 'recharts';
-import DiffViewer from "../components/DiffViewer";
+import { useCallback, useMemo, useState } from "react";
+import {
+  Legend,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+} from "recharts";
+
 import { apiFetch } from "@/config";
+import DiffViewer from "../components/DiffViewer";
+import InfoButton from "../components/InfoButton";
+import {
+  BENCHMARK_MODEL_GROUPS,
+  getBenchmarkModelById,
+} from "./modelCatalog";
 
 type BenchmarkPayload = {
-    raw_output: string;
-    compiled_output: string;
-    metrics: {
-        safety: { raw: number, compiled: number };
-        clarity: { raw: number, compiled: number };
-        conciseness: { raw: number, compiled: number };
-    };
-    processing_ms: number;
-    winner: "compiled" | "raw";
-    improvement_score: number;
+  raw_output: string;
+  compiled_output: string;
+  metrics: {
+    safety: { raw: number; compiled: number };
+    clarity: { raw: number; compiled: number };
+    conciseness: { raw: number; compiled: number };
+  };
+  processing_ms: number;
+  winner: "compiled" | "raw";
+  improvement_score: number;
 };
 
-import InfoButton from "../components/InfoButton";
+function buildBenchmarkErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  return "Benchmark failed. Try another model or re-run with the mock engine.";
+}
 
 export default function BenchmarkPage() {
-    const [prompt, setPrompt] = useState("");
-    const [loading, setLoading] = useState(false);
-    const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkPayload | null>(null);
-    const [selectedModel, setSelectedModel] = useState("mock");
-    const [status, setStatus] = useState("Ready");
+  const [prompt, setPrompt] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkPayload | null>(null);
+  const [selectedModel, setSelectedModel] = useState("mock");
+  const [status, setStatus] = useState("Ready");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-    // Model name mapping for the API (Groq-compatible model IDs)
-    const modelApiMap = useMemo<Record<string, string>>(() => ({
-        "llama-3.3-70b": "llama-3.3-70b-versatile",
-        "llama-3.1-8b": "llama-3.1-8b-instant",
-        "llama4-scout": "meta-llama/llama-4-scout-17b-16e-instruct",
-        "llama4-maverick": "meta-llama/llama-4-maverick-17b-128e-instruct",
-        "gpt-oss-120b": "openai/gpt-oss-120b",
-        "gpt-oss-20b": "openai/gpt-oss-20b",
-        "mistral-saba": "mistral-saba-24b",
-        "compound": "compound-beta",
-    }), []);
+  const selectedModelMeta = useMemo(
+    () => (selectedModel === "mock" ? null : getBenchmarkModelById(selectedModel)),
+    [selectedModel],
+  );
 
-    const _generateMockResult = useCallback((): BenchmarkPayload => {
-        const raw = `Here is a response to: "${prompt.slice(0, 40)}..."\n\nIt's a straightforward answer. The model tries to be helpful but might miss specific constraints or tone requirements. It generally covers the basics but lacks structure.`;
-        const compiled = `Here is an OPTIMIZED response to: "${prompt.slice(0, 40)}..."\n\n[Structure]\n1. Direct Answer\n2. Detailed Explanation\n3. Examples\n\n[Content]\nThis response is structured, follows strict constraints, and uses a professional tone. It ensures all safety guidelines are met and clarifies ambiguities before answering.`;
-        return {
-            raw_output: raw,
-            compiled_output: compiled,
-            metrics: {
-                safety: { raw: +(6 + Math.random() * 2).toFixed(1), compiled: +(9 + Math.random()).toFixed(1) },
-                clarity: { raw: +(5 + Math.random() * 2).toFixed(1), compiled: +(8 + Math.random() * 2).toFixed(1) },
-                conciseness: { raw: +(4 + Math.random() * 3).toFixed(1), compiled: +(7 + Math.random() * 2).toFixed(1) },
-            },
-            processing_ms: 850 + Math.floor(Math.random() * 400),
-            winner: "compiled",
-            improvement_score: 35,
-        };
-    }, [prompt]);
+  const generateMockResult = useCallback((): BenchmarkPayload => {
+    const promptPreview = prompt.slice(0, 40) || "your prompt";
+    const raw =
+      `Here is a response to "${promptPreview}..."\n\n` +
+      "This baseline answer is helpful but generic and lightly structured.";
+    const compiled =
+      `Here is an optimized response to "${promptPreview}..."\n\n` +
+      "1. Direct answer\n2. Constraints\n3. Examples\n\n" +
+      "The compiled version keeps tighter structure, clearer phrasing, and safer guardrails.";
 
-    const handleBenchmark = useCallback(async () => {
-        if (!prompt.trim()) return;
-        setLoading(true);
-        setStatus(`Benchmarking with ${selectedModel}...`);
-        setBenchmarkResult(null);
+    return {
+      raw_output: raw,
+      compiled_output: compiled,
+      metrics: {
+        safety: { raw: +(6 + Math.random() * 2).toFixed(1), compiled: +(9 + Math.random()).toFixed(1) },
+        clarity: { raw: +(5 + Math.random() * 2).toFixed(1), compiled: +(8 + Math.random() * 2).toFixed(1) },
+        conciseness: {
+          raw: +(4 + Math.random() * 3).toFixed(1),
+          compiled: +(7 + Math.random() * 2).toFixed(1),
+        },
+      },
+      processing_ms: 850 + Math.floor(Math.random() * 400),
+      winner: "compiled",
+      improvement_score: 35,
+    };
+  }, [prompt]);
+
+  const handleBenchmark = useCallback(async () => {
+    if (!prompt.trim()) {
+      return;
+    }
+
+    setLoading(true);
+    setBenchmarkResult(null);
+    setErrorMessage(null);
+
+    const modelLabel = selectedModelMeta?.label ?? "Mock Engine";
+    setStatus(`Benchmarking with ${modelLabel}...`);
+
+    try {
+      if (selectedModel === "mock") {
+        await new Promise((resolve) => setTimeout(resolve, 1200));
+        setBenchmarkResult(generateMockResult());
+        setStatus("Benchmark complete (Mock)");
+        return;
+      }
+
+      const response = await apiFetch("/benchmark/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: prompt.trim(), model: selectedModel }),
+      });
+
+      if (!response.ok) {
+        let detail = "Benchmark failed. Try another model.";
 
         try {
-            // --- Mock Engine: client-side only ---
-            if (selectedModel === "mock") {
-                await new Promise((r) => setTimeout(r, 1200));
-                setBenchmarkResult(_generateMockResult());
-                setStatus("Benchmark Complete (Mock)");
-                return;
-            }
-
-            // --- Real API call ---
-            const apiModel = modelApiMap[selectedModel] || selectedModel;
-            const res = await apiFetch("/benchmark/run", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ text: prompt, model: apiModel }),
-            });
-
-            if (!res.ok) {
-                const detail = await res.text().catch(() => "Unknown error");
-                throw new Error(`API ${res.status}: ${detail}`);
-            }
-
-            const data = await res.json();
-            setBenchmarkResult({
-                raw_output: data.raw_output,
-                compiled_output: data.compiled_output,
-                metrics: data.metrics,
-                processing_ms: data.processing_ms,
-                winner: data.winner,
-                improvement_score: data.improvement_score,
-            });
-            setStatus(`Benchmark Complete (${data.processing_ms}ms)`);
-
-        } catch (e: unknown) {
-            console.warn("Benchmark API error, falling back to mock:", e instanceof Error ? e.message : String(e));
-            setBenchmarkResult(_generateMockResult());
-            setStatus("Benchmark Complete (Fallback Mock)");
-        } finally {
-            setLoading(false);
+          const payload = (await response.json()) as { detail?: string };
+          if (typeof payload.detail === "string" && payload.detail.trim()) {
+            detail = payload.detail;
+          }
+        } catch {
+          // Keep the generic message when the payload is not JSON.
         }
-    }, [prompt, selectedModel, _generateMockResult, modelApiMap]);
 
-    const chartData = useMemo(() => {
-        if (!benchmarkResult) return [];
-        return [
-            { subject: 'Safety', A: benchmarkResult.metrics.safety.raw, B: benchmarkResult.metrics.safety.compiled, fullMark: 10 },
-            { subject: 'Clarity', A: benchmarkResult.metrics.clarity.raw, B: benchmarkResult.metrics.clarity.compiled, fullMark: 10 },
-            { subject: 'Conciseness', A: benchmarkResult.metrics.conciseness.raw, B: benchmarkResult.metrics.conciseness.compiled, fullMark: 10 },
-        ];
-    }, [benchmarkResult]);
+        throw new Error(detail);
+      }
 
-    return (
-        <main className="flex h-screen flex-col items-center justify-center p-4 md:p-8 relative overflow-hidden bg-[#050505]">
-            <div className="absolute top-[-20%] left-[-20%] w-[50vw] h-[50vw] rounded-full bg-amber-600/10 blur-[150px] pointer-events-none" />
-            <div className="absolute bottom-[-20%] right-[-20%] w-[50vw] h-[50vw] rounded-full bg-orange-600/10 blur-[150px] pointer-events-none" />
+      const data = (await response.json()) as BenchmarkPayload;
+      setBenchmarkResult(data);
+      setStatus(`Benchmark complete (${data.processing_ms}ms)`);
+    } catch (error) {
+      setStatus("Benchmark failed");
+      setErrorMessage(buildBenchmarkErrorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [generateMockResult, prompt, selectedModel, selectedModelMeta]);
 
-            {/* Container */}
-            <div className="glass w-full max-w-7xl h-full max-h-[95vh] rounded-3xl flex flex-col shadow-2xl overflow-hidden ring-1 ring-white/10 z-10">
+  const chartData = useMemo(() => {
+    if (!benchmarkResult) {
+      return [];
+    }
 
-                {/* Header */}
-                <header className="border-b border-white/5 bg-black/40 p-4 flex items-center justify-between backdrop-blur-md shrink-0">
-                    <div className="flex items-center gap-4">
-                        <div className="flex items-center gap-4">
-                            <div className="h-10 w-10 bg-gradient-to-br from-amber-600 to-orange-600 rounded-xl flex items-center justify-center font-bold text-white shadow-lg shadow-amber-500/20 text-xl">⚡</div>
-                            <div>
-                                <h1 className="font-bold text-xl tracking-tight text-white/90">Battle Arena</h1>
-                                <div className="text-[10px] text-zinc-500 font-mono tracking-wider uppercase">Raw vs Compiled Benchmark</div>
-                            </div>
-                        </div>
-                        <InfoButton
-                            title="Benchmark Suite"
-                            description="Run automated tests across multiple LLM models to evaluate the effectiveness and token efficiency of your compiled prompts."
-                        />
-                    </div>
+    return [
+      { subject: "Safety", A: benchmarkResult.metrics.safety.raw, B: benchmarkResult.metrics.safety.compiled, fullMark: 10 },
+      { subject: "Clarity", A: benchmarkResult.metrics.clarity.raw, B: benchmarkResult.metrics.clarity.compiled, fullMark: 10 },
+      {
+        subject: "Conciseness",
+        A: benchmarkResult.metrics.conciseness.raw,
+        B: benchmarkResult.metrics.conciseness.compiled,
+        fullMark: 10,
+      },
+    ];
+  }, [benchmarkResult]);
 
-                    <div className="flex items-center gap-4">
-                        {/* Model Selector */}
-                        <div className="flex items-center gap-2 bg-black/30 rounded-lg p-1 border border-white/5">
-                            <span className="text-[10px] font-medium text-zinc-500 uppercase px-2">Model</span>
-                            <select
-                                value={selectedModel}
-                                onChange={(e) => setSelectedModel(e.target.value)}
-                                className="text-xs text-zinc-200 rounded px-2 py-1.5 focus:outline-none border-none cursor-pointer transition-colors"
-                                style={{ backgroundColor: "#1a1a1a" }}
-                            >
-                                <option value="mock" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>🧪 Mock Engine</option>
-                                <optgroup label="── Meta Llama ──" style={{ backgroundColor: "#1a1a1a", color: "#888" }}>
-                                    <option value="llama-3.3-70b" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>🦙 Llama 3.3 70B</option>
-                                    <option value="llama-3.1-8b" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>⚡ Llama 3.1 8B (Fast)</option>
-                                    <option value="llama4-scout" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>🔭 Llama 4 Scout</option>
-                                    <option value="llama4-maverick" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>🚀 Llama 4 Maverick</option>
-                                </optgroup>
-                                <optgroup label="── OpenAI GPT-OSS ──" style={{ backgroundColor: "#1a1a1a", color: "#888" }}>
-                                    <option value="gpt-oss-120b" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>🧠 GPT-OSS 120B</option>
-                                    <option value="gpt-oss-20b" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>💡 GPT-OSS 20B</option>
-                                </optgroup>
-                                <optgroup label="── Other ──" style={{ backgroundColor: "#1a1a1a", color: "#888" }}>
-                                    <option value="mistral-saba" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>🌊 Mistral Saba 24B</option>
-                                    <option value="compound" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>🔮 Groq Compound</option>
-                                </optgroup>
-                            </select>
-                        </div>
+  return (
+    <main className="relative flex h-screen flex-col items-center justify-center overflow-hidden bg-[#050505] p-4 md:p-8">
+      <div className="pointer-events-none absolute left-[-20%] top-[-20%] h-[50vw] w-[50vw] rounded-full bg-amber-600/10 blur-[150px]" />
+      <div className="pointer-events-none absolute bottom-[-20%] right-[-20%] h-[50vw] w-[50vw] rounded-full bg-orange-600/10 blur-[150px]" />
 
-                        <div className="px-3 py-1.5 rounded-full text-xs font-bold border flex items-center gap-2 bg-amber-500/10 border-amber-500/30 text-amber-400">
-                            {status}
-                        </div>
-                    </div>
-                </header>
-
-                <div className="flex-1 flex overflow-hidden">
-                    {/* Left: Controls & Input */}
-                    <div className="w-[350px] flex flex-col border-r border-white/5 bg-black/20 p-5 gap-5 shrink-0 z-20">
-                        <div className="flex-1 relative group">
-                            <div className="absolute inset-0 bg-gradient-to-br from-amber-500/5 to-orange-500/5 rounded-2xl pointer-events-none opacity-0 group-focus-within:opacity-100 transition-opacity duration-500" />
-                            <textarea
-                                className="w-full h-full bg-black/30 p-4 rounded-xl border border-white/10 resize-none focus:outline-none focus:ring-1 focus:ring-amber-500/50 font-mono text-sm leading-relaxed text-zinc-300 placeholder-zinc-600 transition-all shadow-inner"
-                                placeholder="Enter a prompt to start the battle...&#10;&#10;e.g. 'Write a python script to scrape data'"
-                                value={prompt}
-                                onChange={(e) => setPrompt(e.target.value)}
-                            />
-                        </div>
-                        <button
-                            onClick={handleBenchmark}
-                            disabled={loading || !prompt.trim()}
-                            className="w-full py-4 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-500 hover:to-orange-500 shadow-amber-500/20"
-                        >
-                            {loading ? <span className="animate-pulse">FIGHTING...</span> : "START BATTLE ⚡"}
-                        </button>
-                    </div>
-
-                    {/* Right: Visualization */}
-                    <div className="flex-1 flex flex-col bg-black/10 relative overflow-hidden">
-                        {benchmarkResult ? (
-                            <div className="flex-1 flex flex-col h-full overflow-hidden">
-                                {/* Top Half: Visuals */}
-                                <div className="h-[40%] min-h-[300px] border-b border-white/5 flex">
-                                    {/* Metrics Chart */}
-                                    <div className="flex-1 p-4 relative flex items-center justify-center">
-                                        <h3 className="absolute top-4 left-4 text-xs font-semibold text-zinc-500 uppercase">Performance Radar</h3>
-                                        <div className="w-full h-full max-w-[400px]">
-                                            <ResponsiveContainer width="100%" height="100%">
-                                                <RadarChart outerRadius="70%" data={chartData}>
-                                                    <PolarGrid stroke="rgba(255,255,255,0.1)" />
-                                                    <PolarAngleAxis dataKey="subject" tick={{ fill: '#71717a', fontSize: 10 }} />
-                                                    <PolarRadiusAxis angle={30} domain={[0, 10]} tick={false} axisLine={false} />
-                                                    <Radar name="Raw" dataKey="A" stroke="#f59e0b" fill="#f59e0b" fillOpacity={0.3} />
-                                                    <Radar name="Compiled" dataKey="B" stroke="#10b981" fill="#10b981" fillOpacity={0.4} />
-                                                    <Legend wrapperStyle={{ fontSize: '12px', paddingTop: '10px' }} />
-                                                </RadarChart>
-                                            </ResponsiveContainer>
-                                        </div>
-                                    </div>
-
-                                    {/* Winner Stats */}
-                                    <div className="w-[300px] border-l border-white/5 bg-black/10 p-6 flex flex-col items-center justify-center gap-4">
-                                        <div className="text-center space-y-1">
-                                            <div className="text-xs font-mono text-zinc-500 uppercase">Winner</div>
-                                            <div className={`text-2xl font-black tracking-tighter ${benchmarkResult.winner === 'compiled' ? 'text-emerald-400' : 'text-amber-400'}`}>
-                                                {benchmarkResult.winner === 'compiled' ? "COMPILED PROMPT" : "RAW PROMPT"}
-                                            </div>
-                                        </div>
-
-                                        <div className="w-full h-px bg-white/10" />
-
-                                        <div className="text-center space-y-1">
-                                            <div className="text-xs font-mono text-zinc-500 uppercase">Improvement</div>
-                                            <div className="text-4xl font-black text-emerald-400 drop-shadow-lg">
-                                                +{benchmarkResult.improvement_score}%
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {/* Bottom Half: Diff Viewer */}
-                                <div className="flex-1 flex flex-col min-h-0 bg-black/20">
-                                    <div className="flex-1 overflow-hidden p-4">
-                                        <DiffViewer oldText={benchmarkResult.raw_output} newText={benchmarkResult.compiled_output} />
-                                    </div>
-                                </div>
-                            </div>
-                        ) : (
-                            <div className="flex-1 flex flex-col items-center justify-center text-zinc-600 gap-6 p-10 text-center opacity-40">
-                                <div className="text-6xl filter drop-shadow-2xl">⚡</div>
-                                <div className="max-w-xs space-y-2">
-                                    <h3 className="text-zinc-300 font-medium tracking-wide">Battle Arena Empty</h3>
-                                    <p className="text-sm text-zinc-500">Enter a prompt and select a model to see the visual comparison.</p>
-                                </div>
-                            </div>
-                        )}
-                    </div>
+      <div className="glass animate-fade-in z-10 flex h-full max-h-[95vh] w-full max-w-7xl flex-col overflow-hidden rounded-3xl shadow-2xl ring-1 ring-white/10">
+        <header className="flex shrink-0 items-center justify-between border-b border-white/5 bg-black/40 p-4 backdrop-blur-md">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-amber-600 to-orange-600 text-xl font-bold text-white shadow-lg shadow-amber-500/20">
+                B
+              </div>
+              <div>
+                <h1 className="text-xl font-bold tracking-tight text-white/90">Battle Arena</h1>
+                <div className="font-mono text-[10px] uppercase tracking-wider text-zinc-500">
+                  Raw vs Compiled Benchmark
                 </div>
+              </div>
             </div>
-        </main>
-    );
+            <InfoButton
+              title="Benchmark Suite"
+              description="Run automated tests across multiple LLM models to evaluate the effectiveness and token efficiency of your compiled prompts."
+            />
+          </div>
+
+          <div className="flex items-center gap-4">
+            <div className="rounded-lg border border-white/5 bg-black/30 p-1">
+              <div className="px-2 pb-1 pt-1 font-mono text-[10px] uppercase tracking-wider text-zinc-500">
+                Model
+              </div>
+              <select
+                value={selectedModel}
+                onChange={(event) => setSelectedModel(event.target.value)}
+                className="min-w-[240px] cursor-pointer rounded border-none px-2 py-1.5 text-xs text-zinc-200 transition-colors focus:outline-none"
+                style={{ backgroundColor: "#1a1a1a" }}
+              >
+                <option value="mock" style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}>
+                  Mock Engine [local]
+                </option>
+                {BENCHMARK_MODEL_GROUPS.map((group) => (
+                  <optgroup
+                    key={group.label}
+                    label={`-- ${group.label} --`}
+                    style={{ backgroundColor: "#1a1a1a", color: "#888" }}
+                  >
+                    {group.options.map((model) => (
+                      <option
+                        key={model.id}
+                        value={model.id}
+                        style={{ backgroundColor: "#1a1a1a", color: "#e4e4e7" }}
+                      >
+                        {`${model.label} [${model.badge}]`}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+              <p className="px-2 pb-1 pt-2 text-[11px] text-zinc-500">
+                {selectedModel === "mock"
+                  ? "Client-side mock engine for instant UI previews."
+                  : selectedModelMeta?.helperText}
+              </p>
+            </div>
+
+            <div
+              className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-bold ${
+                errorMessage
+                  ? "border-red-500/30 bg-red-500/10 text-red-300"
+                  : "border-amber-500/30 bg-amber-500/10 text-amber-400"
+              }`}
+            >
+              {status}
+            </div>
+          </div>
+        </header>
+
+        <div className="flex flex-1 overflow-hidden">
+          <div className="z-20 flex w-[350px] shrink-0 flex-col gap-5 border-r border-white/5 bg-black/20 p-5">
+            <div className="group relative flex-1">
+              <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-500/5 to-orange-500/5 opacity-0 transition-opacity duration-500 group-focus-within:opacity-100" />
+              <textarea
+                className="h-full w-full resize-none rounded-xl border border-white/10 bg-black/30 p-4 font-mono text-sm leading-relaxed text-zinc-300 shadow-inner transition-all placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
+                placeholder={"Enter a prompt to start the battle...\n\ne.g. 'Write a Python script to scrape data'"}
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+              />
+            </div>
+
+            <button
+              onClick={handleBenchmark}
+              disabled={loading || !prompt.trim()}
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 hover:from-amber-500 hover:to-orange-500"
+            >
+              {loading ? <span className="animate-pulse">FIGHTING...</span> : "START BATTLE"}
+            </button>
+
+            {errorMessage && (
+              <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-200">
+                {errorMessage}
+              </div>
+            )}
+          </div>
+
+          <div className="relative flex flex-1 flex-col overflow-hidden bg-black/10">
+            {benchmarkResult ? (
+              <div className="flex h-full flex-1 flex-col overflow-hidden animate-fade-in">
+                <div className="flex h-[40%] min-h-[300px] border-b border-white/5">
+                  <div className="relative flex flex-1 items-center justify-center p-4">
+                    <h3 className="absolute left-4 top-4 text-xs font-semibold uppercase text-zinc-500">
+                      Performance Radar
+                    </h3>
+                    <div className="h-full w-full max-w-[400px]">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <RadarChart outerRadius="70%" data={chartData}>
+                          <PolarGrid stroke="rgba(255,255,255,0.1)" />
+                          <PolarAngleAxis dataKey="subject" tick={{ fill: "#71717a", fontSize: 10 }} />
+                          <PolarRadiusAxis angle={30} domain={[0, 10]} tick={false} axisLine={false} />
+                          <Radar name="Raw" dataKey="A" stroke="#f59e0b" fill="#f59e0b" fillOpacity={0.3} />
+                          <Radar name="Compiled" dataKey="B" stroke="#10b981" fill="#10b981" fillOpacity={0.4} />
+                          <Legend wrapperStyle={{ fontSize: "12px", paddingTop: "10px" }} />
+                        </RadarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </div>
+
+                  <div className="flex w-[300px] flex-col items-center justify-center gap-4 border-l border-white/5 bg-black/10 p-6">
+                    <div className="space-y-1 text-center">
+                      <div className="font-mono text-xs uppercase text-zinc-500">Winner</div>
+                      <div
+                        className={`text-2xl font-black tracking-tighter ${
+                          benchmarkResult.winner === "compiled" ? "text-emerald-400" : "text-amber-400"
+                        }`}
+                      >
+                        {benchmarkResult.winner === "compiled" ? "COMPILED PROMPT" : "RAW PROMPT"}
+                      </div>
+                    </div>
+
+                    <div className="h-px w-full bg-white/10" />
+
+                    <div className="space-y-1 text-center">
+                      <div className="font-mono text-xs uppercase text-zinc-500">Improvement</div>
+                      <div className="text-4xl font-black text-emerald-400 drop-shadow-lg">
+                        +{benchmarkResult.improvement_score}%
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex min-h-0 flex-1 flex-col bg-black/20">
+                  <div className="flex-1 overflow-hidden p-4">
+                    <DiffViewer oldText={benchmarkResult.raw_output} newText={benchmarkResult.compiled_output} />
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-1 flex-col items-center justify-center gap-6 p-10 text-center opacity-60 animate-fade-in">
+                <div className={`text-6xl drop-shadow-2xl ${errorMessage ? "text-red-300" : "text-zinc-500"}`}>
+                  {errorMessage ? "!" : "B"}
+                </div>
+                <div className="max-w-xs space-y-2">
+                  <h3 className="font-medium tracking-wide text-zinc-300">
+                    {errorMessage ? "Benchmark unavailable" : "Battle Arena Empty"}
+                  </h3>
+                  <p className="text-sm text-zinc-500">
+                    {errorMessage
+                      ? errorMessage
+                      : "Enter a prompt and select a model to see the visual comparison."}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- add the shared benchmark page entrance animation, move models into a typed catalog, and remove the deprecated Maverick option
- route the selected benchmark model through backend validation for both raw and compiled generations, with safe provider errors and regression coverage
- harden the extension config flow by removing bundled secrets and add popup preview/history/restore controls while keeping the chat-bar optimize action single-click

## Test Plan
- python -m pytest tests/test_benchmark_api.py -q
- node --test extension/popup-preview.test.mjs extension/preview-history.test.mjs extension/config.test.mjs
- node --test web/app/benchmark/modelCatalog.test.mts
- node --check extension/background.js
- node --check extension/popup.js
- npm run lint
- npm run build