### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile regexes in pick_persona

### DIFF
--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -201,17 +201,18 @@ PERSONA_KEYWORDS = {
 
 # Bolt Optimization: Pre-compile regexes for developer persona
 _COMPILED_DEV_PATS = [re.compile(p) for p in PERSONA_KEYWORDS["developer"]]
+_COMPILED_PERSONA_KEYWORDS = {k: [re.compile(p) for p in v] for k, v in PERSONA_KEYWORDS.items()}
 
 
 def pick_persona(text: str) -> tuple[str, dict]:
     lower = text.lower()
     scores = {k: 0 for k in PERSONA_KEYWORDS}
     evidence: dict[str, list[str]] = {k: [] for k in PERSONA_KEYWORDS}
-    for persona, pats in PERSONA_KEYWORDS.items():
+    for persona, pats in _COMPILED_PERSONA_KEYWORDS.items():
         for p in pats:
-            if re.search(p, lower):
+            if p.search(lower):
                 scores[persona] += 1
-                evidence[persona].append(p)
+                evidence[persona].append(p.pattern)
     # choose highest score, tie -> deterministic alphabetical order of persona key
     ranked = sorted(scores.items(), key=lambda x: (-x[1], x[0]))
     if ranked and ranked[0][1] > 0:


### PR DESCRIPTION
💡 **What:**
Pre-compiled the regex patterns for `PERSONA_KEYWORDS` at the module level in `app/heuristics/__init__.py`. The `pick_persona` function now uses these pre-compiled regex objects (`_COMPILED_PERSONA_KEYWORDS`) and calls `p.search(lower)` inside its iteration loop rather than calling the top-level `re.search(p, lower)` method for each string pattern.

🎯 **Why:**
Calling `re.search` inside a loop requires Python to look up the string pattern in its internal regex compilation cache on every iteration. While fast, this cache lookup adds unnecessary overhead in hot paths compared to executing `.search()` directly on an already-compiled `re.Pattern` object. By pre-compiling the entire `PERSONA_KEYWORDS` dictionary once at module load time, we bypass this cache lookup entirely, making the string matching loops faster and more efficient without altering the functional semantics.

📊 **Impact:**
Micro-optimization: slightly reduces the CPU overhead of processing heuristic triggers inside `pick_persona` by avoiding internal dictionary lookups in the `re` module cache for every persona keyword evaluated.

🔬 **Measurement:**
The code structure guarantees the overhead removal. The functionality was verified by running `python -m pytest tests/heuristics/` and `pytest tests/ -n 4` which all successfully pass, showing exact semantic preservation (since `p.pattern` is correctly stored in the evidence list).

---
*PR created automatically by Jules for task [13841939694576210617](https://jules.google.com/task/13841939694576210617) started by @madara88645*