### PR TITLE
🧪 Add tests for `parse_pdf` in `app/rag/parsers.py`

### DIFF
--- a/tests/test_rag_parsers.py
+++ b/tests/test_rag_parsers.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from app.rag.parsers import (
     can_parse,
@@ -99,3 +100,99 @@ def test_can_parse():
     assert can_parse(Path("test.docx")) is True
     assert can_parse(Path("test.unknown_extension")) is False
     assert can_parse(Path("no_extension")) is False
+
+
+def test_parse_pdf_fitz_success(tmp_path):
+    from app.rag.parsers import parse_pdf
+
+    # Create a dummy file
+    test_pdf = tmp_path / "test.pdf"
+    test_pdf.touch()
+
+    # Mock fitz (PyMuPDF)
+    mock_fitz = MagicMock()
+    mock_doc = MagicMock()
+
+    # Mock 2 pages
+    mock_page_1 = MagicMock()
+    mock_page_1.get_text.return_value = "Page 1 content."
+    mock_page_2 = MagicMock()
+    mock_page_2.get_text.return_value = "Page 2 content."
+
+    # Set up len(doc)
+    mock_doc.__len__.return_value = 2
+    # Set up iteration over doc
+    mock_doc.__iter__.return_value = iter([mock_page_1, mock_page_2])
+
+    mock_fitz.open.return_value = mock_doc
+
+    with patch.dict(sys.modules, {"fitz": mock_fitz}):
+        result = parse_pdf(test_pdf)
+
+    assert "Page 1 content." in result.content
+    assert "Page 2 content." in result.content
+    assert result.page_count == 2
+    assert result.metadata["format"] == "pdf"
+    assert result.metadata["parser"] == "pymupdf"
+    assert result.metadata["page_count"] == 2
+    assert result.metadata["pages_with_text"] == 2
+    mock_fitz.open.assert_called_once_with(str(test_pdf))
+    mock_doc.close.assert_called_once()
+
+
+def test_parse_pdf_pdfplumber_success(tmp_path):
+    from app.rag.parsers import parse_pdf
+
+    test_pdf = tmp_path / "test.pdf"
+    test_pdf.touch()
+
+    # Mock pdfplumber
+    mock_pdfplumber = MagicMock()
+    mock_pdf = MagicMock()
+
+    # Mock pages
+    mock_page = MagicMock()
+    mock_page.extract_text.return_value = "Plumber page content."
+    mock_pdf.pages = [mock_page]
+
+    # Set up context manager
+    mock_pdfplumber.open.return_value.__enter__.return_value = mock_pdf
+
+    # Patch fitz to raise ImportError, and patch pdfplumber
+    with patch.dict(sys.modules, {"fitz": None, "pdfplumber": mock_pdfplumber}):
+        result = parse_pdf(test_pdf)
+
+    assert "Plumber page content." in result.content
+    assert result.page_count == 1
+    assert result.metadata["format"] == "pdf"
+    assert result.metadata["parser"] == "pdfplumber"
+    mock_pdfplumber.open.assert_called_once_with(str(test_pdf))
+
+
+def test_parse_pdf_no_parsers(tmp_path):
+    from app.rag.parsers import parse_pdf
+
+    test_pdf = tmp_path / "test.pdf"
+    test_pdf.touch()
+
+    with patch.dict(sys.modules, {"fitz": None, "pdfplumber": None}):
+        result = parse_pdf(test_pdf)
+
+    assert result.content == ""
+    assert "No PDF parser available" in result.metadata["error"]
+
+
+def test_parse_pdf_exception_handling(tmp_path):
+    from app.rag.parsers import parse_pdf
+
+    test_pdf = tmp_path / "test.pdf"
+    test_pdf.touch()
+
+    mock_fitz = MagicMock()
+    mock_fitz.open.side_effect = Exception("Corrupt PDF file")
+
+    with patch.dict(sys.modules, {"fitz": mock_fitz}):
+        result = parse_pdf(test_pdf)
+
+    assert result.content == ""
+    assert result.metadata["error"] == "Corrupt PDF file"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing tests for `parse_pdf` in `app/rag/parsers.py`.
📊 **Coverage:** Covered successful parsing scenarios with both `fitz` and `pdfplumber`, testing behavior when neither parser is available, and an exception handling scenario during PDF opening.
✨ **Result:** Improved test coverage, ensuring `parse_pdf` logic executes without missing or failing fallback cases, contributing to the robustness of the RAG pipeline.

---
*PR created automatically by Jules for task [1341455339482758352](https://jules.google.com/task/1341455339482758352) started by @madara88645*