### PR TITLE
🧪 Add error handling and auth tests for Jules reply endpoint

### DIFF
--- a/tests/test_jules_api.py
+++ b/tests/test_jules_api.py
@@ -132,6 +132,7 @@ def test_jules_reply_endpoint_passes_session_context_into_generation():
     assert kwargs["session_title"] == "Compiler smoke test"
     assert kwargs["session_prompt"] == "Inspect the repo and answer the current agent question."
 
+
 @pytest.mark.auth_required
 def test_jules_reply_endpoint_requires_auth():
     client = TestClient(app)
@@ -139,6 +140,7 @@ def test_jules_reply_endpoint_requires_auth():
     response = client.post("/jules/sessions/session-123/reply", json={"instruction": "Be concise"})
 
     assert response.status_code == 403
+
 
 def test_jules_reply_endpoint_missing_agent_activity():
     activities = {
@@ -164,6 +166,7 @@ def test_jules_reply_endpoint_missing_agent_activity():
     assert response.status_code == 404
     assert response.json()["detail"] == "No agent message found in session activities."
 
+
 def test_jules_reply_endpoint_client_runtime_error():
     with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
         "app.routers.jules.JulesClient"
@@ -180,6 +183,7 @@ def test_jules_reply_endpoint_client_runtime_error():
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Failed to connect"
+
 
 def test_jules_reply_endpoint_client_generic_error():
     with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(

--- a/tests/test_jules_api.py
+++ b/tests/test_jules_api.py
@@ -131,3 +131,69 @@ def test_jules_reply_endpoint_passes_session_context_into_generation():
     kwargs = mock_reply.call_args.kwargs
     assert kwargs["session_title"] == "Compiler smoke test"
     assert kwargs["session_prompt"] == "Inspect the repo and answer the current agent question."
+
+@pytest.mark.auth_required
+def test_jules_reply_endpoint_requires_auth():
+    client = TestClient(app)
+
+    response = client.post("/jules/sessions/session-123/reply", json={"instruction": "Be concise"})
+
+    assert response.status_code == 403
+
+def test_jules_reply_endpoint_missing_agent_activity():
+    activities = {
+        "activities": [
+            {"id": "u1", "originator": "user", "progressUpdated": {"title": "Manual answer"}},
+        ]
+    }
+
+    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
+        "app.routers.jules.JulesClient"
+    ) as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.list_activities.return_value = activities
+        mock_client.get_session.return_value = {}
+
+        client = TestClient(app)
+        response = client.post(
+            "/jules/sessions/session-123/reply",
+            json={"instruction": "Be concise"},
+            headers=_auth_headers(),
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "No agent message found in session activities."
+
+def test_jules_reply_endpoint_client_runtime_error():
+    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
+        "app.routers.jules.JulesClient"
+    ) as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.get_session.side_effect = RuntimeError("Failed to connect")
+
+        client = TestClient(app)
+        response = client.post(
+            "/jules/sessions/session-123/reply",
+            json={"instruction": "Be concise"},
+            headers=_auth_headers(),
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to connect"
+
+def test_jules_reply_endpoint_client_generic_error():
+    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
+        "app.routers.jules.JulesClient"
+    ) as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.get_session.side_effect = Exception("Unknown failure")
+
+        client = TestClient(app)
+        response = client.post(
+            "/jules/sessions/session-123/reply",
+            json={"instruction": "Be concise"},
+            headers=_auth_headers(),
+        )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Failed to reply to Jules session."


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `/sessions/{session_id}/reply` endpoint lacked coverage for error handling and authentication edge cases.

📊 **Coverage:** What scenarios are now tested
- 403 Forbidden response when API key is missing or invalid.
- 404 Not Found response when no agent messages are present in session activities.
- 500 Internal Server Error handling when `JulesClient` raises a `RuntimeError`.
- 502 Bad Gateway handling when `JulesClient` raises an unexpected `Exception`.

✨ **Result:** The improvement in test coverage
Increased test reliability by ensuring the endpoint gracefully handles edge cases and dependencies failures, making future refactoring safer.

---
*PR created automatically by Jules for task [17926904131700829428](https://jules.google.com/task/17926904131700829428) started by @madara88645*