### PR TITLE
🧪 [test] Improve coverage for `parse_file` in RAG parsers

### DIFF
--- a/tests/test_rag_parsers.py
+++ b/tests/test_rag_parsers.py
@@ -8,6 +8,7 @@ from app.rag.parsers import (
     get_supported_extensions,
     parse_yaml,
     parse_yaml_file,
+    parse_file,
     ParseResult,
 )
 
@@ -99,3 +100,50 @@ def test_can_parse():
     assert can_parse(Path("test.docx")) is True
     assert can_parse(Path("test.unknown_extension")) is False
     assert can_parse(Path("no_extension")) is False
+
+
+def test_parse_file_not_exists(tmp_path):
+    non_existent_path = tmp_path / "does_not_exist.txt"
+    result = parse_file(non_existent_path)
+    assert result.content == ""
+    assert "error" in result.metadata
+    assert "File not found" in result.metadata["error"]
+
+
+def test_parse_file_registered_parser(tmp_path):
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("Hello, world!")
+    result = parse_file(test_file)
+    assert result.content == "Hello, world!"
+    assert result.metadata["format"] == "plain_text"
+    assert result.metadata["extension"] == ".txt"
+
+
+def test_parse_file_unknown_fallback_true(tmp_path):
+    test_file = tmp_path / "test.unknown_extension"
+    test_file.write_text("Hello, world!")
+    result = parse_file(test_file, fallback_to_text=True)
+    assert result.content == "Hello, world!"
+    assert result.metadata["format"] == "plain_text"
+    assert result.metadata["extension"] == ".unknown_extension"
+
+
+def test_parse_file_unknown_fallback_false(tmp_path):
+    test_file = tmp_path / "test.unknown_extension"
+    test_file.write_text("Hello, world!")
+    result = parse_file(test_file, fallback_to_text=False)
+    assert result.content == ""
+    assert "error" in result.metadata
+    assert "No parser registered" in result.metadata["error"]
+
+
+def test_parse_file_fallback_exception(tmp_path):
+    test_file = tmp_path / "test.unknown_extension"
+    test_file.write_text("Hello, world!")
+
+    # We mock parse_plain_text to raise an exception
+    with patch("app.rag.parsers.parse_plain_text", side_effect=Exception("Mocked error")):
+        result = parse_file(test_file, fallback_to_text=True)
+        assert result.content == ""
+        assert "error" in result.metadata
+        assert "Unable to parse file" in result.metadata["error"]


### PR DESCRIPTION
🎯 **What:** The testing gap for `app/rag/parsers.py:parse_file` has been addressed by adding a suite of unit tests.
📊 **Coverage:** The following scenarios are now covered:
- File does not exist (gracefully handles `Path.exists()` failure).
- File with a supported extension (e.g., `.txt`) routes to the correct parser.
- Unknown extensions gracefully fall back to plain text parsing (`fallback_to_text=True`).
- Unknown extensions return an error when fallback is disabled (`fallback_to_text=False`).
- The fallback parser itself handles internal exceptions.
✨ **Result:** Test coverage for `parse_file` is now robust, verifying internal registry logic, edge cases, and integrations. Code stability is improved for RAG ingestion.

---
*PR created automatically by Jules for task [15536708996045526865](https://jules.google.com/task/15536708996045526865) started by @madara88645*