### PR TITLE
🧪 [Testing improvement for parse_yaml]

### DIFF
--- a/tests/test_rag_parsers.py
+++ b/tests/test_rag_parsers.py
@@ -46,6 +46,27 @@ def test_parse_yaml_import_error():
         assert result == yaml_str
 
 
+def test_parse_yaml_import_error_bytes():
+    yaml_bytes = b"key: value\nnumber: 42"
+    # Simulate ImportError for 'yaml' with bytes content
+    with patch.dict(sys.modules, {"yaml": None}):
+        result = parse_yaml(yaml_bytes)
+        # Should decode the bytes and fall back to returning the original plain text content
+        assert result == "key: value\nnumber: 42"
+
+
+def test_parse_yaml_empty_string():
+    # Empty string should return empty string since parsed will be None
+    result = parse_yaml("")
+    assert result == ""
+
+
+def test_parse_yaml_empty_bytes():
+    # Empty bytes should return empty string since parsed will be None
+    result = parse_yaml(b"")
+    assert result == ""
+
+
 def test_parse_yaml_file_success(tmp_path):
     yaml_content = "key: value\nnumber: 42\n"
     test_file = tmp_path / "test.yaml"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test coverage in `app/rag/parsers.py` for the `parse_yaml` function when `ImportError` occurs while processing bytes, and when parsing empty content resulting in `None`.

📊 **Coverage:** What scenarios are now tested:
- `ImportError` for `yaml` when handling `bytes` input content.
- `yaml.safe_load` returning `None` for empty string `""`.
- `yaml.safe_load` returning `None` for empty bytes `b""`.

✨ **Result:** The improvement in test coverage: Reached full test coverage for the targeted edge case branches in `parse_yaml`.

---
*PR created automatically by Jules for task [3562995725102942350](https://jules.google.com/task/3562995725102942350) started by @madara88645*