### PR TITLE
🧪 Add missing bytes ImportError test for parse_yaml

### DIFF
--- a/tests/test_rag_parsers.py
+++ b/tests/test_rag_parsers.py
@@ -99,3 +99,12 @@ def test_can_parse():
     assert can_parse(Path("test.docx")) is True
     assert can_parse(Path("test.unknown_extension")) is False
     assert can_parse(Path("no_extension")) is False
+
+
+def test_parse_yaml_bytes_import_error():
+    yaml_bytes = b"key: value\nnumber: 42"
+    # Simulate ImportError for 'yaml'
+    with patch.dict(sys.modules, {"yaml": None}):
+        result = parse_yaml(yaml_bytes)
+        # Should fall back to returning the original plain text content decoded as string
+        assert result == yaml_bytes.decode("utf-8", errors="ignore")


### PR DESCRIPTION
🎯 **What:** Added a missing test scenario `test_parse_yaml_bytes_import_error` to `tests/test_rag_parsers.py` to cover the scenario where `parse_yaml` receives a `bytes` object and the `yaml` library is unavailable (raising an `ImportError`).

📊 **Coverage:** Specifically covers the missing branch at `app/rag/parsers.py:325`, ensuring that `bytes` are properly decoded to a `utf-8` string before falling back to plain text handling when the `yaml` module is not installed. 

✨ **Result:** Improved overall test coverage for `app/rag/parsers.py` by fully covering `parse_yaml` error handling paths, solidifying the test suite for RAG parsing utilities.

---
*PR created automatically by Jules for task [17273162425718142153](https://jules.google.com/task/17273162425718142153) started by @madara88645*