### PR TITLE
🧪 Add parse_pdf tests in app/rag/parsers.py

### DIFF
--- a/tests/test_rag_parsers.py
+++ b/tests/test_rag_parsers.py
@@ -99,3 +99,113 @@ def test_can_parse():
     assert can_parse(Path("test.docx")) is True
     assert can_parse(Path("test.unknown_extension")) is False
     assert can_parse(Path("no_extension")) is False
+
+
+def test_parse_pdf_success_pymupdf(tmp_path):
+    """Test PDF parsing successfully using PyMuPDF (fitz)."""
+    import sys
+    from unittest.mock import MagicMock, patch
+    from app.rag.parsers import parse_pdf
+
+    mock_fitz = MagicMock()
+    mock_doc = MagicMock()
+
+    mock_page1 = MagicMock()
+    mock_page1.get_text.return_value = "Hello, Page 1\n"
+    mock_page2 = MagicMock()
+    mock_page2.get_text.return_value = "World, Page 2"
+
+    # Iterator support for 'for page_num, page in enumerate(doc, 1)'
+    mock_doc.__iter__.return_value = iter([mock_page1, mock_page2])
+    mock_doc.__len__.return_value = 2
+
+    mock_fitz.open.return_value = mock_doc
+
+    with patch.dict(sys.modules, {"fitz": mock_fitz}):
+        test_file = tmp_path / "test.pdf"
+        test_file.touch()
+
+        result = parse_pdf(test_file)
+
+        assert "Hello, Page 1" in result.content
+        assert "World, Page 2" in result.content
+        assert "[Page 1]" in result.content
+        assert "[Page 2]" in result.content
+
+        assert result.metadata["format"] == "pdf"
+        assert result.metadata["extension"] == ".pdf"
+        assert result.metadata["parser"] == "pymupdf"
+        assert result.metadata["page_count"] == 2
+        assert result.metadata["pages_with_text"] == 2
+
+
+def test_parse_pdf_success_pdfplumber(tmp_path):
+    """Test PDF parsing falling back to pdfplumber when fitz fails to import."""
+    import sys
+    from unittest.mock import MagicMock, patch
+    from app.rag.parsers import parse_pdf
+
+    mock_pdfplumber = MagicMock()
+    mock_pdf_context = MagicMock()
+    mock_pdf_instance = MagicMock()
+
+    mock_page1 = MagicMock()
+    mock_page1.extract_text.return_value = "Plumber Page 1"
+
+    mock_pdf_instance.pages = [mock_page1]
+
+    # Context manager support
+    mock_pdf_context.__enter__.return_value = mock_pdf_instance
+    mock_pdfplumber.open.return_value = mock_pdf_context
+
+    with patch.dict(sys.modules, {"fitz": None, "pdfplumber": mock_pdfplumber}):
+        test_file = tmp_path / "test.pdf"
+        test_file.touch()
+
+        result = parse_pdf(test_file)
+
+        assert "Plumber Page 1" in result.content
+        assert "[Page 1]" in result.content
+
+        assert result.metadata["format"] == "pdf"
+        assert result.metadata["extension"] == ".pdf"
+        assert result.metadata["parser"] == "pdfplumber"
+        assert result.metadata["page_count"] == 1
+        assert result.metadata["pages_with_text"] == 1
+
+
+def test_parse_pdf_no_parsers(tmp_path):
+    """Test PDF parsing behavior when neither fitz nor pdfplumber are available."""
+    import sys
+    from unittest.mock import patch
+    from app.rag.parsers import parse_pdf
+
+    with patch.dict(sys.modules, {"fitz": None, "pdfplumber": None}):
+        test_file = tmp_path / "test.pdf"
+        test_file.touch()
+
+        result = parse_pdf(test_file)
+
+        assert result.content == ""
+        assert result.metadata["format"] == "pdf"
+        assert "No PDF parser available" in result.metadata.get("error", "")
+
+
+def test_parse_pdf_exception(tmp_path):
+    """Test PDF parsing behavior when an unexpected exception occurs."""
+    import sys
+    from unittest.mock import MagicMock, patch
+    from app.rag.parsers import parse_pdf
+
+    mock_fitz = MagicMock()
+    mock_fitz.open.side_effect = ValueError("Corrupt PDF file")
+
+    with patch.dict(sys.modules, {"fitz": mock_fitz}):
+        test_file = tmp_path / "test.pdf"
+        test_file.touch()
+
+        result = parse_pdf(test_file)
+
+        assert result.content == ""
+        assert result.metadata["format"] == "pdf"
+        assert "Corrupt PDF file" in result.metadata.get("error", "")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `parse_pdf` function in `app/rag/parsers.py`.
📊 **Coverage:** Four scenarios are now fully tested: 
- Successful parsing using PyMuPDF (`fitz`).
- Fallback parsing using `pdfplumber` when `fitz` fails to import.
- Graceful error handling and metadata population when neither parser is available.
- Broad exception handling covering unexpected failures during parsing.
✨ **Result:** Test coverage improved for document ingestion, safely validating both successful text extraction paths and fallback behaviors without needing heavy dependency installations.

---
*PR created automatically by Jules for task [1510075995823395159](https://jules.google.com/task/1510075995823395159) started by @madara88645*