### PR TITLE
⚡ Bolt: pre-compile regex patterns in security scanner

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-03-22 - Safely Handling Monkeypatched Constants with Pre-compiled Caches
 **Learning:** When pre-compiling dictionaries of regular expressions at the module level (e.g., `_COMPILED_PATS = {k: [re.compile(p) for p in v] for k, v in PATTERNS.items()}`), do not implement fragile runtime cache-invalidation logic (like checking list lengths or comparing first elements). Such logic adds overhead, risks `IndexError` on empty lists, and fails to invalidate if internal elements change.
 **Action:** Simply iterate over the pre-compiled dictionary. If tests monkeypatch the original raw dictionary, modify those tests to explicitly `monkeypatch` the pre-compiled cache as well to ensure consistent test environments.
+
+## 2025-03-09 - Pre-compiling Regex Patterns for Performance
+**Learning:** In Python, iterating over uncompiled string patterns using `re.finditer(pattern, text)` repeatedly compiles the regex patterns on every call, leading to significant overhead in hot loops like security scanners.
+**Action:** Always pre-compile regular expressions at the module level (e.g., `COMPILED_PATTERNS = {k: re.compile(v) for k, v in PATTERNS.items()}`) and use `.finditer` directly on the compiled objects to improve performance.

--- a/app/heuristics/security.py
+++ b/app/heuristics/security.py
@@ -38,6 +38,9 @@ PATTERNS = {
     "credit_card": r"\b(?:\d[ -]*?){13,16}\b",
 }
 
+# Pre-compile regex patterns for faster scanning
+COMPILED_PATTERNS = {k: re.compile(v) for k, v in PATTERNS.items()}
+
 # Allow-list for common IP-like false positives
 IP_ALLOWLIST = {"127.0.0.1", "0.0.0.0", "192.168.0.1", "192.168.1.1", "10.0.0.1"}
 
@@ -55,8 +58,8 @@ def scan_text(text: str) -> SecurityResult:
 
     matches = []
 
-    for label, pattern in PATTERNS.items():
-        for match in re.finditer(pattern, text):
+    for label, pattern in COMPILED_PATTERNS.items():
+        for match in pattern.finditer(text):
             val = match.group(0)
 
             # Special handling for generic key to capture just the value group if present


### PR DESCRIPTION
💡 What:
Pre-compiled the regular expressions in the `PATTERNS` dictionary at the module level in `app/heuristics/security.py` and updated `scan_text` to use the `.finditer()` method directly on these compiled objects instead of relying on the `re.finditer` string method.

🎯 Why:
The `scan_text` function executes a nested loop that calls `re.finditer(pattern, text)` on string patterns. This leads to repeated overhead inside hot loops as Python has to repeatedly look up the cached regex objects. Pre-compiling them once reduces function call overhead and speeds up the entire scanning module.

📊 Impact:
In micro-benchmarks, this reduces the time spent on regex instantiation overhead within `scan_text`, optimizing performance directly inside an inner scanning loop without sacrificing readability or modifying public API structures.

🔬 Measurement:
Run `pytest tests/test_security.py` and the full test suite (`python -m pytest tests/ -n 4`) to verify that all functional correctness assertions still exactly match. The module behavior remains identical while execution time overhead decreases.

---
*PR created automatically by Jules for task [1854308463677291382](https://jules.google.com/task/1854308463677291382) started by @madara88645*