### PR TITLE
🎨 Palette: Add keyboard focus state to Battle Arena button

### DIFF
--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -246,7 +246,7 @@ export default function BenchmarkPage() {
             <button
               onClick={handleBenchmark}
               disabled={loading || !prompt.trim()}
-              className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 hover:from-amber-500 hover:to-orange-500"
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
             >
               {loading ? <span className="animate-pulse">FIGHTING...</span> : "START BATTLE"}
             </button>


### PR DESCRIPTION
### 💡 What
Added explicit `focus-visible` ring styling to the main "START BATTLE" action button in the Battle Arena benchmark page.

### 🎯 Why
Previously, the primary call-to-action button lacked a distinct visual indicator when navigated via keyboard. This made it difficult for keyboard-only users and screen readers to perceive when the element was in focus, violating accessibility standards and creating a confusing experience.

### 📸 Before/After
- **Before:** The button appearance remained largely unchanged when focused via keyboard tab navigation, relying on obscure default browser rings or being completely indistinguishable from an unfocused state.
- **After:** The button now elegantly highlights with an amber outline (`focus-visible:ring-amber-500/50`), clearly indicating focus while seamlessly matching the component's existing color palette.

### ♿ Accessibility
This micro-UX improvement enhances keyboard navigability by ensuring the primary action button has a clear, accessible focus state. It uses the `focus-visible` pseudo-class, which guarantees the focus ring only appears during keyboard navigation, preserving the clean aesthetic for mouse/touch interactions while remaining fully compliant with accessibility guidelines.

---
*PR created automatically by Jules for task [14870281176785480539](https://jules.google.com/task/14870281176785480539) started by @madara88645*