### PR TITLE
[codex] expand intent compiler coverage

### DIFF
--- a/app/_schemas/ir_v2.schema.json
+++ b/app/_schemas/ir_v2.schema.json
@@ -54,13 +54,23 @@
       "items": {
         "enum": [
           "teaching",
+          "explanation",
           "summary",
           "compare",
+          "creative",
           "variants",
+          "proposal",
+          "review",
+          "preparation",
+          "troubleshooting",
           "recency",
           "risk",
           "code",
-          "ambiguous"
+          "debug",
+          "ambiguous",
+          "capability_mismatch",
+          "decompose",
+          "summarize"
         ]
       }
     },
@@ -103,19 +113,7 @@
             "type": "string"
           },
           "priority": {
-            "enum": [
-              10,
-              20,
-              30,
-              40,
-              50,
-              60,
-              65,
-              70,
-              75,
-              80,
-              90
-            ]
+            "type": "integer"
           },
           "rationale": {
             "type": [

--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -249,6 +249,67 @@ VARIANT_KEYWORDS = [
     r"choices",
 ]
 
+CREATIVE_INTENT_KEYWORDS = [
+    "creative",
+    "story",
+    "poem",
+    "headline",
+    "tagline",
+    "launch post",
+    "copywriting",
+    "fiction",
+    "narrative",
+    "brainstorm names",
+]
+
+EXPLANATION_INTENT_KEYWORDS = [
+    "explain",
+    "walk me through",
+    "how does",
+    "how do",
+    "clarify",
+    "break down",
+    "help me understand",
+]
+
+PROPOSAL_INTENT_KEYWORDS = [
+    "proposal",
+    "propose",
+    "pitch",
+    "recommend a strategy",
+    "suggest a strategy",
+]
+
+REVIEW_INTENT_KEYWORDS = [
+    "review",
+    "critique",
+    "audit",
+    "evaluate",
+    "assess",
+    "check my",
+]
+
+PREPARATION_INTENT_KEYWORDS = [
+    "prepare me",
+    "prep me",
+    "interview prep",
+    "study plan",
+    "practice questions",
+    "mock interview",
+]
+
+TROUBLESHOOTING_INTENT_KEYWORDS = [
+    "troubleshoot",
+    "troubleshooting",
+    "diagnose",
+    "debug this",
+    "fix this error",
+    "why is this failing",
+    "why my",
+    "traceback",
+    "stack trace",
+]
+
 
 def detect_summary(text: str) -> tuple[bool, int | None]:
     lower = text.lower()
@@ -322,6 +383,35 @@ def extract_variant_count(text: str) -> int:
         # default if keyword present but no number
         return 3
     return 1
+
+
+def _contains_any_keyword(text: str, keywords: list[str]) -> bool:
+    lower = text.lower()
+    return any(keyword in lower for keyword in keywords)
+
+
+def detect_creative_intent(text: str) -> bool:
+    return _contains_any_keyword(text, CREATIVE_INTENT_KEYWORDS)
+
+
+def detect_explanation_intent(text: str) -> bool:
+    return _contains_any_keyword(text, EXPLANATION_INTENT_KEYWORDS)
+
+
+def detect_proposal_intent(text: str) -> bool:
+    return _contains_any_keyword(text, PROPOSAL_INTENT_KEYWORDS)
+
+
+def detect_review_intent(text: str) -> bool:
+    return _contains_any_keyword(text, REVIEW_INTENT_KEYWORDS)
+
+
+def detect_preparation_intent(text: str) -> bool:
+    return _contains_any_keyword(text, PREPARATION_INTENT_KEYWORDS)
+
+
+def detect_troubleshooting_intent(text: str) -> bool:
+    return detect_live_debug(text) or _contains_any_keyword(text, TROUBLESHOOTING_INTENT_KEYWORDS)
 
 
 # --- Extended heuristics (IR & heuristics expansion) ---

--- a/app/heuristics/handlers/content.py
+++ b/app/heuristics/handlers/content.py
@@ -1,4 +1,12 @@
 from .base import BaseHandler
+from app.heuristics import (
+    detect_creative_intent,
+    detect_explanation_intent,
+    detect_preparation_intent,
+    detect_proposal_intent,
+    detect_review_intent,
+    detect_troubleshooting_intent,
+)
 from app.models import IR
 from app.models_v2 import IRv2
 
@@ -6,6 +14,7 @@ from app.models_v2 import IRv2
 class ContentHandler(BaseHandler):
     def handle(self, ir_v2: IRv2, ir_v1: IR) -> None:
         md = ir_v1.metadata or {}
+        original_text = md.get("original_text", "")
 
         if md.get("summary") == "true":
             ir_v2.intents.append("summary")
@@ -24,3 +33,22 @@ class ContentHandler(BaseHandler):
 
         if "web" in (ir_v1.tools or []):
             ir_v2.intents.append("recency")
+
+        if original_text:
+            if detect_creative_intent(original_text):
+                ir_v2.intents.append("creative")
+
+            if detect_explanation_intent(original_text):
+                ir_v2.intents.append("explanation")
+
+            if detect_proposal_intent(original_text):
+                ir_v2.intents.append("proposal")
+
+            if detect_review_intent(original_text):
+                ir_v2.intents.append("review")
+
+            if detect_preparation_intent(original_text):
+                ir_v2.intents.append("preparation")
+
+            if detect_troubleshooting_intent(original_text):
+                ir_v2.intents.append("troubleshooting")

--- a/app/heuristics/handlers/deduplicator.py
+++ b/app/heuristics/handlers/deduplicator.py
@@ -52,5 +52,5 @@ class DeduplicatorHandler(BaseHandler):
                 if not normalized or normalized in seen_intents:
                     continue
                 seen_intents.add(normalized)
-                deduped_intents.append(intent)
+                deduped_intents.append(normalized)
             ir_v2.intents = deduped_intents

--- a/app/heuristics/handlers/deduplicator.py
+++ b/app/heuristics/handlers/deduplicator.py
@@ -43,3 +43,14 @@ class DeduplicatorHandler(BaseHandler):
                 for f in found[1:]:
                     if f in ir_v2.constraints:
                         ir_v2.constraints.remove(f)
+
+        if ir_v2.intents:
+            deduped_intents = []
+            seen_intents = set()
+            for intent in ir_v2.intents:
+                normalized = intent.strip().lower()
+                if not normalized or normalized in seen_intents:
+                    continue
+                seen_intents.add(normalized)
+                deduped_intents.append(intent)
+            ir_v2.intents = deduped_intents

--- a/schema/ir_v2.schema.json
+++ b/schema/ir_v2.schema.json
@@ -8,7 +8,31 @@
     "persona": { "enum": ["assistant","teacher","researcher","coach","mentor","developer"] },
     "role": { "type": "string" },
     "domain": { "type": "string" },
-    "intents": { "type": "array", "items": { "enum": ["teaching","summary","compare","variants","recency","risk","code","ambiguous"] } },
+    "intents": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "teaching",
+          "explanation",
+          "summary",
+          "compare",
+          "creative",
+          "variants",
+          "proposal",
+          "review",
+          "preparation",
+          "troubleshooting",
+          "recency",
+          "risk",
+          "code",
+          "debug",
+          "ambiguous",
+          "capability_mismatch",
+          "decompose",
+          "summarize"
+        ]
+      }
+    },
     "goals": { "type": "array", "items": { "type": "string" } },
     "tasks": { "type": "array", "items": { "type": "string" } },
     "inputs": { "type": "object", "additionalProperties": { "type": "string" } },
@@ -21,7 +45,7 @@
           "id": { "type": "string" },
           "text": { "type": "string" },
           "origin": { "type": "string" },
-          "priority": { "enum": [10,20,30,40,50,60,65,70,75,80,90] },
+          "priority": { "type": "integer" },
           "rationale": { "type": ["string","null"] }
         },
         "additionalProperties": false

--- a/tests/test_deduplicator.py
+++ b/tests/test_deduplicator.py
@@ -47,3 +47,28 @@ def test_deduplicator_removes_redundant_constraints():
     assert "No conversational filler" not in v1_texts
     assert "Output strict JSON" in v2_texts
     assert "No conversational filler" not in v2_texts
+
+
+def test_deduplicator_removes_duplicate_intents_preserving_order():
+    handler = DeduplicatorHandler()
+
+    ir_v1 = IR(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        output_format="markdown",
+        length_hint="medium",
+    )
+
+    ir_v2 = IRv2(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        intents=["code", "review", "code", "risk", "review"],
+    )
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert ir_v2.intents == ["code", "review", "risk"]

--- a/tests/test_deduplicator.py
+++ b/tests/test_deduplicator.py
@@ -72,3 +72,28 @@ def test_deduplicator_removes_duplicate_intents_preserving_order():
     handler.handle(ir_v2, ir_v1)
 
     assert ir_v2.intents == ["code", "review", "risk"]
+
+
+def test_deduplicator_normalizes_intents_while_deduping():
+    handler = DeduplicatorHandler()
+
+    ir_v1 = IR(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        output_format="markdown",
+        length_hint="medium",
+    )
+
+    ir_v2 = IRv2(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        intents=[" Code ", "review", "code", " REVIEW "],
+    )
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert ir_v2.intents == ["code", "review"]

--- a/tests/test_intent_coverage_v2.py
+++ b/tests/test_intent_coverage_v2.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+from jsonschema import validate
+
+from app.compiler import compile_text_v2
+from app.resources import get_ir_schema_text
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected_intent"),
+    [
+        ("Write a creative launch post for my AI startup", "creative"),
+        (
+            "Explain async await like I'm a beginner and give a simple Python example",
+            "explanation",
+        ),
+        ("Propose a pricing strategy for a student SaaS", "proposal"),
+        ("Prepare me for a machine learning interview", "preparation"),
+        ("Troubleshoot why my FastAPI app fails on Railway", "troubleshooting"),
+    ],
+)
+def test_ir_v2_detects_high_value_intents(prompt, expected_intent):
+    ir2 = compile_text_v2(prompt)
+
+    assert expected_intent in ir2.intents
+
+
+def test_ir_v2_code_review_keeps_multi_intent_context():
+    ir2 = compile_text_v2("Review this auth code for security vulnerabilities")
+
+    assert "code" in ir2.intents
+    assert "review" in ir2.intents
+    assert "risk" in ir2.intents
+
+
+def test_ir_v2_debug_and_troubleshooting_prompt_validates_against_schema():
+    schema = json.loads(get_ir_schema_text(v2=True))
+    ir2 = compile_text_v2("Debug this Python traceback from my repo and troubleshoot the failure")
+
+    validate(instance=ir2.model_dump(), schema=schema)
+    assert "debug" in ir2.intents
+    assert "troubleshooting" in ir2.intents

--- a/web/app/components/IntentPolicyPanel.tsx
+++ b/web/app/components/IntentPolicyPanel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { normalizeIntentPolicy } from "./intent-policy-utils";
+import type { CompileResponse } from "../../lib/api/types";
+import { humanizeIntentPolicyValue, normalizeIntentPolicy, type IntentDisplayGroup } from "./intent-policy-utils";
 
 type IntentPolicyPanelProps = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  result: any;
+  result: CompileResponse;
 };
 
 function FieldList({
@@ -37,6 +37,20 @@ function FieldList({
   );
 }
 
+function IntentGroupBadge({ group }: { group: IntentDisplayGroup }) {
+  const styles: Record<IntentDisplayGroup, string> = {
+    content: "border-cyan-400/20 bg-cyan-400/10 text-cyan-100",
+    workflow: "border-violet-400/20 bg-violet-400/10 text-violet-100",
+    risk: "border-amber-400/20 bg-amber-400/10 text-amber-100",
+  };
+
+  return (
+    <span className={`rounded-full border px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.18em] ${styles[group]}`}>
+      {group}
+    </span>
+  );
+}
+
 export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
   const intentPolicy = normalizeIntentPolicy(result);
 
@@ -54,24 +68,33 @@ export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
             </div>
             <div>
               <div className="text-xs text-zinc-500">Persona</div>
-              <div className="text-sm text-zinc-200">{intentPolicy.persona}</div>
+              <div className="text-sm text-zinc-200">{humanizeIntentPolicyValue(intentPolicy.persona)}</div>
             </div>
             <div>
               <div className="mb-2 text-xs text-zinc-500">Detected Intents</div>
-              <div className="flex flex-wrap gap-2">
-                {intentPolicy.intents.length > 0 ? (
-                  intentPolicy.intents.map((intent) => (
-                    <span
-                      key={intent}
-                      className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-3 py-1 text-xs text-cyan-100"
+              {intentPolicy.intentDetails.length > 0 ? (
+                <div className="grid gap-3">
+                  {intentPolicy.intentDetails.map((intent) => (
+                    <div
+                      key={intent.key}
+                      className="rounded-2xl border border-white/8 bg-black/20 p-3"
                     >
-                      {intent}
-                    </span>
-                  ))
-                ) : (
-                  <span className="text-sm text-zinc-500">No special intent flags.</span>
-                )}
-              </div>
+                      <div className="mb-2 flex items-center justify-between gap-3">
+                        <div className="text-sm font-semibold text-white">{intent.label}</div>
+                        <IntentGroupBadge group={intent.group} />
+                      </div>
+                      <div className="text-xs leading-relaxed text-zinc-400">{intent.description}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-4">
+                  <div className="text-sm font-medium text-white">General Request</div>
+                  <div className="mt-1 text-sm text-zinc-500">
+                    No special intent signals were inferred, so the compiler is treating this as a general-purpose request.
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -83,20 +106,22 @@ export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
               <div className="text-xs text-zinc-500">Risk Level</div>
-              <div className="mt-1 text-lg font-semibold text-white">{intentPolicy.riskLevel}</div>
+              <div className="mt-1 text-lg font-semibold text-white">{humanizeIntentPolicyValue(intentPolicy.riskLevel)}</div>
             </div>
             <div>
               <div className="text-xs text-zinc-500">Execution Mode</div>
-              <div className="mt-1 text-lg font-semibold text-white">{intentPolicy.executionMode}</div>
+              <div className="mt-1 text-lg font-semibold text-white">{humanizeIntentPolicyValue(intentPolicy.executionMode)}</div>
             </div>
             <div>
               <div className="text-xs text-zinc-500">Data Sensitivity</div>
-              <div className="mt-1 text-sm text-zinc-200">{intentPolicy.dataSensitivity}</div>
+              <div className="mt-1 text-sm text-zinc-200">{humanizeIntentPolicyValue(intentPolicy.dataSensitivity)}</div>
             </div>
             <div>
               <div className="text-xs text-zinc-500">Risk Domains</div>
               <div className="mt-1 text-sm text-zinc-200">
-                {intentPolicy.riskDomains.length > 0 ? intentPolicy.riskDomains.join(", ") : "none"}
+                {intentPolicy.riskDomains.length > 0
+                  ? intentPolicy.riskDomains.map(humanizeIntentPolicyValue).join(", ")
+                  : "None"}
               </div>
             </div>
           </div>
@@ -104,18 +129,18 @@ export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
 
         <FieldList
           title="Allowed Tools"
-          items={intentPolicy.allowedTools}
+          items={intentPolicy.allowedTools.map(humanizeIntentPolicyValue)}
           emptyLabel="No tool allowlist needed for this request."
         />
         <FieldList
           title="Forbidden Tools"
-          items={intentPolicy.forbiddenTools}
+          items={intentPolicy.forbiddenTools.map(humanizeIntentPolicyValue)}
           emptyLabel="No explicit forbidden tools inferred."
         />
         <div className="lg:col-span-2">
           <FieldList
             title="Sanitization Rules"
-            items={intentPolicy.sanitizationRules}
+            items={intentPolicy.sanitizationRules.map(humanizeIntentPolicyValue)}
             emptyLabel="No extra sanitization rules inferred."
           />
         </div>

--- a/web/app/components/intent-policy-utils.test.mts
+++ b/web/app/components/intent-policy-utils.test.mts
@@ -49,3 +49,49 @@ test("normalizeIntentPolicy falls back to legacy ir metadata when ir_v2 is absen
   assert.equal(result.executionMode, "advice_only");
   assert.deepEqual(result.riskDomains, ["security"]);
 });
+
+test("normalizeIntentPolicy returns ordered intent details with human-friendly labels", async () => {
+  const { humanizeIntentPolicyValue, normalizeIntentPolicy } = await import("./intent-policy-utils.ts");
+
+  const result = normalizeIntentPolicy({
+    ir_v2: {
+      intents: ["risk", "review", "teaching", "debug"],
+      policy: {
+        allowed_tools: ["workspace_read", "run_tests"],
+        forbidden_tools: ["write_outside_workspace"],
+        sanitization_rules: ["mask_sensitive_values"],
+        execution_mode: "human_approval_required",
+      },
+    },
+  });
+
+  assert.deepEqual(
+    result.intentDetails.map((item) => item.key),
+    ["teaching", "review", "debug", "risk"],
+  );
+  assert.equal(result.intentDetails[0]?.label, "Teaching");
+  assert.equal(result.intentDetails[1]?.description.includes("review"), true);
+  assert.equal(humanizeIntentPolicyValue(result.allowedTools[0]), "Workspace Read");
+  assert.equal(humanizeIntentPolicyValue(result.allowedTools[1]), "Run Tests");
+  assert.equal(humanizeIntentPolicyValue(result.forbiddenTools[0]), "Write Outside Workspace");
+  assert.equal(humanizeIntentPolicyValue(result.sanitizationRules[0]), "Mask Sensitive Values");
+  assert.equal(humanizeIntentPolicyValue(result.executionMode), "Human Approval Required");
+});
+
+test("normalizeIntentPolicy humanizes unknown intents without breaking", async () => {
+  const { normalizeIntentPolicy } = await import("./intent-policy-utils.ts");
+
+  const result = normalizeIntentPolicy({
+    ir_v2: {
+      intents: ["future_magic", "compare"],
+    },
+  });
+
+  assert.deepEqual(
+    result.intentDetails.map((item) => ({ key: item.key, label: item.label })),
+    [
+      { key: "compare", label: "Comparison" },
+      { key: "future_magic", label: "Future Magic" },
+    ],
+  );
+});

--- a/web/app/components/intent-policy-utils.ts
+++ b/web/app/components/intent-policy-utils.ts
@@ -23,10 +23,20 @@ type CompileResultLike = {
   ir_v2?: IRLike;
 };
 
+export type IntentDisplayGroup = "content" | "workflow" | "risk";
+
+export type IntentDetail = {
+  key: string;
+  label: string;
+  description: string;
+  group: IntentDisplayGroup;
+};
+
 export type NormalizedIntentPolicy = {
   domain: string;
   persona: string;
   intents: string[];
+  intentDetails: IntentDetail[];
   riskLevel: string;
   riskDomains: string[];
   allowedTools: string[];
@@ -38,15 +48,192 @@ export type NormalizedIntentPolicy = {
 
 const emptyList = (value: string[] | undefined) => value ?? [];
 
+const INTENT_GROUP_ORDER: Record<IntentDisplayGroup, number> = {
+  content: 0,
+  workflow: 1,
+  risk: 2,
+};
+
+const INTENT_REGISTRY: Record<
+  string,
+  Omit<IntentDetail, "key"> & { order: number }
+> = {
+  teaching: {
+    label: "Teaching",
+    description: "The request is asking for step-by-step learning support.",
+    group: "content",
+    order: 0,
+  },
+  explanation: {
+    label: "Explanation",
+    description: "The user wants a concept clarified or broken down.",
+    group: "content",
+    order: 1,
+  },
+  summary: {
+    label: "Summary",
+    description: "The request asks for a condensed version of source material.",
+    group: "content",
+    order: 2,
+  },
+  summarize: {
+    label: "Summarization",
+    description: "The prompt benefits from compressing information into a shorter form.",
+    group: "content",
+    order: 3,
+  },
+  compare: {
+    label: "Comparison",
+    description: "The user wants trade-offs, differences, or side-by-side evaluation.",
+    group: "content",
+    order: 4,
+  },
+  creative: {
+    label: "Creative",
+    description: "The output should generate original copy, ideas, or expressive content.",
+    group: "content",
+    order: 5,
+  },
+  variants: {
+    label: "Variants",
+    description: "Multiple alternative outputs are expected.",
+    group: "content",
+    order: 6,
+  },
+  proposal: {
+    label: "Proposal",
+    description: "The request is asking for a recommendation, pitch, or suggested plan.",
+    group: "workflow",
+    order: 0,
+  },
+  review: {
+    label: "Review",
+    description: "The task is centered on checking, critiquing, or reviewing something.",
+    group: "workflow",
+    order: 1,
+  },
+  preparation: {
+    label: "Preparation",
+    description: "The user is preparing for an interview, exam, or upcoming task.",
+    group: "workflow",
+    order: 2,
+  },
+  troubleshooting: {
+    label: "Troubleshooting",
+    description: "The request is focused on diagnosing and fixing a failure.",
+    group: "workflow",
+    order: 3,
+  },
+  code: {
+    label: "Code",
+    description: "The prompt involves implementation, code changes, or technical examples.",
+    group: "workflow",
+    order: 4,
+  },
+  debug: {
+    label: "Debug",
+    description: "The prompt points to live debugging, reproduction, or error investigation.",
+    group: "workflow",
+    order: 5,
+  },
+  recency: {
+    label: "Recency",
+    description: "The request depends on up-to-date or time-sensitive information.",
+    group: "workflow",
+    order: 6,
+  },
+  decompose: {
+    label: "Decomposition",
+    description: "The system detected a need to break the task into smaller steps.",
+    group: "workflow",
+    order: 7,
+  },
+  risk: {
+    label: "Risk",
+    description: "The request touches a higher-risk area that needs tighter guardrails.",
+    group: "risk",
+    order: 0,
+  },
+  capability_mismatch: {
+    label: "Capability Mismatch",
+    description: "The request may exceed the model or tool capabilities available.",
+    group: "risk",
+    order: 1,
+  },
+  ambiguous: {
+    label: "Ambiguity",
+    description: "Important details are underspecified and may require clarification.",
+    group: "risk",
+    order: 2,
+  },
+};
+
+function titleCase(value: string): string {
+  return value
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function humanizeIntentPolicyValue(value: string): string {
+  return titleCase(value.replace(/[_-]+/g, " ").trim());
+}
+
+function buildIntentDetail(intent: string): IntentDetail {
+  const entry = INTENT_REGISTRY[intent];
+  if (entry) {
+    return {
+      key: intent,
+      label: entry.label,
+      description: entry.description,
+      group: entry.group,
+    };
+  }
+
+  return {
+    key: intent,
+    label: humanizeIntentPolicyValue(intent),
+    description: "Detected from compiler heuristics; no custom explanation is registered yet.",
+    group: "workflow",
+  };
+}
+
+function getIntentOrder(intent: IntentDetail): number {
+  return INTENT_REGISTRY[intent.key]?.order ?? 999;
+}
+
+function normalizeIntentDetails(intents: string[]): IntentDetail[] {
+  const uniqueIntents = [...new Set(intents)];
+
+  return uniqueIntents
+    .map(buildIntentDetail)
+    .sort((left, right) => {
+      const groupDelta = INTENT_GROUP_ORDER[left.group] - INTENT_GROUP_ORDER[right.group];
+      if (groupDelta !== 0) {
+        return groupDelta;
+      }
+
+      const orderDelta = getIntentOrder(left) - getIntentOrder(right);
+      if (orderDelta !== 0) {
+        return orderDelta;
+      }
+
+      return left.label.localeCompare(right.label);
+    });
+}
+
 export function normalizeIntentPolicy(result: CompileResultLike): NormalizedIntentPolicy {
   const source = result.ir_v2 ?? result.ir ?? {};
   const legacyRiskFlags = emptyList(result.ir?.metadata?.risk_flags);
   const policy = source.policy ?? {};
+  const intents = emptyList(source.intents ?? result.ir?.intents);
 
   return {
     domain: source.domain ?? result.ir?.domain ?? "general",
     persona: source.persona ?? result.ir?.persona ?? "assistant",
-    intents: emptyList(source.intents ?? result.ir?.intents),
+    intents,
+    intentDetails: normalizeIntentDetails(intents),
     riskLevel:
       policy.risk_level ?? (legacyRiskFlags.length > 0 ? (legacyRiskFlags.includes("security") ? "medium" : "high") : "low"),
     riskDomains: emptyList(policy.risk_domains ?? legacyRiskFlags),

--- a/web/app/components/intent-policy-utils.ts
+++ b/web/app/components/intent-policy-utils.ts
@@ -14,8 +14,10 @@ type IRLike = {
   intents?: string[];
   metadata?: {
     risk_flags?: string[];
+    [key: string]: unknown;
   };
   policy?: PolicyLike;
+  [key: string]: unknown;
 };
 
 type CompileResultLike = {


### PR DESCRIPTION
## Summary
- expand IR v2 intent coverage with new deterministic detections for creative, explanation, proposal, review, preparation, and troubleshooting flows
- fix schema drift between emitted runtime intents and the published IR v2 schema, and dedupe intent lists while preserving order
- upgrade the compiler Intent tab with ordered intent cards, humanized policy/tool labels, and a clearer general-request fallback state

## Why
The intent compiler was correctly emitting some newer intent values at runtime, but the schema and UI still reflected an older, narrower model. That caused weak intent summaries for common prompts and let schema validation fall out of sync with real compiler output.

## Developer Impact
- backend intent heuristics now classify more real-world prompt types without changing the public API shape
- IR v2 schema validation now accepts the intents the compiler already emits in practice
- frontend intent rendering is easier to read and more resilient to future unknown intent keys

## Test Plan
- `python -m pytest tests/test_ir_v2_basic.py tests/test_intents_debug_v2.py tests/test_policy_handler.py tests/test_compile_policy_api.py tests/test_intent_coverage_v2.py tests/test_deduplicator.py -q`
- `node --test web/app/components/intent-policy-utils.test.mts web/promptc-api.test.mts`
- `web\\node_modules\\.bin\\eslint.cmd .`
