### PR TITLE
[codex] Centralize generator API key header handling

### DIFF
--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { apiFetch } from "@/config";
+import { apiFetch, buildGeneratorApiHeaders } from "@/config";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
 import ExportPanel from "./components/ExportPanel";
@@ -24,13 +24,9 @@ export default function AgentGenerator() {
     setResult(null);
 
     try {
-      const apiKey = process.env.NEXT_PUBLIC_API_KEY;
       const res = await apiFetch("/agent-generator/generate", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(apiKey ? { "x-api-key": apiKey } : {}),
-        },
+        headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({
           description,
           multi_agent: multiAgent,

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { apiFetch } from "@/config";
+import { apiFetch, buildGeneratorApiHeaders } from "@/config";
 import InfoButton from "../components/InfoButton";
 import ContextManager from "../components/ContextManager";
 import SkillExportPanel from "./components/ExportPanel";
@@ -23,13 +23,9 @@ export default function SkillsGenerator() {
     setResult(null);
 
     try {
-      const apiKey = process.env.NEXT_PUBLIC_API_KEY;
       const res = await apiFetch("/skills-generator/generate", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(apiKey ? { "x-api-key": apiKey } : {}),
-        },
+        headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({
           description,
           include_example_code: includeExampleCode,

--- a/web/config.test.mts
+++ b/web/config.test.mts
@@ -26,6 +26,28 @@ test("buildApiHeaders leaves headers unchanged when NEXT_PUBLIC_API_KEY is empty
   assert.equal(normalizedHeaders.has("x-api-key"), false);
 });
 
+test("buildGeneratorApiHeaders injects x-api-key when NEXT_PUBLIC_API_KEY is set", async () => {
+  process.env.NEXT_PUBLIC_API_KEY = "test-key";
+
+  const { buildGeneratorApiHeaders } = await import("./config.ts");
+  const headers = buildGeneratorApiHeaders({ "Content-Type": "application/json" });
+  const normalizedHeaders = new Headers(headers);
+
+  assert.equal(normalizedHeaders.get("content-type"), "application/json");
+  assert.equal(normalizedHeaders.get("x-api-key"), "test-key");
+});
+
+test("buildGeneratorApiHeaders leaves x-api-key unset when NEXT_PUBLIC_API_KEY is empty", async () => {
+  delete process.env.NEXT_PUBLIC_API_KEY;
+
+  const { buildGeneratorApiHeaders } = await import("./config.ts");
+  const headers = buildGeneratorApiHeaders({ Accept: "application/json" });
+  const normalizedHeaders = new Headers(headers);
+
+  assert.equal(normalizedHeaders.get("accept"), "application/json");
+  assert.equal(normalizedHeaders.has("x-api-key"), false);
+});
+
 test("resolveApiBase prefers same-origin in non-local browser environments when env is unset", async () => {
   delete process.env.NEXT_PUBLIC_API_URL;
 

--- a/web/config.ts
+++ b/web/config.ts
@@ -11,6 +11,17 @@ export function buildApiHeaders(headers: HeadersInit = {}): Record<string, strin
   return Object.fromEntries(mergedHeaders.entries());
 }
 
+export function buildGeneratorApiHeaders(headers: HeadersInit = {}): Record<string, string> {
+  const mergedHeaders = new Headers(buildApiHeaders(headers));
+  const apiKey = process.env.NEXT_PUBLIC_API_KEY?.trim();
+
+  if (apiKey && !mergedHeaders.has("x-api-key")) {
+    mergedHeaders.set("x-api-key", apiKey);
+  }
+
+  return Object.fromEntries(mergedHeaders.entries());
+}
+
 export class ApiError extends Error {
   status: number;
   detail: string;


### PR DESCRIPTION
## What changed
- added a shared `buildGeneratorApiHeaders()` helper in the web client
- updated the agent and skills generator pages to use the shared helper instead of duplicating `x-api-key` header logic
- added frontend contract tests covering both key-present and key-absent behavior

## Why
PR #284 fixed a real 403 regression by adding inline `x-api-key` forwarding in two generator pages. That solved the incident, but it left auth-sensitive request logic duplicated and untested at the contract level. This PR centralizes that behavior and locks it down with tests.

## Impact
- lowers the chance of reintroducing generator auth regressions
- keeps global `buildApiHeaders()` behavior unchanged
- makes future generator request changes easier to maintain

## Validation
- `cd web && npm run test:contracts`
- `cd web && npm run lint`
- `cd web && npm run build`