### PR TITLE
🛡️ Sentinel: [HIGH] Fix information leakage in RAG routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -20,3 +20,7 @@
 **Vulnerability:** The RAG index fallback search used string interpolation to wrap the user's query with wildcards for a SQL `LIKE` query (`LIKE f"%{query}%"`), allowing users to inject literal `%` and `_` characters to bypass search filters.
 **Learning:** Using parameterized queries (e.g., `LIKE ?` with `("%" + query + "%",)`) prevents SQL injection, but does not prevent wildcard injection if the parameter itself contains unescaped wildcards.
 **Prevention:** When wrapping user input in wildcards for `LIKE` queries, explicitly escape `\`, `%`, and `_` in the input string, and append the `ESCAPE '\'` clause to the SQL statement.
+## 2025-03-09 - Prevent path disclosure in PathSecurityError handling
+**Vulnerability:** Path disclosure vulnerability
+**Learning:** `PathSecurityError` exception message explicitly included the absolute paths to the allowed directories on the server. Because the API route `rag_ingest` caught this exception and returned `str(exc)` in the 400 error `detail`, this exposed internal server paths to the client.
+**Prevention:** Do not expose raw internal exception strings to the API layer, especially for filesystem or database errors. Always sanitize error messages to be generic.

--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -124,7 +124,7 @@ async def rag_ingest(
     try:
         secure_paths = _secure_ingest_paths(req.paths)
     except PathSecurityError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail="Invalid path specified.") from exc
 
     docs, chunks, secs = await anyio.to_thread.run_sync(
         functools.partial(

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -107,7 +107,7 @@ def test_rag_ingest_rejects_path_outside_allowed_root(test_key, monkeypatch):
         )
 
         assert response.status_code == 400
-        assert "allowed root" in response.json()["detail"].lower()
+        assert "invalid path specified" in response.json()["detail"].lower()
 
 
 def test_worker_client_wraps_user_input_and_context_with_tags():


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Path disclosure vulnerability in RAG data ingestion endpoints. When a user attempted to upload a file outside of the allowed directories, `PathSecurityError` was thrown, containing the absolute server path. The API then sent the string representation of this exception in the 400 Bad Request response body, exposing the server's internal directory structure.
🎯 **Impact:** Information leakage could allow an attacker to learn about the host's directory layout and the web server environment, which could aid in discovering other vulnerabilities (e.g. path traversal exploits).
🔧 **Fix:** Intercepted `PathSecurityError` and mapped it to a generic HTTP 400 exception detailing "Invalid path specified" to fail securely without exposing internal server details.
✅ **Verification:** Verified via `tests/test_api_hardening.py` to ensure `test_rag_ingest_rejects_path_outside_allowed_root` continues correctly blocking out-of-bound paths but asserts against the sanitized, generic error message.

---
*PR created automatically by Jules for task [14520361173048314690](https://jules.google.com/task/14520361173048314690) started by @madara88645*