### PR TITLE
[codex] Fix v1 IR schema developer persona drift

### DIFF
--- a/app/_schemas/ir.schema.json
+++ b/app/_schemas/ir.schema.json
@@ -4,7 +4,7 @@
                "output_format","length_hint","steps","examples","banned","tools","metadata"],
   "properties": {
   "language": { "enum": ["tr","en","es"] },
-    "persona": { "enum": ["assistant","teacher","researcher","coach","mentor"] },
+    "persona": { "enum": ["assistant","teacher","researcher","coach","mentor","developer"] },
     "role": { "type": "string" },
     "domain": { "type": "string" },
     "goals": { "type": "array", "items": { "type": "string" } },

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -4,8 +4,23 @@ from app.compiler import compile_text
 from app.resources import get_ir_schema_text
 
 schema = json.loads(get_ir_schema_text(v2=False))
+schema_v2 = json.loads(get_ir_schema_text(v2=True))
 
 
 def test_schema_validation():
     ir = compile_text("Summarize recent stock market trends in a concise table")
     validate(instance=ir.model_dump(), schema=schema)
+
+
+def test_v1_schema_accepts_developer_persona_for_code_requests():
+    ir = compile_text("Implement a Python URL parser with tests and edge cases")
+
+    assert ir.persona == "developer"
+    validate(instance=ir.model_dump(), schema=schema)
+
+
+def test_v1_and_v2_persona_enums_stay_aligned_for_shared_values():
+    v1_personas = set(schema["properties"]["persona"]["enum"])
+    v2_personas = set(schema_v2["properties"]["persona"]["enum"])
+
+    assert v1_personas == v2_personas


### PR DESCRIPTION
## Summary
- align the shipped v1 IR schema with runtime behavior by allowing the `developer` persona
- add a regression test that validates code-oriented compile output against the v1 schema
- add a parity test so v1 and v2 persona enums do not drift again

## Why
The backend can emit `persona="developer"` for coding requests, but `app/_schemas/ir.schema.json` still rejected that value. This created a real contract mismatch between runtime output and the shipped schema.

## Test Plan
- `python -m pytest -q tests/test_schema_validation.py tests/test_developer_persona.py`