### PR TITLE
[codex] Add IR schema drift guard

### DIFF
--- a/app/ir_contract.py
+++ b/app/ir_contract.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+IR_LANGUAGES = ["tr", "en", "es"]
+IR_PERSONAS = ["assistant", "teacher", "researcher", "coach", "mentor", "developer"]
+IR_OUTPUT_FORMATS = ["markdown", "json", "yaml", "table", "text"]
+IR_LENGTH_HINTS = ["short", "medium", "long"]
+
+IR_INTENTS = ["teaching", "summary", "compare", "variants", "recency", "risk", "code", "ambiguous"]
+IR_STEP_TYPES = ["task", "teach", "research", "compare", "plan"]
+IR_CONSTRAINT_PRIORITIES = [10, 20, 30, 40, 50, 60, 65, 70, 75, 80, 90]
+IR_RISK_LEVELS = ["low", "medium", "high"]
+IR_DATA_SENSITIVITY_LEVELS = ["public", "internal", "confidential", "restricted"]
+IR_EXECUTION_MODES = ["advice_only", "human_approval_required", "auto_ok"]

--- a/app/models.py
+++ b/app/models.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, Field
 from pydantic import field_validator
 from pydantic.config import ConfigDict
 
+from .ir_contract import IR_LANGUAGES, IR_LENGTH_HINTS, IR_OUTPUT_FORMATS, IR_PERSONAS
+
 
 # Intermediate Representation (IR) model mirroring the JSON Schema.
 class IR(BaseModel):
@@ -59,26 +61,26 @@ class IR(BaseModel):
 
     @field_validator("language")
     def _lang(cls, v):  # type: ignore
-        if v not in {"tr", "en", "es"}:
+        if v not in set(IR_LANGUAGES):
             raise ValueError("language must be 'tr' or 'en' or 'es'")
         return v
 
     @field_validator("output_format")
     def _fmt(cls, v):  # type: ignore
-        if v not in {"markdown", "json", "yaml", "table", "text"}:
+        if v not in set(IR_OUTPUT_FORMATS):
             raise ValueError("invalid output_format")
         return v
 
     @field_validator("persona")
     def _persona(cls, v):  # type: ignore
-        allowed = {"assistant", "teacher", "researcher", "coach", "mentor", "developer"}
+        allowed = set(IR_PERSONAS)
         if v not in allowed:
             raise ValueError(f"persona must be one of {sorted(allowed)}")
         return v
 
     @field_validator("length_hint")
     def _len(cls, v):  # type: ignore
-        if v not in {"short", "medium", "long"}:
+        if v not in set(IR_LENGTH_HINTS):
             raise ValueError("invalid length_hint")
         return v
 

--- a/docs/superpowers/plans/2026-04-03-ir-schema-drift-guard.md
+++ b/docs/superpowers/plans/2026-04-03-ir-schema-drift-guard.md
@@ -1,0 +1,40 @@
+# IR Schema Drift Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Checked-in IR schema files ile backend contract sabitleri arasında kritik enum drift'ini CI'da yakalamak.
+
+**Architecture:** Ortak IR contract sabitlerini tek bir Python modülünde topluyoruz. Testler checked-in JSON schema dosyalarını bu sabitlere karşı doğruluyor, modeller de aynı sabitleri validator içinde kullanıyor.
+
+**Tech Stack:** Python, Pydantic, pytest, jsonschema
+
+---
+
+## Chunk 1: Shared Contract Constants
+
+### Task 1: Add central IR contract constants
+
+**Files:**
+- Create: `app/ir_contract.py`
+- Modify: `app/models.py`
+- Test: `tests/test_schema_validation.py`
+
+- [ ] **Step 1: Write the failing test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Add shared enum constants**
+- [ ] **Step 4: Reuse constants in v1 validators**
+- [ ] **Step 5: Run tests to verify they pass**
+
+## Chunk 2: Schema Parity Coverage
+
+### Task 2: Cover high-risk checked-in schema enums
+
+**Files:**
+- Modify: `tests/test_schema_validation.py`
+- Verify: `app/_schemas/ir.schema.json`
+- Verify: `app/_schemas/ir_v2.schema.json`
+
+- [ ] **Step 1: Assert shared enums for v1 and v2**
+- [ ] **Step 2: Assert v2 policy, intent, step, and priority enums**
+- [ ] **Step 3: Run focused schema tests**
+- [ ] **Step 4: Run broader regression tests**

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,6 +1,18 @@
 import json
 from jsonschema import validate
 from app.compiler import compile_text
+from app.ir_contract import (
+    IR_CONSTRAINT_PRIORITIES,
+    IR_DATA_SENSITIVITY_LEVELS,
+    IR_EXECUTION_MODES,
+    IR_INTENTS,
+    IR_LANGUAGES,
+    IR_LENGTH_HINTS,
+    IR_OUTPUT_FORMATS,
+    IR_PERSONAS,
+    IR_RISK_LEVELS,
+    IR_STEP_TYPES,
+)
 from app.resources import get_ir_schema_text
 
 schema = json.loads(get_ir_schema_text(v2=False))
@@ -24,3 +36,26 @@ def test_v1_and_v2_persona_enums_stay_aligned_for_shared_values():
     v2_personas = set(schema_v2["properties"]["persona"]["enum"])
 
     assert v1_personas == v2_personas
+
+
+def test_checked_in_schemas_match_shared_ir_contract_enums():
+    assert schema["properties"]["language"]["enum"] == IR_LANGUAGES
+    assert schema["properties"]["persona"]["enum"] == IR_PERSONAS
+    assert schema["properties"]["output_format"]["enum"] == IR_OUTPUT_FORMATS
+    assert schema["properties"]["length_hint"]["enum"] == IR_LENGTH_HINTS
+
+    assert schema_v2["properties"]["language"]["enum"] == IR_LANGUAGES
+    assert schema_v2["properties"]["persona"]["enum"] == IR_PERSONAS
+    assert schema_v2["properties"]["output_format"]["enum"] == IR_OUTPUT_FORMATS
+    assert schema_v2["properties"]["length_hint"]["enum"] == IR_LENGTH_HINTS
+    assert schema_v2["properties"]["intents"]["items"]["enum"] == IR_INTENTS
+    assert schema_v2["properties"]["steps"]["items"]["properties"]["type"]["enum"] == IR_STEP_TYPES
+    assert (
+        schema_v2["properties"]["constraints"]["items"]["properties"]["priority"]["enum"]
+        == IR_CONSTRAINT_PRIORITIES
+    )
+
+    policy = schema_v2["properties"]["policy"]["properties"]
+    assert policy["risk_level"]["enum"] == IR_RISK_LEVELS
+    assert policy["data_sensitivity"]["enum"] == IR_DATA_SENSITIVITY_LEVELS
+    assert policy["execution_mode"]["enum"] == IR_EXECUTION_MODES


### PR DESCRIPTION
## What changed
- add a shared `app.ir_contract` module for high-risk IR enum values
- reuse those shared constants in v1 model validators
- extend schema validation tests to assert checked-in v1/v2 JSON schema enums stay aligned with the shared contract
- include a short implementation plan note for the schema drift guard work

## Why
A recent v1 persona hotfix showed that checked-in schema files can drift from backend expectations. Runtime schema validation alone does not protect the enum contracts that CLI/API consumers depend on, so this adds a focused CI guard on the most brittle fields.

## Validation
- `python -m pytest -q tests/test_schema_validation.py tests/test_ir_v2_basic.py`
- attempted `python -m pytest -q` but the full suite timed out after ~5 minutes in this environment
