### PR TITLE
docs: add Cursor Cloud development environment setup instructions

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -65,3 +65,31 @@ When modifying existing or creating new FastAPI endpoints, you must adhere to th
 5.  **Review for Injections**: If the endpoint forwards data to the LLM, verify that context isolation and sanitization mechanisms are in place.
 
 By strictly following these guidelines, you ensure the integrity, security, and robustness of the `myCompiler` architecture.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Command | Port | Notes |
+|---------|---------|------|-------|
+| **FastAPI backend** | `python3 -m uvicorn api.main:app --reload --port 8080` | 8080 | Core API; all other surfaces depend on it |
+| **Next.js frontend** | `cd web && npm run dev` | 3000 | Primary UI |
+
+The backend works in **offline heuristics mode** without LLM API keys. To enable LLM-powered compilation, set `GROQ_API_KEY` or `OPENAI_API_KEY` in `.env`.
+
+### Lint / Test / Build
+
+Standard commands are documented in `README.md`. Quick reference:
+
+- **Python lint**: `ruff check .` (from repo root)
+- **Python tests**: `pytest -q` (734+ tests, all offline-safe, ~23s)
+- **Frontend lint**: `cd web && npx eslint`
+- **Frontend contract tests**: `cd web && npm run test:contracts` (requires backend running)
+
+### Gotchas
+
+- `python` is not on PATH in the Cloud VM; always use `python3`.
+- pip installs scripts to `~/.local/bin`; ensure `PATH` includes it (`export PATH="$HOME/.local/bin:$PATH"`).
+- The `.env` file must exist for the backend to start (copy from `.env.example` if missing).
+- SQLite databases (RAG index, user auth) are created automatically at runtime — no external DB needed.
+- The backend's `--reload` flag watches the entire `/workspace` directory; avoid creating large temp files in the repo root.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor Cloud specific development instructions to `agents.md` so future cloud agents can quickly set up and run the Prompt Compiler development environment.

## Changes

- Added `## Cursor Cloud specific instructions` section to `agents.md` with:
  - Services overview table (FastAPI backend on port 8080, Next.js frontend on port 3000)
  - Lint/test/build quick reference commands
  - Cloud VM-specific gotchas (python3 path, pip bin directory, .env requirement, SQLite auto-creation)

## Environment Verification

All checks passed during setup:

| Check | Result |
|-------|--------|
| Python lint (`ruff check .`) | All checks passed |
| Python tests (`pytest -q`) | 734 passed |
| Frontend lint (`npx eslint`) | Clean |
| Backend startup (port 8080) | Running |
| Frontend startup (port 3000) | Running |
| End-to-end compile | Working (offline heuristics mode) |

## Demo

[demo_prompt_compiler_compile_flow.mp4](https://cursor.com/agents/bc-b0b199ee-4b41-4af2-b8a4-c4a724bc7cc7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_prompt_compiler_compile_flow.mp4)

Prompt compilation working end-to-end: entering a natural language prompt and viewing structured output across Intent, System, User, Plan, and Expanded tabs.

[Compiled output showing Intent and Policy analysis](https://cursor.com/agents/bc-b0b199ee-4b41-4af2-b8a4-c4a724bc7cc7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompile_result_intent.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0b199ee-4b41-4af2-b8a4-c4a724bc7cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0b199ee-4b41-4af2-b8a4-c4a724bc7cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

