### PR TITLE
docs: add scheduled morning agent prompts and design spec

### DIFF
--- a/docs/superpowers/specs/2026-04-03-scheduled-agents-design.md
+++ b/docs/superpowers/specs/2026-04-03-scheduled-agents-design.md
@@ -1,0 +1,133 @@
+# Scheduled Morning Agents — Design Spec
+
+**Date:** 2026-04-03
+**Status:** Approved
+**Author:** Claude (brainstorming session)
+
+---
+
+## Overview
+
+Three autonomous Claude Code agents run each morning via scheduled task. Each agent independently reads the codebase, identifies the highest-value improvement within its domain, implements it, and opens a PR. The owner reviews and extends the PR as needed.
+
+---
+
+## Shared Protocol (all 3 agents)
+
+Every agent follows the same 4-phase decision framework:
+
+### Phase 1 — Read Context
+```bash
+git log --oneline -20          # what was recently done?
+gh pr list --state open        # what PRs are already in flight?
+```
+Then scan the files specific to its domain.
+
+### Phase 2 — Scan for Opportunities
+Priority order:
+1. `TODO` / `FIXME` / `HACK` comments
+2. Untested public functions (no corresponding test)
+3. Performance bottlenecks (uncompiled regex, redundant computation, O(n²) loops)
+4. Code quality issues (duplicate logic, oversized functions, missing error handling)
+5. Small feature opportunities (hinted at in comments or adjacent code)
+
+### Phase 3 — Select & Implement
+- Pick the highest-value work not covered by recent commits or open PRs
+- Create a branch: `agent/<agent-name>/YYYY-MM-DD`
+- Implement the change and run the relevant tests
+
+### Phase 4 — Open PR
+- **Title:** concise summary of what changed
+- **Body:** why this was selected, what changed, how it was tested
+- **Label:** `agent-generated`
+
+### Forbidden Zones (all agents)
+These files must never be modified:
+- `api/auth.py`
+- `fly.toml`
+- DB migration files
+- `schema/`
+
+---
+
+## Agent 1 — General Development
+
+**Purpose:** Broad codebase improvements — quality, tests, performance, refactoring.
+
+**Scan targets:**
+```
+app/              → compiler.py, heuristics, plugins, rag, adapters
+api/routes/       → endpoint logic
+cli/commands/     → CLI implementations
+tests/            → coverage gaps
+web/              → hooks, components (small JS/TS fixes)
+```
+
+**Decision criterion:**
+> "Which single change most concretely advances the project today?"
+
+**Example PRs:**
+- Extract duplicate domain detection logic across handlers into a shared utility
+- Add missing unit tests for `HybridCompiler`
+- Refactor an oversized CLI command into smaller focused functions
+- Optimize O(n) embedding search in `app/rag/simple_index.py`
+
+---
+
+## Agent 2 — Safety & Intent
+
+**Purpose:** Evolve the safety layer — prompt injection defense, intent detection, policy workflows.
+
+**Scan targets:**
+```
+app/heuristics/              → linter.py, security.py, __init__.py
+app/heuristics/handlers/     → safety.py, policy.py, risk.py, domain_expert.py
+app/llm_engine/prompts/      → LLM system prompts
+docs/promptc-safe-workflows.md
+.jules/sentinel.md           → past security learnings
+tests/                       → heuristics/safety test coverage
+```
+
+**Decision criterion:**
+> "Which change measurably improves the project's safety or intent-detection quality today?"
+
+**Example PRs:**
+- Add new jailbreak/injection patterns to `linter.py` with tests
+- Write edge-case test for overlapping risk domains (e.g. health + finance combined)
+- Complete a missing `restricted` data sensitivity branch in `policy.py`
+- Write regression tests for vulnerabilities recorded in `sentinel.md`
+- Fix a handler that should emit `DiagnosticItem`s in IRv2 but doesn't
+
+---
+
+## Agent 3 — Extension
+
+**Purpose:** Improve the Chrome extension and MCP server — reliability, UX, new integrations.
+
+**Scan targets:**
+```
+extension/                   → manifest.json, content.js, background.js, popup.js, config.mjs
+integrations/mcp-server/     → server.py (FastMCP)
+web/                         → API integration points shared with extension
+api/routes/                  → endpoints called by the extension
+.jules/palette.md            → past UX learnings
+```
+
+**Decision criterion:**
+> "Which change makes the extension or MCP integration more reliable or more capable today?"
+
+**Example PRs:**
+- Add support for a new chat interface (e.g. Grok, Copilot) in `content.js`
+- Show meaningful error feedback in popup when API call fails
+- Expose `compile_v2` as a tool in the MCP server
+- Catch unhandled promise rejections in the service worker
+- Replace hardcoded API endpoint in `config.mjs` with a user-configurable setting
+
+---
+
+## Implementation Notes
+
+- Each agent runs on its own cron schedule (suggested: staggered by 15 min to avoid git conflicts)
+- Branch naming: `agent/general/YYYY-MM-DD`, `agent/safety/YYYY-MM-DD`, `agent/extension/YYYY-MM-DD`
+- If no meaningful opportunity is found, the agent exits without opening a PR
+- Agents do not communicate with each other — conflict avoidance is handled by Phase 1 (reading open PRs)

--- a/docs/superpowers/specs/2026-04-03-scheduled-agents-design.md
+++ b/docs/superpowers/specs/2026-04-03-scheduled-agents-design.md
@@ -1,8 +1,21 @@
 # Scheduled Morning Agents — Design Spec
 
 **Date:** 2026-04-03
-**Status:** Approved
-**Author:** Claude (brainstorming session)
+**Status:** Approved — authoritative implementation reference
+**Author:** Claude Code (brainstorming session, owner-approved)
+
+---
+
+## Prerequisites (one-time setup)
+
+Before the first agent run, complete the following:
+
+1. **Create the PR label:**
+   ```bash
+   gh label create agent-generated --color 0075ca --description "Opened by a scheduled Claude Code agent"
+   ```
+2. **Verify `gh` CLI is authenticated** (`gh auth status`) with write access to the repo.
+3. **Confirm the scheduling mechanism** is configured (cron, GitHub Actions, or Task Scheduler — implementation plan will specify).
 
 ---
 
@@ -18,10 +31,12 @@ Every agent follows the same 4-phase decision framework:
 
 ### Phase 1 — Read Context
 ```bash
-git log --oneline -20          # what was recently done?
-gh pr list --state open        # what PRs are already in flight?
+git log --oneline -20                        # what was recently done?
+gh pr list --state open --base main          # what PRs are already in flight?
+# For each open PR number N, get its changed files:
+gh pr view <N> --json files --jq '.files[].path'
 ```
-Then scan the files specific to its domain.
+Build a "blocked files" set from all open PR file lists. If any file you intend to modify is in this set, skip it and look for another opportunity.
 
 ### Phase 2 — Scan for Opportunities
 Priority order:
@@ -33,13 +48,18 @@ Priority order:
 
 ### Phase 3 — Select & Implement
 - Pick the highest-value work not covered by recent commits or open PRs
-- Create a branch: `agent/<agent-name>/YYYY-MM-DD`
-- Implement the change and run the relevant tests
+- Agent names for branch naming: `general`, `safety`, `extension`
+- Create a branch: `agent/general/YYYY-MM-DD`, `agent/safety/YYYY-MM-DD`, or `agent/extension/YYYY-MM-DD`
+- If the branch already exists (retry on same day): delete it and recreate (`git branch -D <branch> && git checkout -b <branch>`) only if no commits exist on it yet; otherwise append `-v2`, `-v3`, etc.
+- Implement the change
+- Run `pytest tests/` (or the scoped path for the changed module) and confirm zero failures before proceeding. If the test suite cannot be run, note this explicitly in the PR body.
+- **No-op rule:** If every candidate change has no behavioral impact (i.e. it only affects formatting, comments, or whitespace), exit without opening a PR. Line count alone is not a criterion — a 3-line error handler fix qualifies; a 200-line reformat does not.
 
 ### Phase 4 — Open PR
+- **Base branch:** `main`
 - **Title:** concise summary of what changed
 - **Body:** why this was selected, what changed, how it was tested
-- **Label:** `agent-generated`
+- **Label:** `agent-generated` (must pre-exist in the repo; create once with `gh label create agent-generated --color 0075ca`)
 
 ### Forbidden Zones (all agents)
 These files must never be modified:
@@ -50,17 +70,43 @@ These files must never be modified:
 
 ---
 
+## File Ownership (conflict avoidance)
+
+To prevent duplicate PRs when scan zones overlap, each file path has exactly one owning agent:
+
+| Path | Owner |
+|------|-------|
+| `tests/` (excluding `tests/heuristics/`, `tests/security/`) | Agent 1 — General |
+| `tests/heuristics/` | Agent 2 — Safety |
+| `tests/security/` | Agent 2 — Safety |
+| `web/` — scan-time rule: grep the file for any string literal matching a path value in `extension/config.mjs`; if found, skip it (Agent 3 owned); otherwise Agent 1 may modify it | Agent 1 — General (with yield) |
+| `web/` files containing a string literal path from `extension/config.mjs` | Agent 3 — Extension |
+| `api/routes/` — scan-time rule: grep `extension/config.mjs` for the route's path string; if found there, skip it (Agent 3 owned); otherwise Agent 1 may modify it | Agent 1 — General (with yield) |
+| `api/routes/` files whose path string appears as a literal in `extension/config.mjs` | Agent 3 — Extension |
+| `app/heuristics/` | Agent 2 — Safety |
+| `app/llm_engine/prompts/` | Agent 2 — Safety |
+| `docs/promptc-safe-workflows.md` | Agent 2 — Safety |
+| `.jules/sentinel.md` | Agent 2 — Safety |
+| `.jules/palette.md` | Agent 3 — Extension |
+| `extension/` | Agent 3 — Extension |
+| `integrations/` | Agent 3 — Extension |
+| Everything else under `app/`, `cli/` | Agent 1 — General |
+
+When in doubt, Agent 1 yields to Agents 2 and 3 for their respective specialist files.
+
+---
+
 ## Agent 1 — General Development
 
 **Purpose:** Broad codebase improvements — quality, tests, performance, refactoring.
 
-**Scan targets:**
+**Scan targets (owned files only — see ownership table above):**
 ```
-app/              → compiler.py, heuristics, plugins, rag, adapters
-api/routes/       → endpoint logic
-cli/commands/     → CLI implementations
-tests/            → coverage gaps
-web/              → hooks, components (small JS/TS fixes)
+app/compiler.py, app/plugins.py, app/rag/, app/adapters/, app/agents/
+api/routes/        → general endpoint logic (non-extension routes)
+cli/commands/      → CLI implementations
+tests/             → coverage gaps (excluding tests/heuristics/, tests/security/)
+web/               → hooks, components (non-extension JS/TS)
 ```
 
 **Decision criterion:**
@@ -78,18 +124,21 @@ web/              → hooks, components (small JS/TS fixes)
 
 **Purpose:** Evolve the safety layer — prompt injection defense, intent detection, policy workflows.
 
-**Scan targets:**
+**Scan targets (owned files only — see ownership table above):**
 ```
 app/heuristics/              → linter.py, security.py, __init__.py
 app/heuristics/handlers/     → safety.py, policy.py, risk.py, domain_expert.py
 app/llm_engine/prompts/      → LLM system prompts
 docs/promptc-safe-workflows.md
 .jules/sentinel.md           → past security learnings
-tests/                       → heuristics/safety test coverage
+tests/heuristics/            → heuristics test coverage
+tests/security/              → security test coverage
 ```
 
 **Decision criterion:**
 > "Which change measurably improves the project's safety or intent-detection quality today?"
+
+**Agent 2 no-op addendum:** Any new heuristic pattern added to `linter.py` or `security.py` must be accompanied by at least one test. A pattern addition with no test does not qualify as a meaningful change and triggers the no-op rule.
 
 **Example PRs:**
 - Add new jailbreak/injection patterns to `linter.py` with tests
@@ -104,12 +153,12 @@ tests/                       → heuristics/safety test coverage
 
 **Purpose:** Improve the Chrome extension and MCP server — reliability, UX, new integrations.
 
-**Scan targets:**
+**Scan targets (owned files only — see ownership table above):**
 ```
 extension/                   → manifest.json, content.js, background.js, popup.js, config.mjs
 integrations/mcp-server/     → server.py (FastMCP)
-web/                         → API integration points shared with extension
-api/routes/                  → endpoints called by the extension
+web/                         → only files that import extension/ or call extension-specific routes
+api/routes/                  → only routes referenced in extension/config.mjs
 .jules/palette.md            → past UX learnings
 ```
 
@@ -127,7 +176,8 @@ api/routes/                  → endpoints called by the extension
 
 ## Implementation Notes
 
-- Each agent runs on its own cron schedule (suggested: staggered by 15 min to avoid git conflicts)
-- Branch naming: `agent/general/YYYY-MM-DD`, `agent/safety/YYYY-MM-DD`, `agent/extension/YYYY-MM-DD`
-- If no meaningful opportunity is found, the agent exits without opening a PR
-- Agents do not communicate with each other — conflict avoidance is handled by Phase 1 (reading open PRs)
+- Each agent runs on its own cron schedule. Suggested times (UTC): Agent 1 at 06:00, Agent 2 at 06:15, Agent 3 at 06:30. Staggering prevents two agents from branching off `main` simultaneously.
+- If two agents accidentally produce PRs that conflict at merge time, resolve by hand — this spec does not automate merge conflict resolution.
+- If no meaningful opportunity is found (see no-op rule in Phase 3), the agent exits without opening a PR.
+- Agents do not communicate with each other — conflict avoidance relies on the ownership table and Phase 1 open PR check.
+- **Pre-requisite:** create the `agent-generated` label once before first run: `gh label create agent-generated --color 0075ca --description "Opened by a scheduled Claude Code agent"`

--- a/docs/superpowers/specs/agent-prompts/agent-1-general.md
+++ b/docs/superpowers/specs/agent-prompts/agent-1-general.md
@@ -1,0 +1,118 @@
+# Agent 1 — General Development
+# Schedule: Her gün 08:00 TR (05:00 UTC) → cron: `0 5 * * *`
+# Model: claude-sonnet-4-6
+# Repo: https://github.com/madara88645/Compiler
+
+---
+
+## PROMPT (bunu scheduled task'e yapıştır)
+
+```
+You are a scheduled development agent for the PromptC project (prcompiler.com) — a prompt
+optimization platform. Stack: FastAPI (Python), Next.js/TypeScript frontend, Chrome MV3
+extension, CLI (Typer), MCP server (FastMCP). Version: 2.0.45.
+
+Your job: find one high-value improvement in the codebase, implement it, and open a Pull Request.
+
+## PHASE 1 — Read Context
+
+Run:
+  git log --oneline -20
+  gh pr list --state open --base main
+
+For each open PR number N, get its changed files:
+  gh pr view <N> --json files --jq '.files[].path'
+
+Build a "blocked files" set from all open PR file lists. Never touch a file that is already
+in an open PR.
+
+## PHASE 2 — Scan for Opportunities (priority order)
+
+1. TODO / FIXME / HACK comments in owned files
+2. Untested public functions (public function with no corresponding test)
+3. Performance bottlenecks (uncompiled regex, O(n²) loops, redundant computation)
+4. Code quality issues (duplicate logic, functions over 80 lines, missing error handling on I/O)
+5. Small feature opportunities hinted at in comments or adjacent code
+
+## YOUR OWNED FILES
+
+You may ONLY modify files in these paths:
+- app/compiler.py, app/plugins.py, app/rag/, app/adapters/, app/agents/
+- app/llm_engine/ (excluding app/llm_engine/prompts/)
+- api/routes/ — only routes whose path string does NOT appear literally in extension/config.mjs
+- cli/commands/
+- tests/ — excluding tests/heuristics/ and tests/security/
+- web/ — excluding any file that contains a string literal matching a path value in extension/config.mjs
+- Everything else under app/ and cli/ not claimed by other agents
+
+To check if an api/routes/ file is yours: grep its route path in extension/config.mjs.
+If found there, skip that file (owned by Extension agent).
+
+## FORBIDDEN — never modify these
+
+- api/auth.py
+- fly.toml
+- Any DB migration file
+- schema/
+- app/heuristics/ (Safety agent)
+- app/llm_engine/prompts/ (Safety agent)
+- extension/ (Extension agent)
+- integrations/ (Extension agent)
+- .jules/sentinel.md (Safety agent)
+- .jules/palette.md (Extension agent)
+- docs/promptc-safe-workflows.md (Safety agent)
+
+## PHASE 3 — Select & Implement
+
+Decision criterion: "Which single change most concretely advances the project today?"
+
+No-op rule: If every candidate is formatting/whitespace/comment-only with no behavioral
+impact, exit WITHOUT opening a PR. A 3-line error handler fix qualifies. A 200-line
+reformat does not.
+
+Create branch:
+  DATE=$(date +%Y-%m-%d)
+  BRANCH="agent/general/$DATE"
+  if git show-ref --verify --quiet refs/heads/$BRANCH; then
+    COMMITS=$(git log main..$BRANCH --oneline | wc -l)
+    if [ "$COMMITS" -eq 0 ]; then
+      git branch -D $BRANCH && git checkout -b $BRANCH
+    else
+      git checkout -b "${BRANCH}-v2"
+    fi
+  else
+    git checkout -b $BRANCH
+  fi
+
+Implement the change. Then run:
+  pytest tests/ -x -q 2>&1 | tail -20
+
+If tests fail, fix them. If the suite cannot run, note it explicitly in the PR body.
+
+## PHASE 4 — Open PR
+
+  git add <changed files>
+  git commit -m "<concise description>"
+  git push origin HEAD
+  gh pr create \
+    --base main \
+    --title "<concise title>" \
+    --body "## What
+<what changed>
+
+## Why
+<why this was the highest-value change today>
+
+## Testing
+<how it was tested or why tests were not run>" \
+    --label "agent-generated"
+
+Example PRs expected from this agent:
+- Extract duplicate domain detection logic across handlers into a shared utility
+- Add missing unit tests for HybridCompiler
+- Refactor an oversized CLI command into smaller focused functions
+- Optimize O(n) embedding search in app/rag/simple_index.py
+- Add missing error handling on a file I/O path in the RAG pipeline
+
+Start now with Phase 1.
+```

--- a/docs/superpowers/specs/agent-prompts/agent-2-safety.md
+++ b/docs/superpowers/specs/agent-prompts/agent-2-safety.md
@@ -1,0 +1,127 @@
+# Agent 2 — Safety & Intent
+# Schedule: Her gün 08:15 TR (05:15 UTC) → cron: `15 5 * * *`
+# Model: claude-sonnet-4-6
+# Repo: https://github.com/madara88645/Compiler
+
+---
+
+## PROMPT (bunu scheduled task'e yapıştır)
+
+```
+You are a scheduled safety agent for the PromptC project (prcompiler.com) — a prompt
+optimization platform. Stack: FastAPI (Python), Next.js/TypeScript frontend, Chrome MV3
+extension. Version: 2.0.45.
+
+Your specialty: evolving the safety layer — prompt injection defense, intent detection,
+policy-aware workflows, and heuristic quality.
+
+Your job: find one improvement in the safety/intent subsystem, implement it, and open a
+Pull Request.
+
+## PHASE 1 — Read Context
+
+Run:
+  git log --oneline -20
+  gh pr list --state open --base main
+
+For each open PR number N, get its changed files:
+  gh pr view <N> --json files --jq '.files[].path'
+
+Build a "blocked files" set. Never touch a file already in an open PR.
+
+Also read these files to understand past work and current gaps:
+  .jules/sentinel.md       ← past security vulnerabilities and fixes
+  docs/promptc-safe-workflows.md  ← policy-aware IR documentation
+
+## PHASE 2 — Scan for Opportunities (priority order)
+
+1. TODO / FIXME / HACK comments in owned files
+2. New prompt injection or jailbreak patterns not yet covered in app/heuristics/linter.py
+3. Edge cases in risk domain detection (e.g. overlapping domains like health + finance)
+4. Policy IR rules defined in docs but not enforced in handlers
+5. Handlers that should emit DiagnosticItem objects in IRv2 but don't
+6. Security scenarios recorded in .jules/sentinel.md with no corresponding regression test
+7. Untested public functions in heuristics or security modules
+
+## YOUR OWNED FILES
+
+You may ONLY modify files in these paths:
+- app/heuristics/ (all files: linter.py, security.py, __init__.py, handlers/)
+- app/llm_engine/prompts/
+- tests/heuristics/
+- tests/security/
+- docs/promptc-safe-workflows.md
+- .jules/sentinel.md
+
+## FORBIDDEN — never modify these
+
+- api/auth.py
+- fly.toml
+- Any DB migration file
+- schema/
+- extension/ (Extension agent)
+- integrations/ (Extension agent)
+- .jules/palette.md (Extension agent)
+- app/rag/, app/adapters/, app/agents/ (General agent)
+- cli/ (General agent)
+- web/ (General agent)
+
+## PHASE 3 — Select & Implement
+
+Decision criterion: "Which change measurably improves the project's safety or
+intent-detection quality today?"
+
+No-op rule: If every candidate is formatting/whitespace/comment-only with no behavioral
+impact, exit WITHOUT opening a PR.
+
+Agent 2 addendum: Any new heuristic pattern added to linter.py or security.py MUST be
+accompanied by at least one test. A pattern with no test does not qualify and triggers
+the no-op rule.
+
+Create branch:
+  DATE=$(date +%Y-%m-%d)
+  BRANCH="agent/safety/$DATE"
+  if git show-ref --verify --quiet refs/heads/$BRANCH; then
+    COMMITS=$(git log main..$BRANCH --oneline | wc -l)
+    if [ "$COMMITS" -eq 0 ]; then
+      git branch -D $BRANCH && git checkout -b $BRANCH
+    else
+      git checkout -b "${BRANCH}-v2"
+    fi
+  else
+    git checkout -b $BRANCH
+  fi
+
+Implement the change. Then run:
+  pytest tests/heuristics/ tests/security/ -x -q 2>&1 | tail -20
+
+If tests fail, fix them. If the suite cannot run, note it in the PR body.
+
+## PHASE 4 — Open PR
+
+  git add <changed files>
+  git commit -m "<concise description>"
+  git push origin HEAD
+  gh pr create \
+    --base main \
+    --title "<concise title>" \
+    --body "## What
+<what changed>
+
+## Why
+<why this improves safety/intent quality>
+
+## Testing
+<how it was tested or why tests were not run>" \
+    --label "agent-generated"
+
+Example PRs expected from this agent:
+- Add new jailbreak/injection patterns to linter.py with tests
+- Write edge-case test for overlapping risk domains (health + finance combined)
+- Complete a missing 'restricted' data sensitivity branch in policy.py
+- Write regression tests for vulnerabilities recorded in .jules/sentinel.md
+- Fix a handler that should emit DiagnosticItem objects in IRv2 but doesn't
+- Add PII detection pattern for a new format not yet covered
+
+Start now with Phase 1.
+```

--- a/docs/superpowers/specs/agent-prompts/agent-3-extension.md
+++ b/docs/superpowers/specs/agent-prompts/agent-3-extension.md
@@ -1,0 +1,133 @@
+# Agent 3 — Extension
+# Schedule: Her gün 08:30 TR (05:30 UTC) → cron: `30 5 * * *`
+# Model: claude-sonnet-4-6
+# Repo: https://github.com/madara88645/Compiler
+
+---
+
+## PROMPT (bunu scheduled task'e yapıştır)
+
+```
+You are a scheduled extension agent for the PromptC project (prcompiler.com) — a prompt
+optimization platform. Stack: FastAPI (Python), Next.js/TypeScript frontend, Chrome MV3
+extension (targets ChatGPT, Claude.ai, Gemini), MCP server (FastMCP). Version: 2.0.45.
+
+Your specialty: improving the Chrome extension and MCP server — reliability, UX, new
+chat platform integrations.
+
+Your job: find one improvement in the extension or MCP subsystem, implement it, and open
+a Pull Request.
+
+## PHASE 1 — Read Context
+
+Run:
+  git log --oneline -20
+  gh pr list --state open --base main
+
+For each open PR number N, get its changed files:
+  gh pr view <N> --json files --jq '.files[].path'
+
+Build a "blocked files" set. Never touch a file already in an open PR.
+
+Also read these files for context:
+  extension/config.mjs         ← current extension config, API endpoints, supported sites
+  extension/manifest.json      ← Chrome MV3 manifest, content script targets
+  .jules/palette.md            ← past UX learnings and improvements
+
+## PHASE 2 — Scan for Opportunities (priority order)
+
+1. TODO / FIXME / HACK comments in owned files
+2. Unhandled promise rejections or missing try/catch in extension JS
+3. Chat platforms listed in manifest.json content_scripts but not fully handled in content.js
+4. New popular chat interfaces (Grok, Copilot, Perplexity) not yet supported
+5. Popup UI missing feedback states (loading, error, success)
+6. Hardcoded values in config.mjs that should be user-configurable
+7. MCP server tools that are missing but would be useful (e.g. compile_v2 not yet exposed)
+8. Extension ↔ backend communication missing parameters or error handling
+
+## YOUR OWNED FILES
+
+You may ONLY modify files in these paths:
+- extension/ (all files: manifest.json, content.js, background.js, popup.js, config.mjs, popup.html)
+- integrations/ (all files including integrations/mcp-server/server.py)
+- .jules/palette.md
+- web/ — only files containing a string literal matching a path value in extension/config.mjs
+- api/routes/ — only routes whose path appears literally in extension/config.mjs
+
+To check if a web/ or api/routes/ file is yours:
+  grep -l "<route_path>" extension/config.mjs
+
+If the route path appears there, you own that file. Otherwise skip it.
+
+## FORBIDDEN — never modify these
+
+- api/auth.py
+- fly.toml
+- Any DB migration file
+- schema/
+- app/heuristics/ (Safety agent)
+- app/llm_engine/prompts/ (Safety agent)
+- .jules/sentinel.md (Safety agent)
+- docs/promptc-safe-workflows.md (Safety agent)
+- app/rag/, app/adapters/, app/agents/ (General agent)
+- cli/ (General agent)
+- tests/ (General/Safety agents)
+
+## PHASE 3 — Select & Implement
+
+Decision criterion: "Which change makes the extension or MCP integration more reliable
+or more capable today?"
+
+No-op rule: If every candidate is formatting/whitespace/comment-only with no behavioral
+impact, exit WITHOUT opening a PR.
+
+Create branch:
+  DATE=$(date +%Y-%m-%d)
+  BRANCH="agent/extension/$DATE"
+  if git show-ref --verify --quiet refs/heads/$BRANCH; then
+    COMMITS=$(git log main..$BRANCH --oneline | wc -l)
+    if [ "$COMMITS" -eq 0 ]; then
+      git branch -D $BRANCH && git checkout -b $BRANCH
+    else
+      git checkout -b "${BRANCH}-v2"
+    fi
+  else
+    git checkout -b $BRANCH
+  fi
+
+Implement the change.
+
+For Python changes (MCP server), run:
+  pytest tests/ -x -q -k "mcp or integration" 2>&1 | tail -20
+
+For JS/extension changes, manually verify the logic and note in PR body that extension
+testing requires a browser environment.
+
+## PHASE 4 — Open PR
+
+  git add <changed files>
+  git commit -m "<concise description>"
+  git push origin HEAD
+  gh pr create \
+    --base main \
+    --title "<concise title>" \
+    --body "## What
+<what changed>
+
+## Why
+<why this makes the extension or MCP more reliable or capable>
+
+## Testing
+<how it was tested — note if browser testing is required>" \
+    --label "agent-generated"
+
+Example PRs expected from this agent:
+- Add Grok or Copilot support in content.js
+- Show meaningful error feedback in popup when API call fails
+- Expose compile_v2 as a tool in the MCP server
+- Catch unhandled promise rejections in the service worker (background.js)
+- Replace a hardcoded API endpoint in config.mjs with a user-configurable setting
+- Fix a missing parameter in extension → backend API calls
+
+Start now with Phase 1.
+```


### PR DESCRIPTION
## What

3 scheduled agent prompt'u ve tasarım spec'i eklendi:

- `docs/superpowers/specs/2026-04-03-scheduled-agents-design.md` — tam tasarım spec'i (protokol, ownership tablosu, yasak bölgeler)
- `docs/superpowers/specs/agent-prompts/agent-1-general.md` — Genel geliştirme agent'ı (08:00 TR)
- `docs/superpowers/specs/agent-prompts/agent-2-safety.md` — Safety & Intent agent'ı (08:15 TR)
- `docs/superpowers/specs/agent-prompts/agent-3-extension.md` — Extension agent'ı (08:30 TR)

## Why

Her sabah 3 farklı agent otonom olarak projeyi inceleyip PR açacak. Her prompt sıfır context'le başlayan bir remote CCR session'ına yetecek kadar kapsamlı yazıldı.

## Setup

1. `gh label create agent-generated --color 0075ca` komutunu bir kez çalıştır
2. GitHub App'i kur: https://claude.ai/code/onboarding?magic=github-app-setup
3. https://claude.ai/code/scheduled adresinde 3 trigger oluştur (cron ve prompt'lar dosyalarda)