### PR TITLE
Fix optimizer history timestamps and CLI listing

### DIFF
--- a/app/optimizer/history.py
+++ b/app/optimizer/history.py
@@ -1,9 +1,19 @@
 import json
+import logging
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import List, Optional
-from datetime import datetime
 
 from .models import OptimizationRun
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    """Normalize naive and aware datetimes for consistent storage and sorting."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 class HistoryManager:
@@ -24,9 +34,10 @@ class HistoryManager:
     def save_run(self, run: OptimizationRun) -> Path:
         """Save a run to disk."""
         file_path = self.history_dir / f"{run.id}.json"
-
-        # Add timestamp if we want? Or rely on filesystem
-        # For now, just dump the model
+        if run.created_at is None:
+            run.created_at = datetime.now(UTC).replace(microsecond=0)
+        else:
+            run.created_at = _normalize_datetime(run.created_at).replace(tzinfo=None)
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(run.model_dump_json(indent=2))
 
@@ -41,9 +52,12 @@ class HistoryManager:
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            return OptimizationRun.model_validate(data)
+            run = OptimizationRun.model_validate(data)
+            if run.created_at is None:
+                run.created_at = datetime.fromtimestamp(file_path.stat().st_mtime, UTC).replace(tzinfo=None)
+            return run
         except Exception as e:
-            print(f"Error loading run {run_id}: {e}")
+            logger.warning("Error loading optimization run %s: %s", run_id, e)
             return None
 
     def list_runs(self) -> List[dict]:
@@ -54,26 +68,19 @@ class HistoryManager:
         runs = []
         for file_path in self.history_dir.glob("*.json"):
             try:
-                # We could optimize this by having an index.json,
-                # but for <1000 runs, reading files is fine if we're lazy loading
-                # or just reading basic stats. For speed, let's just use file stats for date
-                # and maybe peek at content if needed.
-                # Actually, let's load them for now, assuming they aren't massive.
-                # Optimization: In future, use index or separate meta file.
-
                 with open(file_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
 
                 run = OptimizationRun.model_validate(data)
-
-                # Timestamp from file mtime
-                mtime = file_path.stat().st_mtime
-                timestamp = datetime.fromtimestamp(mtime).strftime("%Y-%m-%d %H:%M:%S")
+                created_at = run.created_at or datetime.fromtimestamp(file_path.stat().st_mtime, UTC).replace(
+                    tzinfo=None
+                )
 
                 runs.append(
                     {
                         "id": run.id,
-                        "date": timestamp,
+                        "date": created_at.strftime("%Y-%m-%d %H:%M:%S"),
+                        "created_at": created_at,
                         "generations": len(run.generations),
                         "best_score": run.best_candidate.score if run.best_candidate else 0.0,
                         "model": run.config.model,
@@ -83,6 +90,7 @@ class HistoryManager:
             except Exception:
                 continue
 
-        # Sort by date desc
-        runs.sort(key=lambda x: x["date"], reverse=True)
+        runs.sort(key=lambda x: x["created_at"], reverse=True)
+        for run in runs:
+            run.pop("created_at", None)
         return runs

--- a/app/optimizer/history.py
+++ b/app/optimizer/history.py
@@ -54,7 +54,9 @@ class HistoryManager:
                 data = json.load(f)
             run = OptimizationRun.model_validate(data)
             if run.created_at is None:
-                run.created_at = datetime.fromtimestamp(file_path.stat().st_mtime, UTC).replace(tzinfo=None)
+                run.created_at = datetime.fromtimestamp(file_path.stat().st_mtime, UTC).replace(
+                    tzinfo=None
+                )
             return run
         except Exception as e:
             logger.warning("Error loading optimization run %s: %s", run_id, e)
@@ -72,9 +74,9 @@ class HistoryManager:
                     data = json.load(f)
 
                 run = OptimizationRun.model_validate(data)
-                created_at = run.created_at or datetime.fromtimestamp(file_path.stat().st_mtime, UTC).replace(
-                    tzinfo=None
-                )
+                created_at = run.created_at or datetime.fromtimestamp(
+                    file_path.stat().st_mtime, UTC
+                ).replace(tzinfo=None)
 
                 runs.append(
                     {

--- a/app/optimizer/models.py
+++ b/app/optimizer/models.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, Field
 from uuid import uuid4
@@ -53,6 +54,7 @@ class OptimizationRun(BaseModel):
 
     id: str = Field(default_factory=lambda: str(uuid4()))
     config: OptimizationConfig
+    created_at: Optional[datetime] = None
     generations: List[List[Candidate]] = Field(default_factory=list)
     best_candidate: Optional[Candidate] = None
     total_cost: float = 0.0  # Accumulated cost across all sessions

--- a/cli/commands/optimize.py
+++ b/cli/commands/optimize.py
@@ -1,6 +1,7 @@
 import typer
 from pathlib import Path
 from typing import Optional
+from datetime import datetime
 import yaml
 from rich.console import Console
 from rich.panel import Panel
@@ -20,6 +21,13 @@ history_app = typer.Typer(help="Manage optimization history")
 app.add_typer(history_app, name="history")
 
 console = Console()
+
+
+def _format_run_date(created_at: Optional[datetime]) -> str:
+    """Format stored run timestamps consistently for CLI output."""
+    if created_at is None:
+        return "Unknown"
+    return created_at.strftime("%Y-%m-%d %H:%M:%S")
 
 
 @app.command("run")
@@ -298,6 +306,7 @@ def optimize_resume(
         console.print(best.prompt_text)
 
 
+@history_app.command("list")
 def history_list(limit: int = typer.Option(10, "--limit", "-l", help="Number of runs to show")):
     """List past optimization runs."""
     from app.optimizer.history import HistoryManager
@@ -355,9 +364,7 @@ def history_show(run_id: str):
         raise typer.Exit(1)
 
     console.print(f"\n[bold cyan]Run Details: {run.id}[/bold cyan]")
-    console.print(
-        f"Date: [green]{run.id}[/green] (TODO: Fix date in model)"
-    )  # Model doesn't have date yet, relying on ID/file
+    console.print(f"Date: [green]{_format_run_date(run.created_at)}[/green]")
     console.print(f"Target Score: {run.config.target_score}")
     console.print(f"Generations: {len(run.generations)}")
 

--- a/tests/test_optimizer_history.py
+++ b/tests/test_optimizer_history.py
@@ -60,7 +60,9 @@ def test_history_manager_backfills_created_at_from_existing_file(tmp_path):
 
     legacy_payload = run.model_dump()
     legacy_payload.pop("created_at", None)
-    file_path.write_text(OptimizationRun.model_validate(legacy_payload).model_dump_json(indent=2), encoding="utf-8")
+    file_path.write_text(
+        OptimizationRun.model_validate(legacy_payload).model_dump_json(indent=2), encoding="utf-8"
+    )
 
     loaded = manager.load_run("legacy-run")
     assert loaded is not None

--- a/tests/test_optimizer_history.py
+++ b/tests/test_optimizer_history.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+from pathlib import Path
+
+from rich.console import Console
+from typer.testing import CliRunner
+
+from app.optimizer.history import HistoryManager
+from app.optimizer.models import Candidate, EvaluationResult, OptimizationConfig, OptimizationRun
+from cli.commands.optimize import app
+import cli.commands.optimize
+
+
+runner = CliRunner()
+
+
+def _build_run(run_id: str, created_at: datetime | None = None) -> OptimizationRun:
+    candidate = Candidate(
+        generation=0,
+        prompt_text="Return concise answers.",
+        mutation_type="initial",
+        result=EvaluationResult(
+            score=0.75,
+            passed_count=3,
+            failed_count=1,
+            error_count=0,
+            avg_latency_ms=12.0,
+            failures=["One failed case"],
+        ),
+    )
+    return OptimizationRun(
+        id=run_id,
+        config=OptimizationConfig(model="mock-model"),
+        created_at=created_at,
+        generations=[[candidate]],
+        best_candidate=candidate,
+    )
+
+
+def test_history_manager_persists_created_at_and_sorts_runs(tmp_path):
+    manager = HistoryManager(base_dir=tmp_path)
+    older = _build_run("older-run", datetime(2024, 1, 2, 3, 4, 5))
+    newer = _build_run("newer-run", datetime(2024, 2, 3, 4, 5, 6))
+
+    manager.save_run(older)
+    manager.save_run(newer)
+
+    loaded = manager.load_run("older-run")
+    runs = manager.list_runs()
+
+    assert loaded is not None
+    assert loaded.created_at == older.created_at
+    assert [run["id"] for run in runs] == ["newer-run", "older-run"]
+    assert runs[0]["date"] == "2024-02-03 04:05:06"
+
+
+def test_history_manager_backfills_created_at_from_existing_file(tmp_path):
+    manager = HistoryManager(base_dir=tmp_path)
+    run = _build_run("legacy-run")
+    file_path = manager.save_run(run)
+
+    legacy_payload = run.model_dump()
+    legacy_payload.pop("created_at", None)
+    file_path.write_text(OptimizationRun.model_validate(legacy_payload).model_dump_json(indent=2), encoding="utf-8")
+
+    loaded = manager.load_run("legacy-run")
+    assert loaded is not None
+    assert loaded.created_at is not None
+
+
+def test_history_cli_list_and_show_use_saved_dates(tmp_path, monkeypatch):
+    promptc_home = tmp_path / ".promptc"
+    manager = HistoryManager(base_dir=promptc_home)
+    run = _build_run("cli-run-1234", datetime(2024, 3, 4, 5, 6, 7))
+    manager.save_run(run)
+
+    original_console = cli.commands.optimize.console
+    try:
+        cli.commands.optimize.console = Console(force_terminal=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        list_result = runner.invoke(app, ["history", "list"])
+        show_result = runner.invoke(app, ["history", "show", "cli-run-1234"])
+
+        assert list_result.exit_code == 0
+        assert show_result.exit_code == 0
+        assert "Optimization History" in list_result.stdout
+        assert "2024-03-04 05:06:07" in list_result.stdout
+        assert "Run Details: cli-run-1234" in show_result.stdout
+        assert "Date: 2024-03-04 05:06:07" in show_result.stdout
+    finally:
+        cli.commands.optimize.console = original_console


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- persist `OptimizationRun.created_at` timestamps when saving optimizer history
- backfill timestamps from file metadata for legacy run files
- register the missing `optimize history list` CLI subcommand and show the saved date in `history show`
- add focused regression tests for history persistence and CLI output

## Why
This was a high-value, low-risk fix in Agent 1 owned files: optimizer history was showing a fake date derived from the run ID in `history show`, and the `history list` command was not registered at all. Persisting a real timestamp makes history output trustworthy while preserving compatibility with existing saved runs.

## Testing
- `pytest tests/test_optimizer_history.py -q`
- verified the optimize history subcommands are registered via a Python CLI introspection snippet (`['list', 'show']`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40e841b2-8e95-49dc-903e-0ed53fc4b530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40e841b2-8e95-49dc-903e-0ed53fc4b530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

