### PR TITLE
fix: resolve 3 CI test failures (UTC compat, extension test, IR_INTENTS sync)

### DIFF
--- a/app/ir_contract.py
+++ b/app/ir_contract.py
@@ -5,7 +5,26 @@ IR_PERSONAS = ["assistant", "teacher", "researcher", "coach", "mentor", "develop
 IR_OUTPUT_FORMATS = ["markdown", "json", "yaml", "table", "text"]
 IR_LENGTH_HINTS = ["short", "medium", "long"]
 
-IR_INTENTS = ["teaching", "summary", "compare", "variants", "recency", "risk", "code", "ambiguous"]
+IR_INTENTS = [
+    "teaching",
+    "explanation",
+    "summary",
+    "compare",
+    "creative",
+    "variants",
+    "proposal",
+    "review",
+    "preparation",
+    "troubleshooting",
+    "recency",
+    "risk",
+    "code",
+    "debug",
+    "ambiguous",
+    "capability_mismatch",
+    "decompose",
+    "summarize",
+]
 IR_STEP_TYPES = ["task", "teach", "research", "compare", "plan"]
 IR_CONSTRAINT_PRIORITIES = [10, 20, 30, 40, 50, 60, 65, 70, 75, 80, 90]
 IR_RISK_LEVELS = ["low", "medium", "high"]

--- a/app/optimizer/history.py
+++ b/app/optimizer/history.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 def _normalize_datetime(value: datetime) -> datetime:
     """Normalize naive and aware datetimes for consistent storage and sorting."""
     if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 class HistoryManager:
@@ -35,7 +35,7 @@ class HistoryManager:
         """Save a run to disk."""
         file_path = self.history_dir / f"{run.id}.json"
         if run.created_at is None:
-            run.created_at = datetime.now(UTC).replace(microsecond=0)
+            run.created_at = datetime.now(timezone.utc).replace(microsecond=0)
         else:
             run.created_at = _normalize_datetime(run.created_at).replace(tzinfo=None)
         with open(file_path, "w", encoding="utf-8") as f:
@@ -54,9 +54,9 @@ class HistoryManager:
                 data = json.load(f)
             run = OptimizationRun.model_validate(data)
             if run.created_at is None:
-                run.created_at = datetime.fromtimestamp(file_path.stat().st_mtime, UTC).replace(
-                    tzinfo=None
-                )
+                run.created_at = datetime.fromtimestamp(
+                    file_path.stat().st_mtime, timezone.utc
+                ).replace(tzinfo=None)
             return run
         except Exception as e:
             logger.warning("Error loading optimization run %s: %s", run_id, e)
@@ -75,7 +75,7 @@ class HistoryManager:
 
                 run = OptimizationRun.model_validate(data)
                 created_at = run.created_at or datetime.fromtimestamp(
-                    file_path.stat().st_mtime, UTC
+                    file_path.stat().st_mtime, timezone.utc
                 ).replace(tzinfo=None)
 
                 runs.append(

--- a/tests/test_extension_background.py
+++ b/tests/test_extension_background.py
@@ -1,10 +1,14 @@
 from pathlib import Path
 
 
-def test_extension_background_uses_public_compile_endpoint_without_api_key():
+def test_extension_background_uses_public_compile_endpoint():
     background = Path("extension/background.js").read_text(encoding="utf-8", errors="ignore")
 
+    # Must use the public /compile endpoint, never the key-gated /compile/fast
     assert "/compile/fast" not in background
-    assert "x-api-key" not in background
-    assert "apiKey:" not in background
     assert "/compile" in background
+
+    # x-api-key is sent conditionally when the user configures an API key
+    # Verify it's guarded by a runtime config check rather than hardcoded
+    assert "x-api-key" in background
+    assert "runtimeConfig" in background


### PR DESCRIPTION
## Summary

Fixes 3 test failures introduced by recent PR merges:

- **Python 3.10 ImportError** (`history.py`): `datetime.UTC` is Python 3.11+ only — replaced with `timezone.utc` which works from 3.6+
- **Extension background test** (`test_extension_background.py`): PR #317 intentionally added conditional `x-api-key` support; updated test to verify it's guarded by `runtimeConfig` rather than asserting it doesn't exist
- **IR schema drift** (`ir_contract.py`): `IR_INTENTS` had 8 values but `ir_v2.schema.json` had 18 — synced the constant to match the schema (source of truth)

## Test plan
- [ ] Full Test (windows-latest, 3.10) passes
- [ ] Full Test (windows-latest, 3.12) passes
- [ ] `test_optimizer_history.py` collects without ImportError
- [ ] `test_extension_background.py` passes
- [ ] `test_schema_validation.py::test_checked_in_schemas_match_shared_ir_contract_enums` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)