### PR TITLE
fix: add enum to ir_v2 schema priority field

### DIFF
--- a/app/_schemas/ir_v2.schema.json
+++ b/app/_schemas/ir_v2.schema.json
@@ -113,7 +113,20 @@
             "type": "string"
           },
           "priority": {
-            "type": "integer"
+            "type": "integer",
+            "enum": [
+              10,
+              20,
+              30,
+              40,
+              50,
+              60,
+              65,
+              70,
+              75,
+              80,
+              90
+            ]
           },
           "rationale": {
             "type": [


### PR DESCRIPTION
## Summary

`test_checked_in_schemas_match_shared_ir_contract_enums` was failing with `KeyError: 'enum'` because `constraints.items.properties.priority` in `ir_v2.schema.json` was defined as `{"type": "integer"}` without an `enum` list, but the test asserts it matches `IR_CONSTRAINT_PRIORITIES`.

Adds `"enum": [10, 20, 30, 40, 50, 60, 65, 70, 75, 80, 90]` to the priority field to bring schema in sync with the contract constant.

## Test plan
- [ ] `test_schema_validation.py::test_checked_in_schemas_match_shared_ir_contract_enums` passes on all platforms/versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)