### PR TITLE
🎨 Palette: Add keyboard shortcuts to Generator pages

### DIFF
--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { apiFetch, buildGeneratorApiHeaders } from "@/config";
 import ContextManager from "../components/ContextManager";
@@ -16,8 +16,12 @@ export default function AgentGenerator() {
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
   const [history, setHistory] = useState<{ label: string; prompt: string }[]>([]);
 
+  const isGeneratingRef = useRef(false);
+
   const handleGenerate = async () => {
     if (!description.trim()) return;
+    if (isGeneratingRef.current) return;
+    isGeneratingRef.current = true;
 
     setLoading(true);
     setError(null);
@@ -51,6 +55,7 @@ export default function AgentGenerator() {
       setError(e instanceof Error ? e.message : "Failed to generate agent");
     } finally {
       setLoading(false);
+      isGeneratingRef.current = false;
     }
   };
 
@@ -109,6 +114,7 @@ export default function AgentGenerator() {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 onKeyDown={(e) => {
+                  if (e.repeat) return;
                   if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
                     e.preventDefault();
                     if (!loading && description.trim()) {

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -108,6 +108,14 @@ export default function AgentGenerator() {
                 placeholder="e.g., 'I need an agent that reviews React code for performance bottlenecks' or 'A creative writer for sci-fi stories'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                    e.preventDefault();
+                    if (!loading && description.trim()) {
+                      void handleGenerate();
+                    }
+                  }
+                }}
               />
             </div>
 
@@ -176,12 +184,12 @@ export default function AgentGenerator() {
             <button
               onClick={handleGenerate}
               disabled={loading || !description.trim()}
-              className={`w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20'}`}
+              className={`w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a] ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20 focus-visible:ring-purple-500' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20 focus-visible:ring-green-500'}`}
             >
               {loading ? (
                 <span className="animate-pulse">Architecting...</span>
               ) : (
-                <>Generate {multiAgent ? 'Swarm' : 'Agent'} <span className="group-hover:translate-x-0.5 transition-transform">→</span></>
+                <>Generate {multiAgent ? 'Swarm' : 'Agent'} <span className="group-hover:translate-x-0.5 transition-transform">→</span> <kbd className="hidden md:inline-block ml-2 text-[10px] font-mono opacity-50 border border-white/20 rounded px-1.5 py-0.5 bg-white/5">Ctrl/⌘ Enter</kbd></>
               )}
             </button>
 

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { apiFetch, buildGeneratorApiHeaders } from "@/config";
 import InfoButton from "../components/InfoButton";
@@ -15,8 +15,12 @@ export default function SkillsGenerator() {
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
   const [history, setHistory] = useState<{ label: string; skill: string }[]>([]);
 
+  const isGeneratingRef = useRef(false);
+
   const handleGenerate = async () => {
     if (!description.trim()) return;
+    if (isGeneratingRef.current) return;
+    isGeneratingRef.current = true;
 
     setLoading(true);
     setError(null);
@@ -49,6 +53,7 @@ export default function SkillsGenerator() {
       setError(e instanceof Error ? e.message : "Failed to generate skill");
     } finally {
       setLoading(false);
+      isGeneratingRef.current = false;
     }
   };
 
@@ -106,6 +111,7 @@ export default function SkillsGenerator() {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 onKeyDown={(e) => {
+                  if (e.repeat) return;
                   if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
                     e.preventDefault();
                     if (!loading && description.trim()) {

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -105,6 +105,14 @@ export default function SkillsGenerator() {
                 placeholder="e.g., 'A skill that parses JSON and validates schemas' or 'Fetch and summarize web pages'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                    e.preventDefault();
+                    if (!loading && description.trim()) {
+                      void handleGenerate();
+                    }
+                  }
+                }}
               />
             </div>
 
@@ -156,12 +164,12 @@ export default function SkillsGenerator() {
             <button
               onClick={handleGenerate}
               disabled={loading || !description.trim()}
-              className="w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20"
+              className="w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a]"
             >
               {loading ? (
                 <span className="animate-pulse">Forging Skill...</span>
               ) : (
-                <>Generate Skill <span className="group-hover:translate-x-0.5 transition-transform">→</span></>
+                <>Generate Skill <span className="group-hover:translate-x-0.5 transition-transform">→</span> <kbd className="hidden md:inline-block ml-2 text-[10px] font-mono opacity-50 border border-white/20 rounded px-1.5 py-0.5 bg-white/5">Ctrl/⌘ Enter</kbd></>
               )}
             </button>
 


### PR DESCRIPTION
💡 **What:** 
Added `Ctrl/Cmd+Enter` keyboard shortcuts to submit prompts directly from the textareas in the Agent Generator and Skills Generator pages. Added visual `<kbd>` hints to the generate buttons, alongside proper `focus-visible` states.

🎯 **Why:** 
To allow power users to remain on the keyboard during the generation workflow without needing to switch to the mouse to click "Generate". The visual `<kbd>` hints make this feature discoverable, and the `focus-visible` styling improves navigation for pure keyboard users.

📸 **Before/After:**
*(See attached video verification in review)*
- **Before:** Textareas could only grow; submit required manual mouse clicking or awkward tabbing. Buttons lacked clear focus rings.
- **After:** Hitting `Ctrl/Cmd+Enter` immediately triggers generation. Submit buttons now display "Ctrl/⌘ Enter" styled cleanly on the right, and tab-focus displays a crisp offset ring.

♿ **Accessibility:**
- Added `focus-visible:ring-2`, `focus-visible:outline-none`, and `focus-visible:ring-offset-2` to the submit buttons for explicit keyboard focus indication.
- Used `<kbd>` semantic markup for the keyboard shortcuts.

---
*PR created automatically by Jules for task [17506313857645639799](https://jules.google.com/task/17506313857645639799) started by @madara88645*