### PR TITLE
[codex] Gate Fly.io deploy on successful CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,16 @@
 name: Deploy to Fly.io
 
 on:
-  push:
-    branches: [ main ]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: []  # CI testlerini beklemek için: needs: [test] — ama ci.yml ayrı workflow, bu yüzden şimdilik bağımsız
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     concurrency:
       group: deploy-production
       cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,15 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.event == 'push' }}
     concurrency:
       group: deploy-production
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/tests/test_deploy_workflow.py
+++ b/tests/test_deploy_workflow.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import yaml
+
+
+def _load_deploy_workflow() -> dict:
+    workflow_path = Path(".github/workflows/deploy.yml")
+    return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+
+def test_deploy_workflow_only_runs_after_successful_ci_on_main():
+    workflow = _load_deploy_workflow()
+    trigger = workflow.get("on", workflow.get(True))
+
+    assert "workflow_run" in trigger
+
+    workflow_run = trigger["workflow_run"]
+    assert workflow_run["workflows"] == ["CI"]
+    assert workflow_run["types"] == ["completed"]
+
+    deploy_job = workflow["jobs"]["deploy"]
+    assert deploy_job["if"] == (
+        "${{ github.event.workflow_run.conclusion == 'success' "
+        "&& github.event.workflow_run.head_branch == 'main' }}"
+    )

--- a/tests/test_deploy_workflow.py
+++ b/tests/test_deploy_workflow.py
@@ -4,7 +4,9 @@ import yaml
 
 
 def _load_deploy_workflow() -> dict:
-    workflow_path = Path(".github/workflows/deploy.yml")
+    workflow_path = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "deploy.yml"
+    )
     return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
 
 
@@ -21,5 +23,17 @@ def test_deploy_workflow_only_runs_after_successful_ci_on_main():
     deploy_job = workflow["jobs"]["deploy"]
     assert deploy_job["if"] == (
         "${{ github.event.workflow_run.conclusion == 'success' "
-        "&& github.event.workflow_run.head_branch == 'main' }}"
+        "&& github.event.workflow_run.head_branch == 'main' "
+        "&& github.event.workflow_run.event == 'push' }}"
     )
+
+
+def test_deploy_workflow_checks_out_ci_tested_sha():
+    workflow = _load_deploy_workflow()
+    steps = workflow["jobs"]["deploy"]["steps"]
+    checkout_step = next(
+        (s for s in steps if isinstance(s.get("uses"), str) and s["uses"].startswith("actions/checkout")),
+        None,
+    )
+    assert checkout_step is not None, "No actions/checkout step found"
+    assert checkout_step.get("with", {}).get("ref") == "${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
## What changed
- switched Fly.io deploy workflow from `push` on `main` to `workflow_run` after the `CI` workflow completes
- gated the deploy job so it only runs when the upstream CI conclusion is `success` and the source branch is `main`
- added a regression test that loads `.github/workflows/deploy.yml` and asserts the deploy workflow remains CI-gated

## Why
The deploy workflow was running independently of CI, so a broken `main` push could still reach production. This change makes deployment depend on a successful CI run and keeps the protection covered by a test.

## Impact
- production deploys now wait for CI success
- future workflow drift should be caught by the new regression test

## Validation
- `python -m pytest -q tests/test_deploy_workflow.py`
- `python -m pre_commit run --files .github/workflows/deploy.yml tests/test_deploy_workflow.py`
