### PR TITLE
🎨 Palette: Add keyboard focus indicator to Conservative Mode switch

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -108,7 +108,7 @@ export default function Home() {
               aria-checked={conservativeMode}
               aria-label={conservativeMode ? "Conservative mode ON" : "Conservative mode OFF"}
               title={conservativeMode ? "Conservative mode ON" : "Conservative mode OFF"}
-              className={`group inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200 ${
+              className={`group inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 ${
                 conservativeMode
                   ? "border-cyan-400/40 bg-cyan-400/10 text-cyan-100 shadow-lg shadow-cyan-900/20"
                   : "border-zinc-700 bg-zinc-900/70 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200"


### PR DESCRIPTION
💡 **What:**
Added standard `focus-visible:ring-2 focus-visible:ring-cyan-400` utility classes to the Conservative Mode switch toggle button in the main application layout (`web/app/page.tsx`).

🎯 **Why:**
The toggle button visually responded to hover states, but entirely lacked a visible focus indicator when navigated via a keyboard (e.g., using Tab). Keyboard users had no clear way to determine when the switch was the active element. This is a crucial interaction point for the application.

📸 **Before/After:**
*   **Before:** `Tab` navigation would leave the button visually unchanged, making it difficult to know if it was focused.
*   **After:** Pressing `Tab` adds a clear cyan focus ring around the pill, seamlessly matching the component's existing color scheme and only appearing on keyboard interaction (via `focus-visible`).

♿ **Accessibility:**
*   Improves WCAG 2.1 Success Criterion 2.4.7 Focus Visible by providing a highly visible focus indicator.
*   Uses `focus-visible` rather than `focus` to ensure the ring doesn't distractingly appear for mouse users who click the toggle.

---
*PR created automatically by Jules for task [3787593673330090975](https://jules.google.com/task/3787593673330090975) started by @madara88645*