### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in DiffViewer fallback

### DIFF
--- a/web/app/components/DiffViewer.tsx
+++ b/web/app/components/DiffViewer.tsx
@@ -76,9 +76,11 @@ export default function DiffViewer({ oldText, newText }: DiffViewerProps) {
                 if (!cancelled) {
                     setSanitizedHtml(DOMPurify.sanitize(rawHtmlContent));
                 }
-            } catch {
+            } catch (error) {
+                console.error("Failed to load DOMPurify:", error);
                 if (!cancelled) {
-                    setSanitizedHtml(rawHtmlContent);
+                    // Fallback: Fail securely rather than exposing XSS
+                    setSanitizedHtml("<div>Error: Diff viewer failed to initialize securely.</div>");
                 }
             }
         }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Cross-Site Scripting (XSS) due to a "fail open" fallback. If `dompurify` failed to load in `web/app/components/DiffViewer.tsx`, the `catch` block would fallback to calling `setSanitizedHtml(rawHtmlContent)`.
🎯 **Impact:** An attacker could exploit this by providing a malicious diff that, under specific network or loading failure conditions, executes arbitrary JavaScript in the victim's browser via the unsanitized `dangerouslySetInnerHTML`.
🔧 **Fix:** Changed the fallback logic to "fail securely". If `DOMPurify` fails to load, it now logs the error and safely sets the HTML to an error string instead of the raw content.
✅ **Verification:** Verified by running the `pytest` backend suite and ensuring the frontend linting/testing passing (`pnpm lint` and `pnpm test`).

---
*PR created automatically by Jules for task [17661532778290093489](https://jules.google.com/task/17661532778290093489) started by @madara88645*