### PR TITLE
⚡ Bolt: [performance improvement] Prevent event loop blocking in RAG search endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,6 @@
 ## 2026-03-24 - Optimizing String Tokens Membership Check
 **Learning:** In Python, when checking for membership of multiple items in a tokenized string within a loop or comprehension (e.g., `[t for t in terms if t in text.split()]`), evaluating `.split()` inside the loop forces Python to allocate new lists and do O(N) membership checks repeatedly.
 **Action:** Extract `.split()` outside the loop and convert it to a `set` (e.g., `words = set(text.split())`). This ensures the string is split only once and provides O(1) membership lookups for the inner evaluation, significantly improving performance especially for large texts.
+## 2026-04-05 - Prevent Event Loop Blocking in FastAPI
+**Learning:** In FastAPI, declaring an endpoint as `async def` while running a blocking synchronous operation (like SQLite I/O) directly within it blocks the main event loop, severely degrading concurrent performance.
+**Action:** Declare endpoints performing blocking I/O as `def` instead of `async def`. FastAPI will automatically offload these synchronous endpoints to a separate threadpool, allowing the main event loop to remain non-blocking.

--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -237,9 +237,13 @@ def rag_stats_endpoint(
 
 
 @router.post("/rag/search", response_model=List[RagSearchResult])
-async def rag_search_endpoint(
+def rag_search_endpoint(
     req: RagSearchRequest,
     api_key: APIKey | None = Depends(verify_api_key_if_required),
 ):
+    """
+    Bolt: Avoid blocking event loop for SQLite query by removing async.
+    FastAPI handles sync endpoints in a threadpool automatically.
+    """
     del api_key
     return [_canonical_search_result(item) for item in rag_search(req.query, k=req.limit)]


### PR DESCRIPTION
💡 **What:** Changed `rag_search_endpoint` in `api/routes/rag.py` from `async def` to `def`.
🎯 **Why:** The endpoint performs a blocking synchronous SQLite query via `rag_search`. Because it was defined as `async def` without offloading to a thread, it blocked FastAPI's main event loop, causing performance bottlenecks for concurrent requests.
📊 **Measured Improvement:** Prevents event loop starvation. Allows FastAPI to automatically run the endpoint in a separate threadpool, significantly improving concurrent request throughput for this endpoint.

---
*PR created automatically by Jules for task [2673749852651451356](https://jules.google.com/task/2673749852651451356) started by @madara88645*