### PR TITLE
🛡️ Sentinel: [security improvement] Add maximum length limit to API Key validation

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -77,6 +77,11 @@ def verify_api_key(
             status_code=status.HTTP_403_FORBIDDEN, detail="Could not validate credentials"
         )
 
+    if len(api_key) > 256:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="API key too long"
+        )
+
     # --- Master Key Check (for Stateless Deployments like Railway) ---
     import os
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -78,9 +78,7 @@ def verify_api_key(
         )
 
     if len(api_key) > 256:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="API key too long"
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="API key too long")
 
     # --- Master Key Check (for Stateless Deployments like Railway) ---
     import os


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length validation on the `x-api-key` header in authentication middleware.
🎯 Impact: An attacker could potentially send excessively long API keys, forcing the application to perform expensive database queries or string comparisons (`secrets.compare_digest`) on massive strings, potentially leading to resource exhaustion (DoS) or buffer-related issues.
🔧 Fix: Implemented an explicit `len(api_key) > 256` check within the `verify_api_key` FastAPI dependency, returning a clean HTTP 400 Bad Request error before any expensive operations are performed.
✅ Verification: Ensure the test suite passes (`pytest tests/`) and verify that standard authentication routes function normally while explicitly rejecting extremely long strings.

---
*PR created automatically by Jules for task [17204963460440412758](https://jules.google.com/task/17204963460440412758) started by @madara88645*