### PR TITLE
🛡️ Sentinel: [security improvement] Add input length limit to API keys

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -77,6 +77,9 @@ def verify_api_key(
             status_code=status.HTTP_403_FORBIDDEN, detail="Could not validate credentials"
         )
 
+    if len(api_key) > 256:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid API Key.")
+
     # --- Master Key Check (for Stateless Deployments like Railway) ---
     import os
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length limit on API keys (DoS risk)
🎯 Impact: An attacker could potentially cause a Denial of Service (DoS) by sending excessively long strings as API keys, consuming server resources during evaluation.
🔧 Fix: Implemented a manual length check (`> 256` characters) inside the `verify_api_key` dependency function in `api/auth.py` to reject overly long inputs with a 400 Bad Request before hitting the database or string comparison logic.
✅ Verification: Tested via the backend test suite (`python -m pytest tests/`), ensuring no regressions, and pre-commit checks pass correctly.

---
*PR created automatically by Jules for task [18019989095601453177](https://jules.google.com/task/18019989095601453177) started by @madara88645*