### PR TITLE
🎨 Palette: [UX improvement] Add copy feedback to generator tools

### DIFF
--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -15,6 +15,7 @@ export default function AgentGenerator() {
   const [multiAgent, setMultiAgent] = useState(false);
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
   const [history, setHistory] = useState<{ label: string; prompt: string }[]>([]);
+  const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
 
@@ -62,6 +63,8 @@ export default function AgentGenerator() {
   const copyToClipboard = () => {
     if (result) {
       navigator.clipboard.writeText(result);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     }
   };
 
@@ -230,11 +233,15 @@ export default function AgentGenerator() {
                   <button
                     onClick={copyToClipboard}
                     className="absolute bottom-6 right-6 bg-green-600 hover:bg-green-500 text-white p-3 rounded-xl shadow-lg shadow-green-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2"
-                    title="Copy to Clipboard"
-                    aria-label="Copy Markdown"
+                    title={copied ? "Copied!" : "Copy to Clipboard"}
+                    aria-label={copied ? "Copied" : "Copy Markdown"}
                   >
-                    <span className="text-xs font-bold">Copy Markdown</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>
+                    <span className="text-xs font-bold">{copied ? "Copied!" : "Copy Markdown"}</span>
+                    {copied ? (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                    ) : (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>
+                    )}
                   </button>
                 </div>
               </div>

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -14,6 +14,7 @@ export default function SkillsGenerator() {
   const [error, setError] = useState<string | null>(null);
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
   const [history, setHistory] = useState<{ label: string; skill: string }[]>([]);
+  const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
 
@@ -60,6 +61,8 @@ export default function SkillsGenerator() {
   const copyToClipboard = () => {
     if (result) {
       navigator.clipboard.writeText(result);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     }
   };
 
@@ -210,11 +213,15 @@ export default function SkillsGenerator() {
                   <button
                     onClick={copyToClipboard}
                     className="absolute bottom-6 right-6 bg-yellow-600 hover:bg-yellow-500 text-white p-3 rounded-xl shadow-lg shadow-yellow-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2"
-                    title="Copy to Clipboard"
-                    aria-label="Copy Markdown"
+                    title={copied ? "Copied!" : "Copy to Clipboard"}
+                    aria-label={copied ? "Copied" : "Copy Markdown"}
                   >
-                    <span className="text-xs font-bold">Copy Markdown</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>
+                    <span className="text-xs font-bold">{copied ? "Copied!" : "Copy Markdown"}</span>
+                    {copied ? (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                    ) : (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>
+                    )}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add copy feedback to generator tools

💡 **What:** Added a temporary "Copied!" state to the copy-to-clipboard buttons in the Agent Generator and Skills Generator pages. When clicked, the button changes its text to "Copied!" and its icon to a checkmark for 2 seconds.
🎯 **Why:** To address the "No feedback on button clicks" UX issue, making the interface more intuitive and confirming to the user that their action was successful.
📸 **Before/After:** The copy buttons will transition to a clear "Copied!" status upon click, providing immediate visual feedback.
♿ **Accessibility:** Updated the buttons to use dynamic ARIA labels (`aria-label`) and `title` attributes that mirror the button's visual state, ensuring screen reader users also receive the immediate feedback.

---
*PR created automatically by Jules for task [5808258415960236405](https://jules.google.com/task/5808258415960236405) started by @madara88645*