### PR TITLE
fix(ci): add vitest config to exclude node:test files

### DIFF
--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    exclude: ["**/*.test.mts", "node_modules/**"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- PR #338 added `npm run test` (vitest) to CI but forgot to include `vitest.config.ts`
- Without the config, vitest uses default file discovery and picks up `.test.mts` files that use `node:test` API instead of vitest
- This caused 4 "No test suite found" failures on every push to main: `config.test.mts`, `promptc-api.test.mts`, `intent-policy-utils.test.mts`, `modelCatalog.test.mts`
- Fix: add `vitest.config.ts` with `exclude: ["**/*.test.mts", "node_modules/**"]` so vitest only runs `.test.ts`/`.test.tsx` files

## Test plan
- [x] `npm run test` passes locally (2 files, 5 tests)
- [x] `npm run test:contracts` still passes (13 tests via node:test)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)