### PR TITLE
fix(ci): add passWithNoTests to vitest config

### DIFF
--- a/web/app/components/OutputSkeleton.tsx
+++ b/web/app/components/OutputSkeleton.tsx
@@ -1,0 +1,32 @@
+import { Skeleton, SkeletonBlock } from "./Skeleton";
+
+export default function OutputSkeleton() {
+  return (
+    <div className="flex flex-col h-full animate-fade-in">
+      {/* Tab bar skeleton */}
+      <div className="flex gap-2 px-4 pt-4 pb-2 border-b border-white/5">
+        {["w-16", "w-20", "w-14", "w-18", "w-22", "w-12", "w-18"].map((w, i) => (
+          <Skeleton key={i} className={`h-8 ${w}`} />
+        ))}
+      </div>
+
+      {/* Content skeleton */}
+      <div className="flex-1 p-6 space-y-6">
+        {/* Title block */}
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-[45%]" />
+          <Skeleton className="h-3 w-[30%]" />
+        </div>
+
+        {/* Body block */}
+        <SkeletonBlock lines={6} />
+
+        {/* Second section */}
+        <div className="pt-4 space-y-2">
+          <Skeleton className="h-5 w-[35%]" />
+        </div>
+        <SkeletonBlock lines={4} />
+      </div>
+    </div>
+  );
+}

--- a/web/app/components/Skeleton.tsx
+++ b/web/app/components/Skeleton.tsx
@@ -1,0 +1,17 @@
+export function Skeleton({ className = "" }: { className?: string }) {
+  return <div className={`skeleton ${className}`} />;
+}
+
+export function SkeletonBlock({ lines = 5 }: { lines?: number }) {
+  const widths = ["w-full", "w-[85%]", "w-[92%]", "w-[78%]", "w-[88%]", "w-full", "w-[70%]"];
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: lines }, (_, i) => (
+        <Skeleton
+          key={i}
+          className={`h-3 ${widths[i % widths.length]}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/web/app/components/ToastProvider.tsx
+++ b/web/app/components/ToastProvider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Toaster } from "sonner";
+
+export default function ToastProvider() {
+  return <Toaster theme="dark" position="bottom-right" richColors />;
+}

--- a/web/app/components/context/ContextSuggestions.tsx
+++ b/web/app/components/context/ContextSuggestions.tsx
@@ -1,0 +1,31 @@
+import type { ContextSuggestion } from "../../../lib/api/types";
+
+type ContextSuggestionsProps = {
+    suggestions: ContextSuggestion[];
+    onInsertContext: (text: string) => void;
+};
+
+export default function ContextSuggestions({ suggestions, onInsertContext }: ContextSuggestionsProps) {
+    if (suggestions.length === 0) return null;
+
+    return (
+        <div className="flex flex-col gap-2 mb-4 animate-fade-in">
+            <span className="text-[9px] text-blue-400 font-bold uppercase tracking-widest px-1">Suggested Files</span>
+            <div className="flex flex-wrap gap-2">
+                {suggestions.map((suggestion) => (
+                    <button
+                        key={suggestion.path}
+                        onClick={() => onInsertContext(`[File: ${suggestion.name}]\n(Reason: ${suggestion.reason})`)}
+                        className="group flex items-center gap-2 px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 hover:border-blue-500/40 rounded-full transition-all text-left"
+                        title={`Add ${suggestion.path} to context`}
+                    >
+                        <span className="text-[10px] text-blue-300 font-mono">{suggestion.name}</span>
+                        <span className="text-[9px] text-blue-400/60 group-hover:text-blue-400 opacity-60 group-hover:opacity-100 transition-opacity">
+                            +
+                        </span>
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/web/app/components/context/FileUploadZone.tsx
+++ b/web/app/components/context/FileUploadZone.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useRef, useState, type ChangeEvent, type DragEvent } from "react";
+import type { UploadProgress } from "../../hooks/useContextManager";
+import UploadProgressCard from "./UploadProgressCard";
+
+type FileUploadZoneProps = {
+    ingesting: boolean;
+    uploadProgress: UploadProgress | null;
+    onUploadFiles: (files: File[]) => Promise<void>;
+};
+
+export default function FileUploadZone({ ingesting, uploadProgress, onUploadFiles }: FileUploadZoneProps) {
+    const [isDragging, setIsDragging] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const directoryInputRef = useRef<HTMLInputElement>(null);
+
+    const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        setIsDragging(false);
+        const files = Array.from(e.dataTransfer.files);
+        if (files.length > 0) {
+            await onUploadFiles(files);
+        }
+    };
+
+    const handleFileSelect = async (e: ChangeEvent<HTMLInputElement>) => {
+        const files = e.target.files;
+        if (!files || files.length === 0) return;
+        await onUploadFiles(Array.from(files));
+        if (fileInputRef.current) fileInputRef.current.value = "";
+    };
+
+    const handleDirectorySelect = async (e: ChangeEvent<HTMLInputElement>) => {
+        const files = e.target.files;
+        if (!files || files.length === 0) return;
+        await onUploadFiles(Array.from(files));
+        if (directoryInputRef.current) directoryInputRef.current.value = "";
+    };
+
+    return (
+        <div
+            onDrop={handleDrop}
+            onDragOver={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setIsDragging(true); }}
+            onDragLeave={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setIsDragging(false); }}
+            className={`
+                relative flex flex-col items-center justify-center gap-2 p-4
+                border-2 border-dashed rounded-xl
+                transition-all duration-200
+                ${isDragging ? "border-blue-500 bg-blue-500/10 scale-[1.02]" : "border-white/10 bg-white/[0.02]"}
+                ${ingesting ? "pointer-events-none opacity-50" : ""}
+            `}
+        >
+            <input ref={fileInputRef} type="file" multiple onChange={handleFileSelect} className="hidden" />
+            <input
+                ref={directoryInputRef}
+                type="file"
+                multiple
+                // @ts-expect-error - webkitdirectory is not in standard types but supported by browsers
+                webkitdirectory=""
+                directory=""
+                onChange={handleDirectorySelect}
+                className="hidden"
+            />
+
+            {ingesting && uploadProgress ? (
+                <UploadProgressCard uploadProgress={uploadProgress} />
+            ) : (
+                <>
+                    <div className={`text-2xl ${isDragging ? "scale-110" : ""} transition-transform`}>Files</div>
+                    <div className="flex gap-2">
+                        <button onClick={() => fileInputRef.current?.click()} className="text-xs text-blue-400 font-medium hover:text-blue-300 transition-colors">
+                            Upload Files
+                        </button>
+                        <span className="text-xs text-zinc-500">|</span>
+                        <button onClick={() => directoryInputRef.current?.click()} className="text-xs text-blue-400 font-medium hover:text-blue-300 transition-colors">
+                            Upload Folder
+                        </button>
+                    </div>
+                    <div className="text-[10px] text-zinc-600 mt-1">Or drag and drop project context</div>
+                </>
+            )}
+        </div>
+    );
+}

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -1,0 +1,69 @@
+import { formatSearchResultForPrompt, formatSearchScore } from "../../../lib/api/promptc";
+import type { RagSearchResult } from "../../../lib/api/types";
+
+type RagSearchPanelProps = {
+    query: string;
+    setQuery: (q: string) => void;
+    searching: boolean;
+    results: RagSearchResult[];
+    onRunSearch: () => void;
+    onInsertContext: (text: string) => void;
+};
+
+export default function RagSearchPanel({
+    query,
+    setQuery,
+    searching,
+    results,
+    onRunSearch,
+    onInsertContext,
+}: RagSearchPanelProps) {
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex gap-2">
+                <input
+                    type="text"
+                    aria-label="Search context..."
+                    className="flex-1 bg-black/30 p-2.5 rounded-lg text-xs border border-white/5 focus:border-blue-500/30 focus:outline-none transition-colors placeholder-zinc-600 font-mono"
+                    placeholder="Search context..."
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && onRunSearch()}
+                />
+                <button
+                    onClick={onRunSearch}
+                    disabled={searching || !query}
+                    className="px-3 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-lg text-xs hover:bg-blue-500/20 transition-all font-medium"
+                >
+                    Search
+                </button>
+            </div>
+
+            <div className="flex flex-col gap-2 max-h-[180px] overflow-y-auto pr-1 custom-scrollbar">
+                {!searching && query && results.length === 0 && (
+                    <div className="text-[10px] text-zinc-500 text-center py-4 bg-white/[0.02] rounded-lg border border-dashed border-white/5">
+                        No results found for &quot;{query}&quot;
+                    </div>
+                )}
+
+                {results.map((result) => (
+                    <div key={result.path} className="group flex flex-col gap-1.5 p-3 bg-white/5 rounded-xl border border-white/5 hover:border-white/10 transition-all hover:bg-white/[0.07]">
+                        <div className="flex justify-between items-center gap-2">
+                            <span className="text-[10px] text-zinc-500 font-mono truncate max-w-[180px] bg-black/20 px-1.5 py-0.5 rounded">{result.path}</span>
+                            <span className="text-[10px] text-green-400/80 font-mono bg-green-500/10 px-1.5 py-0.5 rounded">{formatSearchScore(result)}</span>
+                        </div>
+                        <div className="text-xs text-zinc-300 line-clamp-3 leading-relaxed opacity-80 group-hover:opacity-100">
+                            {result.snippet}
+                        </div>
+                        <button
+                            onClick={() => onInsertContext(formatSearchResultForPrompt(result))}
+                            className="mt-1 text-[10px] text-blue-300 hover:text-blue-200 text-left opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded transition-all flex items-center gap-1 font-medium"
+                        >
+                            <span>+</span> Insert into Prompt
+                        </button>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/web/app/components/context/UploadProgressCard.tsx
+++ b/web/app/components/context/UploadProgressCard.tsx
@@ -1,0 +1,49 @@
+import type { UploadProgress } from "../../hooks/useContextManager";
+
+type UploadProgressCardProps = {
+    uploadProgress: UploadProgress;
+};
+
+export default function UploadProgressCard({ uploadProgress }: UploadProgressCardProps) {
+    const uploadPercent = Math.max(
+        8,
+        Math.min(
+            100,
+            Math.round(
+                ((uploadProgress.completed + (uploadProgress.currentFile ? 0.45 : 0)) / uploadProgress.total) * 100,
+            ),
+        ),
+    );
+    const currentStep = Math.min(
+        uploadProgress.total,
+        uploadProgress.completed + (uploadProgress.currentFile ? 1 : 0),
+    );
+
+    return (
+        <div className="w-full max-w-sm rounded-2xl border border-cyan-400/20 bg-cyan-500/[0.08] p-4 shadow-[0_0_40px_rgba(34,211,238,0.08)]">
+            <div className="flex items-start gap-3">
+                <span className="mt-1 relative flex h-3 w-3 shrink-0">
+                    <span className="absolute inline-flex h-full w-full rounded-full bg-cyan-300/30 animate-ping" />
+                    <span className="relative inline-flex h-3 w-3 rounded-full bg-cyan-300" />
+                </span>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-sm font-medium text-cyan-100">Uploading context</span>
+                        <span className="text-[10px] font-mono text-cyan-200/80">
+                            {currentStep}/{uploadProgress.total}
+                        </span>
+                    </div>
+                    <p className="mt-1 text-[11px] leading-relaxed text-cyan-100/70">
+                        {uploadProgress.currentFile ? uploadProgress.currentFile : "Preparing files..."}
+                    </p>
+                    <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-black/20">
+                        <div
+                            className="h-full rounded-full bg-gradient-to-r from-cyan-300 via-sky-400 to-blue-400 transition-[width] duration-500"
+                            style={{ width: `${uploadPercent}%` }}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/web/app/lib/showError.ts
+++ b/web/app/lib/showError.ts
@@ -1,0 +1,6 @@
+import { toast } from "sonner";
+import { describeRequestError } from "../../config";
+
+export function showError(error: unknown): void {
+  toast.error(describeRequestError(error));
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     globals: true,
+    passWithNoTests: true,
     exclude: ["**/*.test.mts", "node_modules/**"],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- Follows up on #344 which added `vitest.config.ts` but was merged without `passWithNoTests`
- Adds `passWithNoTests: true` so vitest exits with code 0 when no `.test.tsx` files exist yet
- Adds 8 missing frontend module files that PR #338 forgot to commit (showError, OutputSkeleton, ToastProvider, Skeleton, context components)
- These missing files caused 11 "Module not found" errors in Next.js build

## Test plan
- [x] `npm run test` passes locally
- [x] `npm run test:contracts` passes locally (13 tests)
- [x] `next build` compiles successfully (all 7 pages)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)