### PR TITLE
[codex] Add regression coverage for ContextManager RAG UI

### DIFF
--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -99,6 +99,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                         onChange={(e) => setFilePath(e.target.value)}
                     />
                     <button
+                        type="button"
                         onClick={() => void ingestPath(filePath)}
                         disabled={ingesting || !filePath}
                         className="w-full py-2 bg-zinc-800/50 hover:bg-zinc-700/50 text-xs font-medium text-zinc-300 rounded-lg disabled:opacity-50 transition-colors border border-white/5 flex items-center justify-center gap-2"

--- a/web/app/components/__tests__/ContextManager.test.tsx
+++ b/web/app/components/__tests__/ContextManager.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ContextManager from "../ContextManager";
+
+const useContextManagerMock = vi.fn();
+
+vi.mock("../../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+describe("ContextManager", () => {
+  it("renders hook-driven status, stats, and safe ingest action", () => {
+    useContextManagerMock.mockReturnValue({
+      ingesting: false,
+      searching: false,
+      query: "compiler",
+      setQuery: vi.fn(),
+      results: [],
+      filePath: "",
+      setFilePath: vi.fn(),
+      status: "Indexed 2/2 files (8 chunks)",
+      isConnected: true,
+      indexStats: { docs: 2, chunks: 8, total_bytes: 4096 },
+      uploadProgress: null,
+      uploadFiles: vi.fn(),
+      ingestPath: vi.fn(),
+      runSearch: vi.fn(),
+    });
+
+    render(
+      <ContextManager
+        onInsertContext={vi.fn()}
+        suggestions={[
+          {
+            path: "src/compiler.ts",
+            name: "compiler.ts",
+            reason: "Core compile path",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Context Manager")).toBeTruthy();
+    expect(screen.getByText("Connected")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("4.0 KB")).toBeTruthy();
+    expect(screen.getByText("Indexed 2/2 files (8 chunks)")).toBeTruthy();
+
+    const ingestButton = screen.getByRole("button", { name: "Ingest Path" });
+    expect(ingestButton.getAttribute("type")).toBe("button");
+    expect(ingestButton.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/web/app/components/__tests__/ContextSuggestions.test.tsx
+++ b/web/app/components/__tests__/ContextSuggestions.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ContextSuggestions from "../context/ContextSuggestions";
+
+describe("ContextSuggestions", () => {
+  it("formats inserted context and does not submit surrounding forms", () => {
+    const onInsertContext = vi.fn();
+    const onSubmit = vi.fn((event: SubmitEvent) => event.preventDefault());
+
+    render(
+      <form onSubmit={onSubmit}>
+        <ContextSuggestions
+          suggestions={[
+            {
+              path: "src/app.ts",
+              name: "app.ts",
+              reason: "Entry point",
+            },
+          ]}
+          onInsertContext={onInsertContext}
+        />
+      </form>,
+    );
+
+    const button = screen.getByRole("button", { name: /app\.ts/ });
+    fireEvent.click(button);
+
+    expect(button.getAttribute("type")).toBe("button");
+    expect(onInsertContext).toHaveBeenCalledWith("[File: app.ts]\n(Reason: Entry point)");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no suggestions exist", () => {
+    const { container } = render(<ContextSuggestions suggestions={[]} onInsertContext={vi.fn()} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/app/components/__tests__/FileUploadZone.test.tsx
+++ b/web/app/components/__tests__/FileUploadZone.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import FileUploadZone from "../context/FileUploadZone";
+
+describe("FileUploadZone", () => {
+  it("uses non-submit buttons for upload actions", () => {
+    const onSubmit = vi.fn((event: SubmitEvent) => event.preventDefault());
+
+    render(
+      <form onSubmit={onSubmit}>
+        <FileUploadZone ingesting={false} uploadProgress={null} onUploadFiles={vi.fn().mockResolvedValue(undefined)} />
+      </form>,
+    );
+
+    const uploadFilesButton = screen.getByRole("button", { name: "Upload Files" });
+    const uploadFolderButton = screen.getByRole("button", { name: "Upload Folder" });
+
+    fireEvent.click(uploadFilesButton);
+    fireEvent.click(uploadFolderButton);
+
+    expect(uploadFilesButton.getAttribute("type")).toBe("button");
+    expect(uploadFolderButton.getAttribute("type")).toBe("button");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("uploads dropped files and shows progress state", async () => {
+    const onUploadFiles = vi.fn().mockResolvedValue(undefined);
+    const file = new File(["hello"], "notes.md", { type: "text/markdown" });
+    const { rerender, container } = render(
+      <FileUploadZone ingesting={false} uploadProgress={null} onUploadFiles={onUploadFiles} />,
+    );
+
+    fireEvent.drop(container.firstChild as HTMLElement, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+
+    expect(onUploadFiles).toHaveBeenCalledWith([file]);
+
+    rerender(
+      <FileUploadZone
+        ingesting={true}
+        uploadProgress={{ completed: 0, currentFile: "notes.md", total: 1 }}
+        onUploadFiles={onUploadFiles}
+      />,
+    );
+
+    expect(screen.getByText("Uploading context")).toBeTruthy();
+    expect(screen.getByText("notes.md")).toBeTruthy();
+  });
+});

--- a/web/app/components/__tests__/RagSearchPanel.test.tsx
+++ b/web/app/components/__tests__/RagSearchPanel.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import RagSearchPanel from "../context/RagSearchPanel";
+
+describe("RagSearchPanel", () => {
+  it("disables the search action for whitespace-only queries", () => {
+    render(
+      <RagSearchPanel
+        query="   "
+        setQuery={vi.fn()}
+        searching={false}
+        results={[]}
+        onRunSearch={vi.fn()}
+        onInsertContext={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Search" });
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("runs search on Enter and inserts formatted context safely", () => {
+    const onRunSearch = vi.fn();
+    const onInsertContext = vi.fn();
+    const onSubmit = vi.fn((event: SubmitEvent) => event.preventDefault());
+
+    render(
+      <form onSubmit={onSubmit}>
+        <RagSearchPanel
+          query="auth flow"
+          setQuery={vi.fn()}
+          searching={false}
+          results={[
+            {
+              path: "src/auth.ts",
+              snippet: "Handle session creation",
+              score: 0.8123,
+            },
+          ]}
+          onRunSearch={onRunSearch}
+          onInsertContext={onInsertContext}
+        />
+      </form>,
+    );
+
+    fireEvent.keyDown(screen.getByLabelText("Search context..."), { key: "Enter" });
+    expect(onRunSearch).toHaveBeenCalledTimes(1);
+
+    const insertButton = screen.getByRole("button", { name: /insert into prompt/i });
+    fireEvent.click(insertButton);
+
+    expect(insertButton.getAttribute("type")).toBe("button");
+    expect(onInsertContext).toHaveBeenCalledWith("[Source: src/auth.ts]\nHandle session creation");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/components/__tests__/UploadProgressCard.test.tsx
+++ b/web/app/components/__tests__/UploadProgressCard.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import UploadProgressCard from "../context/UploadProgressCard";
+
+describe("UploadProgressCard", () => {
+  it("renders the current file and computed progress", () => {
+    const { container } = render(
+      <UploadProgressCard
+        uploadProgress={{
+          completed: 2,
+          currentFile: "src/index.ts",
+          total: 5,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Uploading context")).toBeTruthy();
+    expect(screen.getByText("3/5")).toBeTruthy();
+    expect(screen.getByText("src/index.ts")).toBeTruthy();
+
+    const progressBar = container.querySelector('[style="width: 49%;"]');
+    expect(progressBar).toBeTruthy();
+  });
+});

--- a/web/app/components/context/ContextSuggestions.tsx
+++ b/web/app/components/context/ContextSuggestions.tsx
@@ -15,6 +15,7 @@ export default function ContextSuggestions({ suggestions, onInsertContext }: Con
                 {suggestions.map((suggestion) => (
                     <button
                         key={suggestion.path}
+                        type="button"
                         onClick={() => onInsertContext(`[File: ${suggestion.name}]\n(Reason: ${suggestion.reason})`)}
                         className="group flex items-center gap-2 px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 hover:border-blue-500/40 rounded-full transition-all text-left"
                         title={`Add ${suggestion.path} to context`}

--- a/web/app/components/context/FileUploadZone.tsx
+++ b/web/app/components/context/FileUploadZone.tsx
@@ -69,11 +69,11 @@ export default function FileUploadZone({ ingesting, uploadProgress, onUploadFile
                 <>
                     <div className={`text-2xl ${isDragging ? "scale-110" : ""} transition-transform`}>Files</div>
                     <div className="flex gap-2">
-                        <button onClick={() => fileInputRef.current?.click()} className="text-xs text-blue-400 font-medium hover:text-blue-300 transition-colors">
+                        <button type="button" onClick={() => fileInputRef.current?.click()} className="text-xs text-blue-400 font-medium hover:text-blue-300 transition-colors">
                             Upload Files
                         </button>
                         <span className="text-xs text-zinc-500">|</span>
-                        <button onClick={() => directoryInputRef.current?.click()} className="text-xs text-blue-400 font-medium hover:text-blue-300 transition-colors">
+                        <button type="button" onClick={() => directoryInputRef.current?.click()} className="text-xs text-blue-400 font-medium hover:text-blue-300 transition-colors">
                             Upload Folder
                         </button>
                     </div>

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -31,8 +31,9 @@ export default function RagSearchPanel({
                     onKeyDown={(e) => e.key === "Enter" && onRunSearch()}
                 />
                 <button
+                    type="button"
                     onClick={onRunSearch}
-                    disabled={searching || !query}
+                    disabled={searching || !query.trim()}
                     className="px-3 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-lg text-xs hover:bg-blue-500/20 transition-all font-medium"
                 >
                     Search
@@ -56,6 +57,7 @@ export default function RagSearchPanel({
                             {result.snippet}
                         </div>
                         <button
+                            type="button"
                             onClick={() => onInsertContext(formatSearchResultForPrompt(result))}
                             className="mt-1 text-[10px] text-blue-300 hover:text-blue-200 text-left opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded transition-all flex items-center gap-1 font-medium"
                         >


### PR DESCRIPTION
## What changed
- add focused Vitest coverage for `ContextManager` and the new `context/*` RAG UI components
- verify safe non-submit button behavior for context insertion, upload, search, and ingest actions
- lock in whitespace-only search button disabling
- cover upload progress rendering and key context insertion formatting paths

## Why
Recent PRs fixed frontend breakage in this exact area after missing `context/*` modules caused build failures. The UI was still largely untested, so regressions here could slip through until build or manual QA.

## Impact
- gives the RAG context UI a real regression net
- prevents accidental form submission if these controls are rendered inside forms in the future
- keeps the search affordance aligned with the hook's trimmed-query behavior

## Verification
- `cd web && npm run test`
- `cd web && npm run lint`
- `cd web && npm run build`

## Notes
I checked the currently open PRs (#337 and #346); they are both API key security fixes and do not overlap with this frontend testing work.