### PR TITLE
feat: complete Phase 1 product items — patterns, artifact tests, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,36 +7,21 @@
   <img src="docs/images/cover.jpg" alt="Prompt Compiler Cover" width="100%">
 </p>
 
-**Prompt Compiler** transforms messy natural language ideas into structured, optimized system instructions and user prompts.
+**Prompt Compiler** turns vague requests into structured prompts, execution plans, and policy-checked workflows — so you can go from idea to safe, usable AI output in seconds.
 
-The project is still growing into a more production-ready developer workflow tool, but the product name, deploy surface, and core experience remain **Prompt Compiler / PromptC**. The newer policy-aware IR, GitHub artifacts, and VS Code flow are additions to that platform, not a rename.
-
-Try the deployed app at [prcompiler.com](https://prcompiler.com).
+Try it now at [pcompiler.com](http://pcompiler.com) | [VS Code extension](integrations/vscode-extension) | [GitHub artifacts](docs/pattern-library.md)
 
 ---
 
-## What Prompt Compiler Does
+## What It Does
 
-Prompt Compiler helps you go from a vague request to usable output fast:
+Type any request — a feature idea, a bug report, a research question — and Prompt Compiler produces:
 
-- **System Prompt** for behavior, role, and constraints
-- **User Prompt** for the cleaned task definition
-- **Execution Plan** for step-by-step decomposition
-- **Expanded Prompt** ready to paste into an LLM chat
-- **Policy & IR layer** for safer workflows when the task touches risky domains, tools, or sensitive data
-
-This means the project is still a broad prompt platform, while quietly becoming stronger for developer workflows behind the scenes.
-
----
-
-## Latest PR Updates
-
-This stabilization pass focused on making the project safer, more consistent, and easier to maintain.
-
-- Replaced mock-style RAG behavior with real upload, indexing, search, and pack flows backed by the local SQLite knowledge base.
-- Standardized backend and frontend contracts for compile and RAG operations, and moved frontend request handling into shared hooks/services.
-- Hardened security around file paths, prompt boundaries, regex-heavy heuristics, and protected routes that now require API keys.
-- Split API responsibilities into clearer route modules and pinned `pillow` above the current Snyk vulnerability floor for safer dependency resolution.
+- **System Prompt** — persona, role, constraints, output format
+- **User Prompt** — structured task definition
+- **Execution Plan** — step-by-step decomposition
+- **Expanded Prompt** — ready to paste into any LLM
+- **Policy Layer** — risk level, allowed tools, execution mode, data sensitivity
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Prompt Compiler** turns vague requests into structured prompts, execution plans, and policy-checked workflows — so you can go from idea to safe, usable AI output in seconds.
 
-Try it now at [pcompiler.com](http://pcompiler.com) | [VS Code extension](integrations/vscode-extension) | [GitHub artifacts](docs/pattern-library.md)
+Try it now at [prcompiler.com](https://prcompiler.com) | [VS Code extension](integrations/vscode-extension) | [GitHub artifacts](docs/pattern-library.md)
 
 ---
 

--- a/app/_builtin_templates/debugging-to-plan.yaml
+++ b/app/_builtin_templates/debugging-to-plan.yaml
@@ -1,0 +1,75 @@
+id: debugging-to-plan
+name: Debugging to Constrained Plan
+description: Transform a bug report into a focused, step-constrained debugging plan with tool limits and escalation criteria
+category: developer-workflow
+version: 1.0.0
+author: promptc
+tags:
+  - debugging
+  - planning
+  - constrained
+  - workflow
+
+template_text: |
+  Create a constrained debugging plan for the following issue.
+
+  Bug summary: {{summary}}
+
+  {{#error_output}}Error output:
+  ```
+  {{error_output}}
+  ```
+  {{/error_output}}
+
+  {{#environment}}Environment: {{environment}}{{/environment}}
+
+  {{#already_tried}}Already tried:
+  {{already_tried}}
+  {{/already_tried}}
+
+  Produce:
+  1. Hypothesis — most likely root cause (one sentence)
+  2. Diagnostic steps — ordered list, max {{max_steps}} steps
+  3. For each step: what to run, what to look for, and when to stop
+  4. Tool constraints — only use these tools/commands
+  5. Escalation criteria — when to stop debugging and ask for help
+  6. Fix verification — how to confirm the fix actually works
+
+variables:
+  - name: summary
+    description: One-line bug description
+    required: true
+
+  - name: error_output
+    description: Error message, stack trace, or log output
+    default: ""
+    required: false
+
+  - name: environment
+    description: Runtime environment details
+    default: ""
+    required: false
+
+  - name: already_tried
+    description: What has already been attempted
+    default: ""
+    required: false
+
+  - name: max_steps
+    description: Maximum number of diagnostic steps
+    default: "5"
+    required: false
+
+example_values:
+  summary: "pytest hangs indefinitely on test_compile_concurrent after upgrading to Python 3.12"
+  error_output: |
+    PASSED test_compile_basic
+    PASSED test_compile_conservative
+    test_compile_concurrent — no output for 120s, killed by CI timeout
+  environment: |
+    Python 3.12.3, pytest 8.1, FastAPI 0.115, Ubuntu 22.04 CI runner
+  already_tried: |
+    - Ran locally on Python 3.11 — passes in 4s
+    - Added -v flag — no extra output before hang
+    - Checked for asyncio deprecation warnings — none
+  max_steps: "5"

--- a/app/_builtin_templates/issue-to-brief.yaml
+++ b/app/_builtin_templates/issue-to-brief.yaml
@@ -1,0 +1,75 @@
+id: issue-to-brief
+name: Issue to Implementation Brief
+description: Transform a GitHub issue or feature request into a structured implementation brief with scope, approach, and acceptance criteria
+category: developer-workflow
+version: 1.0.0
+author: promptc
+tags:
+  - github
+  - issue
+  - planning
+  - implementation
+  - workflow
+
+template_text: |
+  Convert the following issue into a structured implementation brief.
+
+  Issue title: {{title}}
+  Issue body: {{body}}
+
+  {{#repo_context}}Repository context:
+  {{repo_context}}
+  {{/repo_context}}
+
+  {{#constraints}}Constraints:
+  {{constraints}}
+  {{/constraints}}
+
+  Produce:
+  1. One-sentence summary of the change
+  2. Scope — what files/modules are affected
+  3. Approach — high-level implementation steps
+  4. Acceptance criteria — verifiable conditions for "done"
+  5. Risks and open questions
+  {{#priority}}
+
+  Priority: {{priority}}
+  {{/priority}}
+
+variables:
+  - name: title
+    description: Issue title
+    required: true
+
+  - name: body
+    description: Full issue description or body text
+    required: true
+
+  - name: repo_context
+    description: Brief description of the repo or relevant module
+    default: ""
+    required: false
+
+  - name: constraints
+    description: Time, tech, or scope constraints
+    default: ""
+    required: false
+
+  - name: priority
+    description: Priority level (critical/high/medium/low)
+    default: ""
+    required: false
+
+example_values:
+  title: "Add rate limiting to /compile endpoint"
+  body: |
+    The /compile endpoint is publicly accessible and has no rate limiting.
+    Under load testing we saw 500 errors when a single client sent 200+ requests/min.
+    We need per-IP rate limiting with configurable thresholds.
+  repo_context: |
+    FastAPI backend in app/, deployed on Fly.io.
+    No existing rate limiting middleware.
+  constraints: |
+    - Must not add Redis dependency (use in-memory for now)
+    - Should return 429 with Retry-After header
+  priority: high

--- a/app/_builtin_templates/pr-to-review.yaml
+++ b/app/_builtin_templates/pr-to-review.yaml
@@ -1,0 +1,66 @@
+id: pr-to-review
+name: PR to Review Brief
+description: Generate a structured code review brief from a pull request description and diff summary
+category: developer-workflow
+version: 1.0.0
+author: promptc
+tags:
+  - github
+  - pull-request
+  - code-review
+  - workflow
+
+template_text: |
+  Generate a focused review brief for the following pull request.
+
+  PR title: {{title}}
+  PR description: {{description}}
+
+  {{#diff_summary}}Diff summary:
+  {{diff_summary}}
+  {{/diff_summary}}
+
+  {{#related_issues}}Related issues:
+  {{related_issues}}
+  {{/related_issues}}
+
+  Produce:
+  1. What this PR does (one paragraph)
+  2. Key changes to review carefully — list files and why they matter
+  3. Potential issues — bugs, regressions, security, performance
+  4. Test coverage assessment — what is tested, what is missing
+  5. Merge readiness verdict (ready / needs changes / needs discussion)
+
+variables:
+  - name: title
+    description: PR title
+    required: true
+
+  - name: description
+    description: PR body or description text
+    required: true
+
+  - name: diff_summary
+    description: Summary of changed files and line counts
+    default: ""
+    required: false
+
+  - name: related_issues
+    description: Linked issues or context
+    default: ""
+    required: false
+
+example_values:
+  title: "feat: add policy-aware IR to compile pipeline"
+  description: |
+    Adds a PolicyHandler to the handler chain that infers risk_level,
+    allowed_tools, and execution_mode from prompt content. Updates IRv2
+    schema with nested policy block. Includes 12 new tests.
+  diff_summary: |
+    app/heuristics/handlers/policy_handler.py  +180
+    app/models_v2.py                           +25
+    app/_schemas/ir_v2.schema.json             +18
+    tests/test_policy_handler.py               +220
+  related_issues: |
+    - #42 Policy-aware compilation
+    - #38 IRv2 schema expansion

--- a/app/_builtin_templates/research-to-safe-agent.yaml
+++ b/app/_builtin_templates/research-to-safe-agent.yaml
@@ -1,0 +1,64 @@
+id: research-to-safe-agent
+name: Research to Safe Agent Brief
+description: Convert a research query into a policy-aware agent brief with guardrails, tool constraints, and data sensitivity classification
+category: developer-workflow
+version: 1.0.0
+author: promptc
+tags:
+  - research
+  - agent
+  - safety
+  - policy
+  - workflow
+
+template_text: |
+  Convert the following research request into a safe agent execution brief.
+
+  Research goal: {{goal}}
+
+  {{#domain}}Domain: {{domain}}{{/domain}}
+
+  {{#data_sources}}Available data sources:
+  {{data_sources}}
+  {{/data_sources}}
+
+  {{#audience}}Target audience: {{audience}}{{/audience}}
+
+  Produce:
+  1. Refined research objective (one sentence)
+  2. Allowed tools and data sources the agent may use
+  3. Forbidden actions — what the agent must NOT do
+  4. Data sensitivity classification (public / internal / confidential / restricted)
+  5. Risk level (low / medium / high) with justification
+  6. Execution mode recommendation (advice_only / human_approval_required / auto_ok)
+  7. Output format and length guidance
+  8. Sanitization rules — what must be redacted or anonymized
+
+variables:
+  - name: goal
+    description: The research question or objective
+    required: true
+
+  - name: domain
+    description: Domain area (e.g., finance, healthcare, legal, general)
+    default: ""
+    required: false
+
+  - name: data_sources
+    description: Available data sources or APIs
+    default: ""
+    required: false
+
+  - name: audience
+    description: Who will consume the output
+    default: ""
+    required: false
+
+example_values:
+  goal: "Summarize recent SEC filings for NVDA and compare revenue trends over the last 4 quarters"
+  domain: finance
+  data_sources: |
+    - SEC EDGAR public filings
+    - Company investor relations pages
+    - Public earnings call transcripts
+  audience: Internal investment research team

--- a/app/_builtin_templates/spec-to-checklist.yaml
+++ b/app/_builtin_templates/spec-to-checklist.yaml
@@ -1,0 +1,75 @@
+id: spec-to-checklist
+name: Spec to Implementation Checklist
+description: Convert a feature specification into an ordered implementation checklist with dependencies, test criteria, and estimated complexity
+category: developer-workflow
+version: 1.0.0
+author: promptc
+tags:
+  - specification
+  - checklist
+  - planning
+  - implementation
+  - workflow
+
+template_text: |
+  Convert the following specification into an implementation checklist.
+
+  Feature: {{feature}}
+  Specification:
+  {{spec}}
+
+  {{#tech_stack}}Tech stack: {{tech_stack}}{{/tech_stack}}
+
+  {{#existing_code}}Relevant existing code:
+  {{existing_code}}
+  {{/existing_code}}
+
+  Produce:
+  1. Ordered checklist of implementation tasks
+  2. For each task:
+     - What to build or change
+     - Dependencies (which tasks must be done first)
+     - Acceptance test (how to verify this task is done)
+     - Complexity estimate (S / M / L)
+  3. Integration test plan — end-to-end verification after all tasks
+  4. Risks — what could go wrong or block progress
+
+variables:
+  - name: feature
+    description: Feature name or title
+    required: true
+
+  - name: spec
+    description: Full specification or requirements text
+    required: true
+
+  - name: tech_stack
+    description: Relevant technology stack
+    default: ""
+    required: false
+
+  - name: existing_code
+    description: References to existing code that will be modified
+    default: ""
+    required: false
+
+example_values:
+  feature: "RAG-powered context injection for compile requests"
+  spec: |
+    Users can upload documents (PDF, TXT, MD) that get chunked, embedded,
+    and stored in a local SQLite vector store. When a compile request arrives,
+    the system searches the store for relevant chunks and injects them as
+    additional context before the LLM call.
+
+    Requirements:
+    - Max 5 documents, 10MB each
+    - Chunk size 512 tokens with 64-token overlap
+    - Top-3 chunks injected by cosine similarity
+    - Upload progress shown in UI
+    - Context source attribution in output
+  tech_stack: |
+    Python 3.11, FastAPI, SQLite + sqlite-vec, Next.js 14 frontend
+  existing_code: |
+    - app/compiler.py — main compile pipeline
+    - app/rag/ — empty directory, scaffolded but not implemented
+    - web/app/components/ContextManager.tsx — UI shell exists

--- a/integrations/vscode-extension/README.md
+++ b/integrations/vscode-extension/README.md
@@ -1,22 +1,55 @@
 # PromptC for VS Code
 
-VS Code extension surface for PromptC.
+Compile selected text or full files into structured prompts with policy visibility, directly inside VS Code.
+
+## Quickstart (Dogfooding)
+
+1. **Start the backend** (from repo root):
+
+   ```bash
+   uvicorn app.main:app --port 8080
+   ```
+
+2. **Install the extension** locally:
+
+   ```bash
+   cd integrations/vscode-extension
+   # Open VS Code in this folder, then press F5 to launch Extension Development Host
+   # Or use: code --extensionDevelopmentPath="$(pwd)"
+   ```
+
+3. **Compile something:**
+   - Open any file, select text (or leave empty for full file)
+   - Run `Ctrl+Shift+P` > **PromptC: Compile Selection**
+   - The PromptC Panel opens beside your editor with 4 tabs
+
+4. **View results** in the panel:
+   - **Intent** — domain, persona, detected intents
+   - **Policy** — risk level, allowed/forbidden tools, execution mode
+   - **Prompts** — system, user, plan, expanded prompts
+   - **Raw JSON** — full compile response
 
 ## Commands
 
-- `PromptC: Compile Selection`
-- `PromptC: Open Panel`
-
-## Panel Tabs
-
-- `Intent`
-- `Policy`
-- `Prompts`
-- `Raw JSON`
+| Command | Description |
+|---|---|
+| `PromptC: Compile Selection` | Compile selected text (or full file) |
+| `PromptC: Open Panel` | Open/reveal the result panel |
 
 ## Settings
 
-- `promptc.apiBaseUrl`
-- `promptc.conservativeMode`
+| Setting | Default | Description |
+|---|---|---|
+| `promptc.apiBaseUrl` | `http://127.0.0.1:8080` | Backend API URL |
+| `promptc.conservativeMode` | `true` | Grounded output (no hallucinated libs/APIs) |
 
-API keys are never stored in workspace settings. If an API key is needed, the extension stores it in VS Code secret storage.
+## API Key
+
+If the backend requires authentication, the extension prompts for an API key on first 401/403 response. The key is stored securely in VS Code secret storage — never in workspace settings.
+
+## Running Tests
+
+```bash
+cd integrations/vscode-extension
+node --test tests/client.test.mjs
+```

--- a/tests/test_github_artifacts.py
+++ b/tests/test_github_artifacts.py
@@ -1,4 +1,11 @@
+import pytest
+
 from app.github_artifacts import render_github_artifact
+
+
+# ---------------------------------------------------------------------------
+# Existing tests
+# ---------------------------------------------------------------------------
 
 
 def test_issue_brief_renders_intent_and_policy_sections():
@@ -24,3 +31,144 @@ def test_pr_review_brief_is_deterministic_for_policy_and_checkpoints():
     assert "workspace_read" in artifact
     assert "path_must_stay_within_workspace" in artifact
     assert "## Review Focus" in artifact
+
+
+# ---------------------------------------------------------------------------
+# Realistic scenario tests — issue brief
+# ---------------------------------------------------------------------------
+
+
+def test_issue_brief_from_rate_limiting_request():
+    """Real-world issue: add rate limiting to an API endpoint."""
+    artifact = render_github_artifact(
+        "issue-brief",
+        (
+            "Our /compile endpoint is getting hammered by bots. "
+            "Add per-IP rate limiting with a 60 req/min threshold. "
+            "Return 429 with Retry-After header when exceeded."
+        ),
+    )
+
+    assert "# Issue Brief" in artifact
+    assert "## Goals" in artifact
+    # Should detect intents related to the request
+    assert "## Intent" in artifact
+    assert "## Policy" in artifact
+    # Should produce a non-empty Goals section
+    lines = artifact.split("\n")
+    goals_idx = next(i for i, line in enumerate(lines) if "## Goals" in line)
+    # At least one bullet under Goals
+    assert any(line.startswith("- ") for line in lines[goals_idx + 1 : goals_idx + 5])
+
+
+def test_issue_brief_low_risk_documentation_request():
+    """Low-risk issue: improve README documentation."""
+    artifact = render_github_artifact(
+        "issue-brief",
+        "Update the README to include a quickstart guide and installation instructions.",
+    )
+
+    assert "# Issue Brief" in artifact
+    assert "Risk Level: low" in artifact
+    assert "advice_only" in artifact
+
+
+# ---------------------------------------------------------------------------
+# Realistic scenario tests — implementation checklist
+# ---------------------------------------------------------------------------
+
+
+def test_implementation_checklist_has_checkbox_items():
+    """Checklist should produce markdown checkboxes."""
+    artifact = render_github_artifact(
+        "implementation-checklist",
+        (
+            "Build a file upload feature: accept PDF and TXT files up to 10MB, "
+            "chunk them into 512-token segments, embed with a local model, "
+            "store in SQLite vector store, and show upload progress in the UI."
+        ),
+    )
+
+    assert "# Implementation Checklist" in artifact
+    assert "## Checklist" in artifact
+    # Must have at least 1 checkbox item (heuristic step count depends on input)
+    checkbox_count = artifact.count("- [ ]")
+    assert checkbox_count >= 1, f"Expected >=1 checkboxes, got {checkbox_count}"
+
+
+def test_implementation_checklist_sensitive_domain():
+    """Healthcare spec should trigger high risk + human approval."""
+    artifact = render_github_artifact(
+        "implementation-checklist",
+        (
+            "Create a patient intake form that collects name, date of birth, "
+            "insurance ID, and medical history. Store data encrypted at rest "
+            "and ensure HIPAA compliance for all API endpoints."
+        ),
+    )
+
+    assert "# Implementation Checklist" in artifact
+    assert "Risk Level: high" in artifact
+    assert "human_approval_required" in artifact
+
+
+# ---------------------------------------------------------------------------
+# Realistic scenario tests — PR review brief
+# ---------------------------------------------------------------------------
+
+
+def test_pr_review_brief_from_feature_pr():
+    """PR review brief for a typical feature PR."""
+    artifact = render_github_artifact(
+        "pr-review-brief",
+        (
+            "This PR adds a caching layer to the compile pipeline. "
+            "Identical prompts return cached IR within 50ms instead of "
+            "re-running the full heuristic chain. Cache is LRU with "
+            "128 entries and 5-minute TTL. Includes 8 new tests."
+        ),
+    )
+
+    assert "# PR Review Brief" in artifact
+    assert "## Review Focus" in artifact
+    assert "## Policy" in artifact
+    # Review Focus should have at least one bullet
+    lines = artifact.split("\n")
+    focus_idx = next(i for i, line in enumerate(lines) if "## Review Focus" in line)
+    assert any(line.startswith("- ") for line in lines[focus_idx + 1 : focus_idx + 8])
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and structural assertions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["issue-brief", "implementation-checklist", "pr-review-brief"],
+)
+def test_all_artifact_types_produce_valid_markdown(kind):
+    """Every artifact type should start with an H1 and end with a newline."""
+    artifact = render_github_artifact(kind, "Write unit tests for the auth module.")
+
+    assert artifact.startswith("# ")
+    assert artifact.endswith("\n")
+    # Must contain both Intent and Policy sections
+    assert "## Intent" in artifact
+    assert "## Policy" in artifact
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["issue-brief", "implementation-checklist", "pr-review-brief"],
+)
+def test_artifact_policy_fields_always_present(kind):
+    """Policy section must always include risk level, execution mode, data sensitivity."""
+    artifact = render_github_artifact(
+        kind,
+        "Refactor the token counting utility to use a singleton encoder pattern.",
+    )
+
+    assert "Risk Level:" in artifact
+    assert "Execution Mode:" in artifact
+    assert "Data Sensitivity:" in artifact

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -99,7 +99,7 @@ export default function Home() {
             </div>
             <InfoButton
               title="Prompt Compiler"
-              description="Turns messy natural language into structured prompts, plans, and an inspectable policy layer when the task needs safer workflow guidance."
+              description="Turns vague requests into structured prompts, execution plans, and policy-checked workflows — idea to safe, usable AI output in seconds."
             />
           </div>
 


### PR DESCRIPTION
## Summary
- **5 flagship developer-workflow patterns** added to pattern library: issue-to-brief, pr-to-review, research-to-safe-agent, debugging-to-plan, spec-to-checklist
- **GitHub artifacts test suite** expanded from 2 → 13 tests with realistic scenarios (rate limiting, healthcare compliance, feature PRs) covering all 3 artifact types
- **README sharpened**: single-sentence opening, stale "Latest PR Updates" removed, hedging language cleaned up
- **Web landing tagline** synced with README
- **VS Code extension README** updated with dogfooding quickstart guide

## Context
Closes the product-side gaps in Phase 1 of the Notion roadmap. Stabilization was already done (#338); this PR completes the remaining items: pattern library, artifact testing, VS Code dogfooding prep, and narrative clarity.

## Faz 1 Skorkartı (tamamlandı)
- [x] Mevcut merge'leri stabilize et
- [x] README/landing/demo akışını netleştir
- [x] VS Code extension'ı dogfood-ready yap
- [x] GitHub artefakt üretimini gerçek örneklerle test et
- [x] Pattern library: 5 flagship senaryo

## Test plan
- [x] `pytest tests/test_github_artifacts.py` — 13/13 passed
- [x] `pytest tests/test_templates.py tests/test_ir_v2_basic.py` — 17/17 passed
- [x] `npm run build` (web/) — 7 routes, 0 errors
- [x] `node --test tests/client.test.mjs` (vscode) — 2/2 passed
- [x] All pre-commit hooks passed (ruff, ruff-format, yaml, trailing whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)