### PR TITLE
[codex] Fix false-positive coding security suggestion

### DIFF
--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -841,12 +841,19 @@ class DomainHandler(BaseHandler):
         for check_name, check_rules in rules["universal_checks"].items():
             compiled = self._compiled_universal_checks.get(check_name, {})
 
-            # Check if any pattern matches
+            # Missing-based checks suggest absent concepts; risk-based checks suggest
+            # only when security-related terms are actually present.
             missing_pat = compiled.get("missing")
-            has_mention = bool(missing_pat.search(text_lower)) if missing_pat else False
+            risk_pat = compiled.get("risk")
 
-            # If not mentioned, suggest it
-            if not has_mention:
+            if missing_pat is not None:
+                should_suggest = not bool(missing_pat.search(text_lower))
+            elif risk_pat is not None:
+                should_suggest = bool(risk_pat.search(text_lower))
+            else:
+                should_suggest = False
+
+            if should_suggest:
                 analysis.suggestions.append(check_rules["suggestion"])
 
             # Special case: Security Scanning (Expanded)

--- a/tests/test_regex_precompilation.py
+++ b/tests/test_regex_precompilation.py
@@ -86,3 +86,19 @@ class TestPrecompiledPatternsWork:
         text = "quickly and carefully process the data"
         matches = handler._compiled_adverb_pattern.findall(text)
         assert len(matches) >= 2
+
+    def test_coding_security_suggestion_only_when_risk_terms_present(self, handler):
+        generic = handler._analyze_coding(
+            "Write a Python function to sort a list and include tests.",
+            "write a python function to sort a list and include tests.",
+        )
+        risky = handler._analyze_coding(
+            "Write Python code that handles an auth token securely using environment variables.",
+            "write python code that handles an auth token securely using environment variables.",
+        )
+
+        generic_security = [s for s in generic.suggestions if s.category == "security"]
+        risky_security = [s for s in risky.suggestions if s.category == "security"]
+
+        assert generic_security == []
+        assert len(risky_security) == 1


### PR DESCRIPTION
## Summary
- fix the coding-domain universal security check so it uses `risk_patterns` instead of the generic `missing_patterns` path
- stop adding the security suggestion for generic coding prompts with no auth/secret context
- add a regression test covering both a generic coding prompt and a security-related coding prompt

## Root Cause
`DomainHandler._analyze_coding()` compiled both `missing` and `risk` patterns, but only ever evaluated `missing`. The `security` check defines only `risk_patterns`, so it defaulted to `False` and appended the security suggestion for every coding prompt.

## Validation
- `python -m pytest tests/test_regex_precompilation.py -q`
- `python -m pytest tests/test_domain_confidence.py -q`
- `python -m pytest tests/test_regex_precompilation.py tests/test_domain_confidence.py -q`
- manual reproduction script verifying generic prompt => `0` security suggestions and risky prompt => `1`
