### PR TITLE
⚡ Bolt: Prevent event loop blocking in optimize_endpoint

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import time
 import uuid
+import anyio
+import functools
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -289,10 +291,13 @@ async def optimize_endpoint(
     compiler = _get_compiler()
 
     try:
-        result = compiler.worker.optimize_prompt(
-            req.text,
-            max_chars=req.max_chars,
-            max_tokens=req.max_tokens,
+        result = await anyio.to_thread.run_sync(
+            functools.partial(
+                compiler.worker.optimize_prompt,
+                req.text,
+                max_chars=req.max_chars,
+                max_tokens=req.max_tokens,
+            )
         )
         before_len = len(req.text)
         after_len = len(result)


### PR DESCRIPTION
💡 **What:** Offloaded the synchronous `compiler.worker.optimize_prompt` call inside the async `optimize_endpoint` to a worker thread using `anyio.to_thread.run_sync`.

🎯 **Why:** The endpoint was defined with `async def` but executed a CPU/network-bound synchronous task directly on the main thread, blocking the entire FastAPI event loop for the duration of the request. Offloading it prevents concurrent requests from queuing sequentially.

📊 **Impact:** The event loop remains unblocked.
*   **Baseline:** 10 concurrent requests to a 0.5s mocked function took `~5.0s` total (completely sequential).
*   **Improved:** 10 concurrent requests to a 0.5s mocked function take `~0.5s` total (completely overlapping).

🔬 **Measurement:** Using an asyncio/httpx script firing concurrent POST requests and monitoring server health using periodic GET requests, we verified that concurrent requests overlap correctly and the event loop continues to serve health checks without hanging.

---
*PR created automatically by Jules for task [5451277164357567753](https://jules.google.com/task/5451277164357567753) started by @madara88645*