### PR TITLE
🎨 Palette: Add focus-visible states to ContextManager accordion

### DIFF
--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -86,7 +86,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
             )}
 
             <details className="group">
-                <summary className="text-[10px] text-zinc-600 cursor-pointer hover:text-zinc-400 transition-colors">
+                <summary className="text-[10px] text-zinc-600 cursor-pointer hover:text-zinc-400 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded">
                     Advanced: Index by path
                 </summary>
                 <div className="flex flex-col gap-2 mt-2 pl-2 border-l border-white/5">


### PR DESCRIPTION
💡 What: Added `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded` utility classes to the `<summary>` element inside `ContextManager.tsx`.
🎯 Why: The "Advanced: Index by path" `<summary>` element acts as a utility accordion toggle. Previously, it lacked an explicit focus state, making it difficult for keyboard users navigating via Tab to identify when the element had focus.
📸 Before/After: Before, keyboard focus on the summary element produced either an inconsistent browser default ring or no visible feedback. After, it displays a clear blue focus ring consistent with the rest of the application's focus states.
♿ Accessibility: Improves keyboard navigation accessibility by providing a clear, visible focus indicator for an interactive UI element.

---
*PR created automatically by Jules for task [5572176836464026608](https://jules.google.com/task/5572176836464026608) started by @madara88645*