### PR TITLE
[codex] Fix implied persona matching pipeline

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,6 +37,7 @@
 ## 2026-03-22 - Fast Character Counting in Strings
 **Learning:** In Python, replacing `sum(1 for c in text if c.isdigit())` with `sum(map(str.isdigit, text))` provides a ~3x performance boost. The generator expression executes a bytecode loop in Python, while `map` pushes the iteration entirely into C. Since `str.isdigit` returns booleans (which are integers `1` or `0` in Python), `sum()` seamlessly counts the matches.
 **Action:** When counting occurrences of characters that match a string method (like `.isdigit()`, `.isalpha()`, `.isspace()`), use `sum(map(str.method, text))` for maximum performance in hot paths.
+
 ## 2025-03-09 - Pre-compiling Regex Patterns for Performance
 **Learning:** In Python, iterating over uncompiled string patterns using `re.finditer(pattern, text)` repeatedly compiles the regex patterns on every call, leading to significant overhead in hot loops like security scanners.
 **Action:** Always pre-compile regular expressions at the module level (e.g., `COMPILED_PATTERNS = {k: re.compile(v) for k, v in PATTERNS.items()}`) and use `.finditer` directly on the compiled objects to improve performance.
@@ -48,9 +49,11 @@
 ## 2026-03-24 - Optimizing String Tokens Membership Check
 **Learning:** In Python, when checking for membership of multiple items in a tokenized string within a loop or comprehension (e.g., `[t for t in terms if t in text.split()]`), evaluating `.split()` inside the loop forces Python to allocate new lists and do O(N) membership checks repeatedly.
 **Action:** Extract `.split()` outside the loop and convert it to a `set` (e.g., `words = set(text.split())`). This ensures the string is split only once and provides O(1) membership lookups for the inner evaluation, significantly improving performance especially for large texts.
+
 ## 2026-04-05 - Prevent Event Loop Blocking in FastAPI
 **Learning:** In FastAPI, declaring an endpoint as `async def` while running a blocking synchronous operation (like SQLite I/O) directly within it blocks the main event loop, severely degrading concurrent performance.
 **Action:** Declare endpoints performing blocking I/O as `def` instead of `async def`. FastAPI will automatically offload these synchronous endpoints to a separate threadpool, allowing the main event loop to remain non-blocking.
+
 ## 2024-05-18 - Schema Sanitizer Fast-Path Avoids Expensive Regex Loops
 **Learning:** Pre-compiling regex substitutions at the module level and using a combined alternated regex (`re.search(r"A|B|C")`) to pre-filter text inside a hot loop is extremely effective when matches are rare. In `SchemaSanitizerHandler`, checking for 7 specific string fields using this pattern skips the expensive and repeated execution of 7 `re.sub` replacements on the vast majority of constraints where those fields do not exist.
 **Action:** When applying multiple regex replacements (`re.sub` or `re.subn`) inside a loop over text, always evaluate if the target patterns can be combined into a fast-path alternated check to skip the replacement logic entirely when not needed. Pre-compile all regexes at the module level to avoid overhead.
@@ -62,3 +65,7 @@
 ## 2024-05-30 - [Optimize re.match with strip in fence parsing]
 **Learning:** Using `re.match` within tight parsing loops (like `_is_fence_close` which is called per line within token optimizer fence handling) can be disproportionately slow.
 **Action:** When matching a homogeneous string prefix combined with full string equality (like checking if a line is exclusively composed of a specific character length `N` or more), use `str.startswith(prefix) and not str.strip(char)` instead. It avoids regex compilation and execution overhead and was measured to be ~7x faster.
+
+## 2024-05-30 - Pre-compiling dictionary iteration patterns
+**Learning:** Iterating over a dictionary of string patterns and compiling them with `re.escape` and string concatenation inside a loop before passing to `re.findall` causes unnecessary string allocations and cache lookups (or cache misses/evictions if the regex cache is full), significantly degrading performance.
+**Action:** When a method loops over a static dictionary of keyword-to-pattern mappings (e.g., `IMPLIED_PERSONAS`), pre-compile the dictionary into `{re.compile(pattern): value}` at the class `__init__` or module level, and iterate over the pre-compiled regex objects in the hot path. This can yield ~1.7x performance improvements for regex matching tasks.

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -658,13 +658,19 @@ class DomainHandler(BaseHandler):
 
         # Compile implied persona patterns
         self._compiled_implied_personas: Dict[re.Pattern, str] = {}
+        self._implied_persona_specificity: Dict[re.Pattern, int] = {}
         for keyword, persona_name in IMPLIED_PERSONAS.items():
             normalized_keyword = keyword.lower()
             escaped = re.escape(normalized_keyword.strip())
             pattern = r"\b" + escaped + r"\b"
             if keyword.endswith(" "):
                 pattern = r"\b" + escaped + r"\s"
-            self._compiled_implied_personas[re.compile(pattern)] = persona_name
+            compiled_pattern = re.compile(pattern)
+            self._compiled_implied_personas[compiled_pattern] = persona_name
+            specificity = len(normalized_keyword.strip())
+            if keyword.endswith(" "):
+                specificity -= 1
+            self._implied_persona_specificity[compiled_pattern] = specificity
 
     def handle(self, ir_v2: IRv2, ir_v1: IR) -> None:
         """
@@ -779,21 +785,38 @@ class DomainHandler(BaseHandler):
 
         best_persona = None
         max_score = 0.0
+        max_specificity = 0
+        best_match_start = -1
 
         # Simple keyword matching
         # Bolt Optimization: Iterate over pre-compiled regex patterns to avoid
         # recompiling patterns repeatedly in a hot loop.
         for pattern_obj, persona_name in self._compiled_implied_personas.items():
             # Count occurrences
-            matches = pattern_obj.findall(text_lower)
-            if matches:
+            match_count = 0
+            first_match_start = -1
+            for match in pattern_obj.finditer(text_lower):
+                if first_match_start < 0:
+                    first_match_start = match.start()
+                match_count += 1
+            if match_count:
                 # Base score 0.6, +0.1 for each extra occurrence, max 0.9
-                score = min(0.9, 0.6 + (len(matches) - 1) * 0.1)
+                score = min(0.9, 0.6 + (match_count - 1) * 0.1)
 
-                # Longer keywords might be more specific?
-                # For now just take the highest score
-                if score > max_score:
+                # Prefer more specific keywords when matches have the same score.
+                specificity = self._implied_persona_specificity.get(pattern_obj, 0)
+                if (
+                    score > max_score
+                    or (score == max_score and specificity > max_specificity)
+                    or (
+                        score == max_score
+                        and specificity == max_specificity
+                        and first_match_start > best_match_start
+                    )
+                ):
                     max_score = score
+                    max_specificity = specificity
+                    best_match_start = first_match_start
                     best_persona = persona_name
 
         return best_persona, max_score

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -656,6 +656,15 @@ class DomainHandler(BaseHandler):
         for lang, rules in DOMAIN_RULES["coding"]["languages"].items():
             self._lowered_indicators[lang] = [ind.lower() for ind in rules.get("indicators", [])]
 
+        # Compile implied persona patterns
+        self._compiled_implied_personas: Dict[re.Pattern, str] = {}
+        for keyword, persona_name in IMPLIED_PERSONAS.items():
+            escaped = re.escape(keyword.strip())
+            pattern = r"\b" + escaped + r"\b"
+            if keyword.endswith(" "):
+                pattern = r"\b" + escaped + r"\s"
+            self._compiled_implied_personas[re.compile(pattern)] = persona_name
+
     def handle(self, ir_v2: IRv2, ir_v1: IR) -> None:
         """
         Apply domain-specific heuristics to enhance IR.
@@ -771,15 +780,11 @@ class DomainHandler(BaseHandler):
         max_score = 0.0
 
         # Simple keyword matching
-        for keyword, persona_name in IMPLIED_PERSONAS.items():
-            # word boundary check for short keywords
-            escaped = re.escape(keyword.strip())
-            pattern = r"\b" + escaped + r"\b"
-            if keyword.endswith(" "):  # if keyword ended with space, strict check
-                pattern = r"\b" + escaped + r"\s"
-
+        # Bolt Optimization: Iterate over pre-compiled regex patterns to avoid
+        # recompiling patterns repeatedly in a hot loop.
+        for pattern_obj, persona_name in self._compiled_implied_personas.items():
             # Count occurrences
-            matches = re.findall(pattern, text_lower)
+            matches = pattern_obj.findall(text_lower)
             if matches:
                 # Base score 0.6, +0.1 for each extra occurrence, max 0.9
                 score = min(0.9, 0.6 + (len(matches) - 1) * 0.1)

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -14,7 +14,13 @@ import textwrap
 from typing import List, Dict, Optional, Tuple
 from dataclasses import dataclass, field
 from .base import BaseHandler
-from app.models import IR
+from app.models import (
+    DEFAULT_ROLE_DEV_EN,
+    DEFAULT_ROLE_DEV_TR,
+    DEFAULT_ROLE_EN,
+    DEFAULT_ROLE_TR,
+    IR,
+)
 from app.models_v2 import IRv2, ConstraintV2, DiagnosticItem
 
 
@@ -42,6 +48,17 @@ class DomainAnalysis:
     suggestions: List[DomainSuggestion] = field(default_factory=list)
     diagnostics: List[DiagnosticItem] = field(default_factory=list)
     detected_patterns: Dict[str, List[str]] = field(default_factory=dict)
+
+
+_GENERIC_PERSONAS = {"", "assistant", "general", "developer"}
+_GENERIC_ROLES = {
+    "",
+    "AI Assistant",
+    DEFAULT_ROLE_EN,
+    DEFAULT_ROLE_TR,
+    DEFAULT_ROLE_DEV_EN,
+    DEFAULT_ROLE_DEV_TR,
+}
 
 
 # ==============================================================================
@@ -702,7 +719,9 @@ class DomainHandler(BaseHandler):
         # Add diagnostics
         ir_v2.diagnostics.extend(analysis.diagnostics)
 
-        if (not ir_v2.persona or ir_v2.persona in ["assistant", "general"]) and not ir_v2.role:
+        persona_is_generic = not ir_v2.persona or ir_v2.persona in _GENERIC_PERSONAS
+        role_is_generic = not ir_v2.role or ir_v2.role in _GENERIC_ROLES
+        if persona_is_generic and role_is_generic:
             implied_persona, confidence = self.detect_implied_persona(original_text)
             if implied_persona:
                 ir_v2.persona = "expert"

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -659,7 +659,8 @@ class DomainHandler(BaseHandler):
         # Compile implied persona patterns
         self._compiled_implied_personas: Dict[re.Pattern, str] = {}
         for keyword, persona_name in IMPLIED_PERSONAS.items():
-            escaped = re.escape(keyword.strip())
+            normalized_keyword = keyword.lower()
+            escaped = re.escape(normalized_keyword.strip())
             pattern = r"\b" + escaped + r"\b"
             if keyword.endswith(" "):
                 pattern = r"\b" + escaped + r"\s"

--- a/tests/test_compile_policy_api.py
+++ b/tests/test_compile_policy_api.py
@@ -15,3 +15,12 @@ def test_compile_endpoint_exposes_policy_in_ir_v2():
     assert "ir_v2" in payload
     assert payload["ir_v2"]["policy"]["risk_level"] == "high"
     assert payload["ir_v2"]["policy"]["execution_mode"] == "human_approval_required"
+
+
+def test_compile_endpoint_applies_implied_persona_in_local_v2_pipeline():
+    response = client.post("/compile", json={"text": 'Console.WriteLine("hello");', "v2": False})
+
+    assert response.status_code == 200
+    implied_persona = response.json()["ir_v2"]["metadata"]["implied_persona"]
+    assert implied_persona["persona"] == "C# Developer"
+    assert response.json()["ir_v2"]["role"] == "Expert C# Developer"

--- a/tests/test_domain_confidence.py
+++ b/tests/test_domain_confidence.py
@@ -1,4 +1,4 @@
-from app.compiler import compile_text
+from app.compiler import compile_text, compile_text_v2
 from app.heuristics.handlers.domain_expert import DomainHandler
 from app.models_v2 import IRv2
 from app.models import IR
@@ -137,3 +137,11 @@ def test_implied_persona_sql():
 
     handler.handle(ir_v2, ir_v1)
     assert "Database Administrator" in ir_v2.role
+
+
+def test_compile_text_v2_applies_implied_persona_over_default_role():
+    ir = compile_text_v2('Console.WriteLine("hello");', offline_only=True)
+
+    assert ir.persona == "expert"
+    assert ir.role == "Expert C# Developer"
+    assert ir.metadata["implied_persona"]["persona"] == "C# Developer"

--- a/tests/test_regex_precompilation.py
+++ b/tests/test_regex_precompilation.py
@@ -108,6 +108,22 @@ class TestPrecompiledPatternsWork:
         assert persona == expected_persona
         assert confidence == 0.6
 
+    @pytest.mark.parametrize(
+        ("text", "expected_persona"),
+        [
+            ("import pandas as pd", "Data Scientist"),
+            ("import numpy as np", "Data Scientist"),
+            ("const docker = true", "DevOps Engineer"),
+        ],
+    )
+    def test_implied_persona_detection_prefers_more_specific_equal_score_match(
+        self, handler, text, expected_persona
+    ):
+        persona, confidence = handler.detect_implied_persona(text)
+
+        assert persona == expected_persona
+        assert confidence == 0.6
+
     def test_coding_security_suggestion_only_when_risk_terms_present(self, handler):
         generic = handler._analyze_coding(
             "Write a Python function to sort a list and include tests.",

--- a/tests/test_regex_precompilation.py
+++ b/tests/test_regex_precompilation.py
@@ -62,6 +62,12 @@ class TestRegexPrecompilation:
             for ind in indicators:
                 assert ind == ind.lower(), f"Indicator '{ind}' for {lang} not lowercased"
 
+    def test_implied_personas_compiled(self, handler):
+        assert hasattr(handler, "_compiled_implied_personas")
+        assert len(handler._compiled_implied_personas) > 0
+        for pat in handler._compiled_implied_personas:
+            assert isinstance(pat, re.Pattern)
+
 
 class TestPrecompiledPatternsWork:
     """Verify pre-compiled patterns produce correct results."""
@@ -86,6 +92,21 @@ class TestPrecompiledPatternsWork:
         text = "quickly and carefully process the data"
         matches = handler._compiled_adverb_pattern.findall(text)
         assert len(matches) >= 2
+
+    @pytest.mark.parametrize(
+        ("text", "expected_persona"),
+        [
+            ('System.out.println("hello");', "Java Developer"),
+            ('Console.WriteLine("hello");', "C# Developer"),
+        ],
+    )
+    def test_implied_persona_detection_handles_mixed_case_snippets(
+        self, handler, text, expected_persona
+    ):
+        persona, confidence = handler.detect_implied_persona(text)
+
+        assert persona == expected_persona
+        assert confidence == 0.6
 
     def test_coding_security_suggestion_only_when_risk_terms_present(self, handler):
         generic = handler._analyze_coding(


### PR DESCRIPTION
﻿## Summary
- normalize implied persona keywords before compiling regex patterns, matching the existing lowercase input path
- prefer more specific implied persona matches when multiple patterns have the same confidence score
- allow implied personas to replace only generic/default roles in the real `compile_text_v2` pipeline
- add regression coverage for handler-level persona detection plus local `/compile` IRv2 output

## Root cause
`detect_implied_persona()` lowercases prompt text before matching, but `_compiled_implied_personas` previously preserved mixed-case keys from `IMPLIED_PERSONAS` such as `System.out.println` and `Console.WriteLine`. Those patterns could not match the lowercased prompt text.

After fixing that, a second pipeline drift showed up: `compile_text()` always seeds IR with a default role such as `Helpful generative AI assistant`, while `DomainHandler.handle()` only applied implied personas when the role was empty. That meant handler tests passed, but `compile_text_v2()` and `/compile` still returned the generic role with no `metadata.implied_persona`.

## Validation
- `python -m pytest tests/test_regex_precompilation.py tests/test_domain_confidence.py tests/test_compile_policy_api.py -q`
- `python -m ruff check app/heuristics/handlers/domain_expert.py tests/test_domain_confidence.py tests/test_compile_policy_api.py`
- `python -m ruff format --check app/heuristics/handlers/domain_expert.py tests/test_domain_confidence.py tests/test_compile_policy_api.py`
- `git diff --cached --check`
