### PR TITLE
🛡️ Sentinel: [security improvement] Add CSP header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,7 @@
 **Vulnerability:** Path disclosure vulnerability
 **Learning:** `PathSecurityError` exception message explicitly included the absolute paths to the allowed directories on the server. Because the API route `rag_ingest` caught this exception and returned `str(exc)` in the 400 error `detail`, this exposed internal server paths to the client.
 **Prevention:** Do not expose raw internal exception strings to the API layer, especially for filesystem or database errors. Always sanitize error messages to be generic.
+## 2025-05-31 - Add Content-Security-Policy header to FastAPI without breaking Swagger UI
+**Vulnerability:** The application's `api/main.py` lacked a `Content-Security-Policy` header, leaving it more vulnerable to XSS and other content injection attacks.
+**Learning:** Adding a generic strict CSP (like `default-src 'none'`) or missing required sources breaks the built-in FastAPI Swagger UI and ReDoc pages, as they dynamically load assets (scripts, styles, images) from `cdn.jsdelivr.net` and `fastapi.tiangolo.com`. This is a surprising architectural constraint where tightening security headers must explicitly accommodate the documentation framework's external dependencies.
+**Prevention:** When adding CSP headers to FastAPI, ensure `script-src` and `style-src` whitelist `'unsafe-inline'` and `https://cdn.jsdelivr.net`, and that `img-src` allows `data:` URIs and `https://fastapi.tiangolo.com`, to prevent breaking the `/docs` endpoints while still enforcing a policy.

--- a/api/main.py
+++ b/api/main.py
@@ -62,6 +62,9 @@ async def add_security_headers(request, call_next):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    response.headers[
+        "Content-Security-Policy"
+    ] = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
     return response
 
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -15,3 +15,4 @@ def test_security_headers_present():
     assert (
         response.headers.get("Strict-Transport-Security") == "max-age=31536000; includeSubDomains"
     )
+    assert response.headers.get("Content-Security-Policy") is not None


### PR DESCRIPTION
🚨 Severity: MEDIUM

💡 Vulnerability: The FastAPI application lacked a `Content-Security-Policy` header in its HTTP middleware.
🎯 Impact: Without a CSP header, the application is more susceptible to Cross-Site Scripting (XSS) and data injection attacks if malicious content is somehow rendered by the browser or extensions.
🔧 Fix: Added a `Content-Security-Policy` header to `add_security_headers` in `api/main.py`. The policy (`default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com`) restricts content loading while explicitly allowing the external assets required by FastAPI's built-in Swagger UI (`/docs`) and ReDoc to function correctly. Updated the corresponding unit test (`test_security_headers_present`) to verify the header.
✅ Verification: Ran `pytest tests/test_security_headers.py` and the full pytest suite. Ran `pre-commit run --all-files` successfully. Manually verified `/docs` responds with a 200 OK and includes the correct CSP header.

---
*PR created automatically by Jules for task [15764148707190318018](https://jules.google.com/task/15764148707190318018) started by @madara88645*