### PR TITLE
🎨 Palette: Improve QualityCoach empty state UX and button accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-09 - Polish RAG Search Panel UX
 **Learning:** When users click an action like 'Insert into Prompt', visual feedback (such as a success toast) is critical so they aren't left wondering if it worked. Also, clearable inputs (with an 'X' button) significantly speed up the iterative search workflow compared to forcing the user to manually backspace long queries.
 **Action:** Add clearable (X) buttons inside text inputs intended for frequent querying/searching, and always include brief visual confirmation notifications (like toasts) when an action completes without an obvious immediate visual state change.
+
+## 2025-04-10 - Empty State Call-to-Actions
+**Learning:** Empty states without Call-to-Action (CTA) buttons create friction, especially when the required action button is visually distant (e.g., in a top-right corner). Adding an inline CTA directly in the empty state significantly improves UX by making the next step obvious and easily accessible.
+**Action:** When designing or refactoring empty states, always include a clear CTA button inline if the state requires user action to change. Ensure the CTA has descriptive disabled states/tooltips if conditions aren't met (e.g., missing input).

--- a/web/app/components/QualityCoach.tsx
+++ b/web/app/components/QualityCoach.tsx
@@ -60,8 +60,9 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                 <div className="flex gap-2">
                     <button
                         onClick={handleAnalyze}
-                        disabled={analyzing}
-                        className="px-4 py-2 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-xl hover:bg-blue-500/20 text-xs font-semibold uppercase tracking-wider disabled:opacity-50 transition-all"
+                        disabled={analyzing || !prompt.trim()}
+                        title={!prompt.trim() ? "Enter a prompt first to run analysis" : "Run quality analysis"}
+                        className="px-4 py-2 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-xl hover:bg-blue-500/20 text-xs font-semibold uppercase tracking-wider disabled:opacity-50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     >
                         {analyzing ? <span className="animate-pulse">Analyzing...</span> : "Run Analysis"}
                     </button>
@@ -73,7 +74,19 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                     <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center text-3xl mb-2">
                         🛡️
                     </div>
-                    <p className="max-w-[200px] text-center text-sm">Run analysis to detect potential improvements and safety issues.</p>
+                    <p className="max-w-[200px] text-center text-sm mb-2">Run analysis to detect potential improvements and safety issues.</p>
+                    <button
+                        onClick={handleAnalyze}
+                        disabled={analyzing || !prompt.trim()}
+                        title={!prompt.trim() ? "Enter a prompt first to run analysis" : "Run quality analysis"}
+                        className="px-6 py-2 bg-blue-600/20 text-blue-300 border border-blue-500/30 rounded-xl hover:bg-blue-600/30 text-sm font-medium transition-all disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex items-center gap-2"
+                    >
+                        {analyzing ? (
+                            <><span className="w-4 h-4 border-2 border-blue-400 border-t-transparent rounded-full animate-spin"></span> Analyzing...</>
+                        ) : (
+                            "Start Analysis"
+                        )}
+                    </button>
                 </div>
             )}
 


### PR DESCRIPTION
💡 **What:** 
- Added an inline Call-To-Action (CTA) button ("Start Analysis") directly within the `QualityCoach` empty state.
- Updated both "Run Analysis" buttons to be properly disabled when the prompt is empty (`!prompt.trim()`).
- Added helpful `title` tooltips explaining the disabled state.
- Added a loading spinner to the new CTA button.

🎯 **Why:** 
Users faced friction when arriving at the empty state because they had to search for the small "Run Analysis" button in the top right corner. The lack of a disabled state on the button also led to confusing behavior if clicked without a prompt. The inline CTA makes the next step obvious and intuitive.

📸 **Before/After:**
*(Visual changes applied to empty state and button states)*

♿ **Accessibility:** 
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` to both analysis buttons for clear keyboard navigation states.
- Added `disabled` attributes linked to the actual required state (`!prompt.trim()`).
- Added `title` attributes that explain to screen readers and mouse users *why* the button is disabled.

---
*PR created automatically by Jules for task [18301340554121221598](https://jules.google.com/task/18301340554121221598) started by @madara88645*