### PR TITLE
[codex] Fix root IR schema drift with packaged schemas

### DIFF
--- a/schema/ir.schema.json
+++ b/schema/ir.schema.json
@@ -4,7 +4,7 @@
                "output_format","length_hint","steps","examples","banned","tools","metadata"],
   "properties": {
   "language": { "enum": ["tr","en","es"] },
-    "persona": { "enum": ["assistant","teacher","researcher","coach","mentor"] },
+    "persona": { "enum": ["assistant","teacher","researcher","coach","mentor","developer"] },
     "role": { "type": "string" },
     "domain": { "type": "string" },
     "goals": { "type": "array", "items": { "type": "string" } },

--- a/schema/ir_v2.schema.json
+++ b/schema/ir_v2.schema.json
@@ -1,13 +1,54 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["version","language","persona","role","domain","goals","tasks","constraints","style","tone","output_format","length_hint","steps","examples","banned","tools","policy","metadata","intents"],
+  "required": [
+    "version",
+    "language",
+    "persona",
+    "role",
+    "domain",
+    "goals",
+    "tasks",
+    "constraints",
+    "style",
+    "tone",
+    "output_format",
+    "length_hint",
+    "steps",
+    "examples",
+    "banned",
+    "tools",
+    "policy",
+    "metadata",
+    "intents"
+  ],
   "properties": {
-    "version": { "const": "2.0" },
-  "language": { "enum": ["tr","en","es"] },
-    "persona": { "enum": ["assistant","teacher","researcher","coach","mentor","developer"] },
-    "role": { "type": "string" },
-    "domain": { "type": "string" },
+    "version": {
+      "const": "2.0"
+    },
+    "language": {
+      "enum": [
+        "tr",
+        "en",
+        "es"
+      ]
+    },
+    "persona": {
+      "enum": [
+        "assistant",
+        "teacher",
+        "researcher",
+        "coach",
+        "mentor",
+        "developer"
+      ]
+    },
+    "role": {
+      "type": "string"
+    },
+    "domain": {
+      "type": "string"
+    },
     "intents": {
       "type": "array",
       "items": {
@@ -33,59 +74,218 @@
         ]
       }
     },
-    "goals": { "type": "array", "items": { "type": "string" } },
-    "tasks": { "type": "array", "items": { "type": "string" } },
-    "inputs": { "type": "object", "additionalProperties": { "type": "string" } },
+    "goals": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "constraints": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id","text","origin","priority"],
+        "required": [
+          "id",
+          "text",
+          "origin",
+          "priority"
+        ],
         "properties": {
-          "id": { "type": "string" },
-          "text": { "type": "string" },
-          "origin": { "type": "string" },
-          "priority": { "type": "integer" },
-          "rationale": { "type": ["string","null"] }
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "origin": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer",
+            "enum": [
+              10,
+              20,
+              30,
+              40,
+              45,
+              50,
+              55,
+              60,
+              65,
+              70,
+              75,
+              80,
+              85,
+              90,
+              95,
+              100
+            ]
+          },
+          "rationale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         },
         "additionalProperties": false
       }
     },
-    "style": { "type": "array", "items": { "type": "string" } },
-    "tone": { "type": "array", "items": { "type": "string" } },
-    "output_format": { "enum": ["markdown","json","yaml","table","text"] },
-    "length_hint": { "enum": ["short","medium","long"] },
+    "style": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tone": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "output_format": {
+      "enum": [
+        "markdown",
+        "json",
+        "yaml",
+        "table",
+        "text"
+      ]
+    },
+    "length_hint": {
+      "enum": [
+        "short",
+        "medium",
+        "long"
+      ]
+    },
     "steps": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["type","text"],
+        "required": [
+          "type",
+          "text"
+        ],
         "properties": {
-          "type": { "enum": ["task","teach","research","compare","plan"] },
-          "text": { "type": "string" }
+          "type": {
+            "enum": [
+              "task",
+              "teach",
+              "research",
+              "compare",
+              "plan"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
         },
         "additionalProperties": false
       }
     },
-    "examples": { "type": "array", "items": { "type": "string" } },
-    "banned": { "type": "array", "items": { "type": "string" } },
-    "tools": { "type": "array", "items": { "type": "string" } },
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "banned": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "policy": {
       "type": "object",
-      "required": ["risk_level","risk_domains","allowed_tools","forbidden_tools","sanitization_rules","data_sensitivity","execution_mode"],
+      "required": [
+        "risk_level",
+        "risk_domains",
+        "allowed_tools",
+        "forbidden_tools",
+        "sanitization_rules",
+        "data_sensitivity",
+        "execution_mode"
+      ],
       "properties": {
-        "risk_level": { "enum": ["low","medium","high"] },
-        "risk_domains": { "type": "array", "items": { "type": "string" } },
-        "allowed_tools": { "type": "array", "items": { "type": "string" } },
-        "forbidden_tools": { "type": "array", "items": { "type": "string" } },
-        "sanitization_rules": { "type": "array", "items": { "type": "string" } },
-        "data_sensitivity": { "enum": ["public","internal","confidential","restricted"] },
-        "execution_mode": { "enum": ["advice_only","human_approval_required","auto_ok"] }
+        "risk_level": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "risk_domains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowed_tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "forbidden_tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sanitization_rules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "data_sensitivity": {
+          "enum": [
+            "public",
+            "internal",
+            "confidential",
+            "restricted"
+          ]
+        },
+        "execution_mode": {
+          "enum": [
+            "advice_only",
+            "human_approval_required",
+            "auto_ok"
+          ]
+        }
       },
       "additionalProperties": false
     },
-    "diagnostics": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
-    "metadata": { "type": "object", "additionalProperties": true }
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
   },
   "additionalProperties": false
 }

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -19,6 +19,7 @@ from app.resources import get_ir_schema_text
 
 schema = json.loads(get_ir_schema_text(v2=False))
 schema_v2 = json.loads(get_ir_schema_text(v2=True))
+repo_root = Path(__file__).resolve().parents[1]
 
 
 def _literal_int(node: ast.AST) -> int | None:
@@ -85,6 +86,16 @@ def test_v1_and_v2_persona_enums_stay_aligned_for_shared_values():
     v2_personas = set(schema_v2["properties"]["persona"]["enum"])
 
     assert v1_personas == v2_personas
+
+
+def test_root_schema_copies_match_packaged_schemas_semantically():
+    root_schema = json.loads((repo_root / "schema" / "ir.schema.json").read_text(encoding="utf-8"))
+    root_schema_v2 = json.loads(
+        (repo_root / "schema" / "ir_v2.schema.json").read_text(encoding="utf-8")
+    )
+
+    assert root_schema == schema
+    assert root_schema_v2 == schema_v2
 
 
 def test_checked_in_schemas_match_shared_ir_contract_enums():


### PR DESCRIPTION
## Summary
- Align root `schema/ir.schema.json` with packaged `app/_schemas/ir.schema.json` so the root v1 schema accepts the `developer` persona.
- Align root `schema/ir_v2.schema.json` with packaged `app/_schemas/ir_v2.schema.json` so constraint `priority` keeps the canonical enum.
- Add a semantic parity regression test so root schema copies cannot drift from packaged schemas without CI catching it.

## Root cause
Runtime schema loading uses `app.resources.get_ir_schema_text()`, which reads packaged schemas from `app/_schemas`. The root `schema/` copies had drifted: v1 still rejected `developer`, and v2 had lost the explicit constraint priority enum.

## Verification
- `python -m pytest tests/test_schema_validation.py -q`
- `python -m pytest tests/test_ir_v2_basic.py tests/test_intent_coverage_v2.py -q`
- `python -m ruff check tests/test_schema_validation.py`
- `git diff --check`