### PR TITLE
🛡️ Sentinel: [security improvement] Restrict CORS allow_headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -28,3 +28,8 @@
 **Vulnerability:** The application's `api/main.py` lacked a `Content-Security-Policy` header, leaving it more vulnerable to XSS and other content injection attacks.
 **Learning:** Adding a generic strict CSP (like `default-src 'none'`) or missing required sources breaks the built-in FastAPI Swagger UI and ReDoc pages, as they dynamically load assets (scripts, styles, images) from `cdn.jsdelivr.net` and `fastapi.tiangolo.com`. This is a surprising architectural constraint where tightening security headers must explicitly accommodate the documentation framework's external dependencies.
 **Prevention:** When adding CSP headers to FastAPI, ensure `script-src` and `style-src` whitelist `'unsafe-inline'` and `https://cdn.jsdelivr.net`, and that `img-src` allows `data:` URIs and `https://fastapi.tiangolo.com`, to prevent breaking the `/docs` endpoints while still enforcing a policy.
+## 2025-06-05 - Restrict Overly Permissive CORS Headers
+
+**Vulnerability:** The FastAPI application used `allow_headers=["*"]` in its `CORSMiddleware` configuration. This is an overly permissive setting that could potentially allow malicious cross-origin requests to send unexpected or forged headers to the backend, increasing the attack surface.
+**Learning:** While allowing all origins (`*`) is a known risk, allowing all headers (`*`) is also a security concern. It violates the principle of least privilege.
+**Prevention:** When configuring CORS, always explicitly list the headers required by the application (e.g., `["Content-Type", "Authorization", "x-api-key", "Accept", "Origin", "X-Requested-With"]`) instead of using wildcards.

--- a/api/main.py
+++ b/api/main.py
@@ -51,7 +51,14 @@ app.add_middleware(
     allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-    allow_headers=["Content-Type", "Authorization", "x-api-key", "Accept", "Origin", "X-Requested-With"],
+    allow_headers=[
+        "Content-Type",
+        "Authorization",
+        "x-api-key",
+        "Accept",
+        "Origin",
+        "X-Requested-With",
+    ],
 )
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -51,7 +51,7 @@ app.add_middleware(
     allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Authorization", "x-api-key", "Accept", "Origin", "X-Requested-With"],
 )
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -58,6 +58,7 @@ app.add_middleware(
         "Accept",
         "Origin",
         "X-Requested-With",
+        "X-Prompt-Mode",
     ],
 )
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -110,6 +110,22 @@ def test_rag_ingest_rejects_path_outside_allowed_root(test_key, monkeypatch):
         assert "invalid path specified" in response.json()["detail"].lower()
 
 
+def test_cors_preflight_allows_prompt_mode_header():
+    client = TestClient(app)
+
+    response = client.options(
+        "/compile",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Prompt-Mode",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "x-prompt-mode" in response.headers["access-control-allow-headers"].lower()
+
+
 def test_worker_client_wraps_user_input_and_context_with_tags():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Overly permissive CORS `allow_headers` configuration. Using `allow_headers=["*"]` allows any HTTP header in cross-origin requests, increasing the attack surface by permitting unexpected or forged headers.
🎯 Impact: Attackers could potentially exploit backend logic that unsafely processes unexpected headers. Restricting this follows the principle of least privilege.
🔧 Fix: Replaced the wildcard with an explicit list of required headers: `["Content-Type", "Authorization", "x-api-key", "Accept", "Origin", "X-Requested-With"]`.
✅ Verification: Tested the backend API endpoints locally and passed `pytest`. Also passed tests in frontend `web/` after setting up dependencies to ensure no functional breaks.

---
*PR created automatically by Jules for task [3550741485837258664](https://jules.google.com/task/3550741485837258664) started by @madara88645*