### PR TITLE
fix: apply implied persona over default roles

### DIFF
--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -14,7 +14,13 @@ import textwrap
 from typing import List, Dict, Optional, Tuple
 from dataclasses import dataclass, field
 from .base import BaseHandler
-from app.models import IR
+from app.models import (
+    DEFAULT_ROLE_DEV_EN,
+    DEFAULT_ROLE_DEV_TR,
+    DEFAULT_ROLE_EN,
+    DEFAULT_ROLE_TR,
+    IR,
+)
 from app.models_v2 import IRv2, ConstraintV2, DiagnosticItem
 
 
@@ -42,6 +48,17 @@ class DomainAnalysis:
     suggestions: List[DomainSuggestion] = field(default_factory=list)
     diagnostics: List[DiagnosticItem] = field(default_factory=list)
     detected_patterns: Dict[str, List[str]] = field(default_factory=dict)
+
+
+_GENERIC_PERSONAS = {"", "assistant", "general", "developer"}
+_GENERIC_ROLES = {
+    "",
+    "AI Assistant",
+    DEFAULT_ROLE_EN,
+    DEFAULT_ROLE_TR,
+    DEFAULT_ROLE_DEV_EN,
+    DEFAULT_ROLE_DEV_TR,
+}
 
 
 # ==============================================================================
@@ -656,6 +673,22 @@ class DomainHandler(BaseHandler):
         for lang, rules in DOMAIN_RULES["coding"]["languages"].items():
             self._lowered_indicators[lang] = [ind.lower() for ind in rules.get("indicators", [])]
 
+        # Compile implied persona patterns against lowercased input text.
+        self._compiled_implied_personas: Dict[re.Pattern, str] = {}
+        self._implied_persona_specificity: Dict[re.Pattern, int] = {}
+        for keyword, persona_name in IMPLIED_PERSONAS.items():
+            normalized_keyword = keyword.lower()
+            escaped = re.escape(normalized_keyword.strip())
+            pattern = r"\b" + escaped + r"\b"
+            if keyword.endswith(" "):
+                pattern = r"\b" + escaped + r"\s"
+            compiled_pattern = re.compile(pattern)
+            self._compiled_implied_personas[compiled_pattern] = persona_name
+            specificity = len(normalized_keyword.strip())
+            if keyword.endswith(" "):
+                specificity -= 1
+            self._implied_persona_specificity[compiled_pattern] = specificity
+
     def handle(self, ir_v2: IRv2, ir_v1: IR) -> None:
         """
         Apply domain-specific heuristics to enhance IR.
@@ -686,7 +719,9 @@ class DomainHandler(BaseHandler):
         # Add diagnostics
         ir_v2.diagnostics.extend(analysis.diagnostics)
 
-        if (not ir_v2.persona or ir_v2.persona in ["assistant", "general"]) and not ir_v2.role:
+        persona_is_generic = not ir_v2.persona or ir_v2.persona in _GENERIC_PERSONAS
+        role_is_generic = not ir_v2.role or ir_v2.role in _GENERIC_ROLES
+        if persona_is_generic and role_is_generic:
             implied_persona, confidence = self.detect_implied_persona(original_text)
             if implied_persona:
                 ir_v2.persona = "expert"
@@ -769,25 +804,35 @@ class DomainHandler(BaseHandler):
 
         best_persona = None
         max_score = 0.0
+        max_specificity = 0
+        best_match_start = -1
 
         # Simple keyword matching
-        for keyword, persona_name in IMPLIED_PERSONAS.items():
-            # word boundary check for short keywords
-            escaped = re.escape(keyword.strip())
-            pattern = r"\b" + escaped + r"\b"
-            if keyword.endswith(" "):  # if keyword ended with space, strict check
-                pattern = r"\b" + escaped + r"\s"
-
+        for pattern_obj, persona_name in self._compiled_implied_personas.items():
             # Count occurrences
-            matches = re.findall(pattern, text_lower)
-            if matches:
+            match_count = 0
+            first_match_start = -1
+            for match in pattern_obj.finditer(text_lower):
+                if first_match_start < 0:
+                    first_match_start = match.start()
+                match_count += 1
+            if match_count:
                 # Base score 0.6, +0.1 for each extra occurrence, max 0.9
-                score = min(0.9, 0.6 + (len(matches) - 1) * 0.1)
+                score = min(0.9, 0.6 + (match_count - 1) * 0.1)
 
-                # Longer keywords might be more specific?
-                # For now just take the highest score
-                if score > max_score:
+                specificity = self._implied_persona_specificity.get(pattern_obj, 0)
+                if (
+                    score > max_score
+                    or (score == max_score and specificity > max_specificity)
+                    or (
+                        score == max_score
+                        and specificity == max_specificity
+                        and first_match_start > best_match_start
+                    )
+                ):
                     max_score = score
+                    max_specificity = specificity
+                    best_match_start = first_match_start
                     best_persona = persona_name
 
         return best_persona, max_score

--- a/tests/test_compile_policy_api.py
+++ b/tests/test_compile_policy_api.py
@@ -15,3 +15,12 @@ def test_compile_endpoint_exposes_policy_in_ir_v2():
     assert "ir_v2" in payload
     assert payload["ir_v2"]["policy"]["risk_level"] == "high"
     assert payload["ir_v2"]["policy"]["execution_mode"] == "human_approval_required"
+
+
+def test_compile_endpoint_applies_implied_persona_in_local_v2_pipeline():
+    response = client.post("/compile", json={"text": 'Console.WriteLine("hello");', "v2": False})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ir_v2"]["metadata"]["implied_persona"]["persona"] == "C# Developer"
+    assert payload["ir_v2"]["role"] == "Expert C# Developer"

--- a/tests/test_domain_confidence.py
+++ b/tests/test_domain_confidence.py
@@ -1,4 +1,4 @@
-from app.compiler import compile_text
+from app.compiler import compile_text, compile_text_v2
 from app.heuristics.handlers.domain_expert import DomainHandler
 from app.models_v2 import IRv2
 from app.models import IR
@@ -137,3 +137,11 @@ def test_implied_persona_sql():
 
     handler.handle(ir_v2, ir_v1)
     assert "Database Administrator" in ir_v2.role
+
+
+def test_compile_text_v2_applies_implied_persona_over_default_role():
+    ir = compile_text_v2('Console.WriteLine("hello");', offline_only=True)
+
+    assert ir.persona == "expert"
+    assert ir.role == "Expert C# Developer"
+    assert ir.metadata["implied_persona"]["persona"] == "C# Developer"

--- a/tests/test_regex_precompilation.py
+++ b/tests/test_regex_precompilation.py
@@ -1,4 +1,5 @@
 """Tests for regex pre-compilation in DomainHandler."""
+
 import re
 import pytest
 from app.heuristics.handlers.domain_expert import DomainHandler
@@ -23,13 +24,11 @@ class TestRegexPrecompilation:
         assert "security" in handler._compiled_universal_checks
         for check_name, compiled in handler._compiled_universal_checks.items():
             if compiled.get("missing"):
-                assert isinstance(
-                    compiled.get("missing"), re.Pattern
-                ), f"{check_name} missing_pattern not compiled"
+                missing_pattern = compiled.get("missing")
+                assert isinstance(missing_pattern, re.Pattern)
             if compiled.get("risk"):
-                assert isinstance(
-                    compiled.get("risk"), re.Pattern
-                ), f"{check_name} risk_pattern not compiled"
+                risk_pattern = compiled.get("risk")
+                assert isinstance(risk_pattern, re.Pattern)
 
     def test_business_required_elements_compiled(self, handler):
         assert hasattr(handler, "_compiled_business_elements")
@@ -62,6 +61,12 @@ class TestRegexPrecompilation:
             for ind in indicators:
                 assert ind == ind.lower(), f"Indicator '{ind}' for {lang} not lowercased"
 
+    def test_implied_personas_compiled(self, handler):
+        assert hasattr(handler, "_compiled_implied_personas")
+        assert len(handler._compiled_implied_personas) > 0
+        for pat in handler._compiled_implied_personas:
+            assert isinstance(pat, re.Pattern)
+
 
 class TestPrecompiledPatternsWork:
     """Verify pre-compiled patterns produce correct results."""
@@ -86,6 +91,37 @@ class TestPrecompiledPatternsWork:
         text = "quickly and carefully process the data"
         matches = handler._compiled_adverb_pattern.findall(text)
         assert len(matches) >= 2
+
+    @pytest.mark.parametrize(
+        ("text", "expected_persona"),
+        [
+            ('System.out.println("hello");', "Java Developer"),
+            ('Console.WriteLine("hello");', "C# Developer"),
+        ],
+    )
+    def test_implied_persona_detection_handles_mixed_case_snippets(
+        self, handler, text, expected_persona
+    ):
+        persona, confidence = handler.detect_implied_persona(text)
+
+        assert persona == expected_persona
+        assert confidence == 0.6
+
+    @pytest.mark.parametrize(
+        ("text", "expected_persona"),
+        [
+            ("import pandas as pd", "Data Scientist"),
+            ("import numpy as np", "Data Scientist"),
+            ("const docker = true", "DevOps Engineer"),
+        ],
+    )
+    def test_implied_persona_detection_prefers_more_specific_equal_score_match(
+        self, handler, text, expected_persona
+    ):
+        persona, confidence = handler.detect_implied_persona(text)
+
+        assert persona == expected_persona
+        assert confidence == 0.6
 
     def test_coding_security_suggestion_only_when_risk_terms_present(self, handler):
         generic = handler._analyze_coding(


### PR DESCRIPTION
## Summary
- Normalize implied persona regex keywords to match the lowercased detection input.
- Prefer more specific implied persona matches when confidence ties.
- Allow implied personas to replace generic/default compile roles while preserving explicit custom roles.
- Add regression coverage for handler detection, `compile_text_v2`, and `/compile` IRv2 output.

Supersedes #365 with a fresh branch based on the current `main`.

## Verification
- `python -m pytest tests/test_regex_precompilation.py tests/test_domain_confidence.py tests/test_compile_policy_api.py -q`
- `python -m ruff check app/heuristics/handlers/domain_expert.py tests/test_domain_confidence.py tests/test_compile_policy_api.py tests/test_regex_precompilation.py`
- `python -m ruff format --check app/heuristics/handlers/domain_expert.py tests/test_domain_confidence.py tests/test_compile_policy_api.py tests/test_regex_precompilation.py`