### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing auth on benchmark endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,7 @@
 **Vulnerability:** The FastAPI application used `allow_headers=["*"]` in its `CORSMiddleware` configuration. This is an overly permissive setting that could potentially allow malicious cross-origin requests to send unexpected or forged headers to the backend, increasing the attack surface.
 **Learning:** While allowing all origins (`*`) is a known risk, allowing all headers (`*`) is also a security concern. It violates the principle of least privilege.
 **Prevention:** When configuring CORS, always explicitly list the headers required by the application (e.g., `["Content-Type", "Authorization", "x-api-key", "Accept", "Origin", "X-Requested-With"]`) instead of using wildcards.
+## 2024-05-24 - Missing Authentication on Cost-Incurring Endpoint
+**Vulnerability:** The `/benchmark/run` API endpoint in `app/routers/benchmark.py`, which makes multiple LLM API calls, was completely unauthenticated.
+**Learning:** Endpoints added later in the lifecycle (like benchmark routers) can sometimes be missed when applying global or required authentication patterns used in core routers (like `rag` or `compile`), leading to unauthorized resource exhaustion.
+**Prevention:** Always verify that newly added routers or endpoints that trigger cost-incurring actions (like LLM calls) explicitly include standard authentication dependencies (e.g., `Depends(verify_api_key)` or `Depends(verify_api_key_if_required)`) in their signature, matching the pattern used in the rest of the application.

--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -18,9 +18,10 @@ import re
 import time
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
+from api.auth import APIKey, verify_api_key_if_required
 from app.compiler import compile_text_v2
 from app.emitters import emit_expanded_prompt_v2
 
@@ -270,10 +271,14 @@ def _heuristic_judge(raw_output: str, compiled_output: str) -> dict:
 
 
 @router.post("/run", response_model=BenchmarkResponse)
-async def benchmark_run(req: BenchmarkRequest):
+async def benchmark_run(
+    req: BenchmarkRequest,
+    api_key: APIKey | None = Depends(verify_api_key_if_required),
+):
     """
     Run an A/B benchmark comparing raw vs compiled prompt quality.
     """
+    del api_key
     t0 = time.time()
 
     # --- Step A: Generate with raw prompt ---------------------------------


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/benchmark/run` API endpoint (`app/routers/benchmark.py`) was completely unauthenticated. This endpoint makes multiple external LLM API calls, meaning it was vulnerable to unauthorized usage and resource exhaustion (financial loss due to automated/abuse API requests).
🎯 **Impact:** An attacker could invoke the benchmark API continuously without an API key, triggering expensive LLM completions via the configured AI provider, causing both a Denial of Wallet (financial) and potentially exhausting rate limits.
🔧 **Fix:** Added `api_key: APIKey | None = Depends(verify_api_key_if_required)` to the `benchmark_run` route signature. This correctly integrates the endpoint into the existing Prompt Compiler API security model.
✅ **Verification:** Ran `python3 -m pytest tests/test_benchmark_api.py` and the full test suite (`python3 -m pytest tests/`). Tests pass.

*(A related learning has been logged to `.jules/sentinel.md`)*

---
*PR created automatically by Jules for task [13006215060411139555](https://jules.google.com/task/13006215060411139555) started by @madara88645*