### PR TITLE
[codex] wire frontend unit tests into documented CI gate

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -250,6 +250,12 @@ Relevant files: `web/app/`, `web/app/components/`, `web/app/hooks/`
 cd web && npm run test:contracts
 ```
 
+**Unit tests (Vitest component coverage):**
+
+```bash
+cd web && npm run test
+```
+
 **Lint:**
 
 ```bash
@@ -358,6 +364,7 @@ pre-commit run --all-files
 cd web
 npm ci
 npm run test:contracts
+npm run test
 npm run lint
 npm run build
 cd ..

--- a/web/app/components/__tests__/Skeleton.test.tsx
+++ b/web/app/components/__tests__/Skeleton.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Skeleton, SkeletonBlock } from "../Skeleton";
+
+describe("Skeleton", () => {
+  it("renders with skeleton class", () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.classList.contains("skeleton")).toBe(true);
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<Skeleton className="h-4 w-full" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.classList.contains("h-4")).toBe(true);
+    expect(el.classList.contains("w-full")).toBe(true);
+  });
+});
+
+describe("SkeletonBlock", () => {
+  it("renders the specified number of lines", () => {
+    const { container } = render(<SkeletonBlock lines={3} />);
+    const skeletons = container.querySelectorAll(".skeleton");
+    expect(skeletons.length).toBe(3);
+  });
+
+  it("defaults to 5 lines", () => {
+    const { container } = render(<SkeletonBlock />);
+    const skeletons = container.querySelectorAll(".skeleton");
+    expect(skeletons.length).toBe(5);
+  });
+});

--- a/web/app/components/__tests__/ToastProvider.test.tsx
+++ b/web/app/components/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import ToastProvider from "../ToastProvider";
+
+describe("ToastProvider", () => {
+  it("renders without crashing", () => {
+    const { container } = render(<ToastProvider />);
+    expect(container).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add lightweight Vitest component tests for Skeleton and ToastProvider.
- Update the agent runbook frontend gate so it includes `npm run test`, matching the GitHub Actions smoke job.
- Keep unrelated local/untracked files out of this PR.

## Why
The CI workflow already runs frontend unit tests, but the local agent instructions only listed contract tests before lint/build. That drift makes it easier for agents to miss component regressions before opening PRs.

## Validation
- `cd web && npm run test` — 7 files passed, 13 tests passed
- `cd web && npm run test:contracts` — 13 tests passed
- `cd web && npm run lint` — passed
- `cd web && npm run build` — passed