### PR TITLE
[codex] fix inline compiler error state

### DIFF
--- a/web/app/__tests__/page-error-state.test.tsx
+++ b/web/app/__tests__/page-error-state.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const retryMock = vi.fn();
+const useCompilerMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+describe("Prompt Compiler home", () => {
+  beforeEach(() => {
+    retryMock.mockReset();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Error",
+      lastError: new Error("Could not reach the backend. Check the API URL or make sure the server is running."),
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: retryMock,
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+  });
+
+  it("keeps compile failures visible in the output workspace", () => {
+    render(<Home />);
+
+    expect(screen.getByText("Compile failed")).toBeTruthy();
+    expect(
+      screen.getByText("Could not reach the backend. Check the API URL or make sure the server is running."),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry compile" }));
+
+    expect(retryMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -8,6 +8,7 @@ import SecurityAlert from "./components/SecurityAlert";
 import IntentPolicyPanel from "./components/IntentPolicyPanel";
 import OutputSkeleton from "./components/OutputSkeleton";
 import { useCompiler } from "./hooks/useCompiler";
+import { describeRequestError } from "../config";
 import type { CompileMode, CompileResponse } from "../lib/api/types";
 
 type OutputTab = "intent" | "system" | "user" | "plan" | "expanded" | "json" | "quality";
@@ -26,6 +27,36 @@ function getTabContent(result: CompileResponse, activeTab: OutputTab): string {
   }
 
   return result.expanded_prompt_v2 || result.expanded_prompt;
+}
+
+function CompilerErrorState({
+  error,
+  onRetry,
+}: {
+  error: unknown;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex-1 flex items-center justify-center p-10 text-center" role="alert">
+      <div className="max-w-md rounded-lg border border-red-500/20 bg-red-500/10 p-6 shadow-xl shadow-red-950/10">
+        <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-lg border border-red-400/30 bg-red-400/10 text-lg font-semibold text-red-200">
+          !
+        </div>
+        <h3 className="text-base font-semibold text-white">Compile failed</h3>
+        <p className="mt-2 text-sm leading-relaxed text-red-100/80">{describeRequestError(error)}</p>
+        <p className="mt-3 text-xs leading-relaxed text-zinc-500">
+          Your prompt is still in the editor. Retry after checking the backend or API URL.
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-5 rounded-lg border border-red-400/30 bg-red-500/20 px-4 py-2 text-sm font-medium text-red-50 transition-colors hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+        >
+          Retry compile
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export default function Home() {
@@ -201,7 +232,9 @@ export default function Home() {
           <div className="w-full md:w-[65%] min-h-0 flex flex-col bg-black/20 relative">
 
             {/* ── Compiler Output View ── */}
-            {result ? (
+            {!!lastError && !loading ? (
+              <CompilerErrorState error={lastError} onRetry={() => void retry()} />
+            ) : result ? (
               <>
                 {/* Tabs */}
                 <div role="tablist" aria-label="Output views" className="flex border-b border-white/5 px-4 pt-4 gap-2 overflow-x-auto no-scrollbar scroll-smooth" style={{ maskImage: "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)" }}>


### PR DESCRIPTION
## Summary

- Add an inline compiler error state to the main output workspace.
- Show the normalized backend/network error message where users expect output.
- Add a regression test that verifies the error copy and retry action stay visible.

## Why

When compile failed, the UI only showed a transient toast and a small header retry button while the output panel fell back to the empty "Ready to Compile" state. That made backend/API failures look like an idle empty state instead of a recoverable error.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`