### PR TITLE
🧹 [code health improvement] Remove unused placeholder function in legacy commands

### DIFF
--- a/cli/commands/legacy.py
+++ b/cli/commands/legacy.py
@@ -11,5 +11,3 @@ import typer
 # This is safer than moving everything at once.
 
 app = typer.Typer(help="Legacy/Extras")
-
-

--- a/cli/commands/legacy.py
+++ b/cli/commands/legacy.py
@@ -13,6 +13,3 @@ import typer
 app = typer.Typer(help="Legacy/Extras")
 
 
-@app.command()
-def placeholder():
-    pass


### PR DESCRIPTION
🎯 **What:** Removed the unused `placeholder` function and its Typer command decorator from `cli/commands/legacy.py`.
💡 **Why:** This function was explicitly marked as a placeholder and served no functional purpose (`pass`). Removing it eliminates dead code, reducing clutter and improving the overall maintainability and readability of the `cli/commands/legacy.py` file without affecting any actual features.
✅ **Verification:** Ran the full pytest suite (`python3 -m pytest tests/`) to ensure no functionality is broken. All 889 tests passed successfully.
✨ **Result:** A cleaner codebase with fewer lines of dead code and no loss of functionality.

---
*PR created automatically by Jules for task [5617444718526056131](https://jules.google.com/task/5617444718526056131) started by @madara88645*