### PR TITLE
🧪 Testing Improvement: Add coverage for count_tokens_approx fallback

### DIFF
--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,51 @@
+import sys
+from unittest import mock
+import pytest
+
+from app.rag.summarizer import count_tokens_approx
+
+def test_count_tokens_approx_happy_path():
+    """Test the happy path where tiktoken is available."""
+    text = "Hello world! This is a test."
+    # Reset global _tiktoken_enc to None to ensure it gets initialized in this test if available
+    import app.rag.summarizer
+    app.rag.summarizer._tiktoken_enc = None
+
+    # Normally tiktoken would be imported and count would be exact
+    try:
+        import tiktoken
+        expected_count = len(tiktoken.get_encoding("cl100k_base").encode(text))
+        count = count_tokens_approx(text)
+        assert count == expected_count
+    except ImportError:
+        pytest.skip("tiktoken not installed, skipping happy path test")
+
+
+def test_count_tokens_approx_fallback():
+    """Test the fallback calculation when tiktoken raises ImportError."""
+    text = "Hello world! This is a test."
+    ratio = 4.0
+    expected_count = int(len(text) / ratio)
+
+    # Reset global _tiktoken_enc to None
+    import app.rag.summarizer
+    app.rag.summarizer._tiktoken_enc = None
+
+    # Patch sys.modules to simulate ImportError
+    with mock.patch.dict("sys.modules", {"tiktoken": None}):
+        count = count_tokens_approx(text, ratio=ratio)
+        assert count == expected_count
+
+def test_count_tokens_approx_fallback_custom_ratio():
+    """Test the fallback calculation with a custom ratio."""
+    text = "1234567890"
+    ratio = 2.0
+    expected_count = int(len(text) / ratio)
+
+    # Reset global _tiktoken_enc to None
+    import app.rag.summarizer
+    app.rag.summarizer._tiktoken_enc = None
+
+    with mock.patch.dict("sys.modules", {"tiktoken": None}):
+        count = count_tokens_approx(text, ratio=ratio)
+        assert count == expected_count

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,19 +1,21 @@
-import sys
 from unittest import mock
 import pytest
 
 from app.rag.summarizer import count_tokens_approx
+
 
 def test_count_tokens_approx_happy_path():
     """Test the happy path where tiktoken is available."""
     text = "Hello world! This is a test."
     # Reset global _tiktoken_enc to None to ensure it gets initialized in this test if available
     import app.rag.summarizer
+
     app.rag.summarizer._tiktoken_enc = None
 
     # Normally tiktoken would be imported and count would be exact
     try:
         import tiktoken
+
         expected_count = len(tiktoken.get_encoding("cl100k_base").encode(text))
         count = count_tokens_approx(text)
         assert count == expected_count
@@ -29,12 +31,14 @@ def test_count_tokens_approx_fallback():
 
     # Reset global _tiktoken_enc to None
     import app.rag.summarizer
+
     app.rag.summarizer._tiktoken_enc = None
 
     # Patch sys.modules to simulate ImportError
     with mock.patch.dict("sys.modules", {"tiktoken": None}):
         count = count_tokens_approx(text, ratio=ratio)
         assert count == expected_count
+
 
 def test_count_tokens_approx_fallback_custom_ratio():
     """Test the fallback calculation with a custom ratio."""
@@ -44,6 +48,7 @@ def test_count_tokens_approx_fallback_custom_ratio():
 
     # Reset global _tiktoken_enc to None
     import app.rag.summarizer
+
     app.rag.summarizer._tiktoken_enc = None
 
     with mock.patch.dict("sys.modules", {"tiktoken": None}):


### PR DESCRIPTION
🎯 **What:** Added tests for `count_tokens_approx` in `app/rag/summarizer.py` to ensure the fallback branch (when `tiktoken` is unavailable) functions correctly.
📊 **Coverage:** Covered the happy path (when `tiktoken` successfully imports) and the fallback path (with both default and custom `ratio` values by mocking `sys.modules` to simulate an `ImportError`).
✨ **Result:** Increased test reliability and coverage by verifying the correct behavior of the fallback character ratio logic.

---
*PR created automatically by Jules for task [5586341707786643882](https://jules.google.com/task/5586341707786643882) started by @madara88645*