### PR TITLE
🎨 Palette: Add disabled state tooltips and icon labels

### DIFF
--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -102,6 +102,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                         type="button"
                         onClick={() => void ingestPath(filePath)}
                         disabled={ingesting || !filePath}
+                        title={!filePath ? "Enter a path to ingest" : "Ingest path"}
                         className="w-full py-2 bg-zinc-800/50 hover:bg-zinc-700/50 text-xs font-medium text-zinc-300 rounded-lg disabled:opacity-50 transition-colors border border-white/5 flex items-center justify-center gap-2"
                     >
                         {ingesting ? <span className="animate-pulse">Indexing...</span> : "Ingest Path"}

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -37,6 +37,7 @@ export default function RagSearchPanel({
                             type="button"
                             onClick={() => { setQuery(""); }}
                             aria-label="Clear search"
+                            title="Clear search"
                             className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 rounded-full flex items-center justify-center text-[10px] text-zinc-500 hover:text-zinc-300 hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
                         >
                             ×
@@ -47,6 +48,7 @@ export default function RagSearchPanel({
                     type="button"
                     onClick={onRunSearch}
                     disabled={searching || !query.trim()}
+                    title={!query.trim() ? "Enter a search query" : "Search context"}
                     className="px-3 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-lg text-xs hover:bg-blue-500/20 transition-all font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
                 >
                     Search

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -211,6 +211,7 @@ export default function Home() {
                 type="button"
                 onClick={() => handleGenerate()}
                 disabled={loading || !prompt.trim()}
+                title={!prompt.trim() ? "Enter a prompt first" : "Generate prompt"}
                 className="w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 shadow-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
               >
                 {loading ? (


### PR DESCRIPTION
💡 **What**: Added contextual tooltips (using the `title` attribute) to key buttons across the app.
🎯 **Why**: When a button is disabled, users often don't know *why*. Adding a small tooltip explaining the reason (e.g., "Enter a prompt first") makes the interface much more intuitive and user-friendly. I also added a tooltip to an icon-only clear button to improve context.
📸 **Before/After**: Buttons just looked disabled. Now, hovering over them provides a helpful message.
♿ **Accessibility**: Provides immediate context on hover for sighted users and matches `aria-label` for screen reader consistency on icon buttons.

---
*PR created automatically by Jules for task [3228105569456015243](https://jules.google.com/task/3228105569456015243) started by @madara88645*