### PR TITLE
Harden policy inference around educational prompts and sensitive identifier detection

### DIFF
--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -652,6 +652,38 @@ PII_PATTERNS = {
 }
 
 
+_PII_CONTEXT_FALSE_POSITIVE_HINTS = (
+    "example",
+    "sample",
+    "dummy",
+    "placeholder",
+    "format",
+    "mask",
+    "regex",
+    "test data",
+    "fake",
+)
+
+
+def _is_tc_kimlik_valid(value: str) -> bool:
+    """Validate Turkish TC Kimlik number checksum to reduce false positives."""
+    if not re.fullmatch(r"[1-9]\d{10}", value):
+        return False
+    digits = [int(ch) for ch in value]
+    odd_sum = sum(digits[0:9:2])
+    even_sum = sum(digits[1:8:2])
+    check_10 = ((odd_sum * 7) - even_sum) % 10
+    check_11 = sum(digits[:10]) % 10
+    return digits[9] == check_10 and digits[10] == check_11
+
+
+def _has_fp_hint_around_match(text: str, start: int, end: int, window: int = 24) -> bool:
+    lo = max(0, start - window)
+    hi = min(len(text), end + window)
+    ctx = text[lo:hi].lower()
+    return any(hint in ctx for hint in _PII_CONTEXT_FALSE_POSITIVE_HINTS)
+
+
 def detect_pii(text: str) -> list[str]:
     flags: list[str] = []
     # To reduce false positives for credit cards: ensure at least 13 digits contiguous when stripped
@@ -668,6 +700,10 @@ def detect_pii(text: str) -> list[str]:
                 digits_count = sum(map(str.isdigit, val))
                 if digits_count < 7:
                     continue
+            if kind in {"ssn", "passport"} and _has_fp_hint_around_match(text, m.start(), m.end()):
+                continue
+            if kind == "tc_kimlik" and not _is_tc_kimlik_valid(val):
+                continue
             if kind not in flags:
                 flags.append(kind)
             # Do not collect more than 5 kinds to keep metadata small

--- a/app/heuristics/handlers/policy.py
+++ b/app/heuristics/handlers/policy.py
@@ -61,6 +61,18 @@ class PolicyHandler(BaseHandler):
     }
 
     _HIGH_RISK_DOMAINS = {"financial", "health", "legal"}
+    _EDUCATIONAL_KEYWORDS = (
+        "explain",
+        "teach",
+        "tutorial",
+        "for beginners",
+        "what is",
+        "overview",
+        "intro",
+        "introduction",
+        "learn",
+        "education",
+    )
 
     def handle(self, ir_v2: IRv2, ir_v1: IR) -> None:
         md = ir_v1.metadata or {}
@@ -79,9 +91,20 @@ class PolicyHandler(BaseHandler):
         has_path = self._has_explicit_path(original_text)
         file_or_system_request = has_path or any(keyword in text for keyword in self._FILE_KEYWORDS)
         debug_request = bool(md.get("code_request")) or bool(persona_flags.get("live_debug"))
+        educational_request = self._is_educational_request(text)
+        benign_educational_risk = (
+            educational_request
+            and not has_high_risk_domain
+            and risk_score == 1
+            and not debug_request
+            and not file_or_system_request
+        )
 
         # Cumulative risk scoring: 2+ overlapping domains always escalate
-        if risk_score >= 2 or has_high_risk_domain:
+        if benign_educational_risk:
+            policy.risk_level = "low"
+            policy.execution_mode = "auto_ok"
+        elif risk_score >= 2 or has_high_risk_domain:
             policy.risk_level = "high"
             policy.execution_mode = "human_approval_required"
         elif risk_score == 1 or debug_request or file_or_system_request:
@@ -135,6 +158,10 @@ class PolicyHandler(BaseHandler):
             policy.data_sensitivity = "internal"
 
         ir_v2.metadata["policy_summary"] = policy.model_dump()
+
+    @classmethod
+    def _is_educational_request(cls, lower_text: str) -> bool:
+        return any(keyword in lower_text for keyword in cls._EDUCATIONAL_KEYWORDS)
 
     @classmethod
     def _has_explicit_path(cls, text: str) -> bool:

--- a/tests/heuristics/test_detect_pii.py
+++ b/tests/heuristics/test_detect_pii.py
@@ -46,6 +46,18 @@ def test_detect_pii_multiple():
     assert "credit_card" not in result
 
 
+def test_detect_pii_turkish_tc_kimlik_checksum_validation():
+    assert "tc_kimlik" in detect_pii("TC Kimlik No: 10000000146")
+    assert "tc_kimlik" not in detect_pii("TC Kimlik No: 12345678901")
+
+
+def test_detect_pii_ignores_educational_examples_for_ssn_and_passport():
+    text = "Use SSN format 123-45-6789 and passport sample AB1234567 in docs."
+    flags = detect_pii(text)
+    assert "ssn" not in flags
+    assert "passport" not in flags
+
+
 def test_detect_pii_max_flags():
     # Mock PII_PATTERNS locally to simulate more than 5 patterns to test the max limit
     mock_patterns = {

--- a/tests/test_policy_handler.py
+++ b/tests/test_policy_handler.py
@@ -129,3 +129,13 @@ def test_pii_detects_ssn():
 
     flags = detect_pii("My SSN is 123-45-6789, please process my application.")
     assert "ssn" in flags
+
+
+def test_policy_harmless_educational_security_prompt_stays_auto_ok():
+    ir2 = compile_text_v2(
+        "Teach me cybersecurity basics for beginners and explain what SQL injection is."
+    )
+
+    assert "security" in ir2.policy.risk_domains
+    assert ir2.policy.risk_level == "low"
+    assert ir2.policy.execution_mode == "auto_ok"


### PR DESCRIPTION
### Motivation

- Reduce false-positive policy escalations for benign educational prompts that mention sensitive domains but are purely explanatory. 
- Reduce false-positive/negative PII matches for common patterns (TC Kimlik, SSN, passport) encountered in documentation, examples, and test data.

### Description

- Add educational cue detection to `PolicyHandler` via `_EDUCATIONAL_KEYWORDS` and `_is_educational_request`, and allow a guarded downgrade to `risk_level = "low"` / `execution_mode = "auto_ok"` for single non-high-risk domain educational requests that have no debug or file/path intent (file: `app/heuristics/handlers/policy.py`).
- Introduce `_PII_CONTEXT_FALSE_POSITIVE_HINTS`, a context window matcher `_has_fp_hint_around_match`, and a Turkish TC Kimlik checksum validator `_is_tc_kimlik_valid` to reduce PII false positives and improve accuracy (file: `app/heuristics/__init__.py`).
- Update `detect_pii` to suppress SSN/passport matches when nearby educational/example hints are present and to validate `tc_kimlik` with checksum rules before flagging (file: `app/heuristics/__init__.py`).
- Add regression tests for the new behaviors: a harmless educational security prompt staying `auto_ok`, TC Kimlik checksum validation, and ignoring SSN/passport in educational/example contexts (files: `tests/test_policy_handler.py` and `tests/heuristics/test_detect_pii.py`).

### Testing

- Ran `pytest -q tests/test_policy_handler.py tests/heuristics/test_detect_pii.py`, and the suite completed successfully (`23 passed`).
- Ran `pytest -q tests/test_compile_policy_api.py tests/test_ir_v2_basic.py`, and the suite completed successfully (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e32a8fdef0832f9030a3eeea490972)