### PR TITLE
[codex] fix RAG SQLite index path isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ PROMPTC_REQUIRE_API_KEY_FOR_ALL=false
 # Optional storage controls
 DB_DIR=.
 PROMPTC_UPLOAD_DIR=.promptc_uploads
+PROMPTC_RAG_DB_PATH=
 PROMPTC_RAG_ALLOWED_ROOTS=
 
 # Optional frontend override

--- a/agents.md
+++ b/agents.md
@@ -39,6 +39,7 @@ You do **not** need to commit `.env`. It is gitignored and only needed for local
 | `PROMPTC_REQUIRE_API_KEY_FOR_ALL` | Force API keys everywhere | `false` for local dev, `true` for hardened deploys |
 | `DB_DIR` | Where `users.db` is written | `.` (repo root) |
 | `PROMPTC_UPLOAD_DIR` | RAG file upload directory | `~/.promptc_uploads` |
+| `PROMPTC_RAG_DB_PATH` | RAG SQLite index path | Empty = `~/.promptc_index_v3.db` |
 | `NEXT_PUBLIC_API_KEY` | Frontend API key for authenticated requests | Optional; injected as `x-api-key` header by `buildGeneratorApiHeaders` |
 | `PROMPTC_RAG_ALLOWED_ROOTS` | Path allowlist for RAG ingest | Empty = restricted to CWD + upload dir |
 | `NEXT_PUBLIC_API_URL` | Frontend → backend URL | `http://127.0.0.1:8080` |

--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -48,6 +48,7 @@ if os.name == "nt":
     DEFAULT_DB_PATH = os.path.join(
         os.environ.get("USERPROFILE", os.path.expanduser("~")), ".promptc_index_v3.db"
     )
+RAG_DB_PATH_ENV = "PROMPTC_RAG_DB_PATH"
 
 CHUNK_SIZE = 1000
 CHUNK_OVERLAP = 200
@@ -83,8 +84,19 @@ def _clear_query_cache() -> None:
         _query_cache.clear()
 
 
+def _resolve_db_path(db_path: Optional[str] = None) -> str:
+    if db_path:
+        return db_path
+
+    configured_path = os.environ.get(RAG_DB_PATH_ENV, "").strip()
+    if configured_path:
+        return configured_path
+
+    return DEFAULT_DB_PATH
+
+
 def _connect(db_path: Optional[str] = None) -> sqlite3.Connection:
-    path = db_path or DEFAULT_DB_PATH
+    path = _resolve_db_path(db_path)
     Path(path).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
     # Increase timeout to 60s (from default 5.0) to handle multiple uvicorn workers
     conn = sqlite3.connect(path, timeout=60.0)
@@ -719,11 +731,12 @@ def _build_fts_query(query: str) -> str:
 
 
 def search(query: str, k: int = 5, db_path: Optional[str] = None) -> List[dict]:
-    cache_key = f"fts::{db_path or DEFAULT_DB_PATH}::{k}::{query}"
+    resolved_db_path = _resolve_db_path(db_path)
+    cache_key = f"fts::{resolved_db_path}::{k}::{query}"
     cached = _cache_get(cache_key)
     if cached is not None:
         return cached[:k]
-    conn = _connect(db_path)
+    conn = _connect(resolved_db_path)
     try:
         _init_schema(conn)
         # Use simple LIKE for robustness if FTS fails or behaves oddly
@@ -810,7 +823,8 @@ def search(query: str, k: int = 5, db_path: Optional[str] = None) -> List[dict]:
 def search_embed(
     query: str, k: int = 5, db_path: Optional[str] = None, embed_dim: int = 64
 ) -> List[dict]:
-    cache_key = f"emb::{embed_dim}::{db_path or DEFAULT_DB_PATH}::{k}::{query}"
+    resolved_db_path = _resolve_db_path(db_path)
+    cache_key = f"emb::{embed_dim}::{resolved_db_path}::{k}::{query}"
     cached = _cache_get(cache_key)
     if cached is not None:
         return cached[:k]
@@ -818,7 +832,7 @@ def search_embed(
 
     Requires that documents were ingested with embed=True.
     """
-    conn = _connect(db_path)
+    conn = _connect(resolved_db_path)
     try:
         _init_schema(conn)
 
@@ -883,12 +897,13 @@ def search_hybrid(
       norm_bm25 = 1 - rank_ft / len_ft
       norm_sim  = similarity (already 0..1-ish for our toy embeddings)
     """
-    cache_key = f"hyb::{embed_dim}::{db_path or DEFAULT_DB_PATH}::{k}::{alpha:.3f}::{query}"
+    resolved_db_path = _resolve_db_path(db_path)
+    cache_key = f"hyb::{embed_dim}::{resolved_db_path}::{k}::{alpha:.3f}::{query}"
     cached = _cache_get(cache_key)
     if cached is not None:
         return cached[:k]
-    fts_results = search(query, k=max(k, 20), db_path=db_path)
-    emb_results = search_embed(query, k=max(k, 50), db_path=db_path, embed_dim=embed_dim)
+    fts_results = search(query, k=max(k, 20), db_path=resolved_db_path)
+    emb_results = search_embed(query, k=max(k, 50), db_path=resolved_db_path, embed_dim=embed_dim)
     # Build rank maps
     fts_rank: Dict[int, int] = {r["chunk_id"]: i for i, r in enumerate(fts_results)}
     fused: Dict[int, dict] = {}
@@ -1029,7 +1044,7 @@ def prune(db_path: Optional[str] = None) -> dict:
     Strategy: capture surviving file paths, record counts, recreate DB from scratch
     for remaining files. This avoids FTS trigger complexities on bulk deletes.
     """
-    db_file = db_path or DEFAULT_DB_PATH
+    db_file = _resolve_db_path(db_path)
     conn = _connect(db_file)
     try:
         _init_schema(conn)

--- a/tests/test_rag_db_path.py
+++ b/tests/test_rag_db_path.py
@@ -1,0 +1,17 @@
+from app.rag import simple_index
+
+
+def test_default_rag_db_path_honors_env_override(tmp_path, monkeypatch):
+    fallback_db = tmp_path / "fallback.db"
+    env_db = tmp_path / "isolated" / "rag.db"
+    unique_term = "env_db_path_unique_signal"
+
+    monkeypatch.setattr(simple_index, "DEFAULT_DB_PATH", str(fallback_db))
+    monkeypatch.setenv("PROMPTC_RAG_DB_PATH", str(env_db))
+
+    simple_index.ingest_text("notes.md", f"Project notes mention {unique_term}.")
+
+    assert env_db.exists()
+    assert not fallback_db.exists()
+    assert any(unique_term in item["snippet"] for item in simple_index.search(unique_term, k=3))
+    assert simple_index.stats()["docs"] == 1


### PR DESCRIPTION
﻿## Summary
- add a runtime `PROMPTC_RAG_DB_PATH` override for the RAG SQLite index
- use the resolved DB path in RAG query cache keys, hybrid search, and prune
- document the env var in `.env.example` and `agents.md`
- add a regression test proving env-based DB isolation wins over the fallback path

## Root cause
The RAG index path was effectively controlled by the import-time `DEFAULT_DB_PATH` unless callers passed `db_path` explicitly. That made test and local isolation depend on monkeypatching module globals instead of using a normal runtime configuration surface.

## Validation
- `python -m pytest -q tests/test_rag_db_path.py` red before implementation, green after
- `python -m pytest -q tests/test_rag_db_path.py tests/test_rag_upload.py tests/test_api_hardening.py tests/test_auth_fast_path.py tests/test_benchmark_api.py` -> 36 passed
- `python -m ruff check app/rag/simple_index.py tests/test_rag_db_path.py`
- `python -m ruff format --check app/rag/simple_index.py tests/test_rag_db_path.py`
- `python -m pre_commit run --all-files`
