### PR TITLE
[codex] optimize compile, RAG, and diff rendering

### DIFF
--- a/app/compiler.py
+++ b/app/compiler.py
@@ -289,6 +289,10 @@ def compile_text_v2(text: str, offline_only: bool = False) -> IRv2:
 def compile_text(text: str) -> IR:
     lang = detect_language(text)
     domain, evidence = detect_domain(text)
+    coding_ctx = detect_coding_context(text)
+    teaching_intent = detect_teaching_intent(text)
+    recency_required = detect_recency(text)
+    live_debug = detect_live_debug(text) if coding_ctx else False
     goals, tasks = extract_goals_tasks(text, lang)
     length_hint = detect_length_hint(text)
     style, tone = extract_style_tone(text)
@@ -311,7 +315,7 @@ def compile_text(text: str) -> IR:
 
     banned: List[str] = []
     tools: List[str] = []
-    if detect_recency(text):
+    if recency_required:
         tools.append("web")
         add_constraint(RECENCY_CONSTRAINT_TR if lang == "tr" else RECENCY_CONSTRAINT_EN, "recency")
 
@@ -352,12 +356,11 @@ def compile_text(text: str) -> IR:
     persona, persona_info = pick_persona(text)
     role = DEFAULT_ROLE_TR if lang == "tr" else DEFAULT_ROLE_EN
     # Developer persona override: if coding context, prefer developer
-    coding_ctx = detect_coding_context(text)
     if coding_ctx:
         persona = "developer"
         role = DEFAULT_ROLE_DEV_TR if lang == "tr" else DEFAULT_ROLE_DEV_EN
     # If user wants teaching AND not coding, switch to teacher
-    if detect_teaching_intent(text) and not coding_ctx:
+    if teaching_intent and not coding_ctx:
         persona = "teacher"
         lvl = (inputs.get("level") or "").lower()
         dur = inputs.get("duration")
@@ -397,7 +400,7 @@ def compile_text(text: str) -> IR:
             tone.append("friendly")
 
     # Coding-oriented constraints if code context requested
-    if detect_coding_context(text):
+    if coding_ctx:
         if lang == "tr":
             add_constraint(
                 "Önce çalışan, küçük parçalara bölünmüş bir çözüm geliştirin (adım adım).",
@@ -417,7 +420,7 @@ def compile_text(text: str) -> IR:
         if "concise" not in style:
             style.append("concise")
         # Live debug mode: emphasize reproduction and hypothesis-driven fixes
-        if detect_live_debug(text):
+        if live_debug:
             if lang == "tr":
                 add_constraint(
                     "Sorunu yeniden üretmek için minimal bir örnek (MRE) oluştur.", "live_debug"

--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -726,81 +726,7 @@ def search(query: str, k: int = 5, db_path: Optional[str] = None) -> List[dict]:
     conn = _connect(db_path)
     try:
         _init_schema(conn)
-        # Use simple LIKE for robustness if FTS fails or behaves oddly
-        # 1. Try FTS Search
-        try:
-            cur = conn.execute(
-                """
-                SELECT c.id, c.doc_id, d.path, c.chunk_index,
-                       snippet(fts, 0, '[', ']', '…', 10) as snippet,
-                       bm25(fts) as score
-                FROM fts JOIN chunks c ON fts.rowid = c.id
-                JOIN docs d ON d.id = c.doc_id
-                WHERE fts MATCH ?
-                ORDER BY score LIMIT ?
-                """,
-                (_build_fts_query(query), k),
-            )
-            results = []
-            for row in cur.fetchall():
-                results.append(
-                    {
-                        "chunk_id": row[0],
-                        "doc_id": row[1],
-                        "path": row[2],
-                        "chunk_index": row[3],
-                        "snippet": row[4],
-                        "score": row[5],
-                    }
-                )
-        except Exception as e:
-            logger.debug("FTS search failed or returned error: %s", e)
-            results = []
-
-        # 2. Fallback to LIKE if not enough results
-        if len(results) < k:
-            seen_ids = {r["chunk_id"] for r in results}
-            limit_needed = k - len(results)
-
-            # Escape LIKE wildcards to prevent LIKE injection
-            escaped_query = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-            cur = conn.execute(
-                """
-                SELECT c.id, c.doc_id, d.path, c.chunk_index,
-                       c.content,
-                       0.5 as score
-                FROM chunks c
-                JOIN docs d ON d.id = c.doc_id
-                WHERE lower(c.content) LIKE lower(?) ESCAPE '\\'
-                LIMIT ?
-                """,
-                (f"%{escaped_query}%", limit_needed * 2),  # Grab a few more to filter dupes
-            )
-
-            for row in cur.fetchall():
-                if row[0] not in seen_ids:
-                    # Create a simple snippet
-                    content = row[4]
-                    idx = content.lower().find(query.lower())
-                    start = max(0, idx - 20)
-                    end = min(len(content), idx + len(query) + 20)
-                    snippet = f"…{content[start:end]}…"
-
-                    results.append(
-                        {
-                            "chunk_id": row[0],
-                            "doc_id": row[1],
-                            "path": row[2],
-                            "chunk_index": row[3],
-                            "snippet": snippet,
-                            "score": row[5],
-                        }
-                    )
-                    seen_ids.add(row[0])
-                    if len(results) >= k:
-                        break
-
+        results = _search_with_conn(conn, query=query, k=k)
         _cache_put(cache_key, results)
         return results
     finally:
@@ -821,45 +747,7 @@ def search_embed(
     conn = _connect(db_path)
     try:
         _init_schema(conn)
-
-        if _HAS_FASTEMBED and embed_dim >= 128:
-            q_vec = _fast_embed(query)
-        else:
-            q_vec = _simple_embed(query, dim=embed_dim)
-
-        # fetch embeddings joined with chunk + doc metadata
-        cur = conn.execute(
-            """
-            SELECT e.chunk_id, c.doc_id, d.path, c.chunk_index, c.content, e.vec, e.dim
-            FROM embeddings e
-            JOIN chunks c ON c.id = e.chunk_id
-            JOIN docs d ON d.id = c.doc_id
-            WHERE e.dim = ?
-            """,
-            (embed_dim,),
-        )
-        results = []
-        for row in cur.fetchall():
-            chunk_id, doc_id, path, chunk_index, content, vec_json, dim = row
-            emb = _parse_embedding(vec_json)
-            # cosine since vectors L2 normalized => dot product
-            # Bolt Optimization: map() with operator.mul is ~25% faster than list comprehension + zip for vector dot products in Python
-            sim = sum(map(operator.mul, q_vec, emb))
-            # score as (1 - sim) so lower is better similar to bm25 semantics
-            score = 1.0 - sim
-            snippet = content[:200].replace("\n", " ")
-            results.append(
-                {
-                    "chunk_id": chunk_id,
-                    "doc_id": doc_id,
-                    "path": path,
-                    "chunk_index": chunk_index,
-                    "snippet": snippet,
-                    "score": score,
-                    "similarity": sim,
-                }
-            )
-        results.sort(key=lambda r: r["score"])  # lower distance first
+        results = _search_embed_with_conn(conn, query=query, k=k, embed_dim=embed_dim)
         _cache_put(cache_key, results)
         return results[:k]
     finally:
@@ -887,8 +775,13 @@ def search_hybrid(
     cached = _cache_get(cache_key)
     if cached is not None:
         return cached[:k]
-    fts_results = search(query, k=max(k, 20), db_path=db_path)
-    emb_results = search_embed(query, k=max(k, 50), db_path=db_path, embed_dim=embed_dim)
+    conn = _connect(db_path)
+    try:
+        _init_schema(conn)
+        fts_results = _search_with_conn(conn, query=query, k=max(k, 20))
+        emb_results = _search_embed_with_conn(conn, query=query, k=max(k, 50), embed_dim=embed_dim)
+    finally:
+        conn.close()
     # Build rank maps
     fts_rank: Dict[int, int] = {r["chunk_id"]: i for i, r in enumerate(fts_results)}
     fused: Dict[int, dict] = {}
@@ -912,6 +805,131 @@ def search_hybrid(
     return ranked[:k]
 
 
+def _search_with_conn(conn: sqlite3.Connection, *, query: str, k: int) -> List[dict]:
+    # Use simple LIKE for robustness if FTS fails or behaves oddly
+    # 1. Try FTS Search
+    try:
+        cur = conn.execute(
+            """
+            SELECT c.id, c.doc_id, d.path, c.chunk_index,
+                   snippet(fts, 0, '[', ']', '…', 10) as snippet,
+                   bm25(fts) as score
+            FROM fts JOIN chunks c ON fts.rowid = c.id
+            JOIN docs d ON d.id = c.doc_id
+            WHERE fts MATCH ?
+            ORDER BY score LIMIT ?
+            """,
+            (_build_fts_query(query), k),
+        )
+        results = []
+        for row in cur.fetchall():
+            results.append(
+                {
+                    "chunk_id": row[0],
+                    "doc_id": row[1],
+                    "path": row[2],
+                    "chunk_index": row[3],
+                    "snippet": row[4],
+                    "score": row[5],
+                }
+            )
+    except Exception as e:
+        logger.debug("FTS search failed or returned error: %s", e)
+        results = []
+
+    # 2. Fallback to LIKE if not enough results
+    if len(results) < k:
+        seen_ids = {r["chunk_id"] for r in results}
+        limit_needed = k - len(results)
+
+        # Escape LIKE wildcards to prevent LIKE injection
+        escaped_query = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        q_lower = query.lower()
+        q_len = len(query)
+
+        cur = conn.execute(
+            """
+            SELECT c.id, c.doc_id, d.path, c.chunk_index,
+                   c.content,
+                   0.5 as score
+            FROM chunks c
+            JOIN docs d ON d.id = c.doc_id
+            WHERE lower(c.content) LIKE lower(?) ESCAPE '\\'
+            LIMIT ?
+            """,
+            (f"%{escaped_query}%", limit_needed * 2),  # Grab a few more to filter dupes
+        )
+
+        for row in cur.fetchall():
+            if row[0] not in seen_ids:
+                # Create a simple snippet
+                content = row[4]
+                idx = content.lower().find(q_lower)
+                start = max(0, idx - 20)
+                end = min(len(content), idx + q_len + 20)
+                snippet = f"…{content[start:end]}…"
+
+                results.append(
+                    {
+                        "chunk_id": row[0],
+                        "doc_id": row[1],
+                        "path": row[2],
+                        "chunk_index": row[3],
+                        "snippet": snippet,
+                        "score": row[5],
+                    }
+                )
+                seen_ids.add(row[0])
+                if len(results) >= k:
+                    break
+
+    return results
+
+
+def _search_embed_with_conn(
+    conn: sqlite3.Connection, *, query: str, k: int, embed_dim: int
+) -> List[dict]:
+    if _HAS_FASTEMBED and embed_dim >= 128:
+        q_vec = _fast_embed(query)
+    else:
+        q_vec = _simple_embed(query, dim=embed_dim)
+
+    # fetch embeddings joined with chunk + doc metadata
+    cur = conn.execute(
+        """
+        SELECT e.chunk_id, c.doc_id, d.path, c.chunk_index, c.content, e.vec, e.dim
+        FROM embeddings e
+        JOIN chunks c ON c.id = e.chunk_id
+        JOIN docs d ON d.id = c.doc_id
+        WHERE e.dim = ?
+        """,
+        (embed_dim,),
+    )
+    results = []
+    for row in cur.fetchall():
+        chunk_id, doc_id, path, chunk_index, content, vec_json, dim = row
+        emb = _parse_embedding(vec_json)
+        # cosine since vectors L2 normalized => dot product
+        # Bolt Optimization: map() with operator.mul is ~25% faster than list comprehension + zip for vector dot products in Python
+        sim = sum(map(operator.mul, q_vec, emb))
+        # score as (1 - sim) so lower is better similar to bm25 semantics
+        score = 1.0 - sim
+        snippet = content[:200].replace("\n", " ")
+        results.append(
+            {
+                "chunk_id": chunk_id,
+                "doc_id": doc_id,
+                "path": path,
+                "chunk_index": chunk_index,
+                "snippet": snippet,
+                "score": score,
+                "similarity": sim,
+            }
+        )
+    results.sort(key=lambda r: r["score"])  # lower distance first
+    return results[:k]
+
+
 # Optional tiktoken support for accurate token counting
 _tiktoken_enc = None
 
@@ -927,7 +945,7 @@ def _count_tokens(text: str, ratio: float = 4.0) -> int:
 
                     _tiktoken_enc = tiktoken.get_encoding("cl100k_base")
         return len(_tiktoken_enc.encode(text))
-    except ImportError:
+    except Exception:
         return int(len(text) / ratio)
 
 
@@ -977,7 +995,12 @@ def pack(
         block = header + chunk_text + "\n\n"
 
         block_len = len(block)
-        block_tokens = _count_tokens(block, token_chars)
+        if max_tokens is not None:
+            block_tokens = _count_tokens(block, token_chars)
+        else:
+            # Fast path: avoid expensive tokenizer initialization when there is
+            # no token budget enforcement. Keep approximate accounting only.
+            block_tokens = int(block_len / token_chars)
 
         if max_tokens is not None and (total_tokens + block_tokens) > max_tokens:
             break

--- a/web/app/components/DiffViewer.tsx
+++ b/web/app/components/DiffViewer.tsx
@@ -1,11 +1,22 @@
 "use client";
 
-import { useDeferredValue, useMemo, useEffect, useState } from "react";
+import { useDeferredValue, useMemo, useEffect, useState, useSyncExternalStore } from "react";
 import { diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL } from "diff-match-patch";
 
 interface DiffViewerProps {
     oldText: string;
     newText: string;
+}
+
+type DomPurifyModule = typeof import("dompurify");
+
+let domPurifyPromise: Promise<DomPurifyModule["default"]> | null = null;
+
+function getDomPurify() {
+    if (!domPurifyPromise) {
+        domPurifyPromise = import("dompurify").then((module) => module.default);
+    }
+    return domPurifyPromise;
 }
 
 /**
@@ -38,28 +49,26 @@ function buildDarkThemeHtml(diffs: [number, string][]): string {
 }
 
 export default function DiffViewer({ oldText, newText }: DiffViewerProps) {
-    const [isClient, setIsClient] = useState(false);
+    const isClient = useSyncExternalStore(
+        () => () => undefined,
+        () => true,
+        () => false,
+    );
     const [sanitizedHtml, setSanitizedHtml] = useState<string | null>(null);
 
-    useEffect(() => {
-        setIsClient(true);
-    }, []);
-
-    // Stabilize both texts as a single object so they are always deferred atomically,
-    // preventing mismatched intermediate diffs.
-    const texts = useMemo(() => ({ oldText, newText }), [oldText, newText]);
-    const deferredTexts = useDeferredValue(texts);
+    const deferredOldText = useDeferredValue(oldText);
+    const deferredNewText = useDeferredValue(newText);
 
     const rawHtmlContent = useMemo(() => {
         try {
             const dmp = new diff_match_patch();
-            const diffs = dmp.diff_main(deferredTexts.oldText, deferredTexts.newText);
+            const diffs = dmp.diff_main(deferredOldText, deferredNewText);
             dmp.diff_cleanupSemantic(diffs);
             return buildDarkThemeHtml(diffs);
         } catch {
             return "<div>Error loading diff tool</div>";
         }
-    }, [deferredTexts]);
+    }, [deferredOldText, deferredNewText]);
 
     useEffect(() => {
         let cancelled = false;
@@ -68,11 +77,9 @@ export default function DiffViewer({ oldText, newText }: DiffViewerProps) {
             return undefined;
         }
 
-        setSanitizedHtml(null);
-
         async function sanitizeHtml() {
             try {
-                const { default: DOMPurify } = await import("dompurify");
+                const DOMPurify = await getDomPurify();
                 if (!cancelled) {
                     setSanitizedHtml(DOMPurify.sanitize(rawHtmlContent));
                 }


### PR DESCRIPTION
## Summary

- Cache repeated compile-path heuristic detections inside `compile_text` so regex-heavy intent checks run once per request.
- Reuse a single SQLite connection/schema init for hybrid RAG search, with shared lexical and embedding search helpers.
- Avoid tokenizer initialization in RAG pack flows when no token budget is enforced, and cache DOMPurify loading in `DiffViewer` while deferring old/new text separately.

## Why

Profiling showed repeated detector calls in the compile path, duplicated connection/schema setup in hybrid RAG retrieval, avoidable tokenizer work in char-budget-only RAG packing, and unnecessary frontend async/rerender churn in diff output rendering.

## Validation

- `python -m pytest tests/test_rag_hybrid_retriever.py tests/test_rag_pack_tokens.py tests/test_features.py tests/test_benchmark_api.py tests/test_rag_pipeline.py -q` → 18 passed
- `npm --prefix web run -s lint` → passed
- `npm --prefix web run -s test:contracts` → 13 passed
- `npm --prefix web run -s build` → passed
- Commit hook: `ruff`, `ruff-format`, whitespace, EOF, YAML, and large-file checks passed

## Notes

Created from a clean `origin/main` worktree so unrelated local changes in the main checkout are not included.