### PR TITLE
chore: cloud agent readiness setup

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,43 @@
+# Build & dependency artifacts — noise for agent context
+node_modules/
+.next/
+out/
+dist/
+build/
+coverage/
+coverage.xml
+htmlcov/
+
+# Test & reporter output
+test-results/
+playwright-report/
+blob-report/
+.playwright-cli/
+.playwright-report/
+.pytest_cache/
+.pytest-temp/
+
+# Caches
+.turbo/
+.cache/
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+*.py[cod]
+
+# Python envs
+.venv/
+venv/
+env/
+ENV/
+
+# Agent worktrees & local state
+.claude/worktrees/
+.Jules/
+.gemini/
+
+# Logs & large artifacts
+*.log
+*.pdf
+*.zip
+*.tar.gz

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,43 @@
+# Build & dependency artifacts — noise for agent context
+node_modules/
+.next/
+out/
+dist/
+build/
+coverage/
+coverage.xml
+htmlcov/
+
+# Test & reporter output
+test-results/
+playwright-report/
+blob-report/
+.playwright-cli/
+.playwright-report/
+.pytest_cache/
+.pytest-temp/
+
+# Caches
+.turbo/
+.cache/
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+*.py[cod]
+
+# Python envs
+.venv/
+venv/
+env/
+ENV/
+
+# Agent worktrees & local state
+.claude/worktrees/
+.Jules/
+.gemini/
+
+# Logs & large artifacts
+*.log
+*.pdf
+*.zip
+*.tar.gz

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "name": "myCompiler",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.10",
+      "installTools": true
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "forwardPorts": [8000, 3000],
+  "portsAttributes": {
+    "8000": { "label": "FastAPI backend", "onAutoForward": "notify" },
+    "3000": { "label": "Next.js web", "onAutoForward": "notify" }
+  },
+  "postCreateCommand": "make install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/python/current/bin/python",
+        "python.testing.pytestEnabled": true
+      }
+    }
+  },
+  "remoteEnv": {
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONUNBUFFERED": "1"
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: install dev dev-backend dev-web test test-backend test-web build clean
+
+install:
+	pip install -r requirements.txt
+	cd web && npm install
+
+dev-backend:
+	uvicorn api.main:app --reload --host 0.0.0.0 --port 8000
+
+dev-web:
+	cd web && npm run dev
+
+dev:
+	@echo "Starting backend (8000) + web (3000) in parallel..."
+	@if command -v npx >/dev/null 2>&1; then \
+		npx -y concurrently -n backend,web -c blue,green \
+			"uvicorn api.main:app --reload --host 0.0.0.0 --port 8000" \
+			"cd web && npm run dev"; \
+	else \
+		echo "npx not found — run 'make dev-backend' and 'make dev-web' in separate terminals"; \
+		exit 1; \
+	fi
+
+test-backend:
+	pytest -q
+
+test-web:
+	cd web && npm test
+
+test: test-backend test-web
+
+build:
+	cd web && npm run build
+
+clean:
+	rm -rf __pycache__ .pytest_cache .ruff_cache .mypy_cache
+	rm -rf web/.next web/node_modules/.cache

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env.local and fill in values.
+# Next.js will auto-load .env.local; do not commit it.
+
+# URL of the FastAPI backend reachable from the browser.
+# Local dev default:
+NEXT_PUBLIC_API_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
Add a deterministic environment and orchestration layer so this repo runs end-to-end inside cloud coding agents (Codex Cloud, Claude Code cloud, Codespaces) without manual setup.

## What's new
- **`.devcontainer/devcontainer.json`** — Node 20 + Python 3.10 universal image; `postCreateCommand: make install`; forwards ports 8000 + 3000
- **`Makefile`** — single-command backend + web orchestration: `make install`, `make dev`, `make test-backend`, `make test-web`, `make build`
- **`web/.env.example`** — client env template (`NEXT_PUBLIC_API_URL`)
- **`.codexignore` / `.claudeignore`** — keep `node_modules/`, `.next/`, `.claude/worktrees/`, pytest/ruff caches, and large artifacts out of the agent file index (complements existing `.gitignore`)

## Non-breaking
Purely additive. No existing files modified — `agents.md`, `Dockerfile`, `.gitignore`, workflows all untouched.

## Test plan
- [ ] `make install` completes cleanly (Python + web npm deps)
- [ ] `make dev` starts backend (8000) + web (3000) in parallel
- [ ] `make test-backend` runs pytest; `make test-web` runs vitest
- [ ] VS Code "Reopen in Container" builds the devcontainer
- [ ] Codex Cloud smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)