### PR TITLE
[codex] Harden RAG DB path fallback in restricted environments

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -39,7 +39,7 @@ You do **not** need to commit `.env`. It is gitignored and only needed for local
 | `PROMPTC_REQUIRE_API_KEY_FOR_ALL` | Force API keys everywhere | `false` for local dev, `true` for hardened deploys |
 | `DB_DIR` | Where `users.db` is written | `.` (repo root) |
 | `PROMPTC_UPLOAD_DIR` | RAG file upload directory | `~/.promptc_uploads` |
-| `PROMPTC_RAG_DB_PATH` | RAG SQLite index path | Empty = `~/.promptc_index_v3.db` |
+| `PROMPTC_RAG_DB_PATH` | RAG SQLite index path | Empty = `~/.promptc_index_v3.db`; if that path is not writable, runtime falls back to `./.promptc/<db-name>` |
 | `NEXT_PUBLIC_API_KEY` | Frontend API key for authenticated requests | Optional; injected as `x-api-key` header by `buildGeneratorApiHeaders` |
 | `PROMPTC_RAG_ALLOWED_ROOTS` | Path allowlist for RAG ingest | Empty = restricted to CWD + upload dir |
 | `NEXT_PUBLIC_API_URL` | Frontend → backend URL | `http://127.0.0.1:8080` |

--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -95,18 +95,39 @@ def _resolve_db_path(db_path: Optional[str] = None) -> str:
     return DEFAULT_DB_PATH
 
 
+def _connection_candidates(db_path: Optional[str] = None) -> list[str]:
+    primary = Path(_resolve_db_path(db_path)).expanduser().resolve()
+    candidates = [str(primary)]
+
+    fallback = (Path.cwd() / ".promptc" / primary.name).resolve()
+    if str(fallback) not in candidates:
+        candidates.append(str(fallback))
+
+    return candidates
+
+
 def _connect(db_path: Optional[str] = None) -> sqlite3.Connection:
-    path = _resolve_db_path(db_path)
-    Path(path).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
-    # Increase timeout to 60s (from default 5.0) to handle multiple uvicorn workers
-    conn = sqlite3.connect(path, timeout=60.0)
-    conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA synchronous=NORMAL;")
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
-    return conn
+    last_error: sqlite3.OperationalError | None = None
+
+    for path in _connection_candidates(db_path):
+        try:
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            # Increase timeout to 60s (from default 5.0) to handle multiple uvicorn workers
+            conn = sqlite3.connect(path, timeout=60.0)
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA synchronous=NORMAL;")
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
+            return conn
+        except sqlite3.OperationalError as exc:
+            last_error = exc
+            logger.warning("RAG DB path unavailable, trying fallback", extra={"db_path": path})
+
+    if last_error is not None:
+        raise last_error
+    raise sqlite3.OperationalError("unable to open database file")
 
 
 def _upsert_doc(conn: sqlite3.Connection, path_value: str, *, mtime: float, size: int) -> int:

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -1,9 +1,12 @@
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch
+import sqlite3
+from pathlib import Path
 from api.main import app
 from api.auth import APIKey, SessionLocal
 from app.compiler import compile_text_v2
+from app.rag import simple_index
 
 client = TestClient(app)
 
@@ -221,3 +224,27 @@ def test_optimize_no_key():
 def test_rag_stats_no_key():
     resp = client.get("/rag/stats")
     assert resp.status_code == 200
+
+
+def test_rag_stats_no_key_falls_back_when_default_db_path_is_unwritable(tmp_path, monkeypatch):
+    primary_db = tmp_path / "blocked" / "rag.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.delenv("PROMPTC_RAG_DB_PATH", raising=False)
+    monkeypatch.setattr(simple_index, "DEFAULT_DB_PATH", str(primary_db))
+    monkeypatch.chdir(workspace)
+
+    real_connect = sqlite3.connect
+
+    def flaky_connect(path, *args, **kwargs):
+        if str(Path(path)) == str(primary_db):
+            raise sqlite3.OperationalError("unable to open database file")
+        return real_connect(path, *args, **kwargs)
+
+    with patch("app.rag.simple_index.sqlite3.connect", side_effect=flaky_connect):
+        resp = client.get("/rag/stats")
+
+    assert resp.status_code == 200
+    assert resp.json()["docs"] == 0
+    assert (workspace / ".promptc" / primary_db.name).exists()

--- a/tests/test_rag_db_path.py
+++ b/tests/test_rag_db_path.py
@@ -1,3 +1,6 @@
+import sqlite3
+from pathlib import Path
+
 from app.rag import simple_index
 
 
@@ -15,3 +18,36 @@ def test_default_rag_db_path_honors_env_override(tmp_path, monkeypatch):
     assert not fallback_db.exists()
     assert any(unique_term in item["snippet"] for item in simple_index.search(unique_term, k=3))
     assert simple_index.stats()["docs"] == 1
+
+
+def test_default_rag_db_path_falls_back_to_workspace_when_primary_is_unwritable(
+    tmp_path, monkeypatch
+):
+    primary_db = tmp_path / "blocked" / "rag.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    unique_term = "workspace_fallback_signal"
+
+    monkeypatch.delenv("PROMPTC_RAG_DB_PATH", raising=False)
+    monkeypatch.setattr(simple_index, "DEFAULT_DB_PATH", str(primary_db))
+    monkeypatch.chdir(workspace)
+
+    real_connect = sqlite3.connect
+    attempted_paths: list[str] = []
+
+    def flaky_connect(path, *args, **kwargs):
+        resolved = str(Path(path))
+        attempted_paths.append(resolved)
+        if resolved == str(primary_db):
+            raise sqlite3.OperationalError("unable to open database file")
+        return real_connect(path, *args, **kwargs)
+
+    monkeypatch.setattr(simple_index.sqlite3, "connect", flaky_connect)
+
+    simple_index.ingest_text("notes.md", f"Project notes mention {unique_term}.")
+
+    fallback_db = workspace / ".promptc" / primary_db.name
+    assert fallback_db.exists()
+    assert attempted_paths[0] == str(primary_db)
+    assert str(fallback_db) in attempted_paths
+    assert any(unique_term in item["snippet"] for item in simple_index.search(unique_term, k=3))


### PR DESCRIPTION
## What changed
- make the RAG sqlite connector retry with a workspace-local `./.promptc/<db-name>` fallback when the configured or default home path is not writable
- add regression coverage for both direct RAG ingestion and the `/rag/stats` API path under an unwritable primary db path
- document the fallback behavior in `agents.md`

## Why
Some restricted Windows/sandbox runs could not open the default `~/.promptc_index_v3.db`, which made `/rag/stats` and related RAG flows fail with `sqlite3.OperationalError: unable to open database file`.

## Impact
RAG routes stay usable in environments where the home-directory sqlite path is blocked, while preserving the configured path as the first choice.

## Verification
- `python -m pytest tests/test_rag_db_path.py -q`
- `python -m pytest tests/test_auth_fast_path.py -q`
- `python -m pytest tests/test_rag_upload.py -q`
