### PR TITLE
🎨 Palette: Add aria-controls and aria-labels for accessibility

### DIFF
--- a/web/app/components/BenchmarkResults.tsx
+++ b/web/app/components/BenchmarkResults.tsx
@@ -81,6 +81,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
                 <button
                     onClick={() => setPromptOpen(!promptOpen)}
                     aria-expanded={promptOpen}
+                    aria-controls="compiled-prompt-content"
                     className="w-full px-5 py-3 flex items-center justify-between text-left hover:bg-white/[0.02] transition-colors group focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20"
                 >
                     <div className="flex items-center gap-2">
@@ -104,7 +105,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
                 </button>
 
                 {promptOpen && (
-                    <div className="px-5 pb-4 animate-fade-in">
+                    <div id="compiled-prompt-content" className="px-5 pb-4 animate-fade-in">
                         <pre className="bg-black/30 p-4 rounded-xl border border-white/5 text-xs font-mono text-zinc-400 overflow-auto max-h-48 shadow-inner leading-relaxed whitespace-pre-wrap">
                             {data.compiled_prompt}
                         </pre>

--- a/web/app/components/context/ContextSuggestions.tsx
+++ b/web/app/components/context/ContextSuggestions.tsx
@@ -18,6 +18,7 @@ export default function ContextSuggestions({ suggestions, onInsertContext }: Con
                         onClick={() => onInsertContext(`[File: ${suggestion.name}]\n(Reason: ${suggestion.reason})`)}
                         className="group flex items-center gap-2 px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 hover:border-blue-500/40 rounded-full transition-all text-left"
                         title={`Add ${suggestion.path} to context`}
+                        aria-label={`Add ${suggestion.path} to context`}
                     >
                         <span className="text-[10px] text-blue-300 font-mono">{suggestion.name}</span>
                         <span className="text-[9px] text-blue-400/60 group-hover:text-blue-400 opacity-60 group-hover:opacity-100 transition-opacity">


### PR DESCRIPTION
🎨 Palette: [UX improvement]
💡 What: Added `aria-controls` to link the toggle button to the expandable content container in `BenchmarkResults.tsx`, and added `aria-label` to the suggestion file buttons in `ContextSuggestions.tsx`.
🎯 Why: Links collapsible trigger buttons with their target content areas, making the relationship clear to screen readers. Provides explicit accessible names for buttons that previously relied only on `title` attributes.
📸 Before/After: Visuals are unchanged (only accessibility markup added).
♿ Accessibility: Improves screen reader navigation and announces the explicit purpose of interactive elements.

---
*PR created automatically by Jules for task [12143705742259032047](https://jules.google.com/task/12143705742259032047) started by @madara88645*