### PR TITLE
🛡️ Sentinel: [security improvement] Prevent orphaned embeddings data bloat

### DIFF
--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -177,6 +177,9 @@ def _init_schema(conn: sqlite3.Connection) -> None:
             DELETE FROM fts WHERE rowid = old.id;
             INSERT INTO fts(rowid, content) VALUES (new.id, new.content);
         END;
+        CREATE TRIGGER IF NOT EXISTS chunks_ad_embed AFTER DELETE ON chunks BEGIN
+            DELETE FROM embeddings WHERE chunk_id = old.id;
+        END;
         """
     )
     conn.commit()

--- a/tests/test_rag_embeddings_cleanup.py
+++ b/tests/test_rag_embeddings_cleanup.py
@@ -1,0 +1,56 @@
+import os
+import sqlite3
+import tempfile
+from app.rag.simple_index import ingest_text, _connect, search_embed
+from unittest.mock import patch
+
+def test_delete_chunk_cleans_up_embeddings():
+    with tempfile.TemporaryDirectory() as td:
+        test_db = os.path.join(td, "test_cleanup.db")
+        upload_dir = os.path.join(td, "uploads")
+
+        with (
+            patch("app.rag.simple_index.DEFAULT_DB_PATH", test_db),
+            patch.dict(
+                os.environ,
+                {
+                    "PROMPTC_UPLOAD_DIR": upload_dir,
+                    "PROMPTC_RAG_ALLOWED_ROOTS": td,
+                },
+                clear=False,
+            ),
+        ):
+            # Ingest text with embed=True
+            doc_path, chunks, _ = ingest_text("secret_doc.txt", "This is a super secret document with sensitive data.", db_path=test_db, embed=True)
+
+            # Verify data is in chunks and embeddings
+            conn = _connect(test_db)
+            cur = conn.cursor()
+
+            cur.execute("SELECT id FROM chunks")
+            chunk_ids = [r[0] for r in cur.fetchall()]
+            assert len(chunk_ids) > 0, "Chunks were not created"
+
+            cur.execute("SELECT chunk_id FROM embeddings")
+            emb_chunk_ids = [r[0] for r in cur.fetchall()]
+            assert len(emb_chunk_ids) > 0, "Embeddings were not created"
+
+            # Re-ingest the document, replacing the old chunks
+            doc_path2, chunks2, _ = ingest_text("secret_doc.txt", "Replacement document.", db_path=test_db, embed=True)
+
+            # The old chunks should have been deleted (since doc_id matches and we do DELETE FROM chunks)
+            # This should also trigger the chunks_ad_embed trigger and delete the old embeddings.
+            # If the trigger didn't exist, we'd have orphaned embeddings.
+
+            cur.execute("SELECT id FROM chunks")
+            new_chunk_ids = [r[0] for r in cur.fetchall()]
+
+            cur.execute("SELECT chunk_id FROM embeddings")
+            new_emb_chunk_ids = [r[0] for r in cur.fetchall()]
+
+            # Verify the old chunk IDs are gone from embeddings
+            for old_id in chunk_ids:
+                if old_id not in new_chunk_ids:
+                    assert old_id not in new_emb_chunk_ids, f"Orphaned embedding found for deleted chunk {old_id}"
+
+            conn.close()

--- a/tests/test_rag_embeddings_cleanup.py
+++ b/tests/test_rag_embeddings_cleanup.py
@@ -1,8 +1,8 @@
 import os
-import sqlite3
 import tempfile
-from app.rag.simple_index import ingest_text, _connect, search_embed
+from app.rag.simple_index import ingest_text, _connect
 from unittest.mock import patch
+
 
 def test_delete_chunk_cleans_up_embeddings():
     with tempfile.TemporaryDirectory() as td:
@@ -21,7 +21,12 @@ def test_delete_chunk_cleans_up_embeddings():
             ),
         ):
             # Ingest text with embed=True
-            doc_path, chunks, _ = ingest_text("secret_doc.txt", "This is a super secret document with sensitive data.", db_path=test_db, embed=True)
+            doc_path, chunks, _ = ingest_text(
+                "secret_doc.txt",
+                "This is a super secret document with sensitive data.",
+                db_path=test_db,
+                embed=True,
+            )
 
             # Verify data is in chunks and embeddings
             conn = _connect(test_db)
@@ -36,7 +41,9 @@ def test_delete_chunk_cleans_up_embeddings():
             assert len(emb_chunk_ids) > 0, "Embeddings were not created"
 
             # Re-ingest the document, replacing the old chunks
-            doc_path2, chunks2, _ = ingest_text("secret_doc.txt", "Replacement document.", db_path=test_db, embed=True)
+            doc_path2, chunks2, _ = ingest_text(
+                "secret_doc.txt", "Replacement document.", db_path=test_db, embed=True
+            )
 
             # The old chunks should have been deleted (since doc_id matches and we do DELETE FROM chunks)
             # This should also trigger the chunks_ad_embed trigger and delete the old embeddings.
@@ -51,6 +58,8 @@ def test_delete_chunk_cleans_up_embeddings():
             # Verify the old chunk IDs are gone from embeddings
             for old_id in chunk_ids:
                 if old_id not in new_chunk_ids:
-                    assert old_id not in new_emb_chunk_ids, f"Orphaned embedding found for deleted chunk {old_id}"
+                    assert (
+                        old_id not in new_emb_chunk_ids
+                    ), f"Orphaned embedding found for deleted chunk {old_id}"
 
             conn.close()


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Prevent orphaned embeddings data bloat

🚨 Severity: MEDIUM
💡 Vulnerability: Data minimization risk and storage bloat. The SQLite database schema for the RAG index created `chunks` and `embeddings` tables. The system correctly deleted old chunks upon document re-ingestion or deletion (`DELETE FROM chunks WHERE doc_id=?`), but it lacked a corresponding cleanup mechanism for the `embeddings` table. This led to orphaned high-dimensional vectors accumulating indefinitely.
🎯 Impact: Unbounded growth of the `.promptc_index_v3.db` file, potentially leading to a local Denial of Service (disk space exhaustion) and violating data lifecycle/minimization principles by retaining sensitive document embeddings that should have been deleted.
🔧 Fix: Added a SQLite `AFTER DELETE` trigger (`chunks_ad_embed`) to the `_init_schema` method in `app/rag/simple_index.py` that automatically cascades deletions from the `chunks` table to the `embeddings` table (`DELETE FROM embeddings WHERE chunk_id = old.id;`).
✅ Verification: Added a targeted test `test_rag_embeddings_cleanup.py` to ensure embeddings are successfully removed when corresponding chunks are deleted via document replacement. Executed the full suite successfully.

---
*PR created automatically by Jules for task [8694269914663407113](https://jules.google.com/task/8694269914663407113) started by @madara88645*