### PR TITLE
fix: remove stale 'OF' text assertion in offline test

### DIFF
--- a/web/app/__tests__/offline-page-error-state.test.tsx
+++ b/web/app/__tests__/offline-page-error-state.test.tsx
@@ -56,7 +56,7 @@ describe("Offline compiler page", () => {
 
     expect(screen.getAllByText("Offline Compiler").length).toBeGreaterThan(0);
     expect(screen.getByText("Ctrl/Cmd Enter")).toBeTruthy();
-    expect(screen.getAllByText("OF").length).toBeGreaterThan(0);
+    // "OF" placeholder was replaced by WifiOff SVG icon in #441 — no text to assert
     expect(screen.queryByText("🔌")).toBeNull();
     expect(screen.queryByText("→")).toBeNull();
     expect(screen.queryByText("Ctrl/⌘ Enter")).toBeNull();


### PR DESCRIPTION
## Summary

- `#435` added a test asserting `getAllByText("OF")` — checking for a text placeholder icon in the offline page header
- `#441` replaced that placeholder with a Lucide `<WifiOff aria-hidden="true" />` SVG, removing the "OF" text node entirely
- Smoke CI on main is now failing with `TestingLibraryElementError: Unable to find an element with the text: OF`

**Fix:** Remove the stale `"OF"` assertion. The test still verifies page title, keyboard shortcut copy, and absence of emoji/fragile glyphs.

## Test plan
- [ ] Smoke CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)