### PR TITLE
[codex] Isolate Windows RAG test temp state

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -228,6 +228,8 @@ Relevant files: `app/rag/simple_index.py`, `api/routes/rag.py`
 pytest tests/test_rag.py tests/test_rag_upload.py tests/test_rag_pipeline.py tests/test_rag_chunking.py tests/test_rag_hybrid_api.py tests/test_rag_parsers.py -v
 ```
 
+**Windows temp-dir note:** if pytest or `tempfile.TemporaryDirectory()` fails with `PermissionError` under `%LOCALAPPDATA%\\Temp`, point `TMP`, `TEMP`, and `DB_DIR` at a repo-local writable directory (for example `.\.tmp-test-run`) before running RAG/auth API tests so SQLite and temp fixtures stay isolated.
+
 **RAG upload smoke (requires running backend and an API key):**
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,22 @@
+import os
+import tempfile
+from pathlib import Path
+
 import pytest
-from api.main import app
-from api.auth import verify_api_key, APIKey
+
+_TEST_RUNTIME_ROOT = Path(__file__).resolve().parent.parent / ".tmp-test-run"
+_TEST_RUNTIME_ROOT.mkdir(parents=True, exist_ok=True)
+_TEST_SESSION_DIR = Path(tempfile.mkdtemp(prefix="pytest-", dir=str(_TEST_RUNTIME_ROOT))).resolve()
+_TEST_DB_DIR = (_TEST_SESSION_DIR / "db").resolve()
+_TEST_DB_DIR.mkdir(parents=True, exist_ok=True)
+
+for env_name in ("TMP", "TEMP", "TMPDIR"):
+    os.environ[env_name] = str(_TEST_SESSION_DIR)
+tempfile.tempdir = str(_TEST_SESSION_DIR)
+os.environ["DB_DIR"] = str(_TEST_DB_DIR)
+
+from api.main import app  # noqa: E402
+from api.auth import verify_api_key, APIKey  # noqa: E402
 
 
 def pytest_addoption(parser):

--- a/tests/test_rag_upload.py
+++ b/tests/test_rag_upload.py
@@ -1,35 +1,45 @@
 """Test the stabilized /rag upload/search endpoints."""
 
 import os
+import shutil
+import sqlite3
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from app.rag import simple_index
+
 
 @pytest.fixture
-def client():
+def rag_test_env(monkeypatch):
+    """Create an isolated temp env for RAG API tests."""
+    td = tempfile.mkdtemp()
+    original_cwd = Path.cwd()
+    test_db = os.path.join(td, "test_upload.db")
+    upload_dir = os.path.join(td, "uploads")
+
+    try:
+        with patch("app.rag.simple_index.DEFAULT_DB_PATH", test_db):
+            monkeypatch.setenv("PROMPTC_UPLOAD_DIR", upload_dir)
+            monkeypatch.setenv("PROMPTC_RAG_ALLOWED_ROOTS", td)
+            os.chdir(td)
+            yield {"temp_dir": td, "test_db": test_db, "upload_dir": upload_dir}
+    finally:
+        os.chdir(original_cwd)
+        shutil.rmtree(td, ignore_errors=True)
+
+
+@pytest.fixture
+def client(rag_test_env):
     """Create a test client, patching startup to skip HybridCompiler."""
-    with tempfile.TemporaryDirectory() as td:
-        test_db = os.path.join(td, "test_upload.db")
-        upload_dir = os.path.join(td, "uploads")
+    del rag_test_env
+    from api.main import app
 
-        with (
-            patch("app.rag.simple_index.DEFAULT_DB_PATH", test_db),
-            patch.dict(
-                os.environ,
-                {
-                    "PROMPTC_UPLOAD_DIR": upload_dir,
-                    "PROMPTC_RAG_ALLOWED_ROOTS": td,
-                },
-                clear=False,
-            ),
-        ):
-            from api.main import app
-
-            with TestClient(app) as c:
-                yield c
+    with TestClient(app) as c:
+        yield c
 
 
 def test_rag_upload_indexes_file(client):
@@ -145,6 +155,53 @@ def test_rag_upload_preserves_relative_paths_for_duplicate_filenames(client):
 
     assert any("src/components/index.ts" in str(row) for row in header_search.json())
     assert any("src/pages/index.ts" in str(row) for row in page_search.json())
+
+
+def test_rag_upload_fallback_db_stays_isolated_per_test(rag_test_env):
+    """Primary DB failures should not leak uploads into a shared workspace fallback DB."""
+    repo_root = Path(__file__).resolve().parent.parent
+    shared_fallback_db = repo_root / ".promptc" / Path(rag_test_env["test_db"]).name
+    simple_index.ingest_text(
+        "seed.md",
+        "shared workspace fallback seed that should stay out of this test",
+        db_path=str(shared_fallback_db),
+    )
+
+    real_connect = sqlite3.connect
+    primary_db = str(Path(rag_test_env["test_db"]))
+
+    def flaky_connect(path, *args, **kwargs):
+        resolved = str(Path(path))
+        if resolved == primary_db:
+            raise sqlite3.OperationalError("unable to open database file")
+        return real_connect(path, *args, **kwargs)
+
+    with patch("app.rag.simple_index.sqlite3.connect", side_effect=flaky_connect):
+        from api.main import app
+
+        with TestClient(app) as client:
+            first = client.post(
+                "/rag/upload",
+                json={
+                    "filename": "index.ts",
+                    "relative_path": "src/components/index.ts",
+                    "content": "export const headerMarker = 'header_unique_signal';",
+                },
+            )
+            second = client.post(
+                "/rag/upload",
+                json={
+                    "filename": "index.ts",
+                    "relative_path": "src/pages/index.ts",
+                    "content": "export const pageMarker = 'page_unique_signal';",
+                },
+            )
+            stats = client.get("/rag/stats")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert stats.status_code == 200
+    assert stats.json()["docs"] == 2
 
 
 def test_rag_upload_with_path_traversal_characters(client):


### PR DESCRIPTION
## What changed
- isolated pytest temp files and auth SQLite state under a repo-local `.tmp-test-run` directory in `tests/conftest.py`
- refactored the RAG upload test fixture to restore `cwd` safely and keep fallback SQLite databases inside each test's temp workspace
- added a regression test proving primary DB failures do not leak RAG uploads into a shared workspace fallback DB
- documented the Windows temp-dir workaround in `agents.md`

## Why
Recent RAG DB fallback behavior can drop test state into `cwd/.promptc/<db>` when the primary temp DB path is unavailable. On Windows this made RAG tests flaky and also exposed temp-directory / `users.db` cross-test contamination.

## Impact
RAG and auth-adjacent tests are now deterministic on Windows-style environments where `%TEMP%` is unreliable or locked.

## Verification
- `python -m pytest tests/test_rag_upload.py tests/test_rag_db_path.py tests/test_rag_hybrid_api.py tests/test_auth_fast_path.py -q -k "rag or test_rag"`
