### PR TITLE
🧹 [code health improvement] Refactor redundant pass in BaseHandler

### DIFF
--- a/app/heuristics/handlers/base.py
+++ b/app/heuristics/handlers/base.py
@@ -10,4 +10,4 @@ class BaseHandler(ABC):
         Apply logic to ir_v2 based on the state of ir_v1 or other factors.
         This method should modify ir_v2 in-place.
         """
-        pass
+        raise NotImplementedError("Subclasses must implement this method")


### PR DESCRIPTION
🎯 **What:** Replaced the redundant `pass` statement in `BaseHandler.handle` abstract method with an explicit `raise NotImplementedError()`.

💡 **Why:** To improve clarity and strictly enforce the overriding of abstract methods.

✅ **Verification:** Ran format, lint, and the full test suite (`pytest`) to confirm no functionality is broken.

✨ **Result:** Better maintainability and error messaging when subclass implementation is missing.

---
*PR created automatically by Jules for task [11085394867428405655](https://jules.google.com/task/11085394867428405655) started by @madara88645*