### PR TITLE
[codex] Make API key rate limiting atomic

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -2,6 +2,7 @@ import logging
 import time
 import secrets
 from pathlib import Path
+from threading import Lock
 from typing import Dict
 import os
 
@@ -65,6 +66,7 @@ def get_db():
 # Simple sliding window or fixed window?
 # Let's do a simple fixed window or just a list of timestamps with cleanup.
 RATE_LIMIT_STORE: Dict[str, list] = {}
+RATE_LIMIT_LOCK = Lock()
 RATE_LIMIT_WINDOW = 60  # seconds
 RATE_LIMIT_MAX_REQUESTS = 10
 
@@ -112,34 +114,34 @@ def verify_api_key(
     # --- Rate Limiting ---
     now = time.time()
 
-    # Periodically clean up stale rate limit entries to prevent memory leaks
-    if getattr(verify_api_key, "_cleanup_counter", 0) > 1000:
-        verify_api_key._cleanup_counter = 0
-        stale_keys = []
-        # Create a list of items to prevent RuntimeError if the dictionary changes size
-        # due to concurrent requests adding new keys during the cleanup iteration.
-        for k, v in list(RATE_LIMIT_STORE.items()):
-            valid_ts = [t for t in v if t > now - RATE_LIMIT_WINDOW]
-            if not valid_ts:
-                stale_keys.append(k)
-            else:
-                RATE_LIMIT_STORE[k] = valid_ts
-        for k in stale_keys:
-            RATE_LIMIT_STORE.pop(k, None)
-    else:
-        verify_api_key._cleanup_counter = getattr(verify_api_key, "_cleanup_counter", 0) + 1
+    with RATE_LIMIT_LOCK:
+        # Periodically clean up stale rate limit entries to prevent memory leaks
+        if getattr(verify_api_key, "_cleanup_counter", 0) > 1000:
+            verify_api_key._cleanup_counter = 0
+            stale_keys = []
+            # Iterate over a snapshot so cleanup stays safe even as new keys arrive.
+            for k, v in list(RATE_LIMIT_STORE.items()):
+                valid_ts = [t for t in v if t > now - RATE_LIMIT_WINDOW]
+                if not valid_ts:
+                    stale_keys.append(k)
+                else:
+                    RATE_LIMIT_STORE[k] = valid_ts
+            for k in stale_keys:
+                RATE_LIMIT_STORE.pop(k, None)
+        else:
+            verify_api_key._cleanup_counter = getattr(verify_api_key, "_cleanup_counter", 0) + 1
 
-    history = RATE_LIMIT_STORE.get(api_key, [])
-    # Filter out timestamps older than window
-    history = [t for t in history if t > now - RATE_LIMIT_WINDOW]
+        history = RATE_LIMIT_STORE.get(api_key, [])
+        # Filter out timestamps older than window
+        history = [t for t in history if t > now - RATE_LIMIT_WINDOW]
 
-    if len(history) >= RATE_LIMIT_MAX_REQUESTS:
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Rate limit exceeded"
-        )
+        if len(history) >= RATE_LIMIT_MAX_REQUESTS:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Rate limit exceeded"
+            )
 
-    history.append(now)
-    RATE_LIMIT_STORE[api_key] = history
+        history.append(now)
+        RATE_LIMIT_STORE[api_key] = history
 
     return key_record
 

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -1,10 +1,14 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch
 import sqlite3
 from pathlib import Path
 from api.main import app
-from api.auth import APIKey, SessionLocal
+from api.auth import APIKey, SessionLocal, verify_api_key
 from app.compiler import compile_text_v2
 from app.rag import simple_index
 
@@ -256,6 +260,59 @@ def test_rate_limit(test_key):
         mock.cache = {}
         resp = client.post("/compile/fast", json={"text": "h"}, headers={"x-api-key": test_key})
         assert resp.status_code == 429
+
+
+def test_verify_api_key_rate_limit_is_atomic(monkeypatch):
+    class SlowDict(dict):
+        def __init__(self):
+            super().__init__()
+            self._lock = threading.Lock()
+            self.active_gets = 0
+            self.max_active_gets = 0
+
+        def get(self, key, default=None):
+            with self._lock:
+                self.active_gets += 1
+                self.max_active_gets = max(self.max_active_gets, self.active_gets)
+            try:
+                threading.Event().wait(0.05)
+            finally:
+                with self._lock:
+                    self.active_gets -= 1
+            return super().get(key, default)
+
+    rate_limit_store = SlowDict()
+
+    db = SessionLocal()
+    key = APIKey(key="sk_atomic_db", owner="pytest")
+    db.add(key)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+
+    monkeypatch.setattr("api.auth.RATE_LIMIT_STORE", rate_limit_store)
+    monkeypatch.setattr("api.auth.RATE_LIMIT_MAX_REQUESTS", 1)
+    monkeypatch.setattr("api.auth.RATE_LIMIT_WINDOW", 60)
+    monkeypatch.setattr(verify_api_key, "_cleanup_counter", 0, raising=False)
+
+    def run_check():
+        try:
+            verify_api_key("sk_atomic_db")
+            return "ok"
+        except HTTPException as exc:
+            return exc.status_code
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _: run_check(), range(2)))
+    finally:
+        db.delete(key)
+        db.commit()
+        db.close()
+
+    assert sorted(results, key=str) == [429, "ok"]
+    assert rate_limit_store.max_active_gets == 1
 
 
 def test_compile_no_key():


### PR DESCRIPTION
## Summary
- make API key rate limiting atomic so concurrent requests cannot both consume the same allowance slot
- add a focused regression test that proves only one concurrent `verify_api_key` call succeeds when the limit is `1`

## Root cause
`verify_api_key` read, filtered, checked, and rewrote `RATE_LIMIT_STORE` without synchronization. Two threads could observe the same pre-update history and both pass the limit check before either write completed.

## Validation
- `python -m pytest tests/test_auth_fast_path.py -q`
- `python -m pytest tests/test_api_hardening.py tests/test_auth_fast_path.py -q`
