### PR TITLE
[codex] Lock admin API key timing hardening

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -71,6 +71,16 @@ RATE_LIMIT_WINDOW = 60  # seconds
 RATE_LIMIT_MAX_REQUESTS = 10
 
 
+def _matches_admin_api_key(provided_key: str, admin_key: str) -> bool:
+    normalized_key = provided_key.strip()
+    if len(normalized_key) == len(admin_key):
+        return secrets.compare_digest(normalized_key, admin_key)
+
+    # Run a same-length dummy comparison to avoid leaking the admin key length.
+    secrets.compare_digest(admin_key, admin_key)
+    return False
+
+
 def verify_api_key(
     api_key: str = Security(api_key_header),
 ) -> APIKey:
@@ -85,18 +95,8 @@ def verify_api_key(
     # --- Master Key Check (for Stateless Deployments like Railway) ---
 
     admin_key = os.environ.get("ADMIN_API_KEY", "").strip()
-    if admin_key:
-        # Prevent length side-channel by ensuring we always compare strings of the same length
-        provided_key = api_key.strip()
-        if len(provided_key) == len(admin_key):
-            is_valid = secrets.compare_digest(provided_key, admin_key)
-        else:
-            # Dummy comparison to prevent timing attacks
-            is_valid = secrets.compare_digest(admin_key, admin_key)
-            is_valid = False
-
-        if is_valid:
-            return APIKey(key=api_key, owner="admin", is_active=True)
+    if admin_key and _matches_admin_api_key(api_key, admin_key):
+        return APIKey(key=api_key, owner="admin", is_active=True)
 
     db = SessionLocal()
     key_record = db.query(APIKey).filter(APIKey.key == api_key).first()

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -316,6 +316,36 @@ def test_verify_api_key_rate_limit_is_atomic(monkeypatch):
     assert rate_limit_store.max_active_gets == 1
 
 
+def test_matches_admin_api_key_uses_dummy_compare_on_length_mismatch(monkeypatch):
+    compare_calls = []
+
+    def fake_compare_digest(left, right):
+        compare_calls.append((left, right))
+        return left == right
+
+    monkeypatch.setattr("api.auth.secrets.compare_digest", fake_compare_digest)
+
+    from api.auth import _matches_admin_api_key
+
+    assert _matches_admin_api_key("short", "much-longer-admin-key") is False
+    assert compare_calls == [("much-longer-admin-key", "much-longer-admin-key")]
+
+
+def test_matches_admin_api_key_compares_provided_key_when_lengths_match(monkeypatch):
+    compare_calls = []
+
+    def fake_compare_digest(left, right):
+        compare_calls.append((left, right))
+        return left == right
+
+    monkeypatch.setattr("api.auth.secrets.compare_digest", fake_compare_digest)
+
+    from api.auth import _matches_admin_api_key
+
+    assert _matches_admin_api_key("admin-key", "admin-key") is True
+    assert compare_calls == [("admin-key", "admin-key")]
+
+
 def test_compile_no_key():
     resp = client.post("/compile", json={"text": "hello", "v2": False})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- extract the admin API key constant-time comparison into a dedicated helper
- add regression tests that lock the equal-length and dummy-compare paths
- keep `verify_api_key` behavior the same while making the hardening easier to review and preserve

## Why
The timing-hardening change on the admin key path was recently added, but it was only protected by implementation comments. This PR adds focused regression coverage so future refactors do not accidentally remove the dummy comparison used for mismatched key lengths.

## Verification
- `python -m pytest tests/test_auth_fast_path.py -q`
- `python -m pytest tests/test_api_hardening.py tests/test_auth_fast_path.py -q`
