### PR TITLE
[codex] Ground prompt compiler outputs

### DIFF
--- a/app/agents/context_strategist.py
+++ b/app/agents/context_strategist.py
@@ -74,9 +74,31 @@ class ContextStrategist:
                 json_mode=True,
             )
             data = json.loads(response)
-            if isinstance(data, list):
-                return data[:3]
-            return []
+            return self._normalize_queries(data)
         except Exception as e:
             print(f"[STRATEGIST] Query expansion failed: {e}", file=sys.stderr)
             return []
+
+    @staticmethod
+    def _normalize_queries(data: Any) -> List[str]:
+        if isinstance(data, dict):
+            data = data.get("queries")
+        if not isinstance(data, list):
+            return []
+
+        queries: List[str] = []
+        seen: set[str] = set()
+        for item in data:
+            if not isinstance(item, str):
+                continue
+            query = " ".join(item.strip().split())
+            if not query:
+                continue
+            key = query.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            queries.append(query)
+            if len(queries) >= 3:
+                break
+        return queries

--- a/app/agents/context_strategist.py
+++ b/app/agents/context_strategist.py
@@ -3,6 +3,7 @@ Agent 6: The Context Strategist.
 Responsible for semantic retrieval, query expansion, and context re-ranking.
 """
 import json
+import re
 import sys
 from typing import List, Dict, Any, Optional
 from app.rag.simple_index import search_hybrid
@@ -40,6 +41,8 @@ class ContextStrategist:
 
         # Search for expanded queries
         for q in expanded_queries:
+            if q.strip().lower() == user_prompt.strip().lower():
+                continue
             sub_results = search_hybrid(q, k=3)
             for r in sub_results:
                 if r["path"] in all_results:
@@ -61,7 +64,8 @@ class ContextStrategist:
             "You are an expert researcher and technical strategist. Analyze the user request and generate "
             "3 specific search queries to find relevant information (code snippets, knowledge base entries, documentation) "
             "in the provided context.\n"
-            'Return ONLY a JSON list of strings. Example: ["auth middleware", "brand color guidelines", "database schema"]'
+            "Do not invent filenames, functions, endpoints, or API names unless they appear in the user request.\n"
+            'Return ONLY a JSON list of strings. Example: ["login page 500 password", "password validation error handling", "authentication form special characters"]'
         )
 
         try:
@@ -74,31 +78,50 @@ class ContextStrategist:
                 json_mode=True,
             )
             data = json.loads(response)
-            return self._normalize_queries(data)
+            return self._normalize_queries(data, prompt)
         except Exception as e:
             print(f"[STRATEGIST] Query expansion failed: {e}", file=sys.stderr)
-            return []
+            return self._normalize_queries([], prompt)
 
-    @staticmethod
-    def _normalize_queries(data: Any) -> List[str]:
+    _ARTIFACT_LIKE_RE = re.compile(
+        r"(?:\b[A-Za-z_]\w*\.[A-Za-z_]\w*\b|\b[A-Za-z_]\w*_[A-Za-z_]\w*\b|\b[\w.-]+\.(?:py|ts|tsx|js|jsx|md|json|ya?ml|toml|sql)\b)"
+    )
+
+    @classmethod
+    def _normalize_queries(cls, data: Any, original_query: str = "") -> List[str]:
         if isinstance(data, dict):
             data = data.get("queries")
         if not isinstance(data, list):
-            return []
+            data = []
 
         queries: List[str] = []
         seen: set[str] = set()
+
+        def add_query(value: str) -> None:
+            query = " ".join(value.strip().split())
+            if not query:
+                return
+            key = query.lower()
+            if key in seen:
+                return
+            if cls._looks_like_invented_artifact(query, original_query):
+                return
+            seen.add(key)
+            queries.append(query)
+
+        if original_query:
+            add_query(original_query)
+
         for item in data:
             if not isinstance(item, str):
                 continue
-            query = " ".join(item.strip().split())
-            if not query:
-                continue
-            key = query.lower()
-            if key in seen:
-                continue
-            seen.add(key)
-            queries.append(query)
+            add_query(item)
             if len(queries) >= 3:
                 break
         return queries
+
+    @classmethod
+    def _looks_like_invented_artifact(cls, query: str, original_query: str) -> bool:
+        if not cls._ARTIFACT_LIKE_RE.search(query):
+            return False
+        return query.lower() not in original_query.lower()

--- a/app/emitters.py
+++ b/app/emitters.py
@@ -338,6 +338,23 @@ def _top_constraints_text_v2(cons: List[ConstraintV2], limit: int = 3) -> str:
     return " | ".join(format_constraint(c) for c in top)
 
 
+def _policy_summary_text_v2(ir: IRv2) -> str:
+    policy = ir.policy
+    parts = [
+        f"risk={policy.risk_level}",
+        f"execution={policy.execution_mode}",
+    ]
+    if policy.risk_domains:
+        parts.append("domains=" + ",".join(policy.risk_domains[:5]))
+    if policy.forbidden_tools:
+        parts.append("forbidden_tools=" + ",".join(policy.forbidden_tools[:5]))
+    if policy.sanitization_rules:
+        parts.append("sanitization=" + ",".join(policy.sanitization_rules[:5]))
+    if policy.data_sensitivity and policy.data_sensitivity != "public":
+        parts.append(f"data={policy.data_sensitivity}")
+    return "; ".join(parts)
+
+
 def emit_system_prompt_v2(ir: IRv2) -> str:
     parts: List[str] = [
         f"Persona: {ir.persona}",
@@ -361,6 +378,9 @@ def emit_system_prompt_v2(ir: IRv2) -> str:
     c_line = _top_constraints_text_v2(ir.constraints, limit=3)
     if c_line:
         parts.append("Key Constraints: " + c_line)
+    policy_line = _policy_summary_text_v2(ir)
+    if policy_line:
+        parts.append("Policy: " + policy_line)
     if ir.style:
         parts.append("Style: " + ", ".join(ir.style))
     if ir.tone:
@@ -407,11 +427,26 @@ def emit_user_prompt_v2(ir: IRv2) -> str:
 
 def emit_plan_v2(ir: IRv2) -> str:
     out: List[str] = []
+    clarify_questions = (ir.metadata or {}).get("clarify_questions") or []
+    if clarify_questions:
+        out.append(
+            "1. [clarify] Ask the unresolved clarification questions before choosing a final approach.\n"
+            "   Rationale: missing details should be resolved instead of guessed"
+        )
+    if ir.policy.execution_mode == "human_approval_required":
+        step_number = len(out) + 1
+        out.append(
+            f"{step_number}. [policy] Pause for human approval before executing or relying on tools.\n"
+            f"   Rationale: policy requires human approval for {ir.policy.risk_level} risk"
+        )
     steps = ir.steps if ir.steps else [StepV2(type="task", text=t) for t in ir.tasks]
     for i, step in enumerate(steps, start=1):
-        rationale = "Rationale: execute task effectively"
+        step_number = len(out) + 1
+        rationale = (
+            "Rationale: complete the user's stated task without adding unstated requirements"
+        )
         kind = step.type if hasattr(step, "type") else "task"
-        out.append(f"{i}. [{kind}] {step.text}\n   {rationale}")
+        out.append(f"{step_number}. [{kind}] {step.text}\n   {rationale}")
     return (
         "\n".join(out)
         if out
@@ -470,6 +505,9 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
             + ": "
             + c_line
         )
+    policy_line = _policy_summary_text_v2(ir)
+    if policy_line:
+        ctx_lines.append("Policy: " + policy_line)
     if ir.inputs:
         kv = [f"{k}={v}" for k, v in list(ir.inputs.items())[:4]]
         ctx_lines.append(
@@ -535,6 +573,17 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
         "",
         fmt_line,
     ]
+    clarify_all = (ir.metadata or {}).get("clarify_questions") or []
+    if clarify_all:
+        prompt.extend(
+            [
+                "",
+                ("Clarification Questions" if lang != "tr" else "Açıklama Soruları") + ":",
+            ]
+        )
+        for q in clarify_all[:5]:
+            prompt.append(f"- {q}")
+
     # Follow-up Questions (same approach as v1)
     followups: List[str] = []
     if lang == "tr":

--- a/app/emitters.py
+++ b/app/emitters.py
@@ -355,6 +355,91 @@ def _policy_summary_text_v2(ir: IRv2) -> str:
     return "; ".join(parts)
 
 
+def _policy_reason_phrases_v2(ir: IRv2) -> List[str]:
+    reasons = (ir.metadata or {}).get("policy_reasons") or []
+    phrases: List[str] = []
+    for reason in reasons:
+        if not isinstance(reason, str):
+            continue
+        if reason.startswith("high_risk_domain:"):
+            phrases.append(f"high-risk domain: {reason.split(':', 1)[1]}")
+        elif reason.startswith("risk_domain:"):
+            phrases.append(f"risk domain: {reason.split(':', 1)[1]}")
+        elif reason.startswith("pii_detected:"):
+            phrases.append(f"sensitive data detected: {reason.split(':', 1)[1]}")
+        elif reason == "overlapping_risk_domains":
+            phrases.append("overlapping risk domains")
+        elif reason == "debug_request":
+            phrases.append("debugging or code execution context")
+        elif reason == "file_or_system_request":
+            phrases.append("file or system access requested")
+        else:
+            phrases.append(reason.replace("_", " "))
+
+    if not phrases and ir.policy.execution_mode == "human_approval_required":
+        phrases.append(f"{ir.policy.risk_level} risk policy")
+    return phrases
+
+
+def _policy_check_lines_v2(ir: IRv2) -> List[str]:
+    policy = ir.policy
+    if (
+        policy.execution_mode != "human_approval_required"
+        and not policy.forbidden_tools
+        and not policy.sanitization_rules
+        and policy.data_sensitivity == "public"
+    ):
+        return []
+
+    lines: List[str] = []
+    reasons = _policy_reason_phrases_v2(ir)
+    if policy.execution_mode == "human_approval_required":
+        lines.append("Approval required because " + ", ".join(reasons) + ".")
+    elif reasons:
+        lines.append("Policy trigger: " + ", ".join(reasons) + ".")
+    if policy.forbidden_tools:
+        lines.append("Do not use: " + ", ".join(policy.forbidden_tools[:5]) + ".")
+    if policy.sanitization_rules:
+        lines.append("Apply sanitization: " + ", ".join(policy.sanitization_rules[:5]) + ".")
+    if policy.data_sensitivity and policy.data_sensitivity != "public":
+        lines.append(f"Data sensitivity: {policy.data_sensitivity}.")
+    return lines
+
+
+def _clean_domain_suggestion_text(text: str) -> str:
+    value = " ".join((text or "").strip().split())
+    for marker in ("Include ", "Add ", "Review ", "Use ", "Follow ", "Consider ", "Handle "):
+        index = value.find(marker)
+        if 0 < index <= 8:
+            return value[index:]
+    return value
+
+
+def _domain_suggestions_v2(ir: IRv2, limit: int = 3) -> List[str]:
+    raw = (ir.metadata or {}).get("domain_suggestions") or []
+    if not isinstance(raw, list):
+        return []
+
+    items: List[tuple[int, str]] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        text = _clean_domain_suggestion_text(str(item.get("text") or ""))
+        key = text.lower()
+        if not text or key in seen:
+            continue
+        seen.add(key)
+        try:
+            priority = int(item.get("priority") or 0)
+        except Exception:
+            priority = 0
+        items.append((priority, text))
+
+    items.sort(key=lambda pair: pair[0], reverse=True)
+    return [text for _, text in items[:limit]]
+
+
 def emit_system_prompt_v2(ir: IRv2) -> str:
     parts: List[str] = [
         f"Persona: {ir.persona}",
@@ -435,9 +520,13 @@ def emit_plan_v2(ir: IRv2) -> str:
         )
     if ir.policy.execution_mode == "human_approval_required":
         step_number = len(out) + 1
+        policy_lines = _policy_check_lines_v2(ir)
+        rationale = "Rationale: policy requires human approval for " f"{ir.policy.risk_level} risk"
+        if policy_lines:
+            rationale += "\n   " + "\n   ".join(policy_lines)
         out.append(
             f"{step_number}. [policy] Pause for human approval before executing or relying on tools.\n"
-            f"   Rationale: policy requires human approval for {ir.policy.risk_level} risk"
+            f"   {rationale}"
         )
     steps = ir.steps if ir.steps else [StepV2(type="task", text=t) for t in ir.tasks]
     for i, step in enumerate(steps, start=1):
@@ -508,6 +597,11 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
     policy_line = _policy_summary_text_v2(ir)
     if policy_line:
         ctx_lines.append("Policy: " + policy_line)
+    policy_checks = _policy_check_lines_v2(ir)
+    if policy_checks:
+        ctx_lines.append("Policy Checks:")
+        for line in policy_checks:
+            ctx_lines.append(f"- {line}")
     if ir.inputs:
         kv = [f"{k}={v}" for k, v in list(ir.inputs.items())[:4]]
         ctx_lines.append(
@@ -531,6 +625,18 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
             + ": "
             + ", ".join(ir.tone)
         )
+    optional_suggestions = _domain_suggestions_v2(ir, limit=3)
+    if optional_suggestions:
+        ctx_lines.append(
+            (
+                "Istege bagli degerlendirmeler"
+                if lang == "tr"
+                else ("Consideraciones opcionales" if lang == "es" else "Optional considerations")
+            )
+            + ":"
+        )
+        for suggestion in optional_suggestions:
+            ctx_lines.append(f"- {suggestion}")
 
     # --- Agent 6: Context Injection ---
     context_snippets = (ir.metadata or {}).get("context_snippets")

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -22,7 +22,7 @@ from app.models import (
     DEFAULT_ROLE_TR,
     IR,
 )
-from app.models_v2 import IRv2, ConstraintV2, DiagnosticItem
+from app.models_v2 import IRv2, DiagnosticItem
 
 
 # ==============================================================================
@@ -705,17 +705,32 @@ class DomainHandler(BaseHandler):
         # Perform domain analysis
         analysis = self.analyze_domain(original_text, detected_domain)
 
-        # Add suggestions as constraints
-        for suggestion in analysis.suggestions:
-            ir_v2.constraints.append(
-                ConstraintV2(
-                    id=self._hash_id(suggestion.text),
-                    text=suggestion.text,
-                    origin=f"domain_{analysis.detected_domain}",
-                    priority=suggestion.priority,
-                    rationale=suggestion.rationale,
+        # Keep inferred domain best practices as optional guidance instead of
+        # promoting them to hard constraints. Explicit user constraints are
+        # already handled earlier by ConstraintHandler.
+        if analysis.suggestions:
+            existing = ir_v2.metadata.get("domain_suggestions")
+            if not isinstance(existing, list):
+                existing = []
+            seen = {
+                (item.get("text") or "").strip().lower()
+                for item in existing
+                if isinstance(item, dict)
+            }
+            for suggestion in analysis.suggestions:
+                key = suggestion.text.strip().lower()
+                if not key or key in seen:
+                    continue
+                existing.append(
+                    {
+                        "text": suggestion.text,
+                        "category": suggestion.category,
+                        "priority": suggestion.priority,
+                        "rationale": suggestion.rationale,
+                    }
                 )
-            )
+                seen.add(key)
+            ir_v2.metadata["domain_suggestions"] = existing
 
         # Add diagnostics
         ir_v2.diagnostics.extend(analysis.diagnostics)

--- a/app/heuristics/handlers/policy.py
+++ b/app/heuristics/handlers/policy.py
@@ -44,6 +44,11 @@ class PolicyHandler(BaseHandler):
             "forbidden": ["secret_access", "write_outside_workspace"],
             "sanitization": ["mask_sensitive_values", "hipaa_filter"],
         },
+        "legal": {
+            "allowed": ["reference_lookup"],
+            "forbidden": ["secret_access", "external_share"],
+            "sanitization": ["jurisdiction_check", "no_professional_advice"],
+        },
         "security": {
             "allowed": ["workspace_read", "run_tests", "log_inspection"],
             "forbidden": ["secret_access", "network_scan"],
@@ -102,6 +107,20 @@ class PolicyHandler(BaseHandler):
             and not debug_request
             and not file_or_system_request
         )
+        policy_reasons: list[str] = []
+        for domain in risk_flags:
+            if domain in self._HIGH_RISK_DOMAINS:
+                policy_reasons.append(f"high_risk_domain:{domain}")
+            else:
+                policy_reasons.append(f"risk_domain:{domain}")
+        if risk_score >= 2:
+            policy_reasons.append("overlapping_risk_domains")
+        if debug_request:
+            policy_reasons.append("debug_request")
+        if file_or_system_request:
+            policy_reasons.append("file_or_system_request")
+        for flag in pii_flags:
+            policy_reasons.append(f"pii_detected:{flag}")
 
         # Cumulative risk scoring: 2+ overlapping domains always escalate
         if benign_educational_risk:
@@ -161,6 +180,7 @@ class PolicyHandler(BaseHandler):
         elif has_high_risk_domain and policy.data_sensitivity == "public":
             policy.data_sensitivity = "internal"
 
+        ir_v2.metadata["policy_reasons"] = self._unique(policy_reasons)
         ir_v2.metadata["policy_summary"] = policy.model_dump()
 
     @classmethod

--- a/app/heuristics/handlers/policy.py
+++ b/app/heuristics/handlers/policy.py
@@ -37,12 +37,12 @@ class PolicyHandler(BaseHandler):
         "financial": {
             "allowed": ["calculator", "spreadsheet_read"],
             "forbidden": ["web_scraper", "secret_access"],
-            "sanitization": ["mask_sensitive_values", "audit_trail"],
+            "sanitization": ["mask_sensitive_values", "audit_trail", "no_professional_advice"],
         },
         "health": {
             "allowed": ["reference_lookup"],
             "forbidden": ["secret_access", "write_outside_workspace"],
-            "sanitization": ["mask_sensitive_values", "hipaa_filter"],
+            "sanitization": ["mask_sensitive_values", "hipaa_filter", "no_professional_advice"],
         },
         "legal": {
             "allowed": ["reference_lookup"],

--- a/app/llm_engine/prompts/query_expansion.md
+++ b/app/llm_engine/prompts/query_expansion.md
@@ -7,7 +7,7 @@ The user wants to modify code or understand a concept. Your job is to bridge the
 1.  **Analyze Intent**: Understand what the user is trying to achieve.
 2.  **Infer Concepts**: Identify related technical or domain concepts.
 3.  **Generate Queries**:
-    *   **Exact Matches**: Likely file names or function names.
+    *   **Exact Matches**: File names, function names, API names, or symbols only when they appear in the user text or supplied context.
     *   **Semantic Queries**: Concepts described in natural language.
     *   **Grounding**: Do not invent filenames, do not invent functions, do not invent endpoints, and do not invent API names unless they are present in the user text or provided context.
 4.  **Format**: Return a JSON object with a list of strings under the key "queries".
@@ -18,12 +18,10 @@ The user wants to modify code or understand a concept. Your job is to bridge the
 ```json
 {
   "queries": [
-    "login handler password validation",
-    "auth middleware error handling",
-    "User.authenticate",
-    "password_regex",
-    "login_route",
-    "handle_500_error"
+    "login page 500 special character password",
+    "password validation error handling",
+    "authentication form special character handling",
+    "500 error login password input"
   ]
 }
 ```

--- a/app/llm_engine/prompts/query_expansion.md
+++ b/app/llm_engine/prompts/query_expansion.md
@@ -9,6 +9,7 @@ The user wants to modify code or understand a concept. Your job is to bridge the
 3.  **Generate Queries**:
     *   **Exact Matches**: Likely file names or function names.
     *   **Semantic Queries**: Concepts described in natural language.
+    *   **Grounding**: Do not invent filenames, do not invent functions, do not invent endpoints, and do not invent API names unless they are present in the user text or provided context.
 4.  **Format**: Return a JSON object with a list of strings under the key "queries".
 
 ## Example

--- a/app/llm_engine/prompts/worker_v1.md
+++ b/app/llm_engine/prompts/worker_v1.md
@@ -60,20 +60,19 @@ Input: "Create a python script for web scraping"
     "language": "en",
     "role": "Senior Python Backend Engineer",
     "domain": "Web Scraping & Automation",
-    "goals": ["Robust Data Extraction", "Anti-Detection Handling"],
+    "goals": ["Create a Python web scraping script"],
     "constraints": [
-      {"id": "c1", "text": "Use requests and BeautifulSoup4", "priority": 100},
-      {"id": "c2", "text": "Implement Retry/Backoff logic", "priority": 90},
-      {"id": "c3", "text": "Includes Type Hints and Docstrings", "priority": 85}
+      {"id": "c1", "text": "Use Python", "priority": 100},
+      {"id": "c2", "text": "Do not assume a target website, selectors, or library stack unless provided", "priority": 90}
     ],
     "steps": [
-      {"type": "reasoning", "text": "Determine target structure"},
-      {"type": "action", "text": "Write robust extraction code"}
+      {"type": "clarify", "text": "Ask for target URL, data fields, and allowed libraries if missing"},
+      {"type": "action", "text": "Draft the smallest scraper that fits the confirmed inputs"}
     ]
   },
-  "system_prompt": "### ROLE\nYou are a Senior Python Backend Engineer specialized in high-scale web scraping and automation.\n\n### MISSION\nWrite robust, production-grade Python code to extract data from web sources while handling edge cases and anti-bot measures.\n\n### RULES\n- **Library Stack**: Use `requests` and `BeautifulSoup4` (bs4).\n- **Resilience**: You MUST implement `HTTPAdapter` with `Retry` strategy for network reliability.\n- **Quality**: All code must include PEP 484 type hints and Google-style docstrings.\n- **User-Agent**: ALways define a realistic User-Agent header.\n- **prohibited**: NEVER use bare `except:` blocks; catch specific exceptions.\n\n### OUTPUT FORMAT\n1. **Prerequisites**: Pip install commands.\n2. **Code**: Single, runnable, well-commented Python block.\n3. **Usage**: Example usage pattern.",
-  "user_prompt": "Write a robust Python script for web scraping, focusing on error handling and clean data extraction.",
-  "plan": "1. Setup: Define user-agent and retry strategy\n2. Request: Fetch URL with timeout handling\n3. Parse: Extract data using CSS selectors\n4. Output: Return structured JSON or Dictionary"
+  "system_prompt": "### ROLE\nYou are a Python developer helping create a grounded web scraping prompt.\n\n### MISSION\nTurn the request into a usable scraping task without inventing missing website, selector, data schema, or library details.\n\n### RULES\n- Preserve the user's request to create a Python scraping script.\n- Ask short clarification questions for missing target URL, fields to extract, output format, and allowed libraries.\n- Treat implementation choices as optional suggestions unless the user specified them.\n- DO NOT invent endpoints, selectors, file names, schemas, or dependencies.\n\n### OUTPUT FORMAT\n1. Clarification questions if required.\n2. Confirmed task summary.\n3. Minimal implementation plan.",
+  "user_prompt": "Create a Python script for web scraping. If target website, fields, output format, or library preferences are missing, ask for them before writing final code.",
+  "plan": "1. Clarify: Identify missing target URL, data fields, output format, and library preferences.\n2. Scope: Restate only the confirmed scraping task so no hidden requirements are added.\n3. Execute: Provide a minimal Python implementation plan after the missing details are known."
 }
 ```
 

--- a/app/llm_engine/prompts/worker_v1.md
+++ b/app/llm_engine/prompts/worker_v1.md
@@ -3,10 +3,10 @@
 Convert user requests into HIGH-UTILITY structured prompts. Output ONLY valid JSON.
 
 ## CRITICAL INSTRUCTION
-Your goal is not just to format, but to **ELEVATE** the prompt. The generated `system_prompt` must be significantly better than what the user asked for.
-- Use **Expert Personas** (e.g., instead of "Coder", use "Senior Systems Architect").
-- Add **Hidden Constraints** that the user didn't think of but are best practices.
-- Enforce **Strict Output Formats**.
+Your goal is not just to format, but to **ELEVATE** the prompt while preserving the user's actual intent.
+- Use **Expert Personas** when the user's domain is clear.
+- Do not add requirements the user did not ask for. If a useful detail is missing, mark assumptions explicitly or ask short clarification questions.
+- Enforce **Strict Output Formats** only when the user's request or obvious task shape supports it.
 
 ## RULES
 1. **LANGUAGE MATCHING**:
@@ -27,7 +27,7 @@ Your goal is not just to format, but to **ELEVATE** the prompt. The generated `s
    - Priority scale: accuracy/safety = 90–100 | format/structure = 60–79 | style/tone = 40–59.
    - You MUST include at least one **negative constraint** (NEVER / YASAK) per output.
    - Never repeat the same constraint with different wording — merge duplicates.
-6. **DOMAIN AWARENESS**: Automatically inject domain best-practice constraints that the user did not mention but are standard for the detected domain (e.g., retry logic for networking, type hints for Python, disclaimers for finance/health/legal).
+6. **DOMAIN AWARENESS**: Mention domain best-practice considerations as optional guidance or assumptions unless the user explicitly requested them. Do not silently turn best practices into mandatory requirements.
 
 ## JSON Structure
 ```json

--- a/app/llm_engine/rag.py
+++ b/app/llm_engine/rag.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol
 
@@ -80,13 +81,17 @@ class ContextStrategist:
         self.vector_db = vector_db
         self.llm = llm_client
 
+    _ARTIFACT_LIKE_RE = re.compile(
+        r"(?:\b[A-Za-z_]\w*\.[A-Za-z_]\w*\b|\b[A-Za-z_]\w*_[A-Za-z_]\w*\b|\b[\w.-]+\.(?:py|ts|tsx|js|jsx|md|json|ya?ml|toml|sql)\b)"
+    )
+
     def expand_query(self, user_text: str) -> List[str]:
         try:
             response = self.llm.expand_query_intent(user_text)
-            return response.get("queries", [user_text])
+            return self._normalize_queries(response.get("queries"), user_text)
         except Exception as exc:
             logger.debug("Query expansion failed: %s", exc)
-            return [user_text]
+            return self._normalize_queries([], user_text)
 
     def retrieve(self, queries: List[str]) -> List[Snippet]:
         all_results: Dict[str, Snippet] = {}
@@ -140,3 +145,38 @@ class ContextStrategist:
                 else "No indexed context available."
             ),
         }
+
+    @classmethod
+    def _normalize_queries(cls, queries: Any, original_query: str) -> List[str]:
+        if not isinstance(queries, list):
+            queries = []
+
+        normalized: List[str] = []
+        seen: set[str] = set()
+
+        def add_query(value: str) -> None:
+            query = " ".join(value.strip().split())
+            if not query:
+                return
+            key = query.lower()
+            if key in seen:
+                return
+            if cls._looks_like_invented_artifact(query, original_query):
+                return
+            seen.add(key)
+            normalized.append(query)
+
+        add_query(original_query)
+        for item in queries:
+            if not isinstance(item, str):
+                continue
+            add_query(item)
+            if len(normalized) >= 3:
+                break
+        return normalized
+
+    @classmethod
+    def _looks_like_invented_artifact(cls, query: str, original_query: str) -> bool:
+        if not cls._ARTIFACT_LIKE_RE.search(query):
+            return False
+        return query.lower() not in original_query.lower()

--- a/tests/test_context_strategist.py
+++ b/tests/test_context_strategist.py
@@ -21,7 +21,7 @@ class TestContextStrategist:
         strategist = ContextStrategist(client=mock_client)
 
         result = strategist._expand_query("test prompt")
-        assert result == ["query1", "query2", "query3"]
+        assert result == ["test prompt", "query1", "query2"]
         mock_client._call_api.assert_called_once()
 
     def test_expand_query_accepts_queries_object(self):
@@ -30,7 +30,7 @@ class TestContextStrategist:
         strategist = ContextStrategist(client=mock_client)
 
         result = strategist._expand_query("test prompt")
-        assert result == ["query1", "query2"]
+        assert result == ["test prompt", "query1", "query2"]
 
     def test_expand_query_filters_invalid_duplicates_and_limits_results(self):
         mock_client = MagicMock()
@@ -40,7 +40,23 @@ class TestContextStrategist:
         strategist = ContextStrategist(client=mock_client)
 
         result = strategist._expand_query("test prompt")
-        assert result == ["query1", "query2", "query3"]
+        assert result == ["test prompt", "query1", "query2"]
+
+    def test_expand_query_filters_invented_artifact_names(self):
+        mock_client = MagicMock()
+        mock_client._call_api.return_value = json.dumps(
+            ["User.authenticate", "password_regex", "login error handling"]
+        )
+        strategist = ContextStrategist(client=mock_client)
+
+        result = strategist._expand_query(
+            "The login page returns 500 when the password has a special character."
+        )
+
+        assert result == [
+            "The login page returns 500 when the password has a special character.",
+            "login error handling",
+        ]
 
     def test_expand_query_malformed_json(self):
         mock_client = MagicMock()
@@ -48,7 +64,7 @@ class TestContextStrategist:
         strategist = ContextStrategist(client=mock_client)
 
         result = strategist._expand_query("test prompt")
-        assert result == []
+        assert result == ["test prompt"]
 
     def test_expand_query_api_exception(self):
         mock_client = MagicMock()
@@ -56,7 +72,7 @@ class TestContextStrategist:
         strategist = ContextStrategist(client=mock_client)
 
         result = strategist._expand_query("test prompt")
-        assert result == []
+        assert result == ["test prompt"]
 
     def test_expand_query_non_list_response(self):
         mock_client = MagicMock()
@@ -64,7 +80,7 @@ class TestContextStrategist:
         strategist = ContextStrategist(client=mock_client)
 
         result = strategist._expand_query("test prompt")
-        assert result == []
+        assert result == ["test prompt"]
 
     @patch("app.agents.context_strategist.search_hybrid")
     def test_retrieve_happy_path(self, mock_search_hybrid):

--- a/tests/test_context_strategist.py
+++ b/tests/test_context_strategist.py
@@ -24,6 +24,24 @@ class TestContextStrategist:
         assert result == ["query1", "query2", "query3"]
         mock_client._call_api.assert_called_once()
 
+    def test_expand_query_accepts_queries_object(self):
+        mock_client = MagicMock()
+        mock_client._call_api.return_value = json.dumps({"queries": ["query1", "query2"]})
+        strategist = ContextStrategist(client=mock_client)
+
+        result = strategist._expand_query("test prompt")
+        assert result == ["query1", "query2"]
+
+    def test_expand_query_filters_invalid_duplicates_and_limits_results(self):
+        mock_client = MagicMock()
+        mock_client._call_api.return_value = json.dumps(
+            ["query1", "", " query1 ", 42, "query2", {"q": "bad"}, "query3", "query4"]
+        )
+        strategist = ContextStrategist(client=mock_client)
+
+        result = strategist._expand_query("test prompt")
+        assert result == ["query1", "query2", "query3"]
+
     def test_expand_query_malformed_json(self):
         mock_client = MagicMock()
         mock_client._call_api.return_value = "invalid json"

--- a/tests/test_expanded_prompt.py
+++ b/tests/test_expanded_prompt.py
@@ -1,5 +1,7 @@
-from app.compiler import compile_text
-from app.emitters import emit_expanded_prompt
+from pathlib import Path
+
+from app.compiler import compile_text, compile_text_v2
+from app.emitters import emit_expanded_prompt, emit_expanded_prompt_v2, emit_plan_v2
 
 
 def test_expanded_prompt_contains_input_and_example():
@@ -9,3 +11,47 @@ def test_expanded_prompt_contains_input_and_example():
     assert "Genişletilmiş İstem" in ep or "Expanded Prompt" in ep
     assert "Input" in ep or "Girdi" in ep
     assert ("Örnek çıktı formatı" in ep) or ("Example output format" in ep)
+
+
+def test_expanded_prompt_v2_surfaces_clarification_questions_without_diagnostics(monkeypatch):
+    monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+    ir2 = compile_text_v2("Optimize this API and make it better", offline_only=True)
+
+    ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
+
+    assert "Clarification Questions:" in ep
+    assert "Which metric or aspect should be optimized?" in ep
+    assert "Better in what sense" in ep
+
+
+def test_plan_v2_starts_with_policy_gate_for_high_risk_prompt():
+    ir2 = compile_text_v2("Analyze my stock portfolio allocation.", offline_only=True)
+
+    plan = emit_plan_v2(ir2)
+
+    first_line = plan.splitlines()[0]
+    assert "[policy]" in first_line
+    assert "human approval" in first_line.lower()
+
+
+def test_expanded_prompt_v2_includes_policy_summary_without_inventing_requirements(monkeypatch):
+    monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+    ir2 = compile_text_v2("Optimize this legal contract review workflow", offline_only=True)
+
+    ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
+
+    assert "Policy:" in ep
+    assert "human_approval_required" in ep
+    assert "forbidden_tools=" in ep
+    assert "Missing details will be filled" not in ep
+
+
+def test_prompt_templates_discourage_invented_project_details():
+    prompts_dir = Path("app/llm_engine/prompts")
+    query_expansion = (prompts_dir / "query_expansion.md").read_text(encoding="utf-8").lower()
+    worker_v1 = (prompts_dir / "worker_v1.md").read_text(encoding="utf-8").lower()
+
+    assert "do not invent filenames" in query_expansion
+    assert "do not invent functions" in query_expansion
+    assert "do not add requirements" in worker_v1
+    assert "mark assumptions explicitly" in worker_v1

--- a/tests/test_expanded_prompt.py
+++ b/tests/test_expanded_prompt.py
@@ -24,6 +24,26 @@ def test_expanded_prompt_v2_surfaces_clarification_questions_without_diagnostics
     assert "Better in what sense" in ep
 
 
+def test_inferred_coding_best_practices_are_optional_not_constraints(monkeypatch):
+    monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+    ir2 = compile_text_v2("Optimize this API and make it better", offline_only=True)
+
+    constraint_text = "\n".join(c.text for c in ir2.constraints)
+    assert "Include comprehensive error handling" not in constraint_text
+    assert "Include unit tests for the implementation" not in constraint_text
+    assert "Add documentation for public interfaces" not in constraint_text
+
+    suggestions = ir2.metadata.get("domain_suggestions") or []
+    suggestion_text = "\n".join(item["text"] for item in suggestions)
+    assert "Include unit tests for the implementation" in suggestion_text
+
+    ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
+    assert "Optional considerations:" in ep
+    assert "- Include unit tests for the implementation" in ep
+    constraints_line = next(line for line in ep.splitlines() if line.startswith("Constraints:"))
+    assert "Include unit tests for the implementation" not in constraints_line
+
+
 def test_plan_v2_starts_with_policy_gate_for_high_risk_prompt():
     ir2 = compile_text_v2("Analyze my stock portfolio allocation.", offline_only=True)
 
@@ -34,6 +54,19 @@ def test_plan_v2_starts_with_policy_gate_for_high_risk_prompt():
     assert "human approval" in first_line.lower()
 
 
+def test_plan_v2_explains_policy_gate_reason_plainly():
+    ir2 = compile_text_v2(
+        "Review this contract for legal risks before I sign it.", offline_only=True
+    )
+
+    plan = emit_plan_v2(ir2)
+
+    assert "Approval required because" in plan
+    assert "high-risk domain: legal" in plan
+    assert "Apply sanitization:" in plan
+    assert "no_professional_advice" in plan
+
+
 def test_expanded_prompt_v2_includes_policy_summary_without_inventing_requirements(monkeypatch):
     monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
     ir2 = compile_text_v2("Optimize this legal contract review workflow", offline_only=True)
@@ -41,6 +74,9 @@ def test_expanded_prompt_v2_includes_policy_summary_without_inventing_requiremen
     ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
 
     assert "Policy:" in ep
+    assert "Policy Checks:" in ep
+    assert "high-risk domain: legal" in ep
+    assert "Apply sanitization:" in ep
     assert "human_approval_required" in ep
     assert "forbidden_tools=" in ep
     assert "Missing details will be filled" not in ep
@@ -55,3 +91,5 @@ def test_prompt_templates_discourage_invented_project_details():
     assert "do not invent functions" in query_expansion
     assert "do not add requirements" in worker_v1
     assert "mark assumptions explicitly" in worker_v1
+    assert "use `requests` and `beautifulsoup4`" not in worker_v1
+    assert "implement retry/backoff" not in worker_v1

--- a/tests/test_policy_handler.py
+++ b/tests/test_policy_handler.py
@@ -112,6 +112,7 @@ def test_policy_domain_tools_financial():
     assert "calculator" in ir2.policy.allowed_tools
     assert "web_scraper" in ir2.policy.forbidden_tools
     assert "audit_trail" in ir2.policy.sanitization_rules
+    assert "no_professional_advice" in ir2.policy.sanitization_rules
 
 
 def test_policy_domain_tools_health():
@@ -121,6 +122,7 @@ def test_policy_domain_tools_health():
 
     assert "health" in ir2.policy.risk_domains
     assert "hipaa_filter" in ir2.policy.sanitization_rules
+    assert "no_professional_advice" in ir2.policy.sanitization_rules
     assert "secret_access" in ir2.policy.forbidden_tools
 
 

--- a/tests/test_policy_handler.py
+++ b/tests/test_policy_handler.py
@@ -124,6 +124,30 @@ def test_policy_domain_tools_health():
     assert "secret_access" in ir2.policy.forbidden_tools
 
 
+def test_policy_domain_tools_legal():
+    ir2 = compile_text_v2("Review this contract for legal risks before I sign it.")
+
+    assert "legal" in ir2.policy.risk_domains
+    assert ir2.policy.risk_level == "high"
+    assert "reference_lookup" in ir2.policy.allowed_tools
+    assert "secret_access" in ir2.policy.forbidden_tools
+    assert "external_share" in ir2.policy.forbidden_tools
+    assert "jurisdiction_check" in ir2.policy.sanitization_rules
+    assert "no_professional_advice" in ir2.policy.sanitization_rules
+
+
+def test_policy_reasons_explain_escalation_sources():
+    ir2 = compile_text_v2(
+        "Debug this legal contract parser using logs from C:\\app\\logs and email memo@example.com."
+    )
+
+    reasons = ir2.metadata.get("policy_reasons") or []
+    assert "high_risk_domain:legal" in reasons
+    assert "file_or_system_request" in reasons
+    assert "debug_request" in reasons
+    assert "pii_detected:email" in reasons
+
+
 def test_pii_detects_ssn():
     from app.heuristics import detect_pii
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -32,6 +32,30 @@ def test_expand_query(strategist):
     assert len(queries) == 2
 
 
+def test_expand_query_filters_invented_artifact_names(mock_db):
+    class ArtifactLLMClient:
+        def expand_query_intent(self, text):
+            return {
+                "queries": [
+                    "User.authenticate",
+                    "password_regex",
+                    "login error handling",
+                    text,
+                ]
+            }
+
+    strategist = ContextStrategist(mock_db, ArtifactLLMClient())
+
+    queries = strategist.expand_query(
+        "The login page returns 500 when the password has a special character."
+    )
+
+    assert queries == [
+        "The login page returns 500 when the password has a special character.",
+        "login error handling",
+    ]
+
+
 def test_retrieve_rrf(strategist, mock_db):
     # Setup mock returns structure for multiple calls if needed
     # But for now the simple return_value is enough


### PR DESCRIPTION
## Summary
- Keep inferred coding best practices out of hard constraints and surface them as optional considerations.
- Add plain-English policy checks for approval reasons, forbidden tools, sanitization, and professional-advice boundaries.
- Ground ContextStrategist query expansion by preserving the original query and filtering invented artifact-like names.
- Tighten LLM prompt template examples against invented libraries, files, functions, endpoints, and implementation details.

## Impact
Compiled outputs should be more useful without hallucinating requirements. Risky or ambiguous requests now produce clearer policy gates and safer, more grounded retrieval queries.

## Validation
- `python -m pytest tests/test_conservative_mode.py tests/test_expanded_prompt.py tests/test_policy_handler.py tests/test_context_strategist.py tests/test_rag.py tests/test_compile_policy_api.py -q` — 72 passed
- `python -m ruff check app\heuristics\handlers\domain_expert.py app\heuristics\handlers\policy.py app\emitters.py app\agents\context_strategist.py app\llm_engine\rag.py tests\test_expanded_prompt.py tests\test_policy_handler.py tests\test_context_strategist.py tests\test_rag.py` — all checks passed