### PR TITLE
[codex] Polish prompt compiler pages

### DIFF
--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -67,16 +67,16 @@ export default function AgentGenerator() {
   };
 
   return (
-    <main className="flex h-full min-h-0 flex-col items-center justify-center p-4 md:p-8 relative overflow-hidden bg-[#050505]">
+    <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden bg-[#050505] p-3 py-4 sm:p-4 md:h-full md:min-h-0 md:justify-center md:overflow-hidden md:p-8">
       {/* Ambient Background */}
       <div className="absolute top-[-10%] left-[-10%] w-[40vw] h-[40vw] rounded-full bg-green-600/10 blur-[120px] pointer-events-none" />
       <div className="absolute bottom-[-10%] right-[-10%] w-[40vw] h-[40vw] rounded-full bg-blue-600/10 blur-[120px] pointer-events-none" />
 
       {/* Main Container */}
-      <div className="glass w-full max-w-7xl h-full max-h-[90vh] rounded-3xl flex flex-col shadow-2xl overflow-hidden animate-fade-in ring-1 ring-white/10 bg-black/40 backdrop-blur-xl">
+      <div className="glass flex min-h-[calc(100vh-2rem)] w-full max-w-7xl flex-col overflow-hidden rounded-2xl bg-black/40 shadow-2xl ring-1 ring-white/10 backdrop-blur-xl animate-fade-in md:h-full md:max-h-[90vh] md:rounded-3xl">
 
         {/* Header */}
-        <header className="border-b border-white/5 bg-black/20 p-4 flex items-center justify-between backdrop-blur-md">
+        <header className="flex flex-col gap-3 border-b border-white/5 bg-black/20 p-4 backdrop-blur-md sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-3">
               <div className="h-9 w-9 bg-gradient-to-br from-green-600 to-emerald-600 rounded-xl flex items-center justify-center text-white shadow-lg shadow-green-500/20">
@@ -96,9 +96,9 @@ export default function AgentGenerator() {
           </div>
         </header>
 
-        <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
+        <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
           {/* Left Panel: Input */}
-          <div className="w-full md:w-[35%] min-h-0 p-5 flex flex-col gap-5 border-r border-white/5 bg-black/10 overflow-hidden">
+          <div className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/10 p-4 sm:p-5 md:min-h-0 md:w-[35%] md:border-b-0 md:border-r md:overflow-y-auto">
             <div className="flex flex-col gap-2">
               <label htmlFor="agent-description" className="text-sm font-medium text-zinc-300">Agent Description</label>
               <p id="agent-description-help" className="text-xs text-zinc-500">
@@ -111,7 +111,7 @@ export default function AgentGenerator() {
                 id="agent-description"
                 aria-label="Agent Description"
                 aria-describedby="agent-description-help"
-                className="flex-1 min-h-[240px] md:min-h-0 w-full bg-black/20 p-5 rounded-2xl border border-white/10 resize-none focus:outline-none focus:ring-1 focus:ring-green-500/50 font-mono text-sm leading-relaxed text-zinc-200 placeholder-zinc-600 transition-all shadow-inner"
+                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-0"
                 placeholder="e.g., 'I need an agent that reviews React code for performance bottlenecks' or 'A creative writer for sci-fi stories'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -127,7 +127,7 @@ export default function AgentGenerator() {
               />
             </div>
 
-            <div className="flex items-center gap-3 bg-white/5 p-3 rounded-xl border border-white/5">
+            <div className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3">
               <button
                 type="button"
                 role="switch"
@@ -138,13 +138,13 @@ export default function AgentGenerator() {
               >
                 <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform ${multiAgent ? 'translate-x-4' : 'translate-x-0'}`} />
               </button>
-              <div className="flex flex-col">
+              <div className="flex min-w-0 flex-col">
                 <span className="text-xs font-medium text-zinc-200">Multi-Agent Swarm</span>
                 <span className="text-xs text-zinc-500">Decompose into 2-4 specialized agents</span>
               </div>
             </div>
 
-            <div className="flex items-center gap-3 bg-white/5 p-3 rounded-xl border border-white/5">
+            <div className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3">
               <button
                 type="button"
                 role="switch"
@@ -155,7 +155,7 @@ export default function AgentGenerator() {
               >
                 <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform ${includeExampleCode ? 'translate-x-4' : 'translate-x-0'}`} />
               </button>
-              <div className="flex flex-col">
+              <div className="flex min-w-0 flex-col">
                 <span className="text-xs font-medium text-zinc-200">Example Code?</span>
                 <span className="text-xs text-zinc-500">
                   Yes = include example code, No = keep it code-free to avoid confusion
@@ -199,7 +199,7 @@ export default function AgentGenerator() {
               {loading ? (
                 <span className="animate-pulse">Architecting...</span>
               ) : (
-                <>Generate {multiAgent ? 'Swarm' : 'Agent'} <span className="group-hover:translate-x-0.5 transition-transform">→</span> <kbd className="hidden md:inline-block ml-2 text-[10px] font-mono opacity-50 border border-white/20 rounded px-1.5 py-0.5 bg-white/5">Ctrl/⌘ Enter</kbd></>
+                <>Generate {multiAgent ? 'Swarm' : 'Agent'} <span className="transition-transform group-hover:translate-x-0.5">{"->"}</span> <kbd className="ml-2 hidden rounded border border-white/20 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] opacity-50 md:inline-block">Ctrl/Cmd Enter</kbd></>
               )}
             </button>
 
@@ -216,7 +216,7 @@ export default function AgentGenerator() {
           </div>
 
           {/* Right Panel: Output */}
-          <div className="w-full md:w-[65%] min-h-0 flex flex-col bg-black/20 relative">
+          <div className="relative flex min-h-[360px] w-full flex-col bg-black/20 md:min-h-0 md:w-[65%]">
             {result ? (
               <div className="flex-1 min-h-0 p-0 overflow-hidden relative group bg-black/20 flex flex-col">
                 <div className="flex items-center justify-between border-b border-white/5 px-6 py-3">
@@ -249,7 +249,7 @@ export default function AgentGenerator() {
                 </div>
               </div>
             ) : (
-              <div className="flex-1 flex flex-col items-center justify-center text-zinc-600 gap-6 p-10 text-center opacity-60">
+              <div className="flex flex-1 flex-col items-center justify-center gap-5 p-6 text-center text-zinc-600 opacity-75 sm:gap-6 sm:p-10">
                 <div className="relative group">
                   <div className="absolute inset-0 bg-green-500/30 blur-[40px] rounded-full group-hover:bg-green-500/50 transition-all duration-700" />
                   <div className="relative w-24 h-24 rounded-2xl bg-gradient-to-br from-zinc-800 to-black border border-white/10 flex items-center justify-center shadow-2xl skew-y-3 group-hover:skew-y-0 transition-transform duration-500">
@@ -259,7 +259,7 @@ export default function AgentGenerator() {
                 <div className="max-w-xs space-y-2">
                   <h3 className="text-zinc-200 font-medium tracking-wide">Agent Blueprint</h3>
                   <p className="text-sm text-zinc-500 mb-4">
-                    Enter a description to generate a professional, structured system prompt for your AI agent.
+                    Describe the role on the left, choose single or swarm mode, then generate and copy the system prompt.
                   </p>
                   <button
                     type="button"

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -135,21 +135,21 @@ export default function BenchmarkPage() {
   }, [benchmarkResult]);
 
   return (
-    <main className="relative flex h-screen flex-col items-center justify-center overflow-hidden bg-[#050505] p-4 md:p-8">
+    <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden bg-[#050505] p-3 py-4 sm:p-4 md:h-screen md:justify-center md:overflow-hidden md:p-8">
       <div className="pointer-events-none absolute left-[-20%] top-[-20%] h-[50vw] w-[50vw] rounded-full bg-amber-600/10 blur-[150px]" />
       <div className="pointer-events-none absolute bottom-[-20%] right-[-20%] h-[50vw] w-[50vw] rounded-full bg-orange-600/10 blur-[150px]" />
 
-      <div className="glass animate-fade-in z-10 flex h-full max-h-[95vh] w-full max-w-7xl flex-col overflow-hidden rounded-3xl shadow-2xl ring-1 ring-white/10">
-        <header className="flex shrink-0 items-center justify-between border-b border-white/5 bg-black/40 p-4 backdrop-blur-md">
+      <div className="glass z-10 flex min-h-[calc(100vh-2rem)] w-full max-w-7xl flex-col overflow-hidden rounded-2xl shadow-2xl ring-1 ring-white/10 animate-fade-in md:h-full md:max-h-[95vh] md:rounded-3xl">
+        <header className="flex shrink-0 flex-col gap-3 border-b border-white/5 bg-black/40 p-4 backdrop-blur-md lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-4">
               <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-amber-600 to-orange-600 text-xl font-bold text-white shadow-lg shadow-amber-500/20">
                 B
               </div>
               <div>
-                <h1 className="text-xl font-bold tracking-tight text-white/90">Battle Arena</h1>
+                <h1 className="text-xl font-bold tracking-tight text-white/90">Prompt Benchmark</h1>
                 <div className="font-mono text-xs uppercase tracking-wider text-zinc-500">
-                  Raw vs Compiled Benchmark
+                  Compare raw vs compiled output
                 </div>
               </div>
             </div>
@@ -159,8 +159,8 @@ export default function BenchmarkPage() {
             />
           </div>
 
-          <div className="flex items-center gap-4">
-            <div className="rounded-lg border border-white/5 bg-black/30 p-1">
+          <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center lg:w-auto">
+            <div className="w-full rounded-lg border border-white/5 bg-black/30 p-1 sm:w-auto">
               <label
                 htmlFor="benchmark-model"
                 className="block px-2 pb-1 pt-1 font-mono text-xs uppercase tracking-wider text-zinc-500"
@@ -171,7 +171,7 @@ export default function BenchmarkPage() {
                 id="benchmark-model"
                 value={selectedModel}
                 onChange={(event) => setSelectedModel(event.target.value)}
-                className="min-w-[240px] cursor-pointer rounded border-none bg-[#1a1a1a] px-2 py-1.5 text-xs text-zinc-200 transition-colors focus:outline-none"
+                className="w-full cursor-pointer rounded border-none bg-[#1a1a1a] px-2 py-1.5 text-xs text-zinc-200 transition-colors focus:outline-none sm:min-w-[240px]"
               >
                 <option value="mock" className="bg-[#1a1a1a] text-zinc-200">
                   Mock Engine [local]
@@ -202,7 +202,7 @@ export default function BenchmarkPage() {
             </div>
 
             <div
-              className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-bold ${
+              className={`flex items-center justify-center gap-2 rounded-full border px-3 py-1.5 text-xs font-bold sm:justify-start ${
                 errorMessage
                   ? "border-red-500/30 bg-red-500/10 text-red-300"
                   : "border-amber-500/30 bg-amber-500/10 text-amber-400"
@@ -213,15 +213,15 @@ export default function BenchmarkPage() {
           </div>
         </header>
 
-        <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
-          <div className="z-20 flex w-full md:w-[350px] md:shrink-0 flex-col gap-5 border-b md:border-b-0 md:border-r border-white/5 bg-black/20 p-5">
+        <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
+          <div className="z-20 flex w-full flex-col gap-4 border-b border-white/5 bg-black/20 p-4 sm:p-5 md:w-[350px] md:shrink-0 md:border-b-0 md:border-r">
             <div className="group relative flex-1">
               <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-500/5 to-orange-500/5 opacity-0 transition-opacity duration-500 group-focus-within:opacity-100" />
               <textarea
                 id="benchmark-prompt"
                 aria-label="Benchmark prompt input"
-                className="h-full min-h-[180px] w-full resize-none rounded-xl border border-white/10 bg-black/30 p-4 font-mono text-sm leading-relaxed text-zinc-300 shadow-inner transition-all placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
-                placeholder={"Enter a prompt to start the battle...\n\ne.g. 'Write a Python script to scrape data'"}
+                className="h-full min-h-[160px] w-full resize-none rounded-xl border border-white/10 bg-black/30 p-4 font-mono text-sm leading-relaxed text-zinc-300 shadow-inner transition-all placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
+                placeholder={"Enter a prompt to benchmark...\n\ne.g. 'Write a Python script to scrape data'"}
                 value={prompt}
                 onChange={(event) => setPrompt(event.target.value)}
               onKeyDown={(e) => {
@@ -239,10 +239,10 @@ export default function BenchmarkPage() {
               type="button"
               onClick={handleBenchmark}
               disabled={loading || !prompt.trim()}
-              title={!prompt.trim() ? "Enter a prompt first to start battle" : "Start Battle"}
+              title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
               className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
             >
-            {loading ? <span className="animate-pulse">FIGHTING...</span> : <>START BATTLE <kbd className="hidden md:inline-block ml-2 text-[10px] font-mono opacity-50 border border-white/20 rounded px-1.5 py-0.5 bg-white/5">Ctrl/⌘ Enter</kbd></>}
+            {loading ? <span className="animate-pulse">Running...</span> : <>Run Benchmark <kbd className="ml-2 hidden rounded border border-white/20 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] opacity-50 md:inline-block">Ctrl/Cmd Enter</kbd></>}
             </button>
 
             {errorMessage && (
@@ -315,17 +315,17 @@ export default function BenchmarkPage() {
                   <p className="text-sm text-zinc-400 mb-4">
                     {errorMessage
                       ? errorMessage
-                      : "Paste a prompt on the left, pick a model, then hit Start Battle to compare raw vs compiled output."}
+                      : "Paste a prompt on the left, pick a model, then run a benchmark to compare raw vs compiled output."}
                   </p>
                   {!errorMessage && (
                     <button
                       type="button"
                       onClick={handleBenchmark}
                       disabled={loading || !prompt.trim()}
-                      title={!prompt.trim() ? "Enter a prompt first to start battle" : "Start Battle"}
+                      title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
                       className="mt-6 mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 flex items-center justify-center gap-2 bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-500 hover:to-orange-500 shadow-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
                     >
-                      Start Battle
+                      Run Benchmark
                     </button>
                   )}
                 </div>

--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -47,8 +47,8 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
     const connectionBadge = getConnectionBadge(isConnected);
 
     return (
-        <div className="flex flex-col gap-4 border-t border-white/5 pt-4 mt-4">
-            <h3 className="text-[10px] font-bold text-zinc-500 uppercase tracking-widest flex items-center justify-between gap-2">
+        <div className="mt-2 flex shrink-0 flex-col gap-3 border-t border-white/5 pt-3">
+            <h3 className="flex items-center justify-between gap-2 text-[10px] font-bold uppercase tracking-widest text-zinc-500">
                 <div className="flex items-center gap-2">
                     <span>Context Manager</span>
                     <span className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 text-[9px]">RAG</span>
@@ -61,7 +61,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
             <ContextSuggestions suggestions={suggestions} onInsertContext={onInsertContext} />
 
             {indexStats && indexStats.docs > 0 && (
-                <div className="flex gap-4 px-3 py-2 bg-white/5 rounded-lg border border-white/5">
+                <div className="grid grid-cols-3 gap-2 rounded-lg border border-white/5 bg-white/5 px-3 py-2">
                     <div className="flex flex-col">
                         <span className="text-[9px] text-zinc-500 uppercase">Documents</span>
                         <span className="text-xs font-mono text-zinc-300">{indexStats.docs}</span>
@@ -80,7 +80,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
             <FileUploadZone ingesting={ingesting} uploadProgress={uploadProgress} onUploadFiles={uploadFiles} />
 
             {status && (
-                <div aria-live="polite" className={`text-[10px] px-2 py-1.5 rounded-lg ${getStatusTone(status)}`}>
+                <div aria-live="polite" className={`rounded-lg px-2 py-1 text-[10px] ${getStatusTone(status)}`}>
                     {status}
                 </div>
             )}
@@ -93,7 +93,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                     <input
                         type="text"
                         aria-label="Path to file or folder..."
-                        className="w-full bg-black/30 p-2.5 rounded-lg text-xs border border-white/5 focus:border-blue-500/30 focus:outline-none transition-colors placeholder-zinc-600 font-mono"
+                        className="w-full rounded-lg border border-white/5 bg-black/30 p-2 text-xs font-mono transition-colors placeholder-zinc-600 focus:border-blue-500/30 focus:outline-none"
                         placeholder="Path to file or folder..."
                         value={filePath}
                         onChange={(e) => setFilePath(e.target.value)}
@@ -103,7 +103,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                         onClick={() => void ingestPath(filePath)}
                         disabled={ingesting || !filePath}
                         title={!filePath ? "Enter a file path first to ingest" : "Ingest Path"}
-                        className="w-full py-2 bg-zinc-800/50 hover:bg-zinc-700/50 text-xs font-medium text-zinc-300 rounded-lg disabled:opacity-50 transition-colors border border-white/5 flex items-center justify-center gap-2"
+                        className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/5 bg-zinc-800/50 py-2 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700/50 disabled:opacity-50"
                     >
                         {ingesting ? <span className="animate-pulse">Indexing...</span> : "Ingest Path"}
                     </button>

--- a/web/app/components/context/FileUploadZone.tsx
+++ b/web/app/components/context/FileUploadZone.tsx
@@ -44,7 +44,7 @@ export default function FileUploadZone({ ingesting, uploadProgress, onUploadFile
             onDragOver={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setIsDragging(true); }}
             onDragLeave={(e: DragEvent<HTMLDivElement>) => { e.preventDefault(); setIsDragging(false); }}
             className={`
-                relative flex flex-col items-center justify-center gap-2 p-4
+                relative flex flex-col items-center justify-center gap-1.5 p-3
                 border-2 border-dashed rounded-xl
                 transition-all duration-200
                 ${isDragging ? "border-blue-500 bg-blue-500/10 scale-[1.02]" : "border-white/10 bg-white/[0.02]"}
@@ -67,8 +67,8 @@ export default function FileUploadZone({ ingesting, uploadProgress, onUploadFile
                 <UploadProgressCard uploadProgress={uploadProgress} />
             ) : (
                 <>
-                    <div className={`text-2xl ${isDragging ? "scale-110" : ""} transition-transform`}>Files</div>
-                    <div className="flex gap-2">
+                    <div className={`text-sm font-semibold text-zinc-300 ${isDragging ? "scale-105" : ""} transition-transform`}>Add context</div>
+                    <div className="flex flex-wrap justify-center gap-2">
                         <button type="button" onClick={() => fileInputRef.current?.click()} className="text-xs text-blue-400 font-medium hover:text-blue-300 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded px-1">
                             Upload Files
                         </button>
@@ -77,7 +77,7 @@ export default function FileUploadZone({ ingesting, uploadProgress, onUploadFile
                             Upload Folder
                         </button>
                     </div>
-                    <div className="text-[10px] text-zinc-600 mt-1">Or drag and drop project context</div>
+                    <div className="mt-0.5 text-[10px] text-zinc-600">Drag and drop files or folders</div>
                 </>
             )}
         </div>

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -26,7 +26,7 @@ export default function RagSearchPanel({
                     <input
                         type="text"
                         aria-label="Search context..."
-                        className="w-full bg-black/30 p-2.5 pr-8 rounded-lg text-xs border border-white/5 focus:border-blue-500/30 focus:outline-none transition-colors placeholder-zinc-600 font-mono"
+                        className="w-full rounded-lg border border-white/5 bg-black/30 p-2 pr-8 font-mono text-xs transition-colors placeholder-zinc-600 focus:border-blue-500/30 focus:outline-none"
                         placeholder="Search context..."
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
@@ -49,13 +49,13 @@ export default function RagSearchPanel({
                     onClick={onRunSearch}
                     disabled={searching || !query.trim()}
                     title={!query.trim() ? "Enter a query first to search" : "Search"}
-                    className="px-3 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-lg text-xs hover:bg-blue-500/20 transition-all font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
+                    className="rounded-lg border border-blue-500/20 bg-blue-500/10 px-3 text-xs font-medium text-blue-400 transition-all hover:bg-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 disabled:opacity-50"
                 >
                     Search
                 </button>
             </div>
 
-            <div className="flex flex-col gap-2 max-h-[180px] overflow-y-auto pr-1 custom-scrollbar">
+            <div className="custom-scrollbar flex max-h-32 flex-col gap-2 overflow-y-auto pr-1 sm:max-h-40">
                 {!searching && query && results.length === 0 && (
                     <div className="text-[10px] text-zinc-500 text-center py-4 bg-white/[0.02] rounded-lg border border-dashed border-white/5">
                         No results found for &quot;{query}&quot;

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -75,16 +75,16 @@ export default function OfflinePage() {
     }, [handleGenerate, lastRequest]);
 
     return (
-        <main className="flex h-screen flex-col items-center justify-center p-4 md:p-8 relative overflow-hidden">
+        <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden p-3 py-4 sm:p-4 md:h-screen md:justify-center md:overflow-hidden md:p-8">
             {/* Darker Ambient Background for Offline Feel */}
             <div className="absolute top-[-10%] left-[-10%] w-[40vw] h-[40vw] rounded-full bg-zinc-600/10 blur-[120px] pointer-events-none" />
             <div className="absolute bottom-[-10%] right-[-10%] w-[40vw] h-[40vw] rounded-full bg-slate-600/10 blur-[120px] pointer-events-none" />
 
             {/* Floating Main Container */}
-            <div className="glass w-full max-w-7xl h-full max-h-[90vh] rounded-3xl flex flex-col shadow-2xl overflow-hidden animate-fade-in ring-1 ring-white/10">
+            <div className="glass flex min-h-[calc(100vh-2rem)] w-full max-w-7xl flex-col overflow-hidden rounded-2xl shadow-2xl ring-1 ring-white/10 animate-fade-in md:h-full md:max-h-[90vh] md:rounded-3xl">
 
                 {/* Header */}
-                <header className="border-b border-white/5 bg-black/40 p-4 flex items-center justify-between backdrop-blur-md">
+                <header className="flex flex-col gap-3 border-b border-white/5 bg-black/40 p-4 backdrop-blur-md sm:flex-row sm:items-center sm:justify-between">
                     <div className="flex items-center gap-3">
                         <div className="flex items-center gap-3">
                             <div className="h-9 w-9 bg-zinc-700 rounded-xl flex items-center justify-center text-white shadow-lg"><WifiOff size={18} aria-hidden="true" /></div>
@@ -99,14 +99,14 @@ export default function OfflinePage() {
                         />
                     </div>
 
-                    <div className="flex items-center gap-4">
+                    <div className="flex flex-wrap items-center gap-2 sm:gap-3">
                         {/* Forced Offline Badge */}
                         <div className="px-3 py-1.5 rounded-full text-xs font-medium border flex items-center gap-2 bg-zinc-800/50 border-zinc-700 text-zinc-400">
                             <div className="w-1.5 h-1.5 rounded-full bg-zinc-500" />
                             OFFLINE MODE
                         </div>
 
-                        <div className="text-xs font-mono text-zinc-500 bg-black/30 px-3 py-1.5 rounded-lg border border-white/5 min-w-[100px] text-center">
+                        <div className="min-w-[88px] rounded-lg border border-white/5 bg-black/30 px-3 py-1.5 text-center font-mono text-xs text-zinc-500">
                             {status}
                         </div>
                         {!!lastError && !loading && (
@@ -121,15 +121,15 @@ export default function OfflinePage() {
                     </div>
                 </header>
 
-                <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
+                <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
                     {/* Left Panel: Input */}
-                    <div className="w-full md:w-[35%] p-5 flex flex-col gap-5 border-r border-white/5 bg-black/20">
+                    <div className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/20 p-4 sm:p-5 md:min-h-0 md:w-[35%] md:border-b-0 md:border-r md:overflow-y-auto">
 
                         <div className="flex-1 flex flex-col relative group">
                             <textarea
                                 id="offline-prompt"
                                 aria-label="Offline prompt input"
-                                className="flex-1 w-full bg-black/20 p-5 rounded-2xl border border-white/10 resize-none focus:outline-none focus:ring-1 focus:ring-zinc-500/50 font-mono text-sm leading-relaxed text-zinc-200 placeholder-zinc-600 transition-all shadow-inner"
+                                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-500/50 sm:min-h-44 md:min-h-0"
                                 placeholder="Enter prompt (offline heuristics active)..."
                                 value={prompt}
                                 onChange={(e) => setPrompt(e.target.value)}
@@ -163,7 +163,7 @@ export default function OfflinePage() {
                                                 {"->"}
                                             </span>{" "}
                                             <kbd className="hidden md:inline-block ml-2 text-[10px] font-mono opacity-50 border border-white/20 rounded px-1.5 py-0.5 bg-white/5">
-                                                Ctrl/Cmd Enter
+                                                    Ctrl/Cmd Enter
                                             </kbd>
                                         </>
                                     )}
@@ -175,16 +175,16 @@ export default function OfflinePage() {
                     </div>
 
                     {/* Right Panel: Output */}
-                    <div className="w-full md:w-[65%] flex flex-col bg-black/30 relative">
+                    <div className="relative flex min-h-[360px] w-full flex-col bg-black/30 md:min-h-0 md:w-[65%]">
                         {result ? (
                             <>
-                                <div className="flex border-b border-white/5 px-4 pt-4 gap-2 overflow-x-auto no-scrollbar">
+                                <div className="flex gap-1 overflow-x-auto scroll-smooth border-b border-white/5 px-4 pt-4 pb-1" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
                                     {(["system", "user", "plan", "expanded", "json"] as const).map((tab) => (
                                         <button
                                             type="button"
                                             key={tab}
                                             onClick={() => setActiveTab(tab)}
-                                            className={`px-4 py-2 text-[13px] font-medium rounded-t-lg transition-all relative whitespace-nowrap ${activeTab === tab
+                                            className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 sm:px-4 ${activeTab === tab
                                                 ? "text-white bg-white/5 border-t border-x border-white/5"
                                                 : "text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
                                                 }`}
@@ -234,11 +234,11 @@ export default function OfflinePage() {
                                 </div>
                             </>
                         ) : (
-                            <div className="flex-1 flex flex-col items-center justify-center text-zinc-600 gap-6 p-10 text-center opacity-60">
+                            <div className="flex flex-1 flex-col items-center justify-center gap-5 p-6 text-center text-zinc-600 opacity-75 sm:gap-6 sm:p-10">
                                 <WifiOff size={56} strokeWidth={1.25} aria-hidden="true" className="text-zinc-500/50" />
                                 <div className="max-w-xs space-y-2">
                                     <h3 className="text-zinc-200 font-medium tracking-wide">Offline Mode</h3>
-                                    <p className="text-sm text-zinc-500">Fast, local heuristic compilation without LLM calls.</p>
+                                    <p className="text-sm text-zinc-500">Paste a prompt on the left, run heuristics, then inspect or copy the local compiled output.</p>
                                 </div>
                             </div>
                         )}

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -162,14 +162,14 @@ export default function OptimizerPage() {
     };
 
     return (
-        <main className="flex h-screen flex-col items-center justify-center p-4 md:p-8 relative overflow-hidden">
+        <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden p-3 py-4 sm:p-4 md:h-screen md:justify-center md:overflow-hidden md:p-8">
             {/* Ambient Background Orbs */}
             <div className="absolute top-[-10%] left-[-10%] w-[40vw] h-[40vw] rounded-full bg-emerald-600/10 blur-[120px] pointer-events-none" />
             <div className="absolute bottom-[-10%] right-[-10%] w-[40vw] h-[40vw] rounded-full bg-teal-600/10 blur-[120px] pointer-events-none" />
 
             {/* Floating Main Container */}
-            <div className="glass w-full max-w-7xl h-full max-h-[90vh] rounded-3xl flex flex-col shadow-2xl overflow-hidden animate-fade-in ring-1 ring-white/10">
-            <header className="border-b border-white/5 bg-black/20 p-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between backdrop-blur-md">
+            <div className="glass flex min-h-[calc(100vh-2rem)] w-full max-w-7xl flex-col overflow-hidden rounded-2xl shadow-2xl ring-1 ring-white/10 animate-fade-in md:h-full md:max-h-[90vh] md:rounded-3xl">
+            <header className="flex flex-col gap-3 border-b border-white/5 bg-black/20 p-4 backdrop-blur-md lg:flex-row lg:items-center lg:justify-between">
                 <div className="flex items-center gap-3">
                     <div className="h-9 w-9 bg-gradient-to-br from-emerald-600 to-teal-600 rounded-xl flex items-center justify-center text-white shadow-lg shadow-emerald-500/20">
                         <Sparkles size={18} aria-hidden="true" />
@@ -177,7 +177,7 @@ export default function OptimizerPage() {
                     <div>
                         <h1 className="font-semibold text-lg tracking-tight text-white">Token Optimizer</h1>
                         <div className="text-xs text-zinc-400 font-mono tracking-wider uppercase opacity-70">
-                            Compress safely • Compare cost
+                            Compress safely / Compare cost
                         </div>
                     </div>
                     <InfoButton
@@ -186,7 +186,7 @@ export default function OptimizerPage() {
                     />
                 </div>
 
-                <div className="flex flex-col gap-3 rounded-lg border border-white/10 bg-zinc-950/40 p-3 sm:flex-row sm:items-center">
+                <div className="flex w-full flex-col gap-3 rounded-lg border border-white/10 bg-zinc-950/50 p-3 sm:flex-row sm:items-center lg:w-auto">
                     <div className="flex min-w-40 flex-col gap-1">
                         <label htmlFor="max-tokens" className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
                             Max Tokens
@@ -199,7 +199,7 @@ export default function OptimizerPage() {
                             step="100"
                             value={maxTokens}
                             onChange={(e) => setMaxTokens(Number.parseInt(e.target.value, 10))}
-                            className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-zinc-700 accent-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+                            className="h-1 w-full cursor-pointer appearance-none rounded-lg bg-zinc-600 accent-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
                         />
                         <span className="text-right font-mono text-xs text-emerald-300">{maxTokens}</span>
                     </div>
@@ -209,13 +209,13 @@ export default function OptimizerPage() {
                         onClick={handleOptimize}
                         disabled={loading || !input.trim()}
                         title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
-                        className="rounded-lg bg-emerald-600 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-emerald-950/30 transition-colors hover:bg-emerald-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                        className="w-full rounded-lg bg-emerald-600 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-emerald-950/30 transition-colors hover:bg-emerald-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 sm:w-auto"
                     >
                         {loading ? "Analyzing..." : (
                             <>
                                 Analyze cost
                                 <kbd className="ml-2 hidden rounded border border-white/20 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] opacity-60 md:inline-block">
-                                    Ctrl/⌘ Enter
+                                    Ctrl/Cmd Enter
                                 </kbd>
                             </>
                         )}
@@ -223,13 +223,13 @@ export default function OptimizerPage() {
                 </div>
             </header>
 
-            <div className="flex-1 min-h-0 overflow-y-auto p-4 md:p-6 flex flex-col gap-5">
+            <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-4 md:min-h-0 md:p-6">
             <div className="grid min-h-[50vh] grid-cols-1 gap-5 lg:grid-cols-2">
                 <section className="flex min-h-80 flex-col gap-2">
                     <label htmlFor="original-prompt" className="ml-1 text-xs font-bold uppercase tracking-wider text-zinc-500">
                         Original Prompt
                     </label>
-                    <div className="min-h-0 flex-1 rounded-lg border border-white/10 bg-zinc-950/30 p-4 transition-colors focus-within:border-emerald-500/40">
+                    <div className="min-h-0 flex-1 rounded-lg border border-white/10 bg-zinc-950/50 p-4 transition-colors focus-within:border-emerald-500/40">
                         <textarea
                             id="original-prompt"
                             aria-label="Original Prompt"
@@ -265,7 +265,7 @@ export default function OptimizerPage() {
                             </button>
                         )}
                     </div>
-                    <div className="min-h-0 flex-1 rounded-lg border border-emerald-500/20 bg-emerald-950/10 p-4">
+                    <div className="min-h-0 flex-1 rounded-lg border border-emerald-500/25 bg-emerald-950/20 p-4">
                         {output ? (
                             <textarea
                                 id="optimized-result"

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Code2 } from "lucide-react";
 import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
@@ -100,7 +99,7 @@ export default function Home() {
   };
 
   return (
-    <main className="flex h-screen flex-col items-center justify-center p-4 md:p-8 relative overflow-hidden">
+    <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden p-3 py-4 sm:p-4 md:h-screen md:justify-center md:overflow-hidden md:p-8">
 
       {/* Security Alert Modal */}
       {securityFindings.length > 0 && (
@@ -117,25 +116,25 @@ export default function Home() {
       <div className="absolute bottom-[-10%] right-[-10%] w-[40vw] h-[40vw] rounded-full bg-purple-600/10 blur-[120px] pointer-events-none" />
 
       {/* Floating Main Container */}
-      <div className="glass w-full max-w-7xl h-full max-h-[90vh] rounded-3xl flex flex-col shadow-2xl overflow-hidden animate-fade-in ring-1 ring-white/10">
+      <div className="glass flex min-h-[calc(100vh-2rem)] w-full max-w-7xl flex-col overflow-hidden rounded-2xl shadow-2xl ring-1 ring-white/10 animate-fade-in md:h-full md:max-h-[90vh] md:rounded-3xl">
 
         {/* Header */}
-        <header className="border-b border-white/5 bg-black/20 p-4 flex items-center justify-between backdrop-blur-md">
+        <header className="flex flex-col gap-3 border-b border-white/5 bg-black/20 p-4 backdrop-blur-md sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-3">
-              <div className="h-9 w-9 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center text-white shadow-lg shadow-blue-500/20"><Code2 size={18} aria-hidden="true" /></div>
+              <div className="h-9 w-9 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center text-lg text-white shadow-lg shadow-blue-500/20">💠</div>
               <div>
                 <h1 className="font-semibold text-lg tracking-tight text-white">Prompt Compiler</h1>
-                <div className="text-xs text-zinc-400 font-mono tracking-wider uppercase opacity-70">Policy-Aware Prompt Workflows</div>
+                <div className="text-[10px] text-zinc-400 font-mono tracking-wider uppercase opacity-70">Vague Request To Prompt, Plan, And Policy</div>
               </div>
             </div>
             <InfoButton
               title="Prompt Compiler"
-              description="Turns vague requests into structured prompts, execution plans, and policy-checked workflows — idea to safe, usable AI output in seconds."
+              description="Turns vague requests into structured prompts, execution plans, and policy-checked workflows so you can go from rough intent to safe, usable AI output in seconds."
             />
           </div>
 
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <button
               type="button"
               onClick={() => setConservativeMode((prev) => !prev)}
@@ -156,7 +155,7 @@ export default function Home() {
               />
               <span className="flex flex-col items-start leading-none">
                 <span>Conservative</span>
-                <span className="mt-1 text-xs font-normal opacity-75">
+                <span className="mt-1 text-[10px] font-normal opacity-75">
                   {conservativeMode ? "No hallucinations" : "Aggressive optimize"}
                 </span>
               </span>
@@ -168,7 +167,7 @@ export default function Home() {
             </div>
 
             <div className="flex items-center gap-2">
-              <div className="text-xs font-mono text-zinc-500 bg-black/30 px-3 py-1.5 rounded-lg border border-white/5 min-w-[100px] text-center">
+              <div className="min-w-[88px] rounded-lg border border-white/5 bg-black/30 px-3 py-1.5 text-center font-mono text-xs text-zinc-500">
                 {status}
               </div>
               {!!lastError && !loading && (
@@ -184,16 +183,16 @@ export default function Home() {
           </div>
         </header>
 
-        <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
+        <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
           {/* Left Panel: Input */}
-          <div className="w-full md:w-[35%] min-h-0 p-5 flex flex-col gap-5 border-r border-white/5 bg-black/10">
+          <div className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/10 p-4 sm:p-5 md:min-h-0 md:w-[35%] md:border-b-0 md:border-r md:overflow-y-auto">
 
             <div className="flex-1 flex flex-col relative group">
               <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-purple-500/5 rounded-2xl pointer-events-none opacity-0 group-focus-within:opacity-100 transition-opacity duration-500" />
               <textarea
                 aria-label="Describe what you want compiled"
-                className="flex-1 w-full bg-black/20 p-5 rounded-2xl border border-white/10 resize-none focus:outline-none focus:ring-1 focus:ring-blue-500/50 font-mono text-sm leading-relaxed text-zinc-200 placeholder-zinc-500 transition-all shadow-inner"
-                placeholder="Describe what you want compiled... e.g. 'Turn this GitHub issue into a safe implementation brief'"
+                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 sm:min-h-44 md:min-h-0"
+                placeholder="Paste a vague task, bug report, spec, or workflow request... e.g. 'Turn this GitHub issue into a safe implementation brief'"
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
                 onKeyDown={(e) => {
@@ -218,7 +217,7 @@ export default function Home() {
                 {loading ? (
                   <span className="animate-pulse">Thinking...</span>
                 ) : (
-                  <>Generate <span className="group-hover:translate-x-0.5 transition-transform">→</span> <kbd className="hidden md:inline-block ml-2 text-[10px] font-mono opacity-50 border border-white/20 rounded px-1.5 py-0.5 bg-white/5">Ctrl/⌘ Enter</kbd></>
+                  <>Generate <span className="transition-transform group-hover:translate-x-0.5">{"->"}</span> <kbd className="ml-2 hidden rounded border border-white/20 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] opacity-50 md:inline-block">Ctrl/Cmd Enter</kbd></>
                 )}
               </button>
             </div>
@@ -231,7 +230,7 @@ export default function Home() {
           </div>
 
           {/* Right Panel: Output */}
-          <div className="w-full md:w-[65%] min-h-0 flex flex-col bg-black/20 relative">
+          <div className="relative flex min-h-[360px] w-full flex-col bg-black/20 md:min-h-0 md:w-[65%]">
 
             {/* ── Compiler Output View ── */}
             {!!lastError && !loading ? (
@@ -239,7 +238,7 @@ export default function Home() {
             ) : result ? (
               <>
                 {/* Tabs */}
-                <div role="tablist" aria-label="Output views" className="flex border-b border-white/5 px-4 pt-4 gap-2 overflow-x-auto scroll-smooth" style={{ maskImage: "linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent)" }}>
+                <div role="tablist" aria-label="Output views" className="flex gap-1 overflow-x-auto scroll-smooth border-b border-white/5 px-4 pt-4 pb-1" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
                   {(["intent", "system", "user", "plan", "expanded", "json", "quality"] as const).map((tab) => (
                     <button
                       type="button"
@@ -249,7 +248,7 @@ export default function Home() {
                       aria-controls={`tabpanel-${tab}`}
                       id={`tab-${tab}`}
                       onClick={() => setActiveTab(tab)}
-                      className={`px-4 py-2 text-[13px] font-medium rounded-t-lg transition-all relative whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:z-10 ${activeTab === tab
+                      className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 sm:px-4 ${activeTab === tab
                         ? "text-white bg-white/5 border-t border-x border-white/5"
                         : "text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
                         }`}
@@ -410,28 +409,22 @@ export default function Home() {
             ) : loading ? (
               <OutputSkeleton />
             ) : (
-              <div className="flex-1 flex flex-col items-center justify-center gap-6 p-10 text-center">
+              <div className="flex flex-1 flex-col items-center justify-center gap-5 p-6 text-center sm:gap-6 sm:p-10">
                 <div className="relative group">
                   <div className="absolute inset-0 bg-blue-500/30 blur-[40px] rounded-full group-hover:bg-blue-500/50 transition-all duration-700" />
                   <div className="relative w-24 h-24 rounded-2xl bg-gradient-to-br from-zinc-800 to-black border border-white/10 flex items-center justify-center shadow-2xl">
-                    <Code2 size={40} strokeWidth={1.5} aria-hidden="true" className="text-blue-400/60" />
+                    <span className="text-4xl filter drop-shadow-[0_0_10px_rgba(255,255,255,0.3)]">💠</span>
                   </div>
                 </div>
                 <div className="max-w-sm space-y-2">
-                  <h3 className="text-zinc-100 font-semibold tracking-tight text-base">Start with any rough idea</h3>
-                  <p className="text-sm text-zinc-400 leading-relaxed mb-4">
-                    Paste a task, question, or workflow on the left, then press <kbd className="text-[11px] font-mono border border-white/20 rounded px-1 py-0.5 bg-white/5">Ctrl/⌘ Enter</kbd>.
-                    You&apos;ll get a clean system &amp; user prompt, an execution plan, and safety checks — ready to drop into any LLM.
+                  <h3 className="text-zinc-100 font-semibold tracking-tight text-base">Start with any rough request</h3>
+                  <p className="text-sm text-zinc-400 leading-relaxed">
+                    Paste a task, question, bug report, or workflow on the left, then press <kbd className="rounded border border-white/20 bg-white/5 px-1 py-0.5 font-mono text-[11px]">Ctrl/Cmd Enter</kbd>.
+                    You&apos;ll get structured prompts, an execution plan, and policy checks you can inspect before using the result downstream.
                   </p>
-                  <button
-                    type="button"
-                    onClick={() => handleGenerate()}
-                    disabled={loading || !prompt.trim()}
-                    title={!prompt.trim() ? "Enter a prompt first to compile" : "Compile Prompt"}
-                    className="mt-6 mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 shadow-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
-                  >
-                    Compile Prompt
-                  </button>
+                  <p className="text-xs text-zinc-500 leading-relaxed">
+                    Good first inputs: GitHub issue to implementation brief, PR description to review checklist, or a spec to implementation plan.
+                  </p>
                   <p className="text-[10px] text-zinc-500 mt-4 font-mono">v0.1.1</p>
                 </div>
               </div>

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -65,16 +65,16 @@ export default function SkillsGenerator() {
   };
 
   return (
-    <main className="flex h-full min-h-0 flex-col items-center justify-center p-4 md:p-8 relative overflow-hidden bg-[#050505]">
+    <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden bg-[#050505] p-3 py-4 sm:p-4 md:h-full md:min-h-0 md:justify-center md:overflow-hidden md:p-8">
       {/* Ambient Background */}
       <div className="absolute top-[-10%] left-[-10%] w-[40vw] h-[40vw] rounded-full bg-yellow-600/10 blur-[120px] pointer-events-none" />
       <div className="absolute bottom-[-10%] right-[-10%] w-[40vw] h-[40vw] rounded-full bg-orange-600/10 blur-[120px] pointer-events-none" />
 
       {/* Main Container */}
-      <div className="glass w-full max-w-7xl h-full max-h-[90vh] rounded-3xl flex flex-col shadow-2xl overflow-hidden animate-fade-in ring-1 ring-white/10 bg-black/40 backdrop-blur-xl">
+      <div className="glass flex min-h-[calc(100vh-2rem)] w-full max-w-7xl flex-col overflow-hidden rounded-2xl bg-black/40 shadow-2xl ring-1 ring-white/10 backdrop-blur-xl animate-fade-in md:h-full md:max-h-[90vh] md:rounded-3xl">
 
         {/* Header */}
-        <header className="border-b border-white/5 bg-black/20 p-4 flex items-center justify-between backdrop-blur-md">
+        <header className="flex flex-col gap-3 border-b border-white/5 bg-black/20 p-4 backdrop-blur-md sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-3">
               <div className="h-9 w-9 bg-gradient-to-br from-yellow-600 to-orange-600 rounded-xl flex items-center justify-center text-white shadow-lg shadow-yellow-500/20">
@@ -94,9 +94,9 @@ export default function SkillsGenerator() {
           </div>
         </header>
 
-        <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
+        <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
           {/* Left Panel: Input */}
-          <div className="w-full md:w-[35%] min-h-0 p-5 flex flex-col gap-5 border-r border-white/5 bg-black/10 overflow-hidden">
+          <div className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/10 p-4 sm:p-5 md:min-h-0 md:w-[35%] md:border-b-0 md:border-r md:overflow-y-auto">
             <div className="flex flex-col gap-2">
               <label htmlFor="skill-description" className="text-sm font-medium text-zinc-300">Skill Description</label>
               <p className="text-xs text-zinc-500">
@@ -108,7 +108,7 @@ export default function SkillsGenerator() {
               <textarea
                 id="skill-description"
                 aria-label="Skill Description"
-                className="flex-1 min-h-[240px] md:min-h-0 w-full bg-black/20 p-5 rounded-2xl border border-white/10 resize-none focus:outline-none focus:ring-1 focus:ring-yellow-500/50 font-mono text-sm leading-relaxed text-zinc-200 placeholder-zinc-600 transition-all shadow-inner"
+                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-0"
                 placeholder="e.g., 'A skill that parses JSON and validates schemas' or 'Fetch and summarize web pages'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -124,7 +124,7 @@ export default function SkillsGenerator() {
               />
             </div>
 
-            <div className="flex items-center gap-3 bg-white/5 p-3 rounded-xl border border-white/5">
+            <div className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3">
               <button
                 type="button"
                 role="switch"
@@ -135,7 +135,7 @@ export default function SkillsGenerator() {
               >
                 <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform ${includeExampleCode ? "translate-x-4" : "translate-x-0"}`} />
               </button>
-              <div className="flex flex-col">
+              <div className="flex min-w-0 flex-col">
                 <span className="text-xs font-medium text-zinc-200">Example Code?</span>
                 <span className="text-xs text-zinc-500">
                   Yes = include implementation code, No = keep it code-free
@@ -179,7 +179,7 @@ export default function SkillsGenerator() {
               {loading ? (
                 <span className="animate-pulse">Forging Skill...</span>
               ) : (
-                <>Generate Skill <span className="group-hover:translate-x-0.5 transition-transform">→</span> <kbd className="hidden md:inline-block ml-2 text-[10px] font-mono opacity-50 border border-white/20 rounded px-1.5 py-0.5 bg-white/5">Ctrl/⌘ Enter</kbd></>
+                <>Generate Skill <span className="transition-transform group-hover:translate-x-0.5">{"->"}</span> <kbd className="ml-2 hidden rounded border border-white/20 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] opacity-50 md:inline-block">Ctrl/Cmd Enter</kbd></>
               )}
             </button>
 
@@ -196,7 +196,7 @@ export default function SkillsGenerator() {
           </div>
 
           {/* Right Panel: Output */}
-          <div className="w-full md:w-[65%] min-h-0 flex flex-col bg-black/20 relative">
+          <div className="relative flex min-h-[360px] w-full flex-col bg-black/20 md:min-h-0 md:w-[65%]">
             {result ? (
               <div className="flex-1 min-h-0 p-0 overflow-hidden relative group bg-black/20 flex flex-col">
                 <div className="flex items-center justify-between border-b border-white/5 px-6 py-3">
@@ -229,7 +229,7 @@ export default function SkillsGenerator() {
                 </div>
               </div>
             ) : (
-              <div className="flex-1 flex flex-col items-center justify-center text-zinc-600 gap-6 p-10 text-center opacity-60">
+              <div className="flex flex-1 flex-col items-center justify-center gap-5 p-6 text-center text-zinc-600 opacity-75 sm:gap-6 sm:p-10">
                 <div className="relative group">
                   <div className="absolute inset-0 bg-yellow-500/30 blur-[40px] rounded-full group-hover:bg-yellow-500/50 transition-all duration-700" />
                   <div className="relative w-24 h-24 rounded-2xl bg-gradient-to-br from-zinc-800 to-black border border-white/10 flex items-center justify-center shadow-2xl skew-y-3 group-hover:skew-y-0 transition-transform duration-500">
@@ -239,7 +239,7 @@ export default function SkillsGenerator() {
                 <div className="max-w-xs space-y-2">
                   <h3 className="text-zinc-200 font-medium tracking-wide">Skill Forge</h3>
                   <p className="text-sm text-zinc-500 mb-4">
-                    Define a capability to generate a robust, modular skill definition for your AI agents.
+                    Describe the capability on the left, choose whether examples belong in it, then generate and copy the skill.
                   </p>
                   <button
                     type="button"


### PR DESCRIPTION
﻿## Summary
- Improves responsive layout for Prompt Compiler user-facing pages without changing the existing dark glass visual style.
- Tightens Context Manager, Agent Generator, and Skills Generator spacing so controls no longer collide on narrow viewports.
- Clarifies benchmark and empty-state copy while replacing risky mojibake-prone UI glyphs with safer text.

## Validation
- `cd web && npm run lint` (passes with existing unrelated `useContextManager.ts` unused eslint-disable warning)
- `cd web && npm run test` (25 tests passed)
- `cd web && npm run build`
- In-app browser visual pass across `/`, `/optimizer`, `/offline`, `/benchmark`, `/agent-generator`, and `/skills-generator`
