### PR TITLE
fix(ui): clear previous result to show loading skeleton on subsequent runs

### DIFF
--- a/web/app/hooks/useCompiler.ts
+++ b/web/app/hooks/useCompiler.ts
@@ -43,6 +43,7 @@ export function useCompiler() {
 
     lastCallRef.current = { text, mode };
     setLastError(null);
+    setResult(null);
     setLoading(true);
     setStatus("Generating...");
 


### PR DESCRIPTION
When a user re-ran a prompt, the loading skeleton was not showing because the previous `result` state wasn't cleared. This clears `result` explicitly so the UI renders the loading state correctly.