### PR TITLE
⚡ Bolt: [performance improvement] Optimize Pydantic JSON serialization

### DIFF
--- a/app/batch.py
+++ b/app/batch.py
@@ -65,7 +65,8 @@ def batch_process_files(
 
             # Generate output content
             if output_format == "json":
-                out_content = json.dumps(ir.model_dump(), indent=2, ensure_ascii=False)
+                # Bolt Optimization: Use native model_dump_json for fast Rust-powered serialization
+                out_content = ir.model_dump_json(indent=2)
             elif output_format in ["yaml", "yml"]:
                 out_content = yaml.safe_dump(ir.model_dump(), sort_keys=False, allow_unicode=True)
             else:
@@ -81,7 +82,7 @@ def batch_process_files(
             out_path = output_dir / out_name
             out_path.write_text(out_content, encoding="utf-8")
 
-            return f, True, ir.model_dump() if jsonl_file else None, ""
+            return f, True, ir.model_dump_json() if jsonl_file else None, ""
         except Exception as e:
             import logging
 
@@ -96,7 +97,7 @@ def batch_process_files(
             if success:
                 result.successful += 1
                 if jsonl_file and data:
-                    jsonl_file.write(json.dumps(data, ensure_ascii=False) + "\n")
+                    jsonl_file.write(data + "\n")
             else:
                 result.failed += 1
                 result.failures.append({"file": str(f), "error": error})

--- a/app/batch.py
+++ b/app/batch.py
@@ -1,5 +1,4 @@
 import time
-import json
 import yaml
 from pathlib import Path
 from typing import List, Optional, Any, Tuple

--- a/app/testing/runner.py
+++ b/app/testing/runner.py
@@ -219,7 +219,8 @@ class TestRunner:
                 return str(assertion.value) in combined
 
         if assertion.target == "ir" and ir_v2 is not None:
-            payload = json.dumps(ir_v2.model_dump(), ensure_ascii=False)
+            # Bolt Optimization: Use model_dump_json for fast Rust-powered serialization
+            payload = ir_v2.model_dump_json()
             if assertion.type in {"contains", "includes"}:
                 return str(assertion.value) in payload
             elif assertion.type == "not_contains":


### PR DESCRIPTION
💡 What: Replaced occurrences of `json.dumps(model.model_dump(), ...)` with Pydantic's native `model.model_dump_json(...)` method in `app/testing/runner.py` and `app/batch.py`.
🎯 Why: Passing `.model_dump()` to the standard `json.dumps()` module incurs a performance penalty because Pydantic has to allocate an intermediate Python dictionary before passing it to Python's built-in C-level JSON serializer. By using `.model_dump_json()`, we leverage Pydantic V2's `pydantic-core` engine written in Rust, which directly serializes the Pydantic object to a JSON string, skipping the intermediate memory allocation.
📊 Impact: Considerably faster and more memory-efficient JSON serialization on hot paths, specifically in batch processing of multiple items.
🔬 Measurement: Run the test suite using `python3 -m pytest tests/` or benchmark batch file generation via `app/batch.py`.

---
*PR created automatically by Jules for task [6098518354828543549](https://jules.google.com/task/6098518354828543549) started by @madara88645*