### PR TITLE
fix: improve compile-state clarity by prioritizing loading output

### DIFF
--- a/web/app/__tests__/page-error-state.test.tsx
+++ b/web/app/__tests__/page-error-state.test.tsx
@@ -14,6 +14,10 @@ vi.mock("../components/ContextManager", () => ({
   default: () => <div data-testid="context-manager" />,
 }));
 
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
 describe("Prompt Compiler home", () => {
   beforeEach(() => {
     retryMock.mockReset();
@@ -42,5 +46,25 @@ describe("Prompt Compiler home", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry compile" }));
 
     expect(retryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows loading skeleton instead of stale result during recompile", () => {
+    useCompilerMock.mockReturnValue({
+      loading: true,
+      result: { system_prompt: "old result should not render while loading" },
+      status: "Generating...",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: retryMock,
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+
+    render(<Home />);
+
+    expect(screen.getByTestId("output-skeleton")).toBeTruthy();
+    expect(screen.queryByText("old result should not render while loading")).toBeNull();
   });
 });

--- a/web/app/hooks/useCompiler.ts
+++ b/web/app/hooks/useCompiler.ts
@@ -43,6 +43,7 @@ export function useCompiler() {
 
     lastCallRef.current = { text, mode };
     setLastError(null);
+    setResult(null);
     setLoading(true);
     setStatus("Generating...");
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -235,6 +235,8 @@ export default function Home() {
             {/* ── Compiler Output View ── */}
             {!!lastError && !loading ? (
               <CompilerErrorState error={lastError} onRetry={() => void retry()} />
+            ) : loading ? (
+              <OutputSkeleton />
             ) : result ? (
               <>
                 {/* Tabs */}
@@ -406,8 +408,6 @@ export default function Home() {
                   )}
                 </div>
               </>
-            ) : loading ? (
-              <OutputSkeleton />
             ) : (
               <div className="flex flex-1 flex-col items-center justify-center gap-5 p-6 text-center sm:gap-6 sm:p-10">
                 <div className="relative group">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Clear previous compile result when a new compile starts so stale output cannot linger.
- Render loading state (`OutputSkeleton`) before output tabs/content when a compile is in-flight.
- Add a focused UI test to assert loading state wins over stale result during recompile.

## Why this matters
The main Prompt Compiler UI could show prior output while a new compile was running, which made the app feel unresponsive and risked users misreading old output as fresh output.

## Validation
- `cd web && npm run test -- page-error-state`
- `cd web && npm run lint` (passes with one pre-existing unrelated warning in `web/app/hooks/useContextManager.ts`)
- `cd web && npm run build`

## Walkthrough artifacts
[compile_state_clarity_demo.mp4](https://cursor.com/agents/bc-2dc9dfe6-bb5b-419b-ac14-0ca6b57eb04e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompile_state_clarity_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dc9dfe6-bb5b-419b-ac14-0ca6b57eb04e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dc9dfe6-bb5b-419b-ac14-0ca6b57eb04e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

