### PR TITLE
⚡ Bolt: [performance improvement] Optimize Pydantic JSON serialization

### DIFF
--- a/app/batch.py
+++ b/app/batch.py
@@ -65,7 +65,9 @@ def batch_process_files(
 
             # Generate output content
             if output_format == "json":
-                out_content = json.dumps(ir.model_dump(), indent=2, ensure_ascii=False)
+                # ⚡ Bolt Performance Optimization: Replace json.dumps(model_dump()) with native model_dump_json()
+                # Impact: Leverages Rust-powered serialization, avoids intermediate dict creation, significantly faster.
+                out_content = ir.model_dump_json(indent=2)
             elif output_format in ["yaml", "yml"]:
                 out_content = yaml.safe_dump(ir.model_dump(), sort_keys=False, allow_unicode=True)
             else:

--- a/app/testing/runner.py
+++ b/app/testing/runner.py
@@ -219,7 +219,9 @@ class TestRunner:
                 return str(assertion.value) in combined
 
         if assertion.target == "ir" and ir_v2 is not None:
-            payload = json.dumps(ir_v2.model_dump(), ensure_ascii=False)
+            # ⚡ Bolt Performance Optimization: Replace json.dumps(model_dump()) with native model_dump_json()
+            # Impact: Leverages Rust-powered serialization, avoids intermediate dict creation, significantly faster.
+            payload = ir_v2.model_dump_json()
             if assertion.type in {"contains", "includes"}:
                 return str(assertion.value) in payload
             elif assertion.type == "not_contains":


### PR DESCRIPTION
💡 What: Replaced `json.dumps(model.model_dump())` with Pydantic's native `model.model_dump_json()` in `app/testing/runner.py` and `app/batch.py`.
🎯 Why: In Pydantic V2, `model_dump()` creates an intermediate Python dictionary before standard library serialization. Directly using `model_dump_json()` bypasses dictionary creation and utilizes Pydantic's fast internal Rust implementation (`pydantic-core`). It natively handles Unicode encoding without the need for `ensure_ascii=False`.
📊 Impact: Significantly faster serialization for LLM evaluations and batch processing by leveraging Rust-powered processing and avoiding intermediate memory allocations.
🔬 Measurement: Run the test suite and benchmark APIs to observe a reduction in time taken per test during large batch compilations.

---
*PR created automatically by Jules for task [7034547078593075354](https://jules.google.com/task/7034547078593075354) started by @madara88645*