### PR TITLE
[codex] Add RAG frontend regression coverage for context flows

### DIFF
--- a/web/app/hooks/useContextManager.test.tsx
+++ b/web/app/hooks/useContextManager.test.tsx
@@ -1,0 +1,206 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useContextManager } from "./useContextManager";
+import { apiFetch } from "../../config";
+import {
+  fetchRagStats,
+  ingestContextPath,
+  searchContext,
+  uploadContextFile,
+} from "../../lib/api/promptc";
+
+vi.mock("../../config", async () => {
+  const actual = await vi.importActual<typeof import("../../config")>("../../config");
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  };
+});
+
+vi.mock("../../lib/api/promptc", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api/promptc")>("../../lib/api/promptc");
+  return {
+    ...actual,
+    fetchRagStats: vi.fn(),
+    ingestContextPath: vi.fn(),
+    searchContext: vi.fn(),
+    uploadContextFile: vi.fn(),
+  };
+});
+
+const apiFetchMock = vi.mocked(apiFetch);
+const fetchRagStatsMock = vi.mocked(fetchRagStats);
+const ingestContextPathMock = vi.mocked(ingestContextPath);
+const searchContextMock = vi.mocked(searchContext);
+const uploadContextFileMock = vi.mocked(uploadContextFile);
+
+describe("useContextManager", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    fetchRagStatsMock.mockReset();
+    ingestContextPathMock.mockReset();
+    searchContextMock.mockReset();
+    uploadContextFileMock.mockReset();
+
+    apiFetchMock.mockResolvedValue({ ok: true } as Response);
+    fetchRagStatsMock.mockResolvedValue({ docs: 0, chunks: 0, total_bytes: 0 });
+  });
+
+  it("clears a stale error status after a successful search", async () => {
+    searchContextMock.mockResolvedValue([
+      {
+        path: "src/compiler.ts",
+        snippet: "Compile request flow",
+        score: 0.91,
+      },
+    ]);
+
+    const { result } = renderHook(() => useContextManager());
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    act(() => {
+      result.current.setStatus("Search failed: timeout");
+      result.current.setQuery(" compiler ");
+    });
+
+    await act(async () => {
+      await result.current.runSearch();
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toHaveLength(1);
+    });
+
+    expect(result.current.status).toBe("");
+    expect(searchContextMock).toHaveBeenCalledWith({ query: "compiler", limit: 5 });
+  });
+
+  it("surfaces a stats warning when health succeeds but stats loading fails", async () => {
+    fetchRagStatsMock.mockRejectedValueOnce(new Error("stats offline"));
+
+    const { result } = renderHook(() => useContextManager());
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("Stats unavailable: stats offline");
+    });
+  });
+
+  it("skips searches for whitespace-only queries", async () => {
+    const { result } = renderHook(() => useContextManager());
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    act(() => {
+      result.current.setQuery("   ");
+    });
+
+    await act(async () => {
+      await result.current.runSearch();
+    });
+
+    expect(searchContextMock).not.toHaveBeenCalled();
+    expect(result.current.searching).toBe(false);
+  });
+
+  it("tracks upload progress and refreshes stats after successful uploads", async () => {
+    const file = new File(["hello world"], "notes.md", { type: "text/markdown" });
+
+    let resolveUpload: ((value: {
+      ingested_docs: number;
+      total_chunks: number;
+      elapsed_ms: number;
+      filename: string;
+      success: boolean;
+      num_chunks: number;
+      message: string;
+    }) => void) | null = null;
+
+    uploadContextFileMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveUpload = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useContextManager());
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    fetchRagStatsMock.mockClear();
+
+    let uploadPromise!: Promise<void>;
+    act(() => {
+      uploadPromise = result.current.uploadFiles([file]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.uploadProgress).toMatchObject({
+        completed: 0,
+        currentFile: "notes.md",
+        total: 1,
+      });
+    });
+
+    resolveUpload?.({
+      ingested_docs: 1,
+      total_chunks: 3,
+      elapsed_ms: 12,
+      filename: "notes.md",
+      success: true,
+      num_chunks: 3,
+      message: "Indexed notes.md into the RAG index.",
+    });
+
+    await act(async () => {
+      await uploadPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.uploadProgress).toBeNull();
+    });
+
+    expect(result.current.status).toBe("Indexed 1/1 files (3 chunks)");
+    expect(fetchRagStatsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the indexed path after a successful manual ingest", async () => {
+    ingestContextPathMock.mockResolvedValueOnce({
+      ingested_docs: 2,
+      total_chunks: 7,
+      elapsed_ms: 15,
+    });
+
+    const { result } = renderHook(() => useContextManager());
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    fetchRagStatsMock.mockClear();
+
+    act(() => {
+      result.current.setFilePath("docs/architecture");
+    });
+
+    await act(async () => {
+      await result.current.ingestPath("docs/architecture");
+    });
+
+    expect(ingestContextPathMock).toHaveBeenCalledWith({ paths: ["docs/architecture"] });
+    expect(result.current.filePath).toBe("");
+    expect(result.current.status).toBe("Indexed 2 files (7 chunks)");
+    expect(fetchRagStatsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/hooks/useContextManager.ts
+++ b/web/app/hooks/useContextManager.ts
@@ -76,7 +76,6 @@ export function useContextManager() {
   }, [refreshStats]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void checkConnection();
   }, [checkConnection]);
 
@@ -172,6 +171,7 @@ export function useContextManager() {
     try {
       const response = await searchContext({ query: query.trim(), limit: 5 });
       setResults(response);
+      setStatus("");
       setIsConnected(true);
     } catch (error: unknown) {
       setStatus(`Search failed: ${toUserMessage(error)}`);

--- a/web/lib/api/promptc.test.ts
+++ b/web/lib/api/promptc.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError, apiJson } from "../../config";
-import { compilePrompt, normalizeCompileResponse } from "./promptc";
+import {
+  compilePrompt,
+  normalizeCompileResponse,
+  normalizeRagSearchResults,
+  normalizeRagStats,
+  normalizeRagUploadResponse,
+} from "./promptc";
 
 vi.mock("../../config", async () => {
   const actual = await vi.importActual<typeof import("../../config")>("../../config");
@@ -46,6 +52,48 @@ describe("compile response normalization", () => {
     expect(response.ir_v2?.policy?.risk_level).toBe("low");
     expect(response.ir_v2?.policy?.execution_mode).toBe("advice_only");
     expect(response.ir_v2?.policy?.risk_domains).toEqual([]);
+  });
+});
+
+describe("RAG response normalization", () => {
+  it("normalizes upload responses that only provide compatibility fields", () => {
+    const response = normalizeRagUploadResponse({
+      success: true,
+      num_chunks: 4,
+      elapsed_ms: 18,
+    });
+
+    expect(response).toEqual({
+      ingested_docs: 1,
+      total_chunks: 4,
+      elapsed_ms: 18,
+      filename: "upload.txt",
+      success: true,
+      num_chunks: 4,
+      message: "Indexed upload.txt into the RAG index.",
+    });
+  });
+
+  it("maps legacy RAG search fields into canonical results", () => {
+    const results = normalizeRagSearchResults([
+      {
+        source: "docs/spec.md",
+        content: "Auth flow notes",
+        score: 0.73,
+      },
+    ]);
+
+    expect(results).toEqual([
+      {
+        path: "docs/spec.md",
+        snippet: "Auth flow notes",
+        score: 0.73,
+      },
+    ]);
+  });
+
+  it("rejects invalid stats payloads", () => {
+    expect(() => normalizeRagStats(null)).toThrow("Invalid RAG stats response.");
   });
 });
 


### PR DESCRIPTION
## What changed
- added RAG API normalization regression tests for upload, search, and stats payloads
- added hook-level coverage for `useContextManager` health checks, trimmed search behavior, upload progress, and manual ingest resets
- fixed a small UX bug where a successful search left a stale error status visible
- removed an obsolete eslint-disable in the same hook

## Why
Recent frontend work moved more logic into the shared RAG API layer and `useContextManager`, but coverage was still strongest at the component level with the hook mocked out. This left the real state flow vulnerable to backend payload drift and stale-status regressions.

## Impact
- safer RAG frontend refactors
- earlier CI detection for backend/frontend response shape drift
- cleaner search UX after transient failures

## Verification
- `cd web && npm run test`
- `cd web && npm run lint`
- `cd web && npm run build`
