### PR TITLE
🛡️ Sentinel: [security improvement] Add timeouts to urllib requests

### DIFF
--- a/scripts/debug_endpoint.py
+++ b/scripts/debug_endpoint.py
@@ -18,7 +18,7 @@ def check(path, method="GET", data=None):
         else:
             req = urllib.request.Request(url, method=method)
 
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=30.0) as response:
             print(f"✅ Status: {response.status}")
             print(response.read().decode()[:200])
     except urllib.error.HTTPError as e:

--- a/scripts/debug_v2.py
+++ b/scripts/debug_v2.py
@@ -15,7 +15,7 @@ print(f"Sending request to {url}...")
 t0 = time.time()
 try:
     req = urllib.request.Request(url, data=json.dumps(data).encode(), headers=headers)
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req, timeout=30.0) as response:
         elapsed = time.time() - t0
         print(f"Time: {elapsed:.2f}s")
         res_data = json.load(response)

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -66,7 +66,7 @@ def test_validate_summary_and_api_schemas(tmp_path: Path):
         import json as _j
 
         for p in ("/schema/ir_v1", "/schema/ir_v2"):
-            with urllib.request.urlopen(f"http://127.0.0.1:8000{p}") as resp:
+            with urllib.request.urlopen(f"http://127.0.0.1:8000{p}", timeout=30.0) as resp:
                 data = _j.loads(resp.read().decode("utf-8"))
                 assert "schema" in data and isinstance(data["schema"], str)
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing timeouts on network requests (DoS risk).
🎯 Impact: Scripts could hang indefinitely if the server does not respond.
🔧 Fix: Added explicit `timeout=30.0` parameters to `urllib.request.urlopen` calls.
✅ Verification: Run test suite to ensure tests still pass.

---
*PR created automatically by Jules for task [9344682303080125416](https://jules.google.com/task/9344682303080125416) started by @madara88645*