### PR TITLE
🎨 Palette: [UX improvement] Add aria accessibility properties to ui panels and tabs

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -127,6 +127,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
         type="button"
         onClick={handleToggle}
         aria-expanded={isOpen}
+        aria-controls="agent-export-panel-content"
         className="w-full flex items-center justify-between px-2 py-1 group"
       >
         <div className="flex items-center gap-2">
@@ -154,7 +155,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
       </button>
 
       {isOpen && (
-        <div className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
+        <div id="agent-export-panel-content" className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
           {/* Framework tabs */}
           <div className="flex gap-1 p-3 border-b border-white/5">
             {FRAMEWORKS.map((fw) => (

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -183,6 +183,8 @@ export default function OfflinePage() {
                                         <button
                                             type="button"
                                             key={tab}
+                                            role="tab"
+                                            aria-selected={activeTab === tab}
                                             onClick={() => setActiveTab(tab)}
                                             className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 sm:px-4 ${activeTab === tab
                                                 ? "text-white bg-white/5 border-t border-x border-white/5"

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -126,6 +126,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
         type="button"
         onClick={handleToggle}
         aria-expanded={isOpen}
+        aria-controls="skill-export-panel-content"
         className="w-full flex items-center justify-between px-2 py-1 group"
       >
         <div className="flex items-center gap-2">
@@ -153,7 +154,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
       </button>
 
       {isOpen && (
-        <div className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
+        <div id="skill-export-panel-content" className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
           {/* Format tabs */}
           <div className="flex gap-1 p-3 border-b border-white/5">
             {FORMATS.map((f) => (


### PR DESCRIPTION
💡 What: Added `aria-controls` missing properties to collapsible panels and `role="tab"` + `aria-selected` to the offline page's tabs. 
🎯 Why: To fix keyboard accessibility traps when using screen readers and to properly link buttons to the conditionally rendered containers.
📸 Before/After: N/A, visual behavior is unmodified.
♿ Accessibility: Ensures that screen readers can correctly associate a toggle button with the panel it expands, as well as correctly navigate between tabs.

---
*PR created automatically by Jules for task [7511475681316810621](https://jules.google.com/task/7511475681316810621) started by @madara88645*