### PR TITLE
🎨 Palette: [UX improvement] Add keyboard submission to Context Manager path input

### DIFF
--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -97,6 +97,11 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                         placeholder="Path to file or folder..."
                         value={filePath}
                         onChange={(e) => setFilePath(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter" && !ingesting && filePath) {
+                                void ingestPath(filePath);
+                            }
+                        }}
                     />
                     <button
                         type="button"


### PR DESCRIPTION
💡 What: Added an `onKeyDown` handler to the "Advanced: Index by path" input field in `ContextManager.tsx` that triggers the ingestion path when the Enter key is pressed.
🎯 Why: Previously, keyboard users had to explicitly tab out of the text input to the "Ingest Path" button (or use a mouse) to trigger the action. This change allows for faster, more intuitive path entry and submission for keyboard/power users.
📸 Before/After: The visual state of the component remains the same, but the element now correctly responds to `Enter` keys seamlessly. 
♿ Accessibility: Improves keyboard navigation flow and reduces friction for non-mouse users.

---
*PR created automatically by Jules for task [5758012040166646672](https://jules.google.com/task/5758012040166646672) started by @madara88645*