### PR TITLE
🛡️ Sentinel: [security improvement] Add cleanup trigger for RAG embeddings

### DIFF
--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -193,6 +193,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
         END;
         CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
             DELETE FROM fts WHERE rowid = old.id;
+            DELETE FROM embeddings WHERE chunk_id = old.id;
         END;
         CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE ON chunks BEGIN
             DELETE FROM fts WHERE rowid = old.id;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Orphaned vector embeddings containing potentially sensitive data.
🎯 Impact: If a document was deleted or re-ingested, its original text representation (`fts`) was deleted, but the vector representation in `embeddings` remained. This could lead to a data leak where deleted sensitive information could still be retrieved via vector search.
🔧 Fix: Updated the `AFTER DELETE` SQLite trigger on the `chunks` table to automatically execute `DELETE FROM embeddings WHERE chunk_id = old.id;`.
✅ Verification: Ran `pytest` suite locally and ensure it passes cleanly. Pre-commit tests show regressions are prevented.

---
*PR created automatically by Jules for task [18358372405940012834](https://jules.google.com/task/18358372405940012834) started by @madara88645*