### PR TITLE
[codex] Harden Windows pytest temp bootstrap

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -228,7 +228,7 @@ Relevant files: `app/rag/simple_index.py`, `api/routes/rag.py`
 pytest tests/test_rag.py tests/test_rag_upload.py tests/test_rag_pipeline.py tests/test_rag_chunking.py tests/test_rag_hybrid_api.py tests/test_rag_parsers.py -v
 ```
 
-**Windows temp-dir note:** if pytest or `tempfile.TemporaryDirectory()` fails with `PermissionError` under `%LOCALAPPDATA%\\Temp`, point `TMP`, `TEMP`, and `DB_DIR` at a repo-local writable directory (for example `.\.tmp-test-run`) before running RAG/auth API tests so SQLite and temp fixtures stay isolated.
+**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
 
 **RAG upload smoke (requires running backend and an API key):**
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,17 +3,18 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from tests.runtime_bootstrap import apply_test_runtime, prepare_test_runtime
 
 _TEST_RUNTIME_ROOT = Path(__file__).resolve().parent.parent / ".tmp-test-run"
-_TEST_RUNTIME_ROOT.mkdir(parents=True, exist_ok=True)
-_TEST_SESSION_DIR = Path(tempfile.mkdtemp(prefix="pytest-", dir=str(_TEST_RUNTIME_ROOT))).resolve()
-_TEST_DB_DIR = (_TEST_SESSION_DIR / "db").resolve()
-_TEST_DB_DIR.mkdir(parents=True, exist_ok=True)
+_FALLBACK_RUNTIME_ROOTS = [Path(tempfile.gettempdir()) / "promptc-pytest-runtime"]
+_TEST_RUNTIME = prepare_test_runtime(
+    preferred_root=_TEST_RUNTIME_ROOT,
+    fallback_roots=_FALLBACK_RUNTIME_ROOTS,
+)
+_TEST_SESSION_DIR = _TEST_RUNTIME.session_dir
+_TEST_DB_DIR = _TEST_RUNTIME.db_dir
 
-for env_name in ("TMP", "TEMP", "TMPDIR"):
-    os.environ[env_name] = str(_TEST_SESSION_DIR)
-tempfile.tempdir = str(_TEST_SESSION_DIR)
-os.environ["DB_DIR"] = str(_TEST_DB_DIR)
+apply_test_runtime(_TEST_RUNTIME)
 
 from api.main import app  # noqa: E402
 from api.auth import verify_api_key, APIKey  # noqa: E402
@@ -29,8 +30,6 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    import os
-
     run_live = config.getoption("--run-live") or os.environ.get("PROMPTC_RUN_LIVE_TESTS") == "1"
     if run_live:
         return

--- a/tests/runtime_bootstrap.py
+++ b/tests/runtime_bootstrap.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class TestRuntime:
+    session_dir: Path
+    db_dir: Path
+    env_updates: dict[str, str]
+
+
+def _candidate_roots(preferred_root: Path, fallback_roots: Iterable[Path]) -> list[Path]:
+    roots = [preferred_root, *fallback_roots]
+    unique_roots: list[Path] = []
+    seen: set[Path] = set()
+
+    for root in roots:
+        resolved = root.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique_roots.append(resolved)
+
+    return unique_roots
+
+
+def prepare_test_runtime(
+    *,
+    preferred_root: Path,
+    fallback_roots: Iterable[Path] = (),
+) -> TestRuntime:
+    errors: list[str] = []
+
+    for root in _candidate_roots(preferred_root, fallback_roots):
+        try:
+            root.mkdir(parents=True, exist_ok=True)
+            session_dir = Path(tempfile.mkdtemp(prefix="pytest-", dir=str(root))).resolve()
+            db_dir = (session_dir / "db").resolve()
+            db_dir.mkdir(parents=True, exist_ok=True)
+
+            env_updates = {
+                "TMP": str(session_dir),
+                "TEMP": str(session_dir),
+                "TMPDIR": str(session_dir),
+                "DB_DIR": str(db_dir),
+            }
+            return TestRuntime(session_dir=session_dir, db_dir=db_dir, env_updates=env_updates)
+        except PermissionError as exc:
+            errors.append(f"{root}: {exc}")
+
+    joined_errors = "; ".join(errors) if errors else "no candidate roots were provided"
+    raise PermissionError(
+        f"Unable to initialize pytest runtime directories. Tried: {joined_errors}"
+    )
+
+
+def apply_test_runtime(runtime: TestRuntime) -> None:
+    for env_name, value in runtime.env_updates.items():
+        os.environ[env_name] = value
+    tempfile.tempdir = str(runtime.session_dir)

--- a/tests/test_test_runtime_bootstrap.py
+++ b/tests/test_test_runtime_bootstrap.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+
+def test_prepare_test_runtime_falls_back_when_db_dir_is_not_writable(tmp_path, monkeypatch):
+    from tests.runtime_bootstrap import prepare_test_runtime
+
+    preferred_root = tmp_path / "preferred"
+    fallback_root = tmp_path / "fallback"
+    fallback_root.mkdir()
+
+    failing_session = preferred_root / "pytest-failing"
+    working_session = fallback_root / "pytest-working"
+
+    created_session_dirs: list[Path] = []
+
+    def fake_mkdtemp(*, prefix: str, dir: str) -> str:
+        target = failing_session if not created_session_dirs else working_session
+        target.mkdir(parents=True, exist_ok=True)
+        created_session_dirs.append(target)
+        return str(target)
+
+    original_mkdir = Path.mkdir
+
+    def patched_mkdir(self: Path, parents: bool = False, exist_ok: bool = False):
+        if self == failing_session / "db":
+            raise PermissionError("simulated db dir failure")
+        return original_mkdir(self, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr("tests.runtime_bootstrap.tempfile.mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(Path, "mkdir", patched_mkdir)
+
+    runtime = prepare_test_runtime(preferred_root=preferred_root, fallback_roots=[fallback_root])
+
+    assert runtime.session_dir == working_session.resolve()
+    assert runtime.db_dir == (working_session / "db").resolve()
+    assert runtime.db_dir.is_dir()
+    assert created_session_dirs == [failing_session, working_session]
+
+
+def test_prepare_test_runtime_sets_process_temp_environment(tmp_path):
+    from tests.runtime_bootstrap import prepare_test_runtime
+
+    runtime = prepare_test_runtime(
+        preferred_root=tmp_path / "preferred", fallback_roots=[tmp_path / "fallback"]
+    )
+
+    assert runtime.session_dir.is_dir()
+    assert runtime.db_dir.is_dir()
+    assert runtime.env_updates["TMP"] == str(runtime.session_dir)
+    assert runtime.env_updates["TEMP"] == str(runtime.session_dir)
+    assert runtime.env_updates["TMPDIR"] == str(runtime.session_dir)
+    assert runtime.env_updates["DB_DIR"] == str(runtime.db_dir)


### PR DESCRIPTION
## What changed
- extracted pytest runtime bootstrap into `tests/runtime_bootstrap.py`
- made test startup fall back to a user temp root when repo-local `.tmp-test-run` cannot create the session DB directory
- added regression tests for fallback selection and env propagation
- updated the Windows temp-dir note in `agents.md`

## Why
On this Windows checkout, `python -m pytest ...` could fail during `tests/conftest.py` import with a `PermissionError` while creating `.tmp-test-run\\pytest-...\\db`. That blocked local verification before tests even started. This change hardens the bootstrap path so stale or unwritable repo-local temp dirs do not take down the whole test session.

## Impact
- Windows local test runs are more resilient
- backend/API regression suites can start even when the preferred repo-local temp root is not writable
- the fallback behavior is now covered by tests

## Verification
- `python -m pytest tests/test_test_runtime_bootstrap.py tests/test_context_strategist.py tests/test_policy_handler.py tests/test_expanded_prompt.py tests/test_auth_fast_path.py tests/test_rag_upload.py -q`
- `python -m ruff check tests/conftest.py tests/runtime_bootstrap.py tests/test_test_runtime_bootstrap.py`
