### PR TITLE
ux: smooth three first-time-user friction points (security dialog, mock benchmark, output tabs)

### DIFF
--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -45,6 +45,7 @@ export default function BenchmarkPage() {
   const [prompt, setPrompt] = useState("");
   const [loading, setLoading] = useState(false);
   const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkPayload | null>(null);
+  const [resultIsMock, setResultIsMock] = useState(false);
   const [selectedModel, setSelectedModel] = useState("mock");
   const [status, setStatus] = useState("Ready");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -88,6 +89,7 @@ export default function BenchmarkPage() {
 
     setLoading(true);
     setBenchmarkResult(null);
+    setResultIsMock(false);
     setErrorMessage(null);
 
     const modelLabel = selectedModelMeta?.label ?? "Mock Engine";
@@ -97,7 +99,8 @@ export default function BenchmarkPage() {
       if (selectedModel === "mock") {
         await new Promise((resolve) => setTimeout(resolve, 1200));
         setBenchmarkResult(generateMockResult());
-        setStatus("Benchmark complete (Mock)");
+        setResultIsMock(true);
+        setStatus("Demo result (Mock Engine — fake scores)");
         return;
       }
 
@@ -107,6 +110,7 @@ export default function BenchmarkPage() {
         body: JSON.stringify({ text: prompt.trim(), model: selectedModel }),
       });
       setBenchmarkResult(data);
+      setResultIsMock(false);
       setStatus(`Benchmark complete (${data.processing_ms}ms)`);
     } catch (error) {
       showError(error);
@@ -174,7 +178,7 @@ export default function BenchmarkPage() {
                 className="w-full cursor-pointer rounded border-none bg-[#1a1a1a] px-2 py-1.5 text-xs text-zinc-200 transition-colors focus:outline-none sm:min-w-[240px]"
               >
                 <option value="mock" className="bg-[#1a1a1a] text-zinc-200">
-                  Mock Engine [local]
+                  Mock Engine — demo (fake scores)
                 </option>
                 {BENCHMARK_MODEL_GROUPS.map((group) => (
                   <optgroup
@@ -194,9 +198,11 @@ export default function BenchmarkPage() {
                   </optgroup>
                 ))}
               </select>
-              <p className="px-2 pb-1 pt-2 text-xs text-zinc-500">
+              <p
+                className={`px-2 pb-1 pt-2 text-xs ${selectedModel === "mock" ? "text-amber-300/80" : "text-zinc-500"}`}
+              >
                 {selectedModel === "mock"
-                  ? "Client-side mock engine for instant UI previews."
+                  ? "No model is called. Numbers below are randomized for UI preview only — pick a real model to run an actual benchmark."
                   : selectedModelMeta?.helperText}
               </p>
             </div>
@@ -255,6 +261,12 @@ export default function BenchmarkPage() {
           <div className="relative flex flex-1 flex-col overflow-hidden bg-black/10">
             {benchmarkResult ? (
               <div className="flex h-full flex-1 flex-col overflow-hidden animate-fade-in">
+                {resultIsMock && (
+                  <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-100">
+                    <strong className="font-bold text-amber-50">Demo data — not a real benchmark.</strong>{" "}
+                    These scores are randomized to show what a real run looks like. Pick a real model above and re-run to measure your prompt.
+                  </div>
+                )}
                 <div className="flex h-[40%] min-h-[300px] border-b border-white/5">
                   <div className="relative flex flex-1 items-center justify-center p-4">
                     <h3 className="absolute left-4 top-4 text-xs font-semibold uppercase text-zinc-500">
@@ -315,7 +327,7 @@ export default function BenchmarkPage() {
                   <p className="text-sm text-zinc-400 mb-4">
                     {errorMessage
                       ? errorMessage
-                      : "Paste a prompt on the left, pick a model, then run a benchmark to compare raw vs compiled output."}
+                      : "Paste a prompt on the left, pick a real model (the default Mock Engine returns demo numbers), then run a benchmark."}
                   </p>
                   {!errorMessage && (
                     <button

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -92,7 +92,10 @@ export default function BenchmarkPage() {
     setResultIsMock(false);
     setErrorMessage(null);
 
-    const modelLabel = selectedModelMeta?.label ?? "Mock Engine";
+    const modelLabel =
+      selectedModel === "mock"
+        ? "Mock Engine (demo)"
+        : selectedModelMeta?.label ?? "Mock Engine (demo)";
     setStatus(`Benchmarking with ${modelLabel}...`);
 
     try {

--- a/web/app/components/IntentPolicyPanel.tsx
+++ b/web/app/components/IntentPolicyPanel.tsx
@@ -11,14 +11,21 @@ function FieldList({
   title,
   items,
   emptyLabel,
+  hint,
 }: {
   title: string;
   items: string[];
   emptyLabel: string;
+  hint?: string;
 }) {
   return (
     <div className="rounded-2xl border border-white/5 bg-black/20 p-4">
-      <div className="mb-3 text-xs font-mono uppercase tracking-[0.18em] text-zinc-500">{title}</div>
+      <div
+        className="mb-3 text-xs font-mono uppercase tracking-[0.18em] text-zinc-500"
+        title={hint}
+      >
+        {title}
+      </div>
       {items.length > 0 ? (
         <div className="flex flex-wrap gap-2">
           {items.map((item) => (
@@ -58,20 +65,38 @@ export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
     <div className="h-full overflow-y-auto p-6 text-zinc-200">
       <div className="grid gap-4 lg:grid-cols-2">
         <div className="rounded-3xl border border-cyan-500/15 bg-gradient-to-br from-cyan-500/10 to-transparent p-5">
-          <div className="mb-2 text-[11px] font-mono uppercase tracking-[0.18em] text-cyan-300/80">
+          <div
+            className="mb-2 text-[11px] font-mono uppercase tracking-[0.18em] text-cyan-300/80"
+            title="What the compiler thinks you're trying to do."
+          >
             Intent
           </div>
           <div className="space-y-3">
             <div>
-              <div className="text-xs text-zinc-500">Domain</div>
+              <div
+                className="text-xs text-zinc-500"
+                title="What kind of work this request is about (code, ops, writing…)."
+              >
+                Domain
+              </div>
               <div className="text-lg font-semibold text-white">{intentPolicy.domain}</div>
             </div>
             <div>
-              <div className="text-xs text-zinc-500">Persona</div>
+              <div
+                className="text-xs text-zinc-500"
+                title="Who the AI should act as while answering."
+              >
+                Persona
+              </div>
               <div className="text-sm text-zinc-200">{humanizeIntentPolicyValue(intentPolicy.persona)}</div>
             </div>
             <div>
-              <div className="mb-2 text-xs text-zinc-500">Detected Intents</div>
+              <div
+                className="mb-2 text-xs text-zinc-500"
+                title="Specific intent signals the compiler picked up from your request."
+              >
+                Detected Intents
+              </div>
               {intentPolicy.intentDetails.length > 0 ? (
                 <div className="grid gap-3">
                   {intentPolicy.intentDetails.map((intent) => (
@@ -100,24 +125,47 @@ export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
         </div>
 
         <div className="rounded-3xl border border-amber-500/15 bg-gradient-to-br from-amber-500/10 to-transparent p-5">
-          <div className="mb-2 text-[11px] font-mono uppercase tracking-[0.18em] text-amber-300/80">
+          <div
+            className="mb-2 text-[11px] font-mono uppercase tracking-[0.18em] text-amber-300/80"
+            title="Safety rules the compiler applied to this request."
+          >
             Policy
           </div>
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
-              <div className="text-xs text-zinc-500">Risk Level</div>
+              <div
+                className="text-xs text-zinc-500"
+                title="How cautious the compiler was when shaping the output."
+              >
+                Risk Level
+              </div>
               <div className="mt-1 text-lg font-semibold text-white">{humanizeIntentPolicyValue(intentPolicy.riskLevel)}</div>
             </div>
             <div>
-              <div className="text-xs text-zinc-500">Execution Mode</div>
+              <div
+                className="text-xs text-zinc-500"
+                title="Whether the result is meant to be run automatically or only suggested."
+              >
+                Execution Mode
+              </div>
               <div className="mt-1 text-lg font-semibold text-white">{humanizeIntentPolicyValue(intentPolicy.executionMode)}</div>
             </div>
             <div>
-              <div className="text-xs text-zinc-500">Data Sensitivity</div>
+              <div
+                className="text-xs text-zinc-500"
+                title="How private the input data looked to the scanner."
+              >
+                Data Sensitivity
+              </div>
               <div className="mt-1 text-sm text-zinc-200">{humanizeIntentPolicyValue(intentPolicy.dataSensitivity)}</div>
             </div>
             <div>
-              <div className="text-xs text-zinc-500">Risk Domains</div>
+              <div
+                className="text-xs text-zinc-500"
+                title="Categories the compiler flagged as needing extra care."
+              >
+                Risk Domains
+              </div>
               <div className="mt-1 text-sm text-zinc-200">
                 {intentPolicy.riskDomains.length > 0
                   ? intentPolicy.riskDomains.map(humanizeIntentPolicyValue).join(", ")
@@ -129,17 +177,20 @@ export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
 
         <FieldList
           title="Allowed Tools"
+          hint="Tools the resulting agent is permitted to call."
           items={intentPolicy.allowedTools.map(humanizeIntentPolicyValue)}
           emptyLabel="No tool allowlist needed for this request."
         />
         <FieldList
           title="Forbidden Tools"
+          hint="Tools the resulting agent is not permitted to call."
           items={intentPolicy.forbiddenTools.map(humanizeIntentPolicyValue)}
           emptyLabel="No explicit forbidden tools inferred."
         />
         <div className="lg:col-span-2">
           <FieldList
             title="Sanitization Rules"
+            hint="Cleanups applied to the prompt before it was used."
             items={intentPolicy.sanitizationRules.map(humanizeIntentPolicyValue)}
             emptyLabel="No extra sanitization rules inferred."
           />

--- a/web/app/components/IntentPolicyPanel.tsx
+++ b/web/app/components/IntentPolicyPanel.tsx
@@ -1,11 +1,22 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import type { CompileResponse } from "../../lib/api/types";
 import { humanizeIntentPolicyValue, normalizeIntentPolicy, type IntentDisplayGroup } from "./intent-policy-utils";
 
 type IntentPolicyPanelProps = {
   result: CompileResponse;
 };
+
+function FieldLabel({ children, hint }: { children: ReactNode; hint?: string }) {
+  return (
+    <div>
+      <div className="text-xs text-zinc-500">{children}</div>
+      {hint && <div className="mt-0.5 text-[11px] leading-snug text-zinc-600">{hint}</div>}
+    </div>
+  );
+}
 
 function FieldList({
   title,
@@ -20,12 +31,8 @@ function FieldList({
 }) {
   return (
     <div className="rounded-2xl border border-white/5 bg-black/20 p-4">
-      <div
-        className="mb-3 text-xs font-mono uppercase tracking-[0.18em] text-zinc-500"
-        title={hint}
-      >
-        {title}
-      </div>
+      <div className="mb-1 text-xs font-mono uppercase tracking-[0.18em] text-zinc-500">{title}</div>
+      {hint && <div className="mb-3 text-[11px] leading-snug text-zinc-600">{hint}</div>}
       {items.length > 0 ? (
         <div className="flex flex-wrap gap-2">
           {items.map((item) => (
@@ -65,107 +72,74 @@ export default function IntentPolicyPanel({ result }: IntentPolicyPanelProps) {
     <div className="h-full overflow-y-auto p-6 text-zinc-200">
       <div className="grid gap-4 lg:grid-cols-2">
         <div className="rounded-3xl border border-cyan-500/15 bg-gradient-to-br from-cyan-500/10 to-transparent p-5">
-          <div
-            className="mb-2 text-[11px] font-mono uppercase tracking-[0.18em] text-cyan-300/80"
-            title="What the compiler thinks you're trying to do."
-          >
+          <div className="mb-1 text-[11px] font-mono uppercase tracking-[0.18em] text-cyan-300/80">
             Intent
           </div>
+          <p className="mb-3 text-[11px] leading-snug text-cyan-200/70">
+            What the compiler thinks you are trying to do.
+          </p>
           <div className="space-y-3">
             <div>
-              <div
-                className="text-xs text-zinc-500"
-                title="What kind of work this request is about (code, ops, writing…)."
-              >
-                Domain
-              </div>
-              <div className="text-lg font-semibold text-white">{intentPolicy.domain}</div>
+              <FieldLabel hint="What kind of work this request is about (code, ops, writing, …).">Domain</FieldLabel>
+              <div className="mt-1 text-lg font-semibold text-white">{intentPolicy.domain}</div>
             </div>
             <div>
-              <div
-                className="text-xs text-zinc-500"
-                title="Who the AI should act as while answering."
-              >
-                Persona
-              </div>
-              <div className="text-sm text-zinc-200">{humanizeIntentPolicyValue(intentPolicy.persona)}</div>
+              <FieldLabel hint="Who the AI should act as while answering.">Persona</FieldLabel>
+              <div className="mt-1 text-sm text-zinc-200">{humanizeIntentPolicyValue(intentPolicy.persona)}</div>
             </div>
             <div>
-              <div
-                className="mb-2 text-xs text-zinc-500"
-                title="Specific intent signals the compiler picked up from your request."
-              >
-                Detected Intents
-              </div>
-              {intentPolicy.intentDetails.length > 0 ? (
-                <div className="grid gap-3">
-                  {intentPolicy.intentDetails.map((intent) => (
-                    <div
-                      key={intent.key}
-                      className="rounded-2xl border border-white/8 bg-black/20 p-3"
-                    >
-                      <div className="mb-2 flex items-center justify-between gap-3">
-                        <div className="text-sm font-semibold text-white">{intent.label}</div>
-                        <IntentGroupBadge group={intent.group} />
+              <FieldLabel hint="Specific intent signals the compiler picked up from your request.">Detected Intents</FieldLabel>
+              <div className="mt-2">
+                {intentPolicy.intentDetails.length > 0 ? (
+                  <div className="grid gap-3">
+                    {intentPolicy.intentDetails.map((intent) => (
+                      <div
+                        key={intent.key}
+                        className="rounded-2xl border border-white/8 bg-black/20 p-3"
+                      >
+                        <div className="mb-2 flex items-center justify-between gap-3">
+                          <div className="text-sm font-semibold text-white">{intent.label}</div>
+                          <IntentGroupBadge group={intent.group} />
+                        </div>
+                        <div className="text-xs leading-relaxed text-zinc-400">{intent.description}</div>
                       </div>
-                      <div className="text-xs leading-relaxed text-zinc-400">{intent.description}</div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-4">
-                  <div className="text-sm font-medium text-white">General Request</div>
-                  <div className="mt-1 text-sm text-zinc-500">
-                    No special intent signals were inferred, so the compiler is treating this as a general-purpose request.
+                    ))}
                   </div>
-                </div>
-              )}
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-4">
+                    <div className="text-sm font-medium text-white">General Request</div>
+                    <div className="mt-1 text-sm text-zinc-500">
+                      No special intent signals were inferred, so the compiler is treating this as a general-purpose request.
+                    </div>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>
 
         <div className="rounded-3xl border border-amber-500/15 bg-gradient-to-br from-amber-500/10 to-transparent p-5">
-          <div
-            className="mb-2 text-[11px] font-mono uppercase tracking-[0.18em] text-amber-300/80"
-            title="Safety rules the compiler applied to this request."
-          >
+          <div className="mb-1 text-[11px] font-mono uppercase tracking-[0.18em] text-amber-300/80">
             Policy
           </div>
+          <p className="mb-3 text-[11px] leading-snug text-amber-200/70">
+            Safety rules the compiler applied to this request.
+          </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
-              <div
-                className="text-xs text-zinc-500"
-                title="How cautious the compiler was when shaping the output."
-              >
-                Risk Level
-              </div>
+              <FieldLabel hint="How cautious the compiler was when shaping the output.">Risk Level</FieldLabel>
               <div className="mt-1 text-lg font-semibold text-white">{humanizeIntentPolicyValue(intentPolicy.riskLevel)}</div>
             </div>
             <div>
-              <div
-                className="text-xs text-zinc-500"
-                title="Whether the result is meant to be run automatically or only suggested."
-              >
-                Execution Mode
-              </div>
+              <FieldLabel hint="Whether the result is meant to be run automatically or only suggested.">Execution Mode</FieldLabel>
               <div className="mt-1 text-lg font-semibold text-white">{humanizeIntentPolicyValue(intentPolicy.executionMode)}</div>
             </div>
             <div>
-              <div
-                className="text-xs text-zinc-500"
-                title="How private the input data looked to the scanner."
-              >
-                Data Sensitivity
-              </div>
+              <FieldLabel hint="How private the input data looked to the scanner.">Data Sensitivity</FieldLabel>
               <div className="mt-1 text-sm text-zinc-200">{humanizeIntentPolicyValue(intentPolicy.dataSensitivity)}</div>
             </div>
             <div>
-              <div
-                className="text-xs text-zinc-500"
-                title="Categories the compiler flagged as needing extra care."
-              >
-                Risk Domains
-              </div>
+              <FieldLabel hint="Categories the compiler flagged as needing extra care.">Risk Domains</FieldLabel>
               <div className="mt-1 text-sm text-zinc-200">
                 {intentPolicy.riskDomains.length > 0
                   ? intentPolicy.riskDomains.map(humanizeIntentPolicyValue).join(", ")

--- a/web/app/components/SecurityAlert.tsx
+++ b/web/app/components/SecurityAlert.tsx
@@ -21,27 +21,33 @@ export default function SecurityAlert({
 }: SecurityAlertProps) {
 
     const findingsSummary = useMemo(() => {
+        // Keys match the backend security scanner types in app/heuristics/security.py
+        // (openai_key, github_token, generic_api_key, private_key, email, ipv4, credit_card).
         const friendlyLabel: Record<string, { singular: string; plural: string }> = {
+            openai_key: { singular: "OpenAI API key", plural: "OpenAI API keys" },
+            github_token: { singular: "GitHub token", plural: "GitHub tokens" },
+            generic_api_key: { singular: "API key", plural: "API keys" },
+            private_key: { singular: "private key", plural: "private keys" },
             email: { singular: "email address", plural: "email addresses" },
+            ipv4: { singular: "IP address", plural: "IP addresses" },
+            credit_card: { singular: "credit-card number", plural: "credit-card numbers" },
             phone: { singular: "phone number", plural: "phone numbers" },
-            secret: { singular: "secret / API key", plural: "secrets / API keys" },
-            apikey: { singular: "API key", plural: "API keys" },
-            token: { singular: "auth token", plural: "auth tokens" },
-            creditcard: { singular: "credit-card number", plural: "credit-card numbers" },
             ssn: { singular: "social security number", plural: "social security numbers" },
-            ip: { singular: "IP address", plural: "IP addresses" },
+        };
+        const humanizeFallback = (type: string, count: number) => {
+            const words = type.toLowerCase().replace(/[_-]+/g, " ").trim();
+            return `${count} ${words}${count === 1 ? "" : "s"}`;
         };
         const counts: Record<string, number> = {};
         findings.forEach(f => {
             counts[f.type] = (counts[f.type] || 0) + 1;
         });
         return Object.entries(counts).map(([type, count]) => {
-            const key = type.toLowerCase().replace(/[\s_-]/g, "");
-            const label = friendlyLabel[key];
+            const label = friendlyLabel[type.toLowerCase()];
             if (label) {
                 return `${count} ${count === 1 ? label.singular : label.plural}`;
             }
-            return `${count} ${type.toLowerCase()}${count === 1 ? "" : "s"}`;
+            return humanizeFallback(type, count);
         });
     }, [findings]);
 
@@ -62,7 +68,7 @@ export default function SecurityAlert({
                         </div>
                         <div>
                             <h2 id="security-alert-title" className="text-xl font-bold text-red-100 tracking-wide">Possible secrets in your prompt</h2>
-                            <p className="text-sm text-red-300/80">We scanned locally and spotted patterns that look like personal data or credentials. Nothing has been sent to any model yet — it's your call.</p>
+                            <p className="text-sm text-red-300/80">Patterns that look like personal data or credentials were detected. Choose how the next compile should handle them.</p>
                         </div>
                     </div>
                 </div>
@@ -81,7 +87,8 @@ export default function SecurityAlert({
                     <div className="bg-black/30 rounded-xl border border-white/5 p-4 flex flex-col gap-2">
                         <span className="text-[10px] text-zinc-500 uppercase font-bold tracking-wider">Preview Redacted Version</span>
                         <p className="text-xs text-zinc-400 leading-relaxed">
-                            <strong className="text-zinc-300">Strip Secrets &amp; Proceed</strong> will send the version below — your local prompt is unchanged.
+                            <strong className="text-zinc-300">Strip Secrets &amp; Proceed</strong> retries with the redacted version below.{" "}
+                            <strong className="text-zinc-300">Send original anyway</strong> retries with your prompt unchanged.
                         </p>
                         <pre className="text-xs text-zinc-400 font-mono whitespace-pre-wrap leading-relaxed max-h-[200px] overflow-y-auto custom-scrollbar">
                             {redactedText}

--- a/web/app/components/SecurityAlert.tsx
+++ b/web/app/components/SecurityAlert.tsx
@@ -21,11 +21,28 @@ export default function SecurityAlert({
 }: SecurityAlertProps) {
 
     const findingsSummary = useMemo(() => {
+        const friendlyLabel: Record<string, { singular: string; plural: string }> = {
+            email: { singular: "email address", plural: "email addresses" },
+            phone: { singular: "phone number", plural: "phone numbers" },
+            secret: { singular: "secret / API key", plural: "secrets / API keys" },
+            apikey: { singular: "API key", plural: "API keys" },
+            token: { singular: "auth token", plural: "auth tokens" },
+            creditcard: { singular: "credit-card number", plural: "credit-card numbers" },
+            ssn: { singular: "social security number", plural: "social security numbers" },
+            ip: { singular: "IP address", plural: "IP addresses" },
+        };
         const counts: Record<string, number> = {};
         findings.forEach(f => {
             counts[f.type] = (counts[f.type] || 0) + 1;
         });
-        return Object.entries(counts).map(([type, count]) => `${count} x ${type.toUpperCase()}`);
+        return Object.entries(counts).map(([type, count]) => {
+            const key = type.toLowerCase().replace(/[\s_-]/g, "");
+            const label = friendlyLabel[key];
+            if (label) {
+                return `${count} ${count === 1 ? label.singular : label.plural}`;
+            }
+            return `${count} ${type.toLowerCase()}${count === 1 ? "" : "s"}`;
+        });
     }, [findings]);
 
     return (
@@ -44,8 +61,8 @@ export default function SecurityAlert({
                             <ShieldAlert size={22} className="text-red-300" aria-hidden="true" />
                         </div>
                         <div>
-                            <h2 id="security-alert-title" className="text-xl font-bold text-red-100 tracking-wide">Security Alert</h2>
-                            <p className="text-sm text-red-300/80">Sensitive information detected in your prompt.</p>
+                            <h2 id="security-alert-title" className="text-xl font-bold text-red-100 tracking-wide">Possible secrets in your prompt</h2>
+                            <p className="text-sm text-red-300/80">We scanned locally and spotted patterns that look like personal data or credentials. Nothing has been sent to any model yet — it's your call.</p>
                         </div>
                     </div>
                 </div>
@@ -63,6 +80,9 @@ export default function SecurityAlert({
 
                     <div className="bg-black/30 rounded-xl border border-white/5 p-4 flex flex-col gap-2">
                         <span className="text-[10px] text-zinc-500 uppercase font-bold tracking-wider">Preview Redacted Version</span>
+                        <p className="text-xs text-zinc-400 leading-relaxed">
+                            <strong className="text-zinc-300">Strip Secrets &amp; Proceed</strong> will send the version below — your local prompt is unchanged.
+                        </p>
                         <pre className="text-xs text-zinc-400 font-mono whitespace-pre-wrap leading-relaxed max-h-[200px] overflow-y-auto custom-scrollbar">
                             {redactedText}
                         </pre>
@@ -92,7 +112,7 @@ export default function SecurityAlert({
                         onClick={onProceedOriginal}
                         className="px-4 py-2 text-sm font-medium text-red-400 border border-red-500/30 hover:bg-red-500/10 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
                     >
-                        Proceed Unsafe (Original)
+                        Send original anyway
                     </button>
 
                     <button

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
@@ -27,6 +27,63 @@ function getTabContent(result: CompileResponse, activeTab: OutputTab): string {
   }
 
   return result.expanded_prompt_v2 || result.expanded_prompt;
+}
+
+function TabButton({
+  tabKey,
+  label,
+  hint,
+  isActive,
+  primary,
+  onSelect,
+}: {
+  tabKey: OutputTab;
+  label: string;
+  hint: string;
+  isActive: boolean;
+  primary: boolean;
+  onSelect: (key: OutputTab) => void;
+}) {
+  const [showTip, setShowTip] = useState(false);
+  const tipId = useId();
+
+  return (
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={isActive}
+        aria-controls={`tabpanel-${tabKey}`}
+        aria-describedby={showTip ? tipId : undefined}
+        id={`tab-${tabKey}`}
+        onClick={() => onSelect(tabKey)}
+        onMouseEnter={() => setShowTip(true)}
+        onMouseLeave={() => setShowTip(false)}
+        onFocus={() => setShowTip(true)}
+        onBlur={() => setShowTip(false)}
+        className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 sm:px-4 ${isActive
+          ? "text-white bg-white/5 border-t border-x border-white/5"
+          : "text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
+          }`}
+      >
+        <span>{label}</span>
+        {primary && (
+          <span className="ml-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-1.5 py-0.5 align-middle text-[9px] font-mono uppercase tracking-wider text-emerald-300">
+            Use this
+          </span>
+        )}
+      </button>
+      {showTip && (
+        <span
+          id={tipId}
+          role="tooltip"
+          className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 w-64 -translate-x-1/2 rounded-md border border-neutral-700 bg-neutral-900 p-2.5 text-left text-xs font-normal leading-snug text-neutral-300 shadow-xl animate-fade-in"
+        >
+          {hint}
+        </span>
+      )}
+    </span>
+  );
 }
 
 function CompilerErrorState({
@@ -243,41 +300,25 @@ export default function Home() {
                 <div role="tablist" aria-label="Output views" className="flex gap-1 overflow-x-auto scroll-smooth border-b border-white/5 px-4 pt-4 pb-1" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
                   {(
                     [
-                      { key: "user", label: "User Prompt", title: "The prompt to copy and send to your model. Most users want this tab.", primary: true },
-                      { key: "system", label: "System Prompt", title: "Role and behavior rules for the model — paste this into a system message.", primary: false },
-                      { key: "plan", label: "Execution Plan", title: "Step-by-step plan the compiler suggests for carrying out the request.", primary: false },
-                      { key: "expanded", label: "Long-form", title: "Verbose, fully expanded version of the prompt with all context inlined.", primary: false },
-                      { key: "intent", label: "Intent", title: "Detected intent and safety policy for this request.", primary: false },
-                      { key: "json", label: "JSON", title: "Raw machine-readable compile output — useful for piping into other tools.", primary: false },
-                      { key: "quality", label: "Quality Scores", title: "Quality, clarity, and safety scores the compiler assigned to the result.", primary: false },
-                    ] satisfies ReadonlyArray<{ key: OutputTab; label: string; title: string; primary: boolean }>
-                  ).map(({ key, label, title, primary }) => {
-                    const isActive = activeTab === key;
-                    const showPrimaryHint = !!primary && !isActive;
-                    return (
-                      <button
-                        type="button"
-                        key={key}
-                        role="tab"
-                        aria-selected={isActive}
-                        aria-controls={`tabpanel-${key}`}
-                        id={`tab-${key}`}
-                        title={title}
-                        onClick={() => setActiveTab(key)}
-                        className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 sm:px-4 ${isActive
-                          ? "text-white bg-white/5 border-t border-x border-white/5"
-                          : "text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
-                          }`}
-                      >
-                        <span>{label}</span>
-                        {showPrimaryHint && (
-                          <span className="ml-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-1.5 py-0.5 align-middle text-[9px] font-mono uppercase tracking-wider text-emerald-300">
-                            Use this
-                          </span>
-                        )}
-                      </button>
-                    );
-                  })}
+                      { key: "user", label: "User Prompt", hint: "The prompt to copy and send to your model. Most users want this tab.", primary: true },
+                      { key: "system", label: "System Prompt", hint: "Role and behavior rules for the model — paste this into a system message.", primary: false },
+                      { key: "plan", label: "Execution Plan", hint: "Step-by-step plan the compiler suggests for carrying out the request.", primary: false },
+                      { key: "expanded", label: "Long-form", hint: "Verbose, fully expanded version of the prompt with all context inlined.", primary: false },
+                      { key: "intent", label: "Intent", hint: "Detected intent and safety policy for this request.", primary: false },
+                      { key: "json", label: "JSON", hint: "Raw machine-readable compile output — useful for piping into other tools.", primary: false },
+                      { key: "quality", label: "Quality Scores", hint: "Quality, clarity, and safety scores the compiler assigned to the result.", primary: false },
+                    ] satisfies ReadonlyArray<{ key: OutputTab; label: string; hint: string; primary: boolean }>
+                  ).map(({ key, label, hint, primary }) => (
+                    <TabButton
+                      key={key}
+                      tabKey={key}
+                      label={label}
+                      hint={hint}
+                      isActive={activeTab === key}
+                      primary={primary}
+                      onSelect={setActiveTab}
+                    />
+                  ))}
                 </div>
 
                 {/* Content — one stable tabpanel per tab, hidden when inactive */}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -61,7 +61,7 @@ function CompilerErrorState({
 
 export default function Home() {
   const [prompt, setPrompt] = useState("");
-  const [activeTab, setActiveTab] = useState<OutputTab>("intent");
+  const [activeTab, setActiveTab] = useState<OutputTab>("user");
   const [copied, setCopied] = useState(false);
   const [conservativeMode, setConservativeMode] = useState(() => {
     if (typeof window === "undefined") {
@@ -241,23 +241,43 @@ export default function Home() {
               <>
                 {/* Tabs */}
                 <div role="tablist" aria-label="Output views" className="flex gap-1 overflow-x-auto scroll-smooth border-b border-white/5 px-4 pt-4 pb-1" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
-                  {(["intent", "system", "user", "plan", "expanded", "json", "quality"] as const).map((tab) => (
-                    <button
-                      type="button"
-                      key={tab}
-                      role="tab"
-                      aria-selected={activeTab === tab}
-                      aria-controls={`tabpanel-${tab}`}
-                      id={`tab-${tab}`}
-                      onClick={() => setActiveTab(tab)}
-                      className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 sm:px-4 ${activeTab === tab
-                        ? "text-white bg-white/5 border-t border-x border-white/5"
-                        : "text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
-                        }`}
-                    >
-                      {tab.charAt(0).toUpperCase() + tab.slice(1)}
-                    </button>
-                  ))}
+                  {(
+                    [
+                      { key: "user", label: "User Prompt", title: "The prompt to copy and send to your model. Most users want this tab.", primary: true },
+                      { key: "system", label: "System Prompt", title: "Role and behavior rules for the model — paste this into a system message.", primary: false },
+                      { key: "plan", label: "Execution Plan", title: "Step-by-step plan the compiler suggests for carrying out the request.", primary: false },
+                      { key: "expanded", label: "Long-form", title: "Verbose, fully expanded version of the prompt with all context inlined.", primary: false },
+                      { key: "intent", label: "Intent", title: "Detected intent and safety policy for this request.", primary: false },
+                      { key: "json", label: "JSON", title: "Raw machine-readable compile output — useful for piping into other tools.", primary: false },
+                      { key: "quality", label: "Quality Scores", title: "Quality, clarity, and safety scores the compiler assigned to the result.", primary: false },
+                    ] satisfies ReadonlyArray<{ key: OutputTab; label: string; title: string; primary: boolean }>
+                  ).map(({ key, label, title, primary }) => {
+                    const isActive = activeTab === key;
+                    const showPrimaryHint = !!primary && !isActive;
+                    return (
+                      <button
+                        type="button"
+                        key={key}
+                        role="tab"
+                        aria-selected={isActive}
+                        aria-controls={`tabpanel-${key}`}
+                        id={`tab-${key}`}
+                        title={title}
+                        onClick={() => setActiveTab(key)}
+                        className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 sm:px-4 ${isActive
+                          ? "text-white bg-white/5 border-t border-x border-white/5"
+                          : "text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
+                          }`}
+                      >
+                        <span>{label}</span>
+                        {showPrimaryHint && (
+                          <span className="ml-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-1.5 py-0.5 align-middle text-[9px] font-mono uppercase tracking-wider text-emerald-300">
+                            Use this
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
 
                 {/* Content — one stable tabpanel per tab, hidden when inactive */}


### PR DESCRIPTION
## Summary

A walk-through of the app as a brand-new user surfaced three moments that reliably break, scare, or mislead first-timers in their first 5 minutes. This PR fixes all three with surgical, low-risk edits.

### 1. Security dialog stops sounding like an accusation
[components/SecurityAlert.tsx](web/app/components/SecurityAlert.tsx)
- **Title**: \`Security Alert\` → \`Possible secrets in your prompt\` with a calmer subline ("We scanned locally and spotted patterns… Nothing has been sent yet — it's your call").
- **Button**: \`Proceed Unsafe (Original)\` → \`Send original anyway\` (red border kept; only the accusatory word is gone).
- **Finding chips**: \`1 x EMAIL\` → \`1 email address\`, \`2 x SECRET\` → \`2 secrets / API keys\`, etc., via a small singular/plural map.
- Added a one-liner above the redacted preview clarifying which button does what.

### 2. Benchmark mock no longer masquerades as a real measurement
[benchmark/page.tsx](web/app/benchmark/page.tsx)
- The default \`Mock Engine\` returns hardcoded \`improvement_score: 35\` and randomized "compiled-always-wins" scores. A first-timer running their first benchmark currently sees a polished radar chart and "+35%" headline that look real.
- Option label: \`Mock Engine [local]\` → \`Mock Engine — demo (fake scores)\`.
- Helper text rewritten in amber while mock is selected: "No model is called. Numbers below are randomized for UI preview only — pick a real model to run an actual benchmark."
- New \`resultIsMock\` state drives an amber banner above the radar whenever the result came from the mock engine: **"Demo data — not a real benchmark."**
- Empty-state copy and status pill updated to match.

### 3. Compile output stops dropping users into a governance dashboard
[page.tsx](web/app/page.tsx) + [components/IntentPolicyPanel.tsx](web/app/components/IntentPolicyPanel.tsx)
- Default landing tab: \`intent\` → \`user\`. Users came here for the prompt; show them the prompt first.
- Tabs renamed and reordered: \`User Prompt\` (with a "Use this" pill), \`System Prompt\`, \`Execution Plan\`, \`Long-form\`, \`Intent\`, \`JSON\`, \`Quality Scores\`. Every tab gets a one-line \`title=\` tooltip.
- Plain-English tooltips added to every label inside the Intent/Policy panel (Domain, Persona, Risk Level, Execution Mode, Data Sensitivity, Risk Domains, Allowed/Forbidden Tools, Sanitization Rules).
- Tab keys are unchanged — only display labels — so existing aria/panel wiring keeps working.

## Test plan
- [ ] \`npm install && npx tsc --noEmit\` in \`web/\` passes
- [ ] \`npm test\` in \`web/\` passes
- [ ] Cold-load \`/\`, paste a short request, hit Generate — landing tab is **User Prompt** with a "Use this" pill; hover any tab shows a one-line tooltip
- [ ] Switch to **Intent** tab; hover any field label shows a plain-English explanation
- [ ] Compile a prompt containing an email like \`support@example.com\` — dialog reads "Possible secrets in your prompt"; chip shows \`1 email address\`; secondary button reads "Send original anyway"
- [ ] On \`/benchmark\` with the default model: helper text under the dropdown is amber and warns about randomized scores; running a benchmark shows the "Demo data — not a real benchmark" banner above the radar
- [ ] Switch to any non-mock model and re-run: banner does **not** appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)