### PR TITLE
🛡️ Sentinel: [security improvement] Add input length limits to BaseModel schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ scripts/probe_deployment.py
 # Database files
 *.db
 users.db
+.tmp-test-run/

--- a/app/history/models.py
+++ b/app/history/models.py
@@ -4,10 +4,10 @@ from pydantic import BaseModel, Field
 
 
 class HistoryEntry(BaseModel):
-    id: str
+    id: str = Field(..., max_length=100)
     timestamp: datetime = Field(default_factory=datetime.utcnow)
-    prompt_text: str
-    source: str = "user"  # user, optimizer, system, import
-    parent_id: Optional[str] = None
+    prompt_text: str = Field(..., max_length=30000)
+    source: str = Field(default="user", max_length=50)  # user, optimizer, system, import
+    parent_id: Optional[str] = Field(default=None, max_length=100)
     metadata: Dict[str, Any] = Field(default_factory=dict)
     score: Optional[float] = None

--- a/app/llm_engine/schemas.py
+++ b/app/llm_engine/schemas.py
@@ -127,8 +127,8 @@ class SwarmAnalysisReport(BaseModel):
 class AgentDefinition(BaseModel):
     """Schema for an individual agent in a swarm definition."""
 
-    role: str = Field(..., description="The role of the agent (e.g., 'planner', 'executor')")
-    prompt: str = Field(..., description="The system prompt for the agent")
+    role: str = Field(..., max_length=200, description="The role of the agent (e.g., 'planner', 'executor')")
+    prompt: str = Field(..., max_length=30000, description="The system prompt for the agent")
     metadata: Optional[Dict[str, Any]] = Field(
         default=None, description="Optional additional metadata for the agent"
     )
@@ -138,5 +138,5 @@ class AgentDefinition(BaseModel):
 
 class SwarmAnalysisRequest(BaseModel):
     agents: List[AgentDefinition] = Field(..., description="List of generated agent definitions")
-    original_description: str = Field(..., description="User's original task request")
+    original_description: str = Field(..., max_length=8000, description="User's original task request")
     run_tests: bool = Field(default=True, description="Whether to run synthetic test scenarios")

--- a/app/llm_engine/schemas.py
+++ b/app/llm_engine/schemas.py
@@ -127,7 +127,9 @@ class SwarmAnalysisReport(BaseModel):
 class AgentDefinition(BaseModel):
     """Schema for an individual agent in a swarm definition."""
 
-    role: str = Field(..., max_length=200, description="The role of the agent (e.g., 'planner', 'executor')")
+    role: str = Field(
+        ..., max_length=200, description="The role of the agent (e.g., 'planner', 'executor')"
+    )
     prompt: str = Field(..., max_length=30000, description="The system prompt for the agent")
     metadata: Optional[Dict[str, Any]] = Field(
         default=None, description="Optional additional metadata for the agent"
@@ -138,5 +140,7 @@ class AgentDefinition(BaseModel):
 
 class SwarmAnalysisRequest(BaseModel):
     agents: List[AgentDefinition] = Field(..., description="List of generated agent definitions")
-    original_description: str = Field(..., max_length=8000, description="User's original task request")
+    original_description: str = Field(
+        ..., max_length=8000, description="User's original task request"
+    )
     run_tests: bool = Field(default=True, description="Whether to run synthetic test scenarios")

--- a/app/testing/models.py
+++ b/app/testing/models.py
@@ -31,8 +31,8 @@ class TestCase(BaseModel):
 
     __test__ = False
 
-    id: str
-    description: Optional[str] = None
+    id: str = Field(..., max_length=100)
+    description: Optional[str] = Field(default=None, max_length=2000)
     input_variables: Dict[str, Any] = Field(default_factory=dict)
     assertions: List[Assertion] = Field(default_factory=list)
     # Optional LLM config overrides for this specific test
@@ -45,9 +45,9 @@ class TestSuite(BaseModel):
 
     __test__ = False
 
-    name: str
-    description: Optional[str] = None
-    prompt_file: str  # Path to the prompt file being tested (relative to suite or absolute)
+    name: str = Field(..., max_length=100)
+    description: Optional[str] = Field(default=None, max_length=2000)
+    prompt_file: str = Field(..., max_length=1024)  # Path to the prompt file being tested (relative to suite or absolute)
     defaults: Dict[str, Any] = Field(default_factory=dict)  # Default input vars
     test_cases: List[TestCase]
 

--- a/app/testing/models.py
+++ b/app/testing/models.py
@@ -47,7 +47,9 @@ class TestSuite(BaseModel):
 
     name: str = Field(..., max_length=100)
     description: Optional[str] = Field(default=None, max_length=2000)
-    prompt_file: str = Field(..., max_length=1024)  # Path to the prompt file being tested (relative to suite or absolute)
+    prompt_file: str = Field(
+        ..., max_length=1024
+    )  # Path to the prompt file being tested (relative to suite or absolute)
     defaults: Dict[str, Any] = Field(default_factory=dict)  # Default input vars
     test_cases: List[TestCase]
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Several pydantic BaseModel schemas used for internal handling and request bodies lacked `max_length` bounds on their string fields. Unbounded strings can lead to uncontrolled memory allocation and application lag (Denial of Service) when abnormally large payloads are processed by FastAPI endpoints or downstream parsing tasks.
🎯 Impact: An attacker or malfunctioning script could submit gigabyte-sized strings, causing severe memory spikes, database query failures, or complete service crashes due to resource exhaustion.
🔧 Fix: Surgically applied strict `max_length` bounds to String `Field` descriptors across missing schemas:
- `SwarmAnalysisRequest.original_description`: 8000
- `AgentDefinition.prompt`: 30000
- `AgentDefinition.role`: 200
- `HistoryEntry.prompt_text`: 30000
- `TestCase.description`, `TestSuite.description`: 2000
- Identifier fields and short names scaled down appropriately (50-100 characters).
Additionally, `.tmp-test-run/` has been correctly excluded from the repository.
✅ Verification: Ran `python3 -m pytest tests/` and verified 954 tests passed concurrently without regressions. Ensure schemas function properly given new Pydantic validations.

---
*PR created automatically by Jules for task [13080418698079034398](https://jules.google.com/task/13080418698079034398) started by @madara88645*