### PR TITLE
[codex] Add ContextManager Enter ingest regression tests

### DIFF
--- a/web/app/components/__tests__/ContextManager.test.tsx
+++ b/web/app/components/__tests__/ContextManager.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import ContextManager from "../ContextManager";
@@ -50,5 +50,87 @@ describe("ContextManager", () => {
     const ingestButton = screen.getByRole("button", { name: "Ingest Path" });
     expect(ingestButton.getAttribute("type")).toBe("button");
     expect(ingestButton.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("runs path ingest on Enter when a file path is present", () => {
+    const ingestPath = vi.fn();
+
+    useContextManagerMock.mockReturnValue({
+      ingesting: false,
+      searching: false,
+      query: "",
+      setQuery: vi.fn(),
+      results: [],
+      filePath: "docs/architecture",
+      setFilePath: vi.fn(),
+      status: "",
+      isConnected: true,
+      indexStats: null,
+      uploadProgress: null,
+      uploadFiles: vi.fn(),
+      ingestPath,
+      runSearch: vi.fn(),
+    });
+
+    render(<ContextManager onInsertContext={vi.fn()} />);
+
+    fireEvent.keyDown(screen.getByLabelText("Path to file or folder..."), { key: "Enter" });
+
+    expect(ingestPath).toHaveBeenCalledTimes(1);
+    expect(ingestPath).toHaveBeenCalledWith("docs/architecture");
+  });
+
+  it("does not run path ingest on Enter when the file path is empty", () => {
+    const ingestPath = vi.fn();
+
+    useContextManagerMock.mockReturnValue({
+      ingesting: false,
+      searching: false,
+      query: "",
+      setQuery: vi.fn(),
+      results: [],
+      filePath: "",
+      setFilePath: vi.fn(),
+      status: "",
+      isConnected: true,
+      indexStats: null,
+      uploadProgress: null,
+      uploadFiles: vi.fn(),
+      ingestPath,
+      runSearch: vi.fn(),
+    });
+
+    render(<ContextManager onInsertContext={vi.fn()} />);
+
+    fireEvent.keyDown(screen.getByLabelText("Path to file or folder..."), { key: "Enter" });
+
+    expect(ingestPath).not.toHaveBeenCalled();
+  });
+
+  it("does not run path ingest on Enter while ingest is already in progress", () => {
+    const ingestPath = vi.fn();
+
+    useContextManagerMock.mockReturnValue({
+      ingesting: true,
+      searching: false,
+      query: "",
+      setQuery: vi.fn(),
+      results: [],
+      filePath: "docs/architecture",
+      setFilePath: vi.fn(),
+      status: "",
+      isConnected: true,
+      indexStats: null,
+      uploadProgress: null,
+      uploadFiles: vi.fn(),
+      ingestPath,
+      runSearch: vi.fn(),
+    });
+
+    render(<ContextManager onInsertContext={vi.fn()} />);
+
+    fireEvent.keyDown(screen.getByLabelText("Path to file or folder..."), { key: "Enter" });
+
+    expect(ingestPath).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add ContextManager regression coverage for Enter-triggered path ingest
- verify ingest runs only when a path is present and no ingest is already in progress
- protect the recent keyboard shortcut added in the advanced path indexing flow

## Why
A recent change added Enter-key submission to the Context Manager path input, but the component test only covered static rendering and disabled state. This PR closes that regression gap around a newly added keyboard interaction.

## Validation
- cd web && npm run test
- cd web && npm run lint
- cd web && npm run build
