### PR TITLE
🛡️ Sentinel: [security improvement] Enforce tag length limits to prevent DoS

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -68,6 +68,8 @@ class CompileRequest(BaseModel):
         if tags is None:
             return None
         normalized = [tag.strip() for tag in tags if tag and tag.strip()]
+        if any(len(t) > 100 for t in normalized):
+            raise ValueError("Tag length must not exceed 100 characters")
         return normalized[:20]
 
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing length validation on strings within the `tags` list in `CompileRequest` model could allow an attacker to send excessively large strings, potentially leading to resource exhaustion (DoS).
🎯 Impact: An attacker could consume excessive memory and CPU by passing a massive string in the tags array, slowing down the server or causing crashes.
🔧 Fix: Implemented an explicit check inside `_validate_tags` to ensure no individual tag string exceeds 100 characters.
✅ Verification: Ensure the test suite passes locally (`pnpm test` and `python3 -m pytest -n 4 tests/`) and that requests with overly long tags return a 422 Unprocessable Entity error.

---
*PR created automatically by Jules for task [11710128274205977101](https://jules.google.com/task/11710128274205977101) started by @madara88645*