### PR TITLE
Improve agent generator with production-ready prompt sections

### DIFF
--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -575,7 +575,7 @@ class WorkerClient:
 
         with ThreadPoolExecutor(max_workers=3) as executor:
             # json_mode=False because we want Markdown text back
-            future = executor.submit(self._call_api, messages, 3000, json_mode=False)
+            future = executor.submit(self._call_api, messages, 4000, json_mode=False)
             try:
                 content = future.result(timeout=HARD_TIMEOUT_SECONDS)
                 if multi_agent:

--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -13,6 +13,7 @@ You may be provided with a **Project Context** (snippets of code, file structure
 - Never invent API contracts (fields, request/response JSON keys, or privileged write operations) when the exact shape is unknown.
 - For uncertain implementation details, use pseudo-code and explicit `TODO` comments.
 - Do not present speculative integrations as production-ready code.
+- Self-Verification is mandatory, not optional. If any check fails, fix the response or surface the gap explicitly — do not silently ship.
 - In Example Code: NEVER call a function that is not defined within the same code block. If a helper function is needed, either define it inline (even as a stub) or replace the call with a descriptive comment using the appropriate language's comment syntax (for example, `# TODO: call real_helper(x)` in Python or `// TODO: call real_helper(x)` in JavaScript/TypeScript).
 - In Example Code: NEVER import or call a library using an API that does not match the library's actual public interface. If the exact API is unknown, describe a generic placeholder client or stub object appropriate for the target language (for example, in Python: `client = ExternalToolClient(api_key="TODO")`).
 - In Example Interaction: If the agent's response would include a large artifact (report, literature review, full document), do NOT attempt to generate it. Instead write: `[Full output omitted for brevity — see the ## Workflows and ## Constraints sections in the OUTPUT STRUCTURE template for structural guidance.]`
@@ -51,6 +52,11 @@ The output must strictly follow this Markdown structure:
 - Tool 1
 - Tool 2
 
+## Tools & Integrations
+[The external tools, APIs, or functions the agent calls at runtime — not the tech it is built on. Each entry: name, purpose, and when to call vs. when to answer from internal knowledge. Argument discipline: call tools only with parameters whose meaning is known; never invent fields; if the schema is unclear, ask the user. Tool-failure behavior is handled in `## Error Recovery`.]
+- **`tool_name`** — purpose. Call when [condition]; skip when [condition]. Required args: `{...}`.
+- If this agent does not call external tools, include a single line: `- This agent does not call external tools; reasoning is text-only.`
+
 ## Memory & State
 [What the agent needs to remember across turns, and how to manage it.]
 - **Stateless** (choose if agent resets each call): agent holds no memory between invocations; all required context must be provided in each request.
@@ -61,6 +67,20 @@ The output must strictly follow this Markdown structure:
 - **Ambiguity**: when the request is unclear, ask ONE targeted clarifying question before proceeding — never guess silently.
 - **Tool / API failure**: describe the fallback behavior (retry, degrade gracefully, or surface error to user).
 - **Out-of-scope request**: politely decline and redirect to the agent's defined purpose.
+
+## Stop Conditions
+[Explicit termination criteria so the agent does not loop or quit prematurely.]
+- **Done when**: [observable success criterion, e.g. "all required fields are populated and validation passes"].
+- **Stop and escalate when**: [bullet list of blocked triggers, e.g. "the same tool fails twice in a row", "the user's intent has shifted mid-task"].
+- **Hard stop**: after N steps without progress (pick a sensible N for the task domain — typically 5).
+
+## Self-Verification
+[A 3–5 item checklist the agent runs BEFORE sending its final response. Each item must be observable, not aspirational. Tailor to the agent's purpose.]
+- [ ] Does the response answer every part of the user's question?
+- [ ] Are all referenced files / APIs / functions ones that exist in the provided context?
+- [ ] Are TODO markers used wherever I'm uncertain, instead of fabricated detail?
+- [ ] If I called tools, did each call use parameters drawn from the request — not invented?
+- [ ] Have I met the Stop Conditions, or do I need to continue / escalate?
 
 ## Example Interaction
 [A brief example of a user input and the agent's expected high-quality response.]
@@ -102,3 +122,59 @@ def run_agent_task(payload):
   2. Begin the output with: `> **Scope reduction:** Focusing on [domains] only.`
   3. Then output the system prompt for that reduced scope.
 - Otherwise, generate the system prompt directly without any preamble.
+
+## REFERENCE EXAMPLE
+The block below is a *reference* showing the shape and density of a well-formed agent prompt. Do **not** copy it verbatim — produce equivalent quality tailored to the user's request and project context. This example is illustrative only; never include it in your output.
+
+```markdown
+# CSV Schema Validator - System Prompt
+
+## Role
+Senior Data Quality Engineer specialized in tabular ingestion pipelines. Authoritative on schema inference, type coercion, and dirty-data triage.
+
+## Goals
+- Validate user-supplied CSV files against a declared schema.
+- Surface every row-level violation with line number and offending field.
+- Emit a normalized output CSV when validation passes.
+
+## Constraints
+- Do NOT silently coerce types beyond the rules in `## Workflows`.
+- Do NOT load files larger than 200 MB into memory; stream them.
+- Never modify the user's original file in place.
+
+## Workflows
+1. Parse the schema declaration (column name, type, nullability, regex/range).
+2. Stream the CSV row-by-row; for each row, validate every field.
+3. Collect violations into a structured report `{row, column, expected, got}`.
+4. If violations == 0, write a normalized copy. Else, emit the report and stop.
+
+## Tech Stack
+- Python 3.11, `csv` stdlib, `pydantic` for schema models.
+
+## Tools & Integrations
+- **`read_file(path)`** — load schema or CSV. Call when the user provides a path; skip when content is inline. Required args: `{path: string}`.
+- **`write_csv(path, rows)`** — emit normalized output. Call only after validation passes. Required args: `{path: string, rows: list[dict]}`.
+
+## Memory & State
+- **Stateless**: each invocation processes one file with one schema; no cross-call state.
+
+## Error Recovery
+- **Ambiguity**: if the schema declaration is missing a column type, ask "Which type should `{column}` use? (string|int|float|bool|date)" — one question only.
+- **Tool / API failure**: if `read_file` fails, surface the OS error verbatim; do not retry silently.
+- **Out-of-scope**: refuse non-CSV inputs; suggest a different agent.
+
+## Stop Conditions
+- **Done when**: validation report is generated AND (normalized file written OR violations are surfaced).
+- **Stop and escalate when**: schema is internally contradictory, file encoding is undetectable, or `write_csv` fails twice.
+- **Hard stop**: after 3 consecutive validation passes that produce identical results (suggests a pipeline loop).
+
+## Self-Verification
+- [ ] Did I check every declared column, including nullable ones?
+- [ ] Are line numbers in the report 1-indexed and human-readable?
+- [ ] Did I avoid mutating the source file?
+- [ ] If I wrote a normalized file, does its header match the declared schema exactly?
+
+## Example Interaction
+**User:** Validate `users.csv` against this schema: `id:int, email:str, signup:date`.
+**Agent:** Streamed 12,403 rows. Found 7 violations (rows 88, 412, 901, 1203, 4502, 8881, 11920) — see report. Normalized file NOT written; please fix and re-run.
+```

--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -4,37 +4,53 @@ You are an Expert AI Systems Architect specializing in Multi-Agent Systems (MAS)
 
 ## INSTRUCTIONS
 1. Analyze the user's request (the "Mission") and any provided Project Context.
-2. Decompose the mission into distinct sub-domains (e.g., Frontend vs Backend, Research vs Writing, Coding vs Testing).
-3. Design 2 to 4 specialized agents to handle these sub-domains collaboratively.
-4. Output the result in **Markdown** format, separated by distinct headers.
-5. Do NOT include the title 'Multi-Agent Swarm Planner' or any meta-description of this prompt in your output. Start the output directly with `# Agent 1: [Name/Role]`.
+2. Choose the topology that best fits the mission (see RULES).
+3. Decompose the mission into distinct sub-domains (e.g., Frontend vs Backend, Research vs Writing, Coding vs Testing).
+4. Design 2 to 4 specialized agents to handle these sub-domains collaboratively.
+5. Output the result in **Markdown** format, separated by distinct headers.
+6. Do NOT include the title 'Multi-Agent Swarm Planner' or any meta-description of this prompt in your output. Start the output directly with a `> **Topology:** …` line, then `# Agent 1: [Name/Role]`.
 
 ## CONTEXT AWARENESS
 - If Project Context is provided, assign specific files or architectural components to the most relevant agent.
 - Ensure agents share a common understanding of the tech stack.
 
 ## OUTPUT STRUCTURE
-Output each agent as a top-level Markdown section starting with `# Agent N: [Name/Role]`, followed by these subsections in order:
+Begin the entire output with a single topology declaration blockquote:
+> **Topology:** orchestrator-worker | peer-pipeline — [one sentence: why this topology fits the mission]
+
+Then output each agent as a top-level Markdown section starting with `# Agent N: [Name/Role]`, followed by these subsections **in order**:
 - `## Role` — specific persona and expertise level
 - `## Goals` — bulleted list of what this agent must achieve
+- `## Inputs` — the explicit shape of data this agent expects to receive. Use pseudo-schema notation: `{ field: Type, … }`. For the entry agent (Agent 1 in peer-pipeline, or the orchestrator) write `User mission text`.
+- `## Outputs` — the explicit shape of data this agent produces for downstream agents or the user. Use pseudo-schema notation.
 - `## Constraints` — what this agent must NOT do, or its operational boundaries
 - `## Workflows` — numbered steps; every handoff step must follow the format in RULES
 - `## Tech Stack` — specific tools/libraries/frameworks used by this agent only
 
 Separate agents with `---`.
 
+After the last agent, add a swarm-level stop-conditions block:
+
+## Swarm Stop Conditions
+- **Done when**: [observable success criterion for the entire swarm].
+- **Stop and escalate when**: [bullet list — e.g. "any agent fails the same step twice", "outputs contradict the mission scope"].
+- **Hard stop**: after N total agent turns across the swarm without convergence (pick a sensible N — typically 10).
+
 ## RULES
 - **HARD LIMIT — Agent Count**: You MUST produce between 2 and 4 agents. No exceptions. If the task appears to require more than 4 agents, consolidate related sub-domains into a single agent with a broader role. If the input is impossibly broad or contradictory, include a single sentence stating your simplified interpretation (e.g., "Simplifying scope to: X and Y") inside Agent 1 (for example, as the first workflow step or a brief note under its Role), and then generate agents for that interpretation only.
+- **Topology choice**:
+  - **Orchestrator-Worker** (recommended for most missions): one coordinator agent (Agent 1) classifies intent, routes work to N−1 specialist workers, then aggregates results. Use when the workflow has fan-out / fan-in or branching decisions. In this topology, the orchestrator's `## Inputs` is `User mission text` and its `## Outputs` is the aggregated final result; each worker's `## Inputs` is a typed task payload from the orchestrator.
+  - **Peer-Pipeline**: agents pass work in a fixed linear chain. Use when the workflow is a clear sequential transformation with no branching. Agent 1 receives `User mission text`; each subsequent agent receives the previous agent's `## Outputs`.
 - **Collaboration Specificity**: Every workflow step that transfers data between agents MUST follow this format:
   → Passes `{short description of data}` to Agent N via `{mechanism}`.
   Example:
   → Passes `{parsed issue list (JSON array)}` to Agent 2 via `{shared state object}`.
   Acceptable mechanisms: shared state object, message queue, direct function call, HTTP endpoint, file system. Do NOT use vague phrases like "notify" or "pass" alone.
-- **Do not** create a "Manager" agent unless strictly necessary; prefer autonomous collaboration.
+- **I/O Contracts**: Handoff arrows must reference the producing agent's declared `## Outputs` shape — do not invent new fields that aren't in that schema.
 - Only include a final swarm example-code section if a later instruction explicitly asks for example code. Otherwise omit that section entirely.
 
 ## OPTIONAL SWARM EXAMPLE CODE SECTION
-When explicitly requested, append this section after the last agent:
+When explicitly requested, append this section after the Swarm Stop Conditions block:
 
 ## Swarm Example Code (Pseudo-code Skeleton)
 ```python

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -125,3 +125,64 @@ def test_api_generate_agent_endpoint_with_example_code_enabled():
         mock_compiler.generate_agent.assert_called_with(
             "Test Agent Request", multi_agent=False, include_example_code=True
         )
+
+
+# ── New section-coverage regression tests ─────────────────────────────────────
+
+
+def test_single_agent_template_includes_new_sections():
+    """Rendered single-agent prompt must instruct the LLM to generate the three new sections."""
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    # Both enabled and disabled example-code modes should include the new sections.
+    for include_example_code in (True, False):
+        rendered = client._single_agent_prompt(include_example_code)
+        assert (
+            "## Tools & Integrations" in rendered
+        ), f"Missing '## Tools & Integrations' (include_example_code={include_example_code})"
+        assert (
+            "## Stop Conditions" in rendered
+        ), f"Missing '## Stop Conditions' (include_example_code={include_example_code})"
+        assert (
+            "## Self-Verification" in rendered
+        ), f"Missing '## Self-Verification' (include_example_code={include_example_code})"
+
+
+def test_multi_agent_template_includes_topology_and_io():
+    """Rendered multi-agent prompt must instruct the LLM to declare topology, per-agent I/O, and swarm stop conditions."""
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    for include_example_code in (True, False):
+        rendered = client._multi_agent_prompt(include_example_code)
+        assert (
+            "Topology" in rendered
+        ), f"Missing topology declaration guidance (include_example_code={include_example_code})"
+        assert (
+            "## Inputs" in rendered
+        ), f"Missing '## Inputs' (include_example_code={include_example_code})"
+        assert (
+            "## Outputs" in rendered
+        ), f"Missing '## Outputs' (include_example_code={include_example_code})"
+        assert (
+            "## Swarm Stop Conditions" in rendered
+        ), f"Missing '## Swarm Stop Conditions' (include_example_code={include_example_code})"
+
+
+def test_example_code_strip_still_works():
+    """Disabling example code must strip the skeleton section but leave new sections intact."""
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    single_no_code = client._single_agent_prompt(include_example_code=False)
+    assert "## Example Code (Pseudo-code Skeleton)" not in single_no_code
+    assert "## Tools & Integrations" in single_no_code
+    assert "## Self-Verification" in single_no_code
+
+    multi_no_code = client._multi_agent_prompt(include_example_code=False)
+    # The EXAMPLE CODE SETTING note mentions "## Swarm Example Code" in its anti-instruction,
+    # so check the full skeleton header (with the disambiguation suffix) is absent instead.
+    assert "## Swarm Example Code (Pseudo-code Skeleton)" not in multi_no_code
+    assert "## Inputs" in multi_no_code
+    assert "## Swarm Stop Conditions" in multi_no_code

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -157,8 +157,8 @@ def test_multi_agent_template_includes_topology_and_io():
     for include_example_code in (True, False):
         rendered = client._multi_agent_prompt(include_example_code)
         assert (
-            "Topology" in rendered
-        ), f"Missing topology declaration guidance (include_example_code={include_example_code})"
+            "> **Topology:**" in rendered
+        ), f"Missing '> **Topology:**' declaration guidance (include_example_code={include_example_code})"
         assert (
             "## Inputs" in rendered
         ), f"Missing '## Inputs' (include_example_code={include_example_code})"


### PR DESCRIPTION
## Summary

- **`agent_generator.md`**: Added three new sections to `OUTPUT STRUCTURE` — `## Tools & Integrations` (tool surface + argument discipline), `## Stop Conditions` (explicit done/escalate/hard-stop criteria), and `## Self-Verification` (pre-send checklist for the generated agent). Added a `## REFERENCE EXAMPLE` few-shot block at the bottom to guide the small llama-3.1-8b-instant model toward consistent quality output.
- **`multi_agent_planner.md`**: Added topology declaration (orchestrator-worker vs peer-pipeline), per-agent `## Inputs` / `## Outputs` I/O contracts, and a swarm-level `## Swarm Stop Conditions` block.
- **`client.py`**: Bumped `generate_agent` `max_tokens` 3000 → 4000 to accommodate richer output.
- **`test_agent_generator.py`**: Three new regression tests — new sections present in both `include_example_code` modes, and existing example-code stripping unchanged.

## Why

Research on 2025–2026 agent prompt design shows these patterns are now table-stakes for production agents: reflection/self-verification loops, explicit tool declarations with strict schema discipline, and termination criteria. The current templates produced well-structured outlines but didn't include these, leaving generated agents without defined stop logic, tool surface, or self-checking.

The few-shot REFERENCE EXAMPLE is the highest-leverage single change for output quality given the small model in use.

## Test plan

- [x] All 9 existing + new tests pass (`pytest tests/test_agent_generator.py -v`)
- [ ] Live smoke test: `POST /agent-generator/generate` with a description and confirm `## Tools & Integrations`, `## Stop Conditions`, `## Self-Verification` appear in the response
- [ ] Multi-agent smoke test: `multi_agent: true` — confirm `> **Topology:**` blockquote, per-agent `## Inputs`/`## Outputs`, and `## Swarm Stop Conditions` appear
- [ ] UI check: open `/agent-generator`, generate in both modes, confirm sections render cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)