### PR TITLE
🎨 Palette: Add Clear Search CTA to empty state in RagSearchPanel

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-05-15 - [Add aria-controls to ExportPanel buttons]
 **Learning:** For collapsible content, buttons with `aria-expanded` must also have an `aria-controls` attribute linking them to the content container's ID for screen readers.
 **Action:** When creating expanding/collapsing UI panels, generate a unique ID (e.g. via `useId`) to link the toggle control directly to its target content.
+
+## 2026-04-24 - Empty States with Actions
+**Learning:** Empty states without Call-to-Action (CTA) buttons create friction, especially when the required action button is visually distant (e.g., in a top-right corner). Adding an inline CTA directly in the empty state significantly improves UX by making the next step obvious and easily accessible.
+**Action:** When designing or refactoring empty states, always include a clear CTA button inline if the state requires user action to change. Ensure the CTA has descriptive disabled states/tooltips if conditions aren't met (e.g., missing input).

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -57,8 +57,17 @@ export default function RagSearchPanel({
 
             <div className="custom-scrollbar flex max-h-32 flex-col gap-2 overflow-y-auto pr-1 sm:max-h-40">
                 {!searching && query && results.length === 0 && (
-                    <div className="text-[10px] text-zinc-500 text-center py-4 bg-white/[0.02] rounded-lg border border-dashed border-white/5">
-                        No results found for &quot;{query}&quot;
+                    <div className="flex flex-col items-center gap-2 py-4 bg-white/[0.02] rounded-lg border border-dashed border-white/5">
+                        <span className="text-[10px] text-zinc-500 text-center">
+                            No results found for &quot;{query}&quot;
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => setQuery("")}
+                            className="px-3 py-1 text-[10px] font-medium text-blue-400 bg-blue-500/10 border border-blue-500/20 rounded-md hover:bg-blue-500/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
+                        >
+                            Clear search
+                        </button>
                     </div>
                 )}
 


### PR DESCRIPTION
💡 What: Added an explicit "Clear search" CTA button to the "No results found" empty state in the RAG search panel.
🎯 Why: Empty states without a clear, inline way to recover (like clearing the input) create friction. This makes the next logical step obvious and easily accessible.
📸 Before/After: The "No results found" state now includes a styled, accessible "Clear search" button beneath the text.
♿ Accessibility: The new button includes proper keyboard focus states (`focus-visible:ring-2`) and uses semantic HTML.

---
*PR created automatically by Jules for task [9187657385734162725](https://jules.google.com/task/9187657385734162725) started by @madara88645*