### PR TITLE
🛡️ Sentinel: [HIGH] Enforce strict authentication on cost-incurring benchmark endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** The FastAPI rate limiter implemented in `api/auth.py` periodically cleans up stale rate limit entries to prevent memory leaks by iterating over `RATE_LIMIT_STORE.items()`. However, if concurrent requests add new keys to the store while the cleanup loop is running, the dictionary size changes, resulting in a `RuntimeError: dictionary changed size during iteration`. This unhandled exception crashes the request and potentially the worker, causing a Denial of Service.
 **Learning:** In asynchronous environments (like FastAPI) or multithreaded applications, iterating over a shared mutable dictionary directly (`.items()`) is unsafe if other concurrent tasks can modify the dictionary's size.
 **Prevention:** To safely iterate over a shared dictionary that might be modified concurrently, always iterate over a static copy of the items (e.g., `list(RATE_LIMIT_STORE.items())`).
+## 2025-06-25 - Prevent Unauthorized LLM Benchmark Usage
+
+**Vulnerability:** The `/benchmark/run` endpoint used `verify_api_key_if_required` instead of `verify_api_key`, allowing unauthenticated users to trigger cost-incurring LLM generation when global key requirements were disabled.
+**Learning:** Endpoints added later in the lifecycle (like benchmark routers) can sometimes be missed when applying global or required authentication patterns used in core routers (like `rag` or `compile`), leading to unauthorized resource exhaustion.
+**Prevention:** Always verify that newly added routers or endpoints that trigger cost-incurring actions (like LLM calls) explicitly include standard authentication dependencies (e.g., `Depends(verify_api_key)`) in their signature, matching the pattern used in the rest of the application.

--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -21,7 +21,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
-from api.auth import APIKey, verify_api_key_if_required
+from api.auth import APIKey, verify_api_key
 from api.shared import logger
 from app.compiler import compile_text_v2
 from app.emitters import emit_expanded_prompt_v2
@@ -274,7 +274,7 @@ def _heuristic_judge(raw_output: str, compiled_output: str) -> dict:
 @router.post("/run", response_model=BenchmarkResponse)
 async def benchmark_run(
     req: BenchmarkRequest,
-    api_key: APIKey | None = Depends(verify_api_key_if_required),
+    api_key: APIKey = Depends(verify_api_key),
 ):
     """
     Run an A/B benchmark comparing raw vs compiled prompt quality.

--- a/tests/test_benchmark_api.py
+++ b/tests/test_benchmark_api.py
@@ -12,9 +12,14 @@ def client():
     """Create a test client with the benchmark router mounted."""
     from fastapi import FastAPI
     from app.routers.benchmark import router
+    from api.auth import verify_api_key
 
     test_app = FastAPI()
     test_app.include_router(router)
+
+    # Override auth to allow unauthenticated test calls
+    test_app.dependency_overrides[verify_api_key] = lambda: None
+
     return TestClient(test_app)
 
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/benchmark/run` endpoint used the optional `verify_api_key_if_required` dependency instead of strictly enforcing authentication. When global strict authentication (`PROMPTC_REQUIRE_API_KEY_FOR_ALL`) was off, unauthenticated users could successfully call this endpoint.
🎯 Impact: The endpoint executes actual backend LLM generation processes which incurs operational costs. Lack of strict authentication leaves the application vulnerable to resource exhaustion / financial abuse (DoS via LLM endpoint abuse).
🔧 Fix: Updated the dependency in `app/routers/benchmark.py` to use `Depends(verify_api_key)` explicitly.
✅ Verification: The test suite was updated to mock the auth layer using `dependency_overrides` so existing integration tests continue to run smoothly, and the codebase passes the full test suite.

---
*PR created automatically by Jules for task [3335993533693832512](https://jules.google.com/task/3335993533693832512) started by @madara88645*