### PR TITLE
Fix unsafe backend proxy URL join and remove undocumented API key fallback

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -4,3 +4,6 @@
 # URL of the FastAPI backend reachable from the browser.
 # Local dev default:
 NEXT_PUBLIC_API_URL=http://127.0.0.1:8080
+
+# API key for the web server to authenticate with the backend proxy.
+# PROMPTC_SERVER_API_KEY=your_secret_key_here

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -20,7 +20,6 @@ describe("Next backend proxy route wiring", () => {
     delete process.env.INTERNAL_API_URL;
     delete process.env.NEXT_PUBLIC_API_URL;
     delete process.env.PROMPTC_SERVER_API_KEY;
-    delete process.env.ADMIN_API_KEY;
   });
 
   afterEach(() => {

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -7,7 +7,6 @@ describe("backend proxy", () => {
     delete process.env.INTERNAL_API_URL;
     delete process.env.NEXT_PUBLIC_API_URL;
     delete process.env.PROMPTC_SERVER_API_KEY;
-    delete process.env.ADMIN_API_KEY;
   });
 
   afterEach(() => {

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -1,6 +1,10 @@
 const DEFAULT_BACKEND_API_BASE = "http://127.0.0.1:8080";
 const CONFIG_ERROR_DETAIL = "PROMPTC_SERVER_API_KEY is not configured on the web server.";
 const NETWORK_ERROR_DETAIL = "Could not reach the backend from the web server.";
+
+if (!process.env.PROMPTC_SERVER_API_KEY?.trim()) {
+  console.warn("PROMPTC_SERVER_API_KEY not set - protected proxy routes will forward no API key");
+}
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "content-length",
@@ -19,11 +23,7 @@ type ProxyOptions = {
 };
 
 function resolveServerApiKey(): string {
-  return (
-    process.env.PROMPTC_SERVER_API_KEY?.trim() ||
-    process.env.ADMIN_API_KEY?.trim() ||
-    ""
-  );
+  return process.env.PROMPTC_SERVER_API_KEY?.trim() || "";
 }
 
 function isBodylessMethod(method: string): boolean {
@@ -72,7 +72,9 @@ export async function proxyBackendRequest(
     headers.set("x-api-key", serverApiKey);
   }
 
-  const targetUrl = `${resolveBackendApiBase()}${backendPath}`;
+  const base = resolveBackendApiBase().replace(/\/+$/, '');
+  const path = backendPath.startsWith('/') ? backendPath : '/' + backendPath;
+  const targetUrl = base + path;
 
   try {
     const upstreamResponse = await fetch(targetUrl, {


### PR DESCRIPTION
Fixes a bug in the backend proxy configuration where an incorrectly constructed URL with double slashes could be forwarded. Also, removes the undocumented `ADMIN_API_KEY` fallback in favor of enforcing `PROMPTC_SERVER_API_KEY` or emitting a startup warning.
Updates `web/.env.example` to explicitly document the `PROMPTC_SERVER_API_KEY` and adjusts tests to remove mentions of `ADMIN_API_KEY`.

---
*PR created automatically by Jules for task [9201934029814768275](https://jules.google.com/task/9201934029814768275) started by @madara88645*