### PR TITLE
⚡ Bolt: [performance improvement] Stream backend proxy requests to prevent OOM kills

### DIFF
--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -57,6 +57,10 @@ describe("backend proxy", () => {
     expect(url).toBe("https://api.memo.dev/agent-generator/generate");
     expect(proxiedHeaders.get("x-api-key")).toBe("server-secret");
     expect(proxiedHeaders.get("content-type")).toBe("application/json");
+
+    expect(init?.duplex).toBe("half");
+    expect(init?.body).toBeInstanceOf(ReadableStream);
+
     await expect(response.json()).resolves.toEqual({ system_prompt: "safe" });
   });
 

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -42,10 +42,14 @@ function copyProxyHeaders(request: Request): Headers {
   return headers;
 }
 
-async function cloneProxyResponse(response: Response): Promise<Response> {
+function cloneProxyResponse(response: Response): Response {
   const headers = new Headers(response.headers);
   headers.delete("content-length");
-  return new Response(await response.arrayBuffer(), {
+  // ⚡ Bolt Performance Optimization
+  // We forward the response.body ReadableStream directly instead of buffering the whole payload
+  // via await response.arrayBuffer(). This prevents OOM kills on machines with low memory
+  // (like Fly.io 512MB VMs) when passing through large RAG payloads.
+  return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers,
@@ -75,13 +79,20 @@ export async function proxyBackendRequest(
   const targetUrl = `${resolveBackendApiBase()}${backendPath}`;
 
   try {
-    const upstreamResponse = await fetch(targetUrl, {
+    // ⚡ Bolt Performance Optimization
+    // We forward the request.body ReadableStream directly instead of buffering it into memory
+    // using await request.arrayBuffer(). Streaming large requests directly to the backend
+    // reduces memory spikes and prevents OOM crashes on constrained environments.
+    const init: RequestInit & { duplex?: "half" } = {
       method: request.method,
       headers,
-      body: isBodylessMethod(request.method) ? undefined : await request.arrayBuffer(),
+      body: isBodylessMethod(request.method) ? undefined : request.body,
       cache: "no-store",
       redirect: "manual",
-    });
+    };
+    if (init.body) init.duplex = "half";
+
+    const upstreamResponse = await fetch(targetUrl, init as RequestInit);
 
     return cloneProxyResponse(upstreamResponse);
   } catch {


### PR DESCRIPTION
💡 What: Refactored the `proxyBackendRequest` and `cloneProxyResponse` functions in `web/lib/server/backendProxy.ts` to stream requests and responses using their `.body` stream instead of awaiting `.arrayBuffer()`. Added `duplex: "half"` to fetch options to support sending the stream in Node.js.
🎯 Why: On constrained deployment environments with limited memory (such as Fly.io VMs with 512MB RAM), fully buffering large RAG request/response payloads in memory caused Out-Of-Memory (OOM) crashes.
📊 Impact: Considerably reduces memory consumption spikes during request proxying by enabling streaming, directly mitigating OOM kills for large payloads.
🔬 Measurement: Verify stable memory utilization and absent crash logs when proxying large (e.g. 50MB+) RAG payloads on a 512MB memory limit VM. Test suite verifies the options sent to fetch.

---
*PR created automatically by Jules for task [11761438951038359956](https://jules.google.com/task/11761438951038359956) started by @madara88645*