### PR TITLE
Fix proxy server API key override and add missing proxy tests

### DIFF
--- a/web/app/agent-generator/export/route.ts
+++ b/web/app/agent-generator/export/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/agent-generator/export");
+  return proxyBackendRequest(request, "/agent-generator/export", { requireServerApiKey: true });
 }

--- a/web/app/benchmark/run/route.ts
+++ b/web/app/benchmark/run/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/benchmark/run");
+  return proxyBackendRequest(request, "/benchmark/run", { requireServerApiKey: true });
 }

--- a/web/app/optimize/route.ts
+++ b/web/app/optimize/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/optimize");
+  return proxyBackendRequest(request, "/optimize", { requireServerApiKey: true });
 }

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -3,7 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET as healthRoute } from "./health/route";
 import { POST as compileRoute } from "./compile/route";
 import { POST as agentGenerateRoute } from "./agent-generator/generate/route";
+import { POST as agentExportRoute } from "./agent-generator/export/route";
+import { POST as benchmarkRunRoute } from "./benchmark/run/route";
+import { POST as optimizeRoute } from "./optimize/route";
+import { POST as ragSearchRoute } from "./rag/search/route";
+import { GET as ragStatsRoute } from "./rag/stats/route";
 import { POST as skillsGenerateRoute } from "./skills-generator/generate/route";
+import { POST as skillsExportRoute } from "./skills-generator/export/route";
 import { POST as ragUploadRoute } from "./rag/upload/route";
 import { POST as ragIngestRoute } from "./rag/ingest/route";
 
@@ -11,6 +17,7 @@ type RouteCase = {
   name: string;
   handler: (request: Request) => Promise<Response>;
   requestUrl: string;
+  requestMethod?: string;
   requestBody?: Record<string, unknown>;
   expectedUrl: string;
 };
@@ -103,14 +110,56 @@ describe("Next backend proxy route wiring", () => {
       requestBody: { path: "docs/README.md" },
       expectedUrl: "https://api.memo.dev/rag/ingest",
     },
-  ])("returns a config error when $name route is missing a server API key", async ({ handler, requestUrl, requestBody }) => {
+    {
+      name: "agent export",
+      handler: agentExportRoute,
+      requestUrl: "http://localhost:3000/agent-generator/export",
+      requestBody: { type: "code" },
+      expectedUrl: "https://api.memo.dev/agent-generator/export",
+    },
+    {
+      name: "benchmark run",
+      handler: benchmarkRunRoute,
+      requestUrl: "http://localhost:3000/benchmark/run",
+      requestBody: { model: "gpt-4" },
+      expectedUrl: "https://api.memo.dev/benchmark/run",
+    },
+    {
+      name: "optimize",
+      handler: optimizeRoute,
+      requestUrl: "http://localhost:3000/optimize",
+      requestBody: { system_prompt: "hello" },
+      expectedUrl: "https://api.memo.dev/optimize",
+    },
+    {
+      name: "RAG search",
+      handler: ragSearchRoute,
+      requestUrl: "http://localhost:3000/rag/search",
+      requestBody: { query: "test" },
+      expectedUrl: "https://api.memo.dev/rag/search",
+    },
+    {
+      name: "RAG stats",
+      handler: ragStatsRoute as (request: Request) => Promise<Response>,
+      requestUrl: "http://localhost:3000/rag/stats",
+      requestMethod: "GET",
+      expectedUrl: "https://api.memo.dev/rag/stats",
+    },
+    {
+      name: "skills export",
+      handler: skillsExportRoute,
+      requestUrl: "http://localhost:3000/skills-generator/export",
+      requestBody: { type: "code" },
+      expectedUrl: "https://api.memo.dev/skills-generator/export",
+    },
+  ])("returns a config error when $name route is missing a server API key", async ({ handler, requestUrl, requestMethod, requestBody }) => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
 
     const response = await handler(
       new Request(requestUrl, {
-        method: "POST",
+        method: requestMethod || "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(requestBody),
+        body: requestBody ? JSON.stringify(requestBody) : undefined,
       }),
     );
 
@@ -150,7 +199,49 @@ describe("Next backend proxy route wiring", () => {
       requestBody: { path: "docs/README.md" },
       expectedUrl: "https://api.memo.dev/rag/ingest",
     },
-  ])("injects the server API key and proxies $name to the backend", async ({ handler, requestUrl, requestBody, expectedUrl }) => {
+    {
+      name: "agent export",
+      handler: agentExportRoute,
+      requestUrl: "http://localhost:3000/agent-generator/export",
+      requestBody: { type: "code" },
+      expectedUrl: "https://api.memo.dev/agent-generator/export",
+    },
+    {
+      name: "benchmark run",
+      handler: benchmarkRunRoute,
+      requestUrl: "http://localhost:3000/benchmark/run",
+      requestBody: { model: "gpt-4" },
+      expectedUrl: "https://api.memo.dev/benchmark/run",
+    },
+    {
+      name: "optimize",
+      handler: optimizeRoute,
+      requestUrl: "http://localhost:3000/optimize",
+      requestBody: { system_prompt: "hello" },
+      expectedUrl: "https://api.memo.dev/optimize",
+    },
+    {
+      name: "RAG search",
+      handler: ragSearchRoute,
+      requestUrl: "http://localhost:3000/rag/search",
+      requestBody: { query: "test" },
+      expectedUrl: "https://api.memo.dev/rag/search",
+    },
+    {
+      name: "RAG stats",
+      handler: ragStatsRoute as (request: Request) => Promise<Response>,
+      requestUrl: "http://localhost:3000/rag/stats",
+      requestMethod: "GET",
+      expectedUrl: "https://api.memo.dev/rag/stats",
+    },
+    {
+      name: "skills export",
+      handler: skillsExportRoute,
+      requestUrl: "http://localhost:3000/skills-generator/export",
+      requestBody: { type: "code" },
+      expectedUrl: "https://api.memo.dev/skills-generator/export",
+    },
+  ])("injects the server API key and proxies $name to the backend", async ({ handler, requestUrl, requestMethod, requestBody, expectedUrl }) => {
     process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
     process.env.PROMPTC_SERVER_API_KEY = "server-secret";
 
@@ -163,12 +254,12 @@ describe("Next backend proxy route wiring", () => {
 
     const response = await handler(
       new Request(requestUrl, {
-        method: "POST",
+        method: requestMethod || "POST",
         headers: {
           Accept: "application/json",
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(requestBody),
+        body: requestBody ? JSON.stringify(requestBody) : undefined,
       }),
     );
 

--- a/web/app/rag/search/route.ts
+++ b/web/app/rag/search/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/rag/search");
+  return proxyBackendRequest(request, "/rag/search", { requireServerApiKey: true });
 }

--- a/web/app/rag/stats/route.ts
+++ b/web/app/rag/stats/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function GET(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/rag/stats");
+  return proxyBackendRequest(request, "/rag/stats", { requireServerApiKey: true });
 }

--- a/web/app/skills-generator/export/route.ts
+++ b/web/app/skills-generator/export/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/skills-generator/export");
+  return proxyBackendRequest(request, "/skills-generator/export", { requireServerApiKey: true });
 }

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -76,4 +76,56 @@ describe("backend proxy", () => {
       detail: "PROMPTC_SERVER_API_KEY is not configured on the web server.",
     });
   });
+
+  it("overrides caller-supplied x-api-key with the server API key", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+    process.env.PROMPTC_SERVER_API_KEY = "server-secret";
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const request = new Request("http://localhost:3000/agent-generator/generate", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "x-api-key": "caller-key",
+      },
+      body: JSON.stringify({ description: "review code" }),
+    });
+
+    await proxyBackendRequest(request, "/agent-generator/generate", {
+      requireServerApiKey: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    const proxiedHeaders = new Headers(init?.headers);
+
+    expect(url).toBe("https://api.memo.dev/agent-generator/generate");
+    expect(proxiedHeaders.get("x-api-key")).toBe("server-secret");
+  });
+
+  it("returns a 502 bad gateway when the upstream fetch throws a network error", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch failed"));
+
+    const request = new Request("http://localhost:3000/health", {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+
+    const response = await proxyBackendRequest(request, "/health", {});
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      detail: "Could not reach the backend from the web server.",
+    });
+  });
 });

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -68,7 +68,7 @@ export async function proxyBackendRequest(
   }
 
   const headers = copyProxyHeaders(request);
-  if (serverApiKey && !headers.has("x-api-key")) {
+  if (serverApiKey) {
     headers.set("x-api-key", serverApiKey);
   }
 


### PR DESCRIPTION
Fixes issue #530 where the proxy layer had untested handlers and a bug allowing caller-supplied API keys to bypass the server API key override.

This PR:
1. Updates `web/lib/server/backendProxy.ts` to unconditionally use the `serverApiKey` (if set) and override any incoming `x-api-key` header.
2. Updates the 6 untested proxy route handlers (`agent-generator/export`, `benchmark/run`, `optimize`, `rag/search`, `rag/stats`, `skills-generator/export`) to enforce `requireServerApiKey: true`.
3. Adds tests in `backendProxy.test.ts` to verify the key overriding behavior and 502 Bad Gateway responses on network failures.
4. Adds test cases in `proxy-routes.test.ts` to verify the routing behavior, method forwarding, and API key protection of the 6 aforementioned route handlers.

---
*PR created automatically by Jules for task [4045635541987384388](https://jules.google.com/task/4045635541987384388) started by @madara88645*