### PR TITLE
[codex] test extension popup regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 
+      - name: Browser extension tests
+        run: node --test extension/*.test.mjs
+
       - name: Install frontend dependencies
         working-directory: web
         run: npm ci

--- a/agents.md
+++ b/agents.md
@@ -394,6 +394,8 @@ pytest -q \
 pre-commit run --all-files
 
 # Step 4: Frontend
+node --test extension/*.test.mjs
+
 cd web
 npm ci
 npm run test:contracts

--- a/extension/popup-ui.mjs
+++ b/extension/popup-ui.mjs
@@ -1,0 +1,57 @@
+export function formatRelativeTime(timestamp, now = Date.now()) {
+  const diffMs = now - timestamp;
+  const diffMinutes = Math.max(1, Math.round(diffMs / 60000));
+
+  if (diffMinutes < 60) {
+    return `${diffMinutes}m ago`;
+  }
+
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `${diffHours}h ago`;
+  }
+
+  const diffDays = Math.round(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+export function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+export function getConfigStatusView(result, justSaved = false) {
+  if (result.ok) {
+    return {
+      text: justSaved ? "Saved" : "Configured",
+      className: "status-enabled",
+    };
+  }
+
+  return {
+    text: justSaved ? "Check fields" : "Missing config",
+    className: justSaved ? "status-warning" : "status-disabled",
+  };
+}
+
+export function renderPreviewHistoryItems(previewHistory, activePreviewId, now = Date.now()) {
+  return previewHistory
+    .map((historyEntry) => {
+      const snippet = historyEntry.optimizedText.replace(/\s+/g, " ").trim().slice(0, 64);
+      const activeClass = historyEntry.id === activePreviewId ? " history-item-active" : "";
+      return `
+          <button class="history-item${activeClass}" type="button" data-preview-id="${historyEntry.id}">
+            <div class="history-item-top">
+              <span class="history-item-title">${escapeHtml(historyEntry.siteLabel)}</span>
+              <span class="history-item-time">${formatRelativeTime(historyEntry.createdAt, now)}</span>
+            </div>
+            <div class="history-item-snippet">${escapeHtml(snippet)}${historyEntry.optimizedText.length > 64 ? "..." : ""}</div>
+          </button>
+        `;
+    })
+    .join("");
+}

--- a/extension/popup-ui.test.mjs
+++ b/extension/popup-ui.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  escapeHtml,
+  formatRelativeTime,
+  getConfigStatusView,
+  renderPreviewHistoryItems,
+} from "./popup-ui.mjs";
+
+test("escapeHtml escapes angle brackets, ampersands, and quotes", () => {
+  const escaped = escapeHtml(`Tom & "Jerry" <tag> 'quote'`);
+
+  assert.equal(escaped, "Tom &amp; &quot;Jerry&quot; &lt;tag&gt; &#039;quote&#039;");
+});
+
+test("formatRelativeTime switches between minutes, hours, and days", () => {
+  const now = 1_700_000_000_000;
+
+  assert.equal(formatRelativeTime(now - 2 * 60_000, now), "2m ago");
+  assert.equal(formatRelativeTime(now - 2 * 60 * 60_000, now), "2h ago");
+  assert.equal(formatRelativeTime(now - 3 * 24 * 60 * 60_000, now), "3d ago");
+});
+
+test("getConfigStatusView returns the saved success state when config is valid", () => {
+  assert.deepEqual(getConfigStatusView({ ok: true }, true), {
+    className: "status-enabled",
+    text: "Saved",
+  });
+});
+
+test("renderPreviewHistoryItems escapes user-controlled text and marks the active item", () => {
+  const html = renderPreviewHistoryItems(
+    [
+      {
+        id: "active",
+        siteLabel: `<Claude "A">`,
+        optimizedText: `Spacing  <b>danger</b>  and "quotes"`,
+        createdAt: 1_700_000_000_000 - 61_000,
+      },
+    ],
+    "active",
+    1_700_000_000_000,
+  );
+
+  assert.match(html, /history-item history-item-active/);
+  assert.match(html, /&lt;Claude &quot;A&quot;&gt;/);
+  assert.match(html, /Spacing &lt;b&gt;danger&lt;\/b&gt; and &quot;quotes&quot;/);
+  assert.doesNotMatch(html, /<b>danger<\/b>/);
+});

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -4,6 +4,11 @@ import {
   getActivePreviewEntry,
   getRestoreText,
 } from "./popup-preview.mjs";
+import {
+  formatRelativeTime,
+  getConfigStatusView,
+  renderPreviewHistoryItems,
+} from "./popup-ui.mjs";
 
 document.addEventListener("DOMContentLoaded", async () => {
   const enabledToggle = document.getElementById("enabledToggle");
@@ -127,15 +132,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     configStatus.classList.remove("status-enabled", "status-disabled", "status-warning");
-
-    if (result.ok) {
-      configStatus.textContent = justSaved ? "Saved" : "Configured";
-      configStatus.classList.add("status-enabled");
-      return;
-    }
-
-    configStatus.textContent = justSaved ? "Check fields" : "Missing config";
-    configStatus.classList.add(justSaved ? "status-warning" : "status-disabled");
+    const view = getConfigStatusView(result, justSaved);
+    configStatus.textContent = view.text;
+    configStatus.classList.add(view.className);
   }
 
   function renderPreview() {
@@ -159,47 +158,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     previewDelta.textContent = formatPreviewDelta(entry);
     previewOriginal.textContent = entry.originalText;
     previewOptimized.textContent = entry.optimizedText;
-    previewHistoryList.innerHTML = previewHistory
-      .map((historyEntry) => {
-        const snippet = historyEntry.optimizedText.replace(/\s+/g, " ").trim().slice(0, 64);
-        const activeClass = historyEntry.id === entry.id ? " history-item-active" : "";
-        return `
-          <button class="history-item${activeClass}" type="button" data-preview-id="${historyEntry.id}">
-            <div class="history-item-top">
-              <span class="history-item-title">${escapeHtml(historyEntry.siteLabel)}</span>
-              <span class="history-item-time">${formatRelativeTime(historyEntry.createdAt)}</span>
-            </div>
-            <div class="history-item-snippet">${escapeHtml(snippet)}${historyEntry.optimizedText.length > 64 ? "..." : ""}</div>
-          </button>
-        `;
-      })
-      .join("");
-  }
-
-  function formatRelativeTime(timestamp) {
-    const diffMs = Date.now() - timestamp;
-    const diffMinutes = Math.max(1, Math.round(diffMs / 60000));
-
-    if (diffMinutes < 60) {
-      return `${diffMinutes}m ago`;
-    }
-
-    const diffHours = Math.round(diffMinutes / 60);
-    if (diffHours < 24) {
-      return `${diffHours}h ago`;
-    }
-
-    const diffDays = Math.round(diffHours / 24);
-    return `${diffDays}d ago`;
-  }
-
-  function escapeHtml(value) {
-    return String(value ?? "")
-      .replaceAll("&", "&amp;")
-      .replaceAll("<", "&lt;")
-      .replaceAll(">", "&gt;")
-      .replaceAll('"', "&quot;")
-      .replaceAll("'", "&#039;");
+    previewHistoryList.innerHTML = renderPreviewHistoryItems(previewHistory, entry.id);
   }
 
   function setRestoreButtonState(restored) {


### PR DESCRIPTION
## What changed
- extracted popup display helpers into `extension/popup-ui.mjs`
- added direct regression tests for popup escaping, relative time labels, config status labels, and preview history rendering
- added browser extension tests to the CI smoke job
- updated `agents.md` so local verification instructions match CI

## Why
Recent popup behavior and security hardening lived only inside `extension/popup.js`, so regressions in escaping and preview rendering could slip through without any automated check. CI also was not running the extension test suite at all.

## Validation
- `node --test extension/*.test.mjs`
