### PR TITLE
[codex] Add Claude agent packs section

### DIFF
--- a/.claude/agents/compiler-architect.md
+++ b/.claude/agents/compiler-architect.md
@@ -1,0 +1,7 @@
+---
+name: compiler-architect
+description: Plans compiler, export, and orchestration changes with an API-first mindset.
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+Focus on IR contracts, export adapters, routes, and backward compatibility. Keep Claude-specific behavior at the edges and preserve provider-agnostic core logic.

--- a/.claude/agents/frontend-polisher.md
+++ b/.claude/agents/frontend-polisher.md
@@ -1,0 +1,7 @@
+---
+name: frontend-polisher
+description: Improves export UX and product positioning for executable agent workflows.
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+Keep the UI intentional and product-grade. Position Prompt Compiler as an agent operating layer rather than a prompt beautifier, and make export targets feel directly runnable.

--- a/.claude/agents/mcp-integrator.md
+++ b/.claude/agents/mcp-integrator.md
@@ -1,0 +1,7 @@
+---
+name: mcp-integrator
+description: Builds and debugs MCP tools, bridges, and Claude/Cursor/Desktop integrations.
+tools: Read, Edit, Write, Grep, Glob, Bash
+---
+
+Own stdio and HTTP MCP connectivity, endpoint payload contracts, setup snippets, and ergonomics for external agent clients that talk to Prompt Compiler.

--- a/.claude/agents/prompt-safety-reviewer.md
+++ b/.claude/agents/prompt-safety-reviewer.md
@@ -1,0 +1,7 @@
+---
+name: prompt-safety-reviewer
+description: Reviews prompt and export changes for leakage, policy regressions, and unsafe instructions.
+tools: Read, Grep, Glob
+---
+
+Check for secret leaks, weak permission defaults, over-broad tool access, unsafe generated instructions, and missing guardrails in exported Claude assets.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)",
+      "Read(./users.db)",
+      "Read(./web/.env.local)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(fly:*)",
+      "Bash(railway:*)"
+    ]
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,21 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: >
+            Follow CLAUDE.md, inspect the linked issue or PR context, and only
+            make changes when the request is actionable and testable.
+          claude_args: "--max-turns 5"

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,11 @@ ENV/
 scripts/probe_deployment.py
 
 # Local agent/worktree metadata
-.claude/
+.claude/*
+!.claude/agents/
+!.claude/agents/**
+!.claude/settings.json
+.claude/worktrees/
 
 # Local PR triage scratch files
 /batch_pr_data.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# Prompt Compiler Claude Code Memory
+
+## Project Summary
+Prompt Compiler is a FastAPI + Next.js product that turns vague requests into structured prompts, policy-aware execution plans, agent exports, MCP-compatible tool stubs, and workflow artifacts.
+
+## Architecture
+- Backend API: `api/` route layer on top of `app/`
+- Compiler and heuristics: `app/compiler.py`, `app/heuristics/`, `app/emitters.py`
+- Export adapters: `app/adapters/`
+- Frontend: `web/app/`
+- MCP bridge: `integrations/mcp-server/`
+
+## Working Rules
+- Start from repo-root commands unless a workflow explicitly says otherwise.
+- Prefer focused tests before broad suites.
+- Keep Claude-native integrations adapter-scoped; preserve provider-agnostic core behavior.
+- Never expose secrets, `.env` contents, or database credentials in outputs.
+
+## Runbook
+- Backend dev server: `python -m uvicorn api.main:app --reload --port 8080`
+- Frontend dev server: `cd web && npm run dev`
+- Backend tests: `python -m pytest tests/ -q`
+- Focused export tests: `python -m pytest tests/test_export_adapters.py tests/test_llm_providers.py -q`
+- MCP tests: `python -m pytest integrations/mcp-server/test_server.py -q`
+- Frontend tests: `cd web && npm run test`
+- Frontend build: `cd web && npm run build`
+
+## Domain Concepts
+- Conservative mode should avoid hallucinated requirements and fake APIs.
+- Export surfaces should feel executable, not just prompt-pretty.
+- Agent packs can map policy into `CLAUDE.md`, `.claude/settings.json`, `.claude/agents/`, and GitHub workflow assets.
+- MCP integration is a first-class bridge for Claude Code, Cursor, and other clients.
+
+## Security
+- Treat generated code and skill definitions as untrusted until reviewed.
+- Deny access to `.env`, `.env.*`, secret folders, and local credential files in Claude settings.
+- Require explicit confirmation for pushes, deploys, and other high-impact shell commands.

--- a/api/main.py
+++ b/api/main.py
@@ -116,6 +116,7 @@ async def log_requests(request, call_next):
 
 
 from api.routes.compile import router as compile_router  # noqa: E402
+from api.routes.agent_packs import router as agent_packs_router  # noqa: E402
 from api.routes.export import router as export_router  # noqa: E402
 from api.routes.generators import router as generators_router  # noqa: E402
 from api.routes.meta import router as meta_router  # noqa: E402
@@ -125,6 +126,7 @@ from app.routers.jules import router as jules_router  # noqa: E402
 
 app.include_router(meta_router)
 app.include_router(compile_router)
+app.include_router(agent_packs_router)
 app.include_router(generators_router)
 app.include_router(export_router)
 app.include_router(rag_router)

--- a/api/routes/agent_packs.py
+++ b/api/routes/agent_packs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.auth import APIKey, verify_api_key
+from api.shared import logger
+from app.adapters.agent_packs import (
+    AGENT_PACK_ADAPTERS,
+    AgentPackManifest,
+    AgentPackRequest,
+    create_download_response,
+)
+
+router = APIRouter(tags=["agent-packs"])
+
+
+def _get_compiler():
+    from api import main as api_main
+
+    return api_main.get_compiler()
+
+
+@router.post("/agent-packs/claude", response_model=AgentPackManifest)
+async def build_claude_agent_pack(
+    req: AgentPackRequest,
+    api_key: APIKey = Depends(verify_api_key),
+):
+    del api_key
+    compiler = _get_compiler()
+    adapter = AGENT_PACK_ADAPTERS["claude"]
+
+    try:
+        return adapter.build_manifest(req, compiler)
+    except Exception as exc:
+        logger.exception(
+            "agent pack generation failed", extra={"provider": "claude", "pack_type": req.pack_type}
+        )
+        raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
+
+
+@router.post("/agent-packs/claude/download")
+async def download_claude_agent_pack(
+    req: AgentPackRequest,
+    api_key: APIKey = Depends(verify_api_key),
+):
+    del api_key
+    compiler = _get_compiler()
+    adapter = AGENT_PACK_ADAPTERS["claude"]
+
+    try:
+        manifest = adapter.build_manifest(req, compiler)
+        return create_download_response(manifest)
+    except Exception as exc:
+        logger.exception(
+            "agent pack download failed", extra={"provider": "claude", "pack_type": req.pack_type}
+        )
+        raise HTTPException(status_code=500, detail="An internal error occurred.") from exc

--- a/api/routes/export.py
+++ b/api/routes/export.py
@@ -24,10 +24,25 @@ async def export_agent(
     api_key: APIKey | None = Depends(verify_api_key_if_required),
 ):
     del api_key
-    if req.format not in ["claude-sdk", "langchain", "langchain-yaml", "langgraph"]:
+    if req.format not in [
+        "claude-sdk",
+        "claude-agent-sdk-py",
+        "claude-agent-sdk-ts",
+        "claude-subagent",
+        "claude-project-pack",
+        "langchain",
+        "langchain-yaml",
+        "langgraph",
+    ]:
         raise HTTPException(status_code=400, detail=f"Unsupported format: {req.format}")
 
     from app.adapters.agent_ir import parse_agent_markdown
+    from app.adapters.claude_code import (
+        to_agent_sdk_python,
+        to_agent_sdk_typescript,
+        to_claude_project_pack,
+        to_claude_subagent,
+    )
     from app.adapters.claude_sdk import to_python, to_yaml
     from app.adapters.langchain import to_langchain_python, to_langgraph_python
 
@@ -35,15 +50,30 @@ async def export_agent(
 
     python_code = None
     yaml_config = None
+    code = None
+    files = []
 
     if req.format == "claude-sdk":
         python_code = to_python(ir)
+        code = python_code
         if req.output_type != "python":
             yaml_config = to_yaml(ir)
+    elif req.format == "claude-agent-sdk-py":
+        python_code = to_agent_sdk_python(ir)
+        code = python_code
+    elif req.format == "claude-agent-sdk-ts":
+        code = to_agent_sdk_typescript(ir)
+    elif req.format == "claude-subagent":
+        files = [to_claude_subagent(ir)]
+        code = files[0]["content"]
+    elif req.format == "claude-project-pack":
+        files = to_claude_project_pack(ir)
     elif req.format in {"langchain", "langchain-yaml"}:
         python_code = to_langchain_python(ir)
+        code = python_code
     elif req.format == "langgraph":
         python_code = to_langgraph_python(ir)
+        code = python_code
 
     if req.output_type == "python":
         yaml_config = None
@@ -51,13 +81,19 @@ async def export_agent(
     return {
         "python_code": python_code,
         "yaml_config": yaml_config,
-        "code": python_code,
-        "files": [],
+        "code": code or python_code,
+        "files": files,
     }
 
 
 _SKILL_EXPORT_FORMATS = frozenset(
-    {"claude-tool", "claude-tool-use", "langchain-tool", "agent-skill"}
+    {
+        "claude-tool",
+        "claude-tool-use",
+        "claude-mcp-tool-stub",
+        "langchain-tool",
+        "agent-skill",
+    }
 )
 
 
@@ -70,6 +106,7 @@ async def export_skill(
     if req.format not in _SKILL_EXPORT_FORMATS:
         raise HTTPException(status_code=400, detail=f"Unsupported format: {req.format}")
 
+    from app.adapters.claude_code import to_claude_mcp_tool_stub
     from app.adapters.skill_adapter import (
         to_agent_skill,
         to_claude_tool_use,
@@ -79,17 +116,20 @@ async def export_skill(
 
     ir = parse_skill_markdown(req.skill_definition or "")
 
-    # Only call the adapters needed for the requested format.
-    # agent-skill needs only SKILL.md; all other formats expose both Python and JSON tabs.
     is_agent_skill = req.format == "agent-skill"
     python_code = None if is_agent_skill else to_langchain_tool(ir)
     json_config = None if is_agent_skill else to_claude_tool_use(ir)
     markdown = to_agent_skill(ir) if is_agent_skill else None
+    files: list[dict] = []
+
+    if req.format == "claude-mcp-tool-stub":
+        files = to_claude_mcp_tool_stub(ir)
+        python_code = files[0]["content"]
 
     return {
         "python_code": python_code,
         "json_config": json_config,
         "markdown": markdown,
         "code": markdown if is_agent_skill else python_code,
-        "files": [],
+        "files": files,
     }

--- a/app/adapters/__init__.py
+++ b/app/adapters/__init__.py
@@ -1,4 +1,11 @@
 from .agent_ir import AgentExportIR, parse_agent_markdown
+from .claude_code import (
+    to_agent_sdk_python,
+    to_agent_sdk_typescript,
+    to_claude_mcp_tool_stub,
+    to_claude_project_pack,
+    to_claude_subagent,
+)
 from .skill_ir import SkillExportIR, parse_skill_markdown
 from .claude_sdk import to_python as claude_sdk_python, to_yaml as claude_sdk_yaml
 from .langchain import to_langchain_python, to_langgraph_python, to_langchain_yaml
@@ -7,8 +14,13 @@ from .skill_adapter import to_langchain_tool, to_claude_tool_use, to_agent_skill
 __all__ = [
     "AgentExportIR",
     "parse_agent_markdown",
+    "to_agent_sdk_python",
+    "to_agent_sdk_typescript",
+    "to_claude_subagent",
+    "to_claude_project_pack",
     "SkillExportIR",
     "parse_skill_markdown",
+    "to_claude_mcp_tool_stub",
     "claude_sdk_python",
     "claude_sdk_yaml",
     "to_langchain_python",

--- a/app/adapters/agent_ir.py
+++ b/app/adapters/agent_ir.py
@@ -49,6 +49,12 @@ class AgentExportIR(BaseModel):
     model: str = "claude-opus-4-6"
     is_multi_agent: bool = False
     agents: list["AgentExportIR"] = Field(default_factory=list)
+    permission_mode: str = "acceptEdits"
+    allowed_tools: list[str] = Field(default_factory=list)
+    hook_suggestions: list[str] = Field(default_factory=list)
+    mcp_servers: list[str] = Field(default_factory=list)
+    ci_automation_intent: list[str] = Field(default_factory=list)
+    memory_outline: list[str] = Field(default_factory=list)
     raw_system_prompt: str = ""  # always the full original markdown
 
 
@@ -138,14 +144,28 @@ def _build_ir(markdown: str, is_multi_agent: bool = False) -> AgentExportIR:
 
     name = _extract_title(markdown)
 
+    role = sections.get("role", "").strip()
+    goals = _parse_bullets(sections.get("goals", ""))
+    constraints = _parse_bullets(sections.get("constraints", ""))
+    workflows = _parse_bullets(sections.get("workflows", ""))
+    tech_stack = _parse_bullets(sections.get("tech_stack", ""))
+    combined_text = "\n".join([name, role, *goals, *constraints, *workflows, *tech_stack]).lower()
+
     return AgentExportIR(
         name=name,
-        role=sections.get("role", "").strip(),
-        goals=_parse_bullets(sections.get("goals", "")),
-        constraints=_parse_bullets(sections.get("constraints", "")),
-        workflows=_parse_bullets(sections.get("workflows", "")),
-        tech_stack=_parse_bullets(sections.get("tech_stack", "")),
+        role=role,
+        goals=goals,
+        constraints=constraints,
+        workflows=workflows,
+        tech_stack=tech_stack,
         is_multi_agent=is_multi_agent,
+        allowed_tools=_infer_allowed_tools(combined_text),
+        hook_suggestions=_infer_hook_suggestions(combined_text),
+        mcp_servers=_infer_mcp_servers(combined_text),
+        ci_automation_intent=_infer_ci_automation_intent(combined_text),
+        memory_outline=_infer_memory_outline(
+            name=name, role=role, goals=goals, constraints=constraints
+        ),
         raw_system_prompt=markdown.strip(),
     )
 
@@ -211,3 +231,62 @@ def _split_multi_agent_blocks(markdown: str) -> list[str]:
         blocks.append(tail)
 
     return blocks
+
+
+def _infer_allowed_tools(text: str) -> list[str]:
+    tools = {"Read", "Edit", "Write", "Glob", "Grep"}
+    if any(
+        keyword in text for keyword in ("code", "react", "python", "typescript", "debug", "build")
+    ):
+        tools.add("Bash")
+    if any(keyword in text for keyword in ("web", "research", "search", "source", "docs")):
+        tools.update({"WebSearch", "WebFetch"})
+    if "github" in text or "pull request" in text or "pr " in text:
+        tools.add("Bash")
+    return sorted(tools)
+
+
+def _infer_hook_suggestions(text: str) -> list[str]:
+    suggestions = [
+        "Block reads of .env and secrets before tool execution.",
+        "Run targeted tests or lint checks after code edits.",
+    ]
+    if any(keyword in text for keyword in ("frontend", "react", "ui")):
+        suggestions.append("Run frontend lint/build hooks after editing TSX or CSS.")
+    if any(keyword in text for keyword in ("deploy", "ci", "release")):
+        suggestions.append("Require human confirmation before git push or deploy commands.")
+    return suggestions
+
+
+def _infer_mcp_servers(text: str) -> list[str]:
+    mapping = {
+        "github": "github",
+        "figma": "figma",
+        "slack": "slack",
+        "notion": "notion",
+        "jira": "jira",
+        "sentry": "sentry",
+    }
+    return [server for keyword, server in mapping.items() if keyword in text]
+
+
+def _infer_ci_automation_intent(text: str) -> list[str]:
+    intents: list[str] = []
+    if any(keyword in text for keyword in ("review", "pull request", "pr ")):
+        intents.append("review")
+    if any(keyword in text for keyword in ("issue", "implement", "feature", "bug")):
+        intents.append("implementation")
+    if any(keyword in text for keyword in ("fix", "autofix", "failing test", "flaky")):
+        intents.append("autofix")
+    return intents
+
+
+def _infer_memory_outline(
+    *, name: str, role: str, goals: list[str], constraints: list[str]
+) -> list[str]:
+    outline = [f"Agent name: {name}"]
+    if role:
+        outline.append(f"Primary role: {role}")
+    outline.extend(f"Goal: {goal}" for goal in goals[:3])
+    outline.extend(f"Constraint: {constraint}" for constraint in constraints[:3])
+    return outline

--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import io
+from typing import Any, Literal, Protocol
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from .agent_ir import parse_agent_markdown
+from .claude_code import (
+    to_claude_mcp_tool_stub,
+    to_claude_pr_reviewer_pack,
+    to_claude_project_pack,
+    to_claude_subagent_bundle,
+)
+from .skill_ir import parse_skill_markdown
+
+PackType = Literal["project-pack", "subagent", "pr-reviewer", "mcp-tool-stub"]
+RiskMode = Literal["balanced", "strict"]
+
+
+class AgentPackRequest(BaseModel):
+    project_type: str = Field(..., min_length=1, max_length=120)
+    stack: str = Field(..., min_length=1, max_length=200)
+    goal: str = Field(..., min_length=1, max_length=8_000)
+    pack_type: PackType
+    risk_mode: RiskMode = "balanced"
+
+
+class AgentPackFile(BaseModel):
+    path: str
+    content: str
+    kind: str
+
+
+class AgentPackManifest(BaseModel):
+    provider: str
+    pack_type: PackType
+    files: list[AgentPackFile]
+    download_name: str
+    preview_order: list[str]
+
+
+class AgentPackAdapter(Protocol):
+    provider: str
+
+    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest:
+        ...
+
+
+class ClaudeAgentPackAdapter:
+    provider = "claude"
+
+    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest:
+        raw_files: list[dict[str, str]]
+
+        if req.pack_type == "mcp-tool-stub":
+            skill_definition = compiler.generate_skill(
+                _build_skill_brief(req),
+                include_example_code=False,
+            )
+            skill_ir = parse_skill_markdown(skill_definition)
+            raw_files = to_claude_mcp_tool_stub(skill_ir)
+        else:
+            system_prompt = compiler.generate_agent(
+                _build_agent_brief(req),
+                multi_agent=False,
+                include_example_code=False,
+            )
+            agent_ir = parse_agent_markdown(system_prompt)
+
+            if req.pack_type == "project-pack":
+                raw_files = to_claude_project_pack(agent_ir)
+            elif req.pack_type == "subagent":
+                raw_files = to_claude_subagent_bundle(agent_ir)
+            else:
+                raw_files = to_claude_pr_reviewer_pack(agent_ir)
+
+        files = [
+            AgentPackFile(
+                path=file["path"], content=file["content"], kind=_classify_kind(file["path"])
+            )
+            for file in raw_files
+        ]
+        preview_order = [
+            kind for kind in _preview_order() if any(file.kind == kind for file in files)
+        ]
+        download_name = _build_download_name(req)
+
+        return AgentPackManifest(
+            provider=self.provider,
+            pack_type=req.pack_type,
+            files=files,
+            download_name=download_name,
+            preview_order=preview_order,
+        )
+
+
+AGENT_PACK_ADAPTERS: dict[str, AgentPackAdapter] = {
+    "claude": ClaudeAgentPackAdapter(),
+}
+
+
+def create_download_response(manifest: AgentPackManifest) -> Response:
+    if len(manifest.files) == 1:
+        file = manifest.files[0]
+        media_type = _media_type_for_path(file.path)
+        filename = file.path.rsplit("/", 1)[-1]
+        return Response(
+            content=file.content.encode("utf-8"),
+            media_type=media_type,
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    buffer = io.BytesIO()
+    with ZipFile(buffer, mode="w", compression=ZIP_DEFLATED) as archive:
+        for file in manifest.files:
+            archive.writestr(file.path, file.content)
+
+    return Response(
+        content=buffer.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{manifest.download_name}.zip"'},
+    )
+
+
+def _build_agent_brief(req: AgentPackRequest) -> str:
+    pack_labels = {
+        "project-pack": "full project pack for repo-aware Claude Code usage",
+        "subagent": "focused Claude subagent",
+        "pr-reviewer": "PR reviewer pack for code review and safety checks",
+        "mcp-tool-stub": "MCP tool stub",
+    }
+    risk_line = (
+        "Use strict security defaults, conservative tool permissions, and emphasize secret protection."
+        if req.risk_mode == "strict"
+        else "Balance usability with strong default safeguards and repo-safe behavior."
+    )
+    review_line = ""
+    if req.pack_type == "pr-reviewer":
+        review_line = (
+            "\nThe agent must review pull requests for prompt leakage, unsafe settings, secret exposure, "
+            "missing tests, and architecture risks."
+        )
+
+    return (
+        f"Create a {pack_labels[req.pack_type]}.\n"
+        f"Project type: {req.project_type}\n"
+        f"Stack: {req.stack}\n"
+        f"Goal: {req.goal}\n"
+        f"{risk_line}{review_line}\n"
+        "Write the output as a practical system prompt that can be exported into Claude-native assets."
+    )
+
+
+def _build_skill_brief(req: AgentPackRequest) -> str:
+    risk_line = (
+        "Favor strict validation, safe defaults, and defensive error handling."
+        if req.risk_mode == "strict"
+        else "Favor clean developer ergonomics with sensible guardrails."
+    )
+    return (
+        "Generate a Claude-compatible MCP tool skill definition.\n"
+        f"Project type: {req.project_type}\n"
+        f"Stack: {req.stack}\n"
+        f"Goal: {req.goal}\n"
+        f"{risk_line}\n"
+        "Include the purpose, parameters, expected behavior, and integration notes."
+    )
+
+
+def _classify_kind(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    if normalized == "CLAUDE.md":
+        return "claude_md"
+    if normalized.endswith("settings.json"):
+        return "settings"
+    if "/agents/" in normalized:
+        return "agents"
+    if normalized.endswith("server.py") or "mcp" in normalized.lower():
+        return "mcp"
+    if normalized.startswith(".github/workflows/") or normalized.endswith(".yml"):
+        return "workflow"
+    if normalized.endswith("README.md"):
+        return "readme"
+    return "files"
+
+
+def _preview_order() -> list[str]:
+    return ["claude_md", "settings", "agents", "workflow", "mcp", "readme", "files"]
+
+
+def _build_download_name(req: AgentPackRequest) -> str:
+    return _slugify(f"{req.project_type}-{req.pack_type}-claude")
+
+
+def _slugify(value: str) -> str:
+    cleaned = "".join(ch.lower() if ch.isalnum() else "-" for ch in value)
+    while "--" in cleaned:
+        cleaned = cleaned.replace("--", "-")
+    return cleaned.strip("-") or "agent-pack"
+
+
+def _media_type_for_path(path: str) -> str:
+    if path.endswith(".json"):
+        return "application/json"
+    if path.endswith(".md"):
+        return "text/markdown; charset=utf-8"
+    if path.endswith(".yml") or path.endswith(".yaml"):
+        return "application/yaml"
+    if path.endswith(".py"):
+        return "text/x-python; charset=utf-8"
+    return "text/plain; charset=utf-8"

--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from typing import Any
+
+from .agent_ir import AgentExportIR
+from .skill_ir import SkillExportIR
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "agent"
+
+
+def _escape_triple_quotes(text: str) -> str:
+    return text.replace('"""', '\\"\\"\\"')
+
+
+def to_agent_sdk_python(ir: AgentExportIR) -> str:
+    prompt = _escape_triple_quotes(ir.raw_system_prompt)
+    allowed_tools = ", ".join(f'"{tool}"' for tool in _ordered_tools(ir.allowed_tools))
+    return textwrap.dedent(
+        f"""\
+        import asyncio
+        from claude_agent_sdk import query, ClaudeAgentOptions
+
+
+        async def main() -> None:
+            async for message in query(
+                prompt="Your task here",
+                options=ClaudeAgentOptions(
+                    system_prompt=\"\"\"{prompt}\"\"\",
+                    allowed_tools=[{allowed_tools}],
+                    model="{ir.model}",
+                ),
+            ):
+                print(message)
+
+
+        asyncio.run(main())
+        """
+    )
+
+
+def to_agent_sdk_typescript(ir: AgentExportIR) -> str:
+    prompt = ir.raw_system_prompt.replace("`", "\\`")
+    allowed_tools = ", ".join(f'"{tool}"' for tool in _ordered_tools(ir.allowed_tools))
+    return textwrap.dedent(
+        f"""\
+        import {{ query }} from "@anthropic-ai/claude-agent-sdk";
+
+        const systemPrompt = `{prompt}`;
+
+        const run = async () => {{
+          for await (const message of query({{
+            prompt: "Your task here",
+            options: {{
+              systemPrompt,
+              allowedTools: [{allowed_tools}],
+              model: "{ir.model}",
+            }},
+          }})) {{
+            console.log(message);
+          }}
+        }};
+
+        void run();
+        """
+    )
+
+
+def to_claude_subagent(ir: AgentExportIR) -> dict[str, str]:
+    slug = _slugify(ir.name)
+    tools = ", ".join(ir.allowed_tools or ["Read", "Edit", "Write"])
+    description = ir.role or (ir.goals[0] if ir.goals else f"Specialized assistant for {ir.name}")
+    content = textwrap.dedent(
+        f"""\
+        ---
+        name: {slug}
+        description: {description}
+        tools: {tools}
+        ---
+
+        {ir.raw_system_prompt.strip()}
+        """
+    )
+    return {"path": f".claude/agents/{slug}.md", "content": content}
+
+
+def to_claude_project_pack(ir: AgentExportIR) -> list[dict[str, str]]:
+    files = [
+        {"path": "CLAUDE.md", "content": _project_claude_md(ir)},
+        {"path": ".claude/settings.json", "content": _project_settings_json(ir)},
+        to_claude_subagent(ir),
+        {
+            "path": ".claude/agents/compiler-architect.md",
+            "content": _named_subagent("compiler-architect"),
+        },
+        {
+            "path": ".claude/agents/prompt-safety-reviewer.md",
+            "content": _named_subagent("prompt-safety-reviewer"),
+        },
+        {"path": ".claude/agents/mcp-integrator.md", "content": _named_subagent("mcp-integrator")},
+        {
+            "path": ".claude/agents/frontend-polisher.md",
+            "content": _named_subagent("frontend-polisher"),
+        },
+        {"path": ".github/workflows/claude.yml", "content": _github_action_workflow()},
+        {"path": ".claude/mcp/claude-desktop.json", "content": _mcp_config_snippet(ir)},
+    ]
+    return files
+
+
+def to_claude_subagent_bundle(ir: AgentExportIR) -> list[dict[str, str]]:
+    subagent = to_claude_subagent(ir)
+    readme = textwrap.dedent(
+        f"""\
+        # Claude Subagent Bundle
+
+        Drop `{subagent["path"]}` into your repo, then ask Claude Code to use the `{_slugify(ir.name)}` subagent.
+
+        Recommended usage:
+        - Keep `CLAUDE.md` in the repo root for shared guidance.
+        - Add `.claude/settings.json` if you want permission guardrails alongside this agent.
+        """
+    )
+    return [
+        subagent,
+        {"path": "README.md", "content": readme},
+    ]
+
+
+def to_claude_pr_reviewer_pack(ir: AgentExportIR) -> list[dict[str, str]]:
+    reviewer = to_claude_subagent(ir)
+    reviewer["path"] = ".claude/agents/pr-reviewer.md"
+    files = [
+        {"path": "CLAUDE.md", "content": _pr_reviewer_memory(ir)},
+        {"path": ".claude/settings.json", "content": _project_settings_json(ir)},
+        reviewer,
+        {"path": ".github/workflows/claude.yml", "content": _github_action_workflow()},
+        {"path": "README.md", "content": _pr_reviewer_readme()},
+    ]
+    return files
+
+
+def to_claude_mcp_tool_stub(ir: SkillExportIR) -> list[dict[str, str]]:
+    tool_name = ir.name
+    param_signature = ", ".join(
+        f"{param.name}: {param.type if param.type != 'Any' else 'str'}"
+        + ("" if param.required else " | None = None")
+        for param in ir.params
+    )
+    content = textwrap.dedent(
+        f"""\
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("{tool_name}")
+
+
+        @mcp.tool()
+        async def {tool_name}({param_signature}) -> str:
+            \"\"\"{ir.purpose or f"Execute {tool_name}."}\"\"\"
+            return "TODO: implement {tool_name}"
+
+
+        if __name__ == "__main__":
+            mcp.run()
+        """
+    )
+    readme = textwrap.dedent(
+        f"""\
+        # {tool_name} MCP Tool Stub
+
+        Generated from Prompt Compiler for Claude Code / MCP workflows.
+
+        Purpose: {ir.purpose}
+        """
+    )
+    return [
+        {"path": "server.py", "content": content},
+        {"path": "README.md", "content": readme},
+    ]
+
+
+def _project_claude_md(ir: AgentExportIR) -> str:
+    goals = (
+        "\n".join(f"- {goal}" for goal in ir.goals[:4])
+        or "- Preserve the existing product behavior."
+    )
+    constraints = (
+        "\n".join(f"- {constraint}" for constraint in ir.constraints[:4])
+        or "- Do not leak secrets."
+    )
+    mcp_servers = ", ".join(ir.mcp_servers) if ir.mcp_servers else "none yet"
+    return textwrap.dedent(
+        f"""\
+        # Prompt Compiler Claude Code Memory
+
+        ## Project Summary
+        Prompt Compiler is a FastAPI + Next.js product that turns vague requests into structured prompts, execution plans, policy layers, agent packs, and workflow artifacts.
+
+        ## Working Rules
+        - Start from repo-root commands.
+        - Prefer targeted tests before broad suites.
+        - Respect API/auth boundaries and never expose secrets.
+        - Keep provider integrations framework-agnostic unless the export surface is explicitly Claude-native.
+
+        ## Domain Concepts
+        {goals}
+
+        ## Constraints
+        {constraints}
+
+        ## Runbook
+        - Backend: `python -m uvicorn api.main:app --reload --port 8080`
+        - Frontend: `cd web && npm run dev`
+        - Python tests: `python -m pytest tests/ -q`
+        - Frontend tests: `cd web && npm run test`
+
+        ## Claude-Native Notes
+        - Permission mode: `{ir.permission_mode}`
+        - Suggested tools: {", ".join(ir.allowed_tools)}
+        - Suggested MCP servers: {mcp_servers}
+        """
+    )
+
+
+def _project_settings_json(ir: AgentExportIR) -> str:
+    settings: dict[str, Any] = {
+        "permissions": {
+            "defaultMode": ir.permission_mode,
+            "deny": [
+                "Read(./.env)",
+                "Read(./.env.*)",
+                "Read(./secrets/**)",
+                "Read(./users.db)",
+                "Read(./web/.env.local)",
+            ],
+            "ask": [
+                "Bash(git push:*)",
+                "Bash(fly:*)",
+            ],
+        }
+    }
+    return json.dumps(settings, indent=2)
+
+
+def _mcp_config_snippet(ir: AgentExportIR) -> str:
+    command = ["python", "integrations/mcp-server/server.py"]
+    config = {
+        "mcpServers": {
+            _slugify(ir.name): {
+                "command": command[0],
+                "args": command[1:],
+            }
+        }
+    }
+    return json.dumps(config, indent=2)
+
+
+def _named_subagent(name: str) -> str:
+    descriptions = {
+        "compiler-architect": "Plans compiler, export, and orchestration changes with an API-first mindset.",
+        "prompt-safety-reviewer": "Reviews prompt changes for leakage, policy regressions, and unsafe instructions.",
+        "mcp-integrator": "Builds and debugs MCP tools, bridges, and Claude/Cursor/Desktop integrations.",
+        "frontend-polisher": "Improves product positioning, export UX, and responsive frontend details.",
+    }
+    prompts = {
+        "compiler-architect": "Focus on IR contracts, adapters, routes, and backward compatibility.",
+        "prompt-safety-reviewer": "Check for secret leaks, weak permissions, unsafe tool allowances, and missing guardrails.",
+        "mcp-integrator": "Own stdio/HTTP MCP connectivity, endpoint contracts, and developer setup docs.",
+        "frontend-polisher": "Keep the UI crisp, intentional, and focused on executable agent workflows.",
+    }
+    tools = {
+        "compiler-architect": "Read, Edit, Write, Grep, Glob, Bash",
+        "prompt-safety-reviewer": "Read, Grep, Glob",
+        "mcp-integrator": "Read, Edit, Write, Grep, Glob, Bash",
+        "frontend-polisher": "Read, Edit, Write, Grep, Glob, Bash",
+    }
+    return textwrap.dedent(
+        f"""\
+        ---
+        name: {name}
+        description: {descriptions[name]}
+        tools: {tools[name]}
+        ---
+
+        {prompts[name]}
+        """
+    )
+
+
+def _github_action_workflow() -> str:
+    return textwrap.dedent(
+        """\
+        name: Claude Code
+
+        on:
+          issue_comment:
+            types: [created]
+          pull_request_review_comment:
+            types: [created]
+
+        jobs:
+          claude:
+            if: contains(github.event.comment.body, '@claude')
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - uses: anthropics/claude-code-action@v1
+                with:
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  prompt: >
+                    Follow CLAUDE.md, inspect the referenced issue or PR context,
+                    and respond or create changes only when the request is actionable.
+                  claude_args: "--max-turns 5"
+        """
+    )
+
+
+def _pr_reviewer_memory(ir: AgentExportIR) -> str:
+    goals = (
+        "\n".join(f"- {goal}" for goal in ir.goals[:4])
+        or "- Review code changes for risk, regressions, and safety gaps."
+    )
+    return textwrap.dedent(
+        f"""\
+        # Claude PR Reviewer Memory
+
+        ## Mission
+        Review pull requests with a focus on prompt safety, secret handling, permission boundaries, and missing tests.
+
+        ## Repo Context
+        - Project type: repo-specific software product
+        - Default review posture: skeptical, concrete, and test-aware
+
+        ## Review Checklist
+        {goals}
+
+        ## Guardrails
+        - Do not expose secrets or credentials.
+        - Flag unsafe `.claude/settings.json` permissions.
+        - Call out prompt leakage, weak validation, and missing regression coverage.
+        """
+    )
+
+
+def _pr_reviewer_readme() -> str:
+    return textwrap.dedent(
+        """\
+        # Claude PR Reviewer Pack
+
+        This pack gives Claude Code a dedicated `pr-reviewer` subagent plus review-focused repo memory.
+
+        Suggested prompts:
+        - `Use the pr-reviewer subagent to review this pull request for prompt leakage and unsafe settings.`
+        - `Review this diff for missing tests, secret exposure, and MCP misconfiguration.`
+        """
+    )
+
+
+def _ordered_tools(tools: list[str]) -> list[str]:
+    preferred_order = ["Read", "Edit", "Write", "Glob", "Grep", "Bash", "WebSearch", "WebFetch"]
+    pool = tools or ["Read", "Edit", "Write"]
+    ordered = [tool for tool in preferred_order if tool in pool]
+    ordered.extend(tool for tool in pool if tool not in ordered)
+    return ordered

--- a/app/llm/factory.py
+++ b/app/llm/factory.py
@@ -5,13 +5,14 @@ import os
 from typing import Optional
 
 from .base import LLMProvider, ProviderConfig
-from .providers import MockProvider, OllamaProvider, OpenAIProvider
+from .providers import AnthropicProvider, MockProvider, OllamaProvider, OpenAIProvider
 
 # Registry of available providers
 PROVIDERS = {
     "mock": MockProvider,
     "ollama": OllamaProvider,
     "openai": OpenAIProvider,
+    "anthropic": AnthropicProvider,
 }
 
 
@@ -45,10 +46,21 @@ def get_provider(
 
     # Build config from env vars if not provided
     if config is None:
+        if name == "anthropic":
+            api_key = os.environ.get("ANTHROPIC_API_KEY")
+            base_url = os.environ.get("PROMPTC_LLM_BASE_URL") or os.environ.get(
+                "ANTHROPIC_BASE_URL"
+            )
+            model = os.environ.get("PROMPTC_LLM_MODEL", "claude-opus-4-7")
+        else:
+            api_key = os.environ.get("OPENAI_API_KEY")
+            base_url = os.environ.get("PROMPTC_LLM_BASE_URL")
+            model = os.environ.get("PROMPTC_LLM_MODEL", "gpt-4o")
+
         config = ProviderConfig(
-            api_key=os.environ.get("OPENAI_API_KEY"),
-            base_url=os.environ.get("PROMPTC_LLM_BASE_URL"),
-            model=os.environ.get("PROMPTC_LLM_MODEL", "gpt-4o"),
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
             temperature=float(os.environ.get("PROMPTC_LLM_TEMPERATURE", "0.7")),
             max_tokens=int(os.environ.get("PROMPTC_LLM_MAX_TOKENS", "2048")),
             timeout=float(os.environ.get("PROMPTC_LLM_TIMEOUT", "30.0")),

--- a/app/llm/providers.py
+++ b/app/llm/providers.py
@@ -136,3 +136,58 @@ class OpenAIProvider(LLMProvider):
 
         latency = (time.time() - start) * 1000
         return LLMResponse(content=content, usage=usage, latency_ms=latency)
+
+
+class AnthropicProvider(LLMProvider):
+    """
+    Provider for Anthropic Messages API.
+    Requires ANTHROPIC_API_KEY env var or config.api_key.
+    """
+
+    def generate(self, prompt: str, system_prompt: Optional[str] = None, **kwargs) -> LLMResponse:
+        api_key = self.config.api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            return LLMResponse(content="Error: Missing Anthropic API Key", latency_ms=0)
+
+        url = (
+            self.config.base_url
+            or os.environ.get("ANTHROPIC_BASE_URL")
+            or "https://api.anthropic.com"
+        ).rstrip("/")
+        url = f"{url}/v1/messages"
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+
+        payload = {
+            "model": kwargs.get("model", self.config.model),
+            "max_tokens": kwargs.get("max_tokens", self.config.max_tokens),
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if system_prompt:
+            payload["system"] = system_prompt
+
+        start = time.time()
+        try:
+            resp = httpx.post(url, json=payload, headers=headers, timeout=self.config.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+            blocks = data.get("content", [])
+            content = "\n".join(
+                block.get("text", "") for block in blocks if block.get("type") == "text"
+            )
+            usage_data = data.get("usage", {})
+            usage = {
+                "prompt_tokens": usage_data.get("input_tokens", 0),
+                "completion_tokens": usage_data.get("output_tokens", 0),
+            }
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).error(f"Provider error: {e}")
+            return LLMResponse(content="Error: An internal error occurred.", latency_ms=0)
+
+        latency = (time.time() - start) * 1000
+        return LLMResponse(content=content, usage=usage, latency_ms=latency)

--- a/integrations/mcp-server/README.md
+++ b/integrations/mcp-server/README.md
@@ -1,7 +1,7 @@
 # myCompiler MCP Server
 
 This directory contains a Model Context Protocol (MCP) server integration for `myCompiler`.
-It exposes `myCompiler` tools (like `optimize_prompt`) to MCP clients such as Claude Desktop and Cursor.
+It exposes Prompt Compiler tools to MCP clients such as Claude Code, Claude Desktop, and Cursor.
 
 ## Setup
 
@@ -57,9 +57,22 @@ Add the following to your `claude_desktop_config.json` (usually in `%APPDATA%\Cl
 4.  **Type**: `stdio`
 5.  **Command**: `python C:\Users\User\Desktop\myCompiler\integrations\mcp-server\server.py`
 
+## Exposed Tools
+
+- `optimize_prompt(text)` — returns the compiled prompt string
+- `compile_prompt(text)` — returns the full `/compile` payload
+- `generate_agent(description, multi_agent=false)` — returns generated agent markdown
+- `generate_skill(description)` — returns generated skill markdown
+- `export_claude_pack(system_prompt)` — returns a Claude Code project-pack manifest
+- `benchmark_prompt(text, model?)` — returns the benchmark comparison payload
+
 ## Usage
 
 Once configured, you can ask Claude or Cursor:
 > "Optimize this prompt for me: 'write a snake game in python'"
 
-The tool `optimize_prompt` will be called, and the optimized system prompt from `myCompiler` will be returned.
+Or:
+
+> "Generate an agent for reviewing React performance and export it as a Claude project pack."
+
+The MCP server will call the corresponding Prompt Compiler backend route and return the result in the same session.

--- a/integrations/mcp-server/server.py
+++ b/integrations/mcp-server/server.py
@@ -48,6 +48,100 @@ async def optimize_prompt(text: str) -> str:
             return f"Error: Unexpected error during optimization: {e}"
 
 
+def _backend_origin() -> str:
+    compile_url = resolve_compile_post_url()
+    if compile_url.endswith("/compile"):
+        return compile_url[: -len("/compile")]
+    return compile_url.rsplit("/", 1)[0]
+
+
+def _json_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    api_key = resolve_api_key()
+    if api_key:
+        headers["x-api-key"] = api_key
+    return headers
+
+
+async def _post_json(path: str, payload: dict) -> dict:
+    url = f"{_backend_origin()}{path}"
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, json=payload, headers=_json_headers(), timeout=30.0)
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def compile_prompt(text: str) -> dict:
+    """
+    Compile a prompt through the Prompt Compiler backend and return the structured response.
+    """
+    mode = resolve_prompt_mode()
+    payload = build_compile_body(text, mode)
+    return await _post_json("/compile", payload)
+
+
+@mcp.tool()
+async def generate_agent(description: str, multi_agent: bool = False) -> str:
+    """
+    Generate a Claude-friendly agent/system prompt from a natural-language description.
+    """
+    data = await _post_json(
+        "/agent-generator/generate",
+        {
+            "description": description,
+            "multi_agent": multi_agent,
+            "include_example_code": False,
+        },
+    )
+    return data["system_prompt"]
+
+
+@mcp.tool()
+async def generate_skill(description: str) -> str:
+    """
+    Generate a structured skill/tool definition from a natural-language capability description.
+    """
+    data = await _post_json(
+        "/skills-generator/generate",
+        {
+            "description": description,
+            "include_example_code": False,
+        },
+    )
+    return data["skill_definition"]
+
+
+@mcp.tool()
+async def export_claude_pack(system_prompt: str) -> dict:
+    """
+    Convert a generated agent prompt into a Claude Code project pack manifest.
+    """
+    return await _post_json(
+        "/agent-generator/export",
+        {
+            "system_prompt": system_prompt,
+            "format": "claude-project-pack",
+            "output_type": "manifest",
+            "is_multi_agent": False,
+        },
+    )
+
+
+@mcp.tool()
+async def benchmark_prompt(text: str, model: str = "llama-3.1-8b-instant") -> dict:
+    """
+    Benchmark a raw prompt against the compiled prompt and return the comparison payload.
+    """
+    return await _post_json(
+        "/benchmark/run",
+        {
+            "text": text,
+            "model": model,
+        },
+    )
+
+
 if __name__ == "__main__":
     # Run the server using stdio transport (default for FastMCP.run())
     mcp.run()

--- a/integrations/mcp-server/test_server.py
+++ b/integrations/mcp-server/test_server.py
@@ -1,0 +1,124 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+import server
+
+
+class _MockResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+        self.text = "ok"
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _MockAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+        self.responses = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json, headers, timeout):
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return self.responses.pop(0)
+
+
+def test_compile_prompt_posts_to_compile_endpoint(monkeypatch: pytest.MonkeyPatch):
+    client = _MockAsyncClient()
+    client.responses.append(
+        _MockResponse(
+            {
+                "expanded_prompt_v2": "compiled output",
+                "policy": {"risk_level": "low"},
+            }
+        )
+    )
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        result = asyncio.run(server.compile_prompt("write a safer deploy script"))
+
+    assert result["expanded_prompt_v2"] == "compiled output"
+    assert client.calls[0]["url"] == "https://api.example/compile"
+    assert client.calls[0]["json"]["text"] == "write a safer deploy script"
+
+
+def test_generate_agent_posts_to_generator_endpoint(monkeypatch: pytest.MonkeyPatch):
+    client = _MockAsyncClient()
+    client.responses.append(_MockResponse({"system_prompt": "# Agent"}))
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        result = asyncio.run(server.generate_agent("Review React performance"))
+
+    assert result == "# Agent"
+    assert client.calls[0]["url"] == "https://api.example/agent-generator/generate"
+    assert client.calls[0]["json"]["description"] == "Review React performance"
+
+
+def test_generate_skill_posts_to_generator_endpoint(monkeypatch: pytest.MonkeyPatch):
+    client = _MockAsyncClient()
+    client.responses.append(_MockResponse({"skill_definition": "# Skill"}))
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        result = asyncio.run(server.generate_skill("Fetch and summarize docs"))
+
+    assert result == "# Skill"
+    assert client.calls[0]["url"] == "https://api.example/skills-generator/generate"
+    assert client.calls[0]["json"]["description"] == "Fetch and summarize docs"
+
+
+def test_export_claude_pack_posts_to_export_endpoint(monkeypatch: pytest.MonkeyPatch):
+    client = _MockAsyncClient()
+    client.responses.append(_MockResponse({"files": [{"path": "CLAUDE.md", "content": "..."}]}))
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        result = asyncio.run(server.export_claude_pack("# Agent"))
+
+    assert result["files"][0]["path"] == "CLAUDE.md"
+    assert client.calls[0]["url"] == "https://api.example/agent-generator/export"
+    assert client.calls[0]["json"]["format"] == "claude-project-pack"
+
+
+def test_benchmark_prompt_posts_to_benchmark_endpoint(monkeypatch: pytest.MonkeyPatch):
+    client = _MockAsyncClient()
+    client.responses.append(
+        _MockResponse(
+            {
+                "winner": "compiled",
+                "improvement_score": 25.0,
+                "raw_output": "raw",
+                "compiled_output": "compiled",
+                "compiled_prompt": "prompt",
+            }
+        )
+    )
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        result = asyncio.run(server.benchmark_prompt("Explain RAG"))
+
+    assert result["winner"] == "compiled"
+    assert client.calls[0]["url"] == "https://api.example/benchmark/run"
+    assert client.calls[0]["json"]["text"] == "Explain RAG"

--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+def _request_payload(pack_type: str) -> dict[str, str]:
+    return {
+        "project_type": "SaaS",
+        "stack": "FastAPI + Next.js",
+        "goal": "Create a repo-aware Claude workflow for this product.",
+        "pack_type": pack_type,
+        "risk_mode": "strict",
+    }
+
+
+def test_agent_packs_claude_project_pack_manifest_shape():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = (
+            "# Review Agent\n\n## Role\nYou review code.\n\n## Goals\n- Catch prompt leaks"
+        )
+
+        client = TestClient(app)
+        response = client.post("/agent-packs/claude", json=_request_payload("project-pack"))
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "claude"
+        assert data["pack_type"] == "project-pack"
+        assert data["download_name"] == "saas-project-pack-claude"
+        assert "claude_md" in data["preview_order"]
+        assert any(file["path"] == "CLAUDE.md" for file in data["files"])
+        assert any(file["path"] == ".claude/settings.json" for file in data["files"])
+        assert any(file["kind"] == "mcp" for file in data["files"])
+
+
+def test_agent_packs_claude_subagent_manifest_shape():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = (
+            "# React Performance Agent\n\n## Role\nYou optimize React apps."
+        )
+
+        client = TestClient(app)
+        response = client.post("/agent-packs/claude", json=_request_payload("subagent"))
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pack_type"] == "subagent"
+        assert len(data["files"]) == 2
+        assert any(file["path"].startswith(".claude/agents/") for file in data["files"])
+        assert any(file["path"] == "README.md" for file in data["files"])
+
+
+def test_agent_packs_claude_pr_reviewer_manifest_shape():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = (
+            "# PR Reviewer\n\n## Goals\n- Catch unsafe settings"
+        )
+
+        client = TestClient(app)
+        response = client.post("/agent-packs/claude", json=_request_payload("pr-reviewer"))
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pack_type"] == "pr-reviewer"
+        assert any(file["path"] == ".github/workflows/claude.yml" for file in data["files"])
+        assert any(file["path"] == ".claude/agents/pr-reviewer.md" for file in data["files"])
+
+
+def test_agent_packs_claude_mcp_stub_manifest_shape():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = "# search_docs - Skill Definition\n\n## Name\nsearch_docs\n\n## Purpose\nSearch project docs.\n"
+
+        client = TestClient(app)
+        response = client.post("/agent-packs/claude", json=_request_payload("mcp-tool-stub"))
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pack_type"] == "mcp-tool-stub"
+        assert all(file["kind"] in {"mcp", "readme"} for file in data["files"])
+        assert any(file["path"] == "server.py" for file in data["files"])
+
+
+def test_agent_packs_download_returns_single_file_when_manifest_has_one_file():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = (
+            "# search_docs - Skill Definition\n\n## Name\nsearch_docs\n\n## Purpose\nSearch docs."
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/agent-packs/claude/download",
+            json={**_request_payload("mcp-tool-stub"), "goal": "Build a single-file stub."},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/zip")
+
+        archive = zipfile.ZipFile(io.BytesIO(response.content))
+        assert set(archive.namelist()) == {"server.py", "README.md"}
+
+
+def test_agent_packs_download_returns_plain_file_for_single_file_manifest():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = "# Review Agent\n\n## Role\nYou review code."
+
+        with patch("app.adapters.agent_packs.to_claude_subagent_bundle") as mock_bundle:
+            mock_bundle.return_value = [
+                {"path": ".claude/agents/review-agent.md", "content": "hello"},
+            ]
+            client = TestClient(app)
+            response = client.post(
+                "/agent-packs/claude/download", json=_request_payload("subagent")
+            )
+
+        assert response.status_code == 200
+        assert response.headers["content-disposition"] == 'attachment; filename="review-agent.md"'
+        assert response.text == "hello"

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -13,6 +13,13 @@ import yaml
 from fastapi.testclient import TestClient
 
 from app.adapters.agent_ir import AgentExportIR, parse_agent_markdown
+from app.adapters.claude_code import (
+    to_agent_sdk_python,
+    to_agent_sdk_typescript,
+    to_claude_project_pack,
+    to_claude_subagent,
+    to_claude_mcp_tool_stub,
+)
 from app.adapters.claude_sdk import to_python, to_yaml
 from app.adapters.langchain import to_langchain_python, to_langgraph_python
 from app.adapters.skill_adapter import to_agent_skill, to_claude_tool_use, to_langchain_tool
@@ -155,6 +162,9 @@ def test_parse_single_agent_ir():
     assert len(ir.workflows) >= 4
     assert len(ir.tech_stack) >= 2
     assert ir.is_multi_agent is False
+    assert ir.permission_mode == "acceptEdits"
+    assert "Read" in ir.allowed_tools
+    assert "Edit" in ir.allowed_tools
     assert ir.raw_system_prompt.strip() == SINGLE_AGENT_MARKDOWN.strip()
 
 
@@ -202,6 +212,58 @@ def test_claude_sdk_yaml_output():
     assert parsed["max_tokens"] == 8096
     assert "system" in parsed
     assert "Data Analyst" in parsed["system"]
+
+
+def test_claude_agent_sdk_python_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    code = to_agent_sdk_python(ir)
+
+    assert "from claude_agent_sdk import query, ClaudeAgentOptions" in code
+    assert 'allowed_tools=["Read", "Edit", "Write"' in code
+    assert "prompt=" in code
+
+
+def test_claude_agent_sdk_typescript_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    code = to_agent_sdk_typescript(ir)
+
+    assert 'import { query } from "@anthropic-ai/claude-agent-sdk"' in code
+    assert "allowedTools" in code
+    assert "claude-opus" in code
+
+
+def test_claude_subagent_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    file_spec = to_claude_subagent(ir)
+
+    assert file_spec["path"].startswith(".claude/agents/")
+    assert file_spec["path"].endswith(".md")
+    assert "name:" in file_spec["content"]
+    assert "description:" in file_spec["content"]
+    assert "tools:" in file_spec["content"]
+
+
+def test_claude_project_pack_output():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    pack = to_claude_project_pack(ir)
+    paths = {item["path"] for item in pack}
+
+    assert "CLAUDE.md" in paths
+    assert ".claude/settings.json" in paths
+    assert ".github/workflows/claude.yml" in paths
+    assert any(path.startswith(".claude/agents/") for path in paths)
+
+
+def test_claude_mcp_tool_stub_output():
+    ir = parse_skill_markdown(SKILL_MARKDOWN)
+    stub = to_claude_mcp_tool_stub(ir)
+    paths = {item["path"] for item in stub}
+
+    assert "server.py" in paths
+    assert "README.md" in paths
+    server_file = next(item for item in stub if item["path"] == "server.py")
+    assert "FastMCP" in server_file["content"]
+    assert "web_search" in server_file["content"]
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +400,89 @@ def test_export_api_endpoint_skill(client):
 
     parsed = json.loads(data["json_config"])
     assert parsed["name"] == "web_search"
+
+
+def test_export_api_endpoint_agent_sdk_python(client):
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": "claude-agent-sdk-py",
+            "output_type": "python",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "claude_agent_sdk" in data["python_code"]
+    assert data["files"] == []
+
+
+def test_export_api_endpoint_agent_sdk_typescript(client):
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": "claude-agent-sdk-ts",
+            "output_type": "typescript",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "@anthropic-ai/claude-agent-sdk" in data["code"]
+
+
+def test_export_api_endpoint_claude_subagent(client):
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": "claude-subagent",
+            "output_type": "markdown",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["python_code"] is None
+    assert len(data["files"]) == 1
+    assert data["files"][0]["path"].startswith(".claude/agents/")
+
+
+def test_export_api_endpoint_claude_project_pack(client):
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": "claude-project-pack",
+            "output_type": "manifest",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    paths = {item["path"] for item in data["files"]}
+    assert "CLAUDE.md" in paths
+    assert ".claude/settings.json" in paths
+    assert ".github/workflows/claude.yml" in paths
+
+
+def test_export_api_endpoint_skill_mcp_stub(client):
+    response = client.post(
+        "/skills-generator/export",
+        json={
+            "skill_definition": SKILL_MARKDOWN,
+            "format": "claude-mcp-tool-stub",
+            "output_type": "python",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    paths = {item["path"] for item in data["files"]}
+    assert "server.py" in paths
+    assert "README.md" in paths
 
 
 def test_export_api_endpoint_skill_agent_skill_format(client):

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -1,11 +1,11 @@
 """Tests for LLM providers and factory."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import pytest
 
 from app.llm.base import LLMProvider, ProviderConfig, LLMResponse
-from app.llm.providers import MockProvider, OllamaProvider, OpenAIProvider
+from app.llm.providers import AnthropicProvider, MockProvider, OllamaProvider, OpenAIProvider
 from app.llm.factory import get_provider, register_provider, PROVIDERS
 
 
@@ -52,6 +52,10 @@ class TestFactory:
         provider = get_provider("openai")
         assert isinstance(provider, OpenAIProvider)
 
+    def test_get_anthropic_provider(self):
+        provider = get_provider("anthropic")
+        assert isinstance(provider, AnthropicProvider)
+
     def test_unknown_provider_raises(self):
         with pytest.raises(ValueError, match="Unknown provider"):
             get_provider("unknown_provider")
@@ -67,6 +71,39 @@ class TestFactory:
         with patch.dict(os.environ, {"PROMPTC_LLM_PROVIDER": "ollama"}):
             provider = get_provider()
             assert isinstance(provider, OllamaProvider)
+
+    def test_anthropic_env_defaults(self):
+        with patch.dict(os.environ, {"PROMPTC_LLM_PROVIDER": "anthropic"}, clear=False):
+            provider = get_provider()
+            assert isinstance(provider, AnthropicProvider)
+            assert provider.config.model == "claude-opus-4-7"
+
+
+class TestAnthropicProvider:
+    def test_missing_api_key_returns_error(self):
+        config = ProviderConfig()
+        provider = AnthropicProvider(config)
+
+        response = provider.generate("Hello")
+
+        assert response.content == "Error: Missing Anthropic API Key"
+
+    def test_successful_response(self):
+        config = ProviderConfig(api_key="test-key", model="claude-opus-4-7")
+        provider = AnthropicProvider(config)
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "content": [{"type": "text", "text": "Anthropic says hi"}],
+            "usage": {"input_tokens": 12, "output_tokens": 34},
+        }
+
+        with patch("app.llm.providers.httpx.post", return_value=mock_response):
+            response = provider.generate("Hello", system_prompt="Be concise")
+
+        assert response.content == "Anthropic says hi"
+        assert response.usage == {"prompt_tokens": 12, "completion_tokens": 34}
 
     def test_custom_config(self):
         config = ProviderConfig(model="custom-model", temperature=0.9)

--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import ExportPanel from "./ExportPanel";
+
+const { apiFetch } = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("@/config", () => ({
+  apiFetch,
+}));
+
+describe("Agent ExportPanel", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        python_code: "print('hello')",
+        yaml_config: null,
+        code: "print('hello')",
+        files: [],
+      }),
+    });
+  });
+
+  test("requests the Claude project pack export", async () => {
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Claude Project Pack" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, options] = apiFetch.mock.calls.at(-1);
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body).format).toBe("claude-project-pack");
+  });
+
+  test("requests the TypeScript Claude Agent SDK export when TypeScript tab is selected", async () => {
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("button", { name: "TypeScript" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, options] = apiFetch.mock.calls.at(-1);
+    expect(JSON.parse(options.body).format).toBe("claude-agent-sdk-ts");
+  });
+});

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,293 +1,330 @@
 "use client";
 
-import { useState, useEffect, useRef, useId } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { apiFetch } from "@/config";
 
-type Framework = "claude-sdk" | "langchain" | "langgraph";
-type OutputTab = "python" | "yaml";
+type ExportTarget =
+  | "claude-agent-sdk"
+  | "claude-subagent"
+  | "claude-project-pack"
+  | "langchain"
+  | "langgraph";
+type OutputMode = "python" | "typescript" | "markdown" | "files";
+
+interface ExportFile {
+  path: string;
+  content: string;
+}
 
 interface ExportResult {
-    python_code: string | null;
-    yaml_config: string | null;
+  python_code: string | null;
+  yaml_config: string | null;
+  code?: string | null;
+  files?: ExportFile[];
 }
 
 interface ExportPanelProps {
-    systemPrompt: string | null;
-    isMultiAgent: boolean;
+  systemPrompt: string | null;
+  isMultiAgent: boolean;
 }
 
-const FRAMEWORKS: {
-    id: Framework;
-    label: string;
-    color: string;
-    activeColor: string;
+const TARGETS: {
+  id: ExportTarget;
+  label: string;
+  color: string;
+  activeColor: string;
 }[] = [
-    {
-        id: "claude-sdk",
-        label: "Claude SDK",
-        color: "text-zinc-400 border-transparent hover:border-orange-500/40 hover:text-orange-300",
-        activeColor: "text-orange-300 border-orange-500/60 bg-orange-500/10",
-    },
-    {
-        id: "langchain",
-        label: "LangChain",
-        color: "text-zinc-400 border-transparent hover:border-green-500/40 hover:text-green-300",
-        activeColor: "text-green-300 border-green-500/60 bg-green-500/10",
-    },
-    {
-        id: "langgraph",
-        label: "LangGraph",
-        color: "text-zinc-400 border-transparent hover:border-blue-500/40 hover:text-blue-300",
-        activeColor: "text-blue-300 border-blue-500/60 bg-blue-500/10",
-    },
+  {
+    id: "claude-agent-sdk",
+    label: "Claude Agent SDK",
+    color: "text-zinc-400 border-transparent hover:border-orange-500/40 hover:text-orange-300",
+    activeColor: "text-orange-300 border-orange-500/60 bg-orange-500/10",
+  },
+  {
+    id: "claude-subagent",
+    label: "Claude Subagent",
+    color: "text-zinc-400 border-transparent hover:border-amber-500/40 hover:text-amber-300",
+    activeColor: "text-amber-300 border-amber-500/60 bg-amber-500/10",
+  },
+  {
+    id: "claude-project-pack",
+    label: "Claude Project Pack",
+    color: "text-zinc-400 border-transparent hover:border-blue-500/40 hover:text-blue-300",
+    activeColor: "text-blue-300 border-blue-500/60 bg-blue-500/10",
+  },
+  {
+    id: "langchain",
+    label: "LangChain",
+    color: "text-zinc-400 border-transparent hover:border-green-500/40 hover:text-green-300",
+    activeColor: "text-green-300 border-green-500/60 bg-green-500/10",
+  },
+  {
+    id: "langgraph",
+    label: "LangGraph",
+    color: "text-zinc-400 border-transparent hover:border-cyan-500/40 hover:text-cyan-300",
+    activeColor: "text-cyan-300 border-cyan-500/60 bg-cyan-500/10",
+  },
 ];
 
-export default function ExportPanel({
-    systemPrompt,
-    isMultiAgent,
-}: ExportPanelProps) {
-    const [isOpen, setIsOpen] = useState(false);
-    const [framework, setFramework] = useState<Framework>("claude-sdk");
-    const [outputTab, setOutputTab] = useState<OutputTab>("python");
-    const [cache, setCache] = useState<
-        Partial<Record<Framework, ExportResult>>
-    >({});
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [copied, setCopied] = useState(false);
-    const prevPromptRef = useRef<string | null>(null);
-    const panelId = useId();
+const OUTPUT_OPTIONS: Record<ExportTarget, { id: OutputMode; label: string }[]> = {
+  "claude-agent-sdk": [
+    { id: "python", label: "Python" },
+    { id: "typescript", label: "TypeScript" },
+  ],
+  "claude-subagent": [{ id: "markdown", label: "Markdown" }],
+  "claude-project-pack": [{ id: "files", label: "Files" }],
+  langchain: [{ id: "python", label: "Python" }],
+  langgraph: [{ id: "python", label: "Python" }],
+};
 
-    // Reset cache when systemPrompt changes
-    useEffect(() => {
-        if (systemPrompt !== prevPromptRef.current) {
-            prevPromptRef.current = systemPrompt;
-            setCache({});
-            setError(null);
-        }
-    }, [systemPrompt]);
+export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [target, setTarget] = useState<ExportTarget>("claude-agent-sdk");
+  const [outputMode, setOutputMode] = useState<OutputMode>("python");
+  const [cache, setCache] = useState<Record<string, ExportResult>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
+  const prevPromptRef = useRef<string | null>(null);
+  const panelId = useId();
 
-    const currentResult = cache[framework] ?? null;
+  useEffect(() => {
+    if (systemPrompt !== prevPromptRef.current) {
+      prevPromptRef.current = systemPrompt;
+      setCache({});
+      setError(null);
+      setSelectedFilePath(null);
+      setTarget("claude-agent-sdk");
+      setOutputMode("python");
+    }
+  }, [systemPrompt]);
 
-    const fetchExport = async (fw: Framework) => {
-        if (!systemPrompt) return;
-        if (cache[fw]) return; // already fetched
+  const activeTarget = TARGETS.find((item) => item.id === target)!;
+  const format = resolveFormat(target, outputMode);
+  const currentResult = cache[format] ?? null;
+  const outputTabs = OUTPUT_OPTIONS[target];
 
-        setLoading(true);
-        setError(null);
-        try {
-            const res = await apiFetch("/agent-generator/export", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    system_prompt: systemPrompt,
-                    format: fw,
-                    output_type: "both",
-                    is_multi_agent: isMultiAgent,
-                }),
-            });
+  const currentContent = useMemo(() => {
+    if (!currentResult) return null;
+    if (outputMode === "python" || outputMode === "typescript") {
+      return currentResult.code ?? currentResult.python_code;
+    }
+    if (outputMode === "markdown") {
+      return currentResult.files?.[0]?.content ?? currentResult.code ?? null;
+    }
+    if (outputMode === "files") {
+      const files = currentResult.files ?? [];
+      if (!files.length) return null;
+      const selected = files.find((file) => file.path === selectedFilePath) ?? files[0];
+      return selected.content;
+    }
+    return null;
+  }, [currentResult, outputMode, selectedFilePath]);
 
-            if (!res.ok) {
-                const body = await res
-                    .json()
-                    .catch(() => ({ detail: res.statusText }));
-                throw new Error(body.detail ?? `Export failed (${res.status})`);
-            }
+  const visibleFiles = currentResult?.files ?? [];
 
-            const data: ExportResult = await res.json();
-            setCache((prev) => ({ ...prev, [fw]: data }));
-        } catch (e: unknown) {
-            setError(e instanceof Error ? e.message : "Export failed");
-        } finally {
-            setLoading(false);
-        }
-    };
+  const fetchExport = async (nextTarget: ExportTarget, nextMode: OutputMode) => {
+    if (!systemPrompt) return;
+    const nextFormat = resolveFormat(nextTarget, nextMode);
+    if (cache[nextFormat]) {
+      const files = cache[nextFormat].files ?? [];
+      if (files.length && !selectedFilePath) {
+        setSelectedFilePath(files[0].path);
+      }
+      return;
+    }
 
-    const handleFrameworkClick = (fw: Framework) => {
-        setFramework(fw);
-        fetchExport(fw);
-    };
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch("/agent-generator/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          system_prompt: systemPrompt,
+          format: nextFormat,
+          output_type: nextMode,
+          is_multi_agent: isMultiAgent,
+        }),
+      });
 
-    const handleToggle = () => {
-        const next = !isOpen;
-        setIsOpen(next);
-        if (next && !cache[framework]) {
-            fetchExport(framework);
-        }
-    };
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(body.detail ?? `Export failed (${res.status})`);
+      }
 
-    const handleCopy = () => {
-        const text =
-            outputTab === "python"
-                ? currentResult?.python_code
-                : currentResult?.yaml_config;
-        if (text) {
-            navigator.clipboard.writeText(text).then(() => {
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
-            });
-        }
-    };
+      const data: ExportResult = await res.json();
+      setCache((prev) => ({ ...prev, [nextFormat]: data }));
+      const files = data.files ?? [];
+      if (files.length) {
+        setSelectedFilePath(files[0].path);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    const activeFramework = FRAMEWORKS.find((f) => f.id === framework)!;
-    const codeContent =
-        outputTab === "python"
-            ? currentResult?.python_code
-            : currentResult?.yaml_config;
+  const handleToggle = () => {
+    const next = !isOpen;
+    setIsOpen(next);
+    if (next) {
+      void fetchExport(target, outputMode);
+    }
+  };
 
-    if (!systemPrompt) return null;
+  const handleTargetClick = (nextTarget: ExportTarget) => {
+    const firstMode = OUTPUT_OPTIONS[nextTarget][0].id;
+    setTarget(nextTarget);
+    setOutputMode(firstMode);
+    void fetchExport(nextTarget, firstMode);
+  };
 
-    return (
-        <div className="mt-6 border-t border-white/5 pt-4">
-            {/* Toggle header */}
-            <button
-                type="button"
-                onClick={handleToggle}
-                aria-expanded={isOpen}
-                aria-controls={panelId}
-                className="w-full flex items-center justify-between px-2 py-1 group"
-            >
-                <div className="flex items-center gap-2">
-                    <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
-                        Export
-                    </span>
-                    <span className="text-[10px] text-zinc-600 font-mono">
-                        → framework code
-                    </span>
-                </div>
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className={`text-zinc-500 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
-                >
-                    <path d="m6 9 6 6 6-6" />
-                </svg>
-            </button>
+  const handleOutputModeClick = (nextMode: OutputMode) => {
+    setOutputMode(nextMode);
+    void fetchExport(target, nextMode);
+  };
 
-            {isOpen && (
-                <div
-                    id={panelId}
-                    className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden"
-                >
-                    {/* Framework tabs */}
-                    <div className="flex gap-1 p-3 border-b border-white/5">
-                        {FRAMEWORKS.map((fw) => (
-                            <button
-                                type="button"
-                                key={fw.id}
-                                onClick={() => handleFrameworkClick(fw.id)}
-                                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
-                                    framework === fw.id
-                                        ? fw.activeColor
-                                        : fw.color
-                                }`}
-                            >
-                                {fw.label}
-                            </button>
-                        ))}
-                    </div>
+  const handleCopy = () => {
+    if (!currentContent) return;
+    navigator.clipboard.writeText(currentContent).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
 
-                    {/* Output type tabs */}
-                    <div className="flex gap-1 px-3 pt-3">
-                        {(["python", "yaml"] as OutputTab[]).map((tab) => (
-                            <button
-                                type="button"
-                                key={tab}
-                                onClick={() => setOutputTab(tab)}
-                                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
-                                    outputTab === tab
-                                        ? "bg-white/10 text-zinc-100"
-                                        : "text-zinc-500 hover:text-zinc-300"
-                                }`}
-                            >
-                                {tab === "python"
-                                    ? "Python Code"
-                                    : "YAML Config"}
-                            </button>
-                        ))}
-                    </div>
+  if (!systemPrompt) return null;
 
-                    {/* Code area */}
-                    <div className="relative p-3">
-                        {loading ? (
-                            <div className="flex items-center justify-center h-24 text-zinc-500 text-xs animate-pulse">
-                                Generating {activeFramework.label} export...
-                            </div>
-                        ) : error ? (
-                            <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                                {error}
-                            </div>
-                        ) : codeContent ? (
-                            <div className="relative group/code">
-                                <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
-                                    <code>{codeContent}</code>
-                                </pre>
-                                <button
-                                    type="button"
-                                    onClick={handleCopy}
-                                    className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
-                                    aria-label="Copy code"
-                                >
-                                    {copied ? (
-                                        <>
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                width="11"
-                                                height="11"
-                                                viewBox="0 0 24 24"
-                                                fill="none"
-                                                stroke="currentColor"
-                                                strokeWidth="2.5"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                            >
-                                                <path d="M20 6 9 17l-5-5" />
-                                            </svg>
-                                            Copied!
-                                        </>
-                                    ) : (
-                                        <>
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                width="11"
-                                                height="11"
-                                                viewBox="0 0 24 24"
-                                                fill="none"
-                                                stroke="currentColor"
-                                                strokeWidth="2"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                            >
-                                                <rect
-                                                    width="14"
-                                                    height="14"
-                                                    x="8"
-                                                    y="8"
-                                                    rx="2"
-                                                    ry="2"
-                                                />
-                                                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-                                            </svg>
-                                            Copy
-                                        </>
-                                    )}
-                                </button>
-                            </div>
-                        ) : (
-                            <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
-                                Select a framework above to generate export code
-                            </div>
-                        )}
-                    </div>
-                </div>
-            )}
+  return (
+    <div className="mt-6 border-t border-white/5 pt-4">
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        className="w-full flex items-center justify-between px-2 py-1 group"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
+            Export
+          </span>
+          <span className="text-[10px] text-zinc-600 font-mono">
+            -&gt; executable agent target
+          </span>
         </div>
-    );
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-zinc-500 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div id={panelId} className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
+          <div className="flex gap-1 p-3 border-b border-white/5 flex-wrap">
+            {TARGETS.map((item) => (
+              <button
+                type="button"
+                key={item.id}
+                onClick={() => handleTargetClick(item.id)}
+                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                  target === item.id ? item.activeColor : item.color
+                }`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex gap-1 px-3 pt-3 flex-wrap">
+            {outputTabs.map((tab) => (
+              <button
+                type="button"
+                key={tab.id}
+                onClick={() => handleOutputModeClick(tab.id)}
+                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
+                  outputMode === tab.id
+                    ? "bg-white/10 text-zinc-100"
+                    : "text-zinc-500 hover:text-zinc-300"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {visibleFiles.length > 1 && (
+            <div className="px-3 pt-3">
+              <label htmlFor="agent-export-file" className="sr-only">
+                Exported file
+              </label>
+              <select
+                id="agent-export-file"
+                value={selectedFilePath ?? visibleFiles[0].path}
+                onChange={(event) => setSelectedFilePath(event.target.value)}
+                className="w-full bg-black/20 border border-white/10 text-zinc-300 text-xs rounded-xl px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+              >
+                {visibleFiles.map((file) => (
+                  <option key={file.path} value={file.path}>
+                    {file.path}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="relative p-3">
+            {loading ? (
+              <div className="flex items-center justify-center h-24 text-zinc-500 text-xs animate-pulse">
+                Generating {activeTarget.label} export...
+              </div>
+            ) : error ? (
+              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
+                {error}
+              </div>
+            ) : currentContent ? (
+              <div className="relative group/code">
+                <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
+                  <code>{currentContent}</code>
+                </pre>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                  aria-label="Copy code"
+                >
+                  {copied ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
+                Select a target above to generate export code
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function resolveFormat(target: ExportTarget, outputMode: OutputMode): string {
+  if (target === "claude-agent-sdk") {
+    return outputMode === "typescript" ? "claude-agent-sdk-ts" : "claude-agent-sdk-py";
+  }
+  if (target === "claude-subagent") return "claude-subagent";
+  if (target === "claude-project-pack") return "claude-project-pack";
+  if (target === "langgraph") return "langgraph";
+  return "langchain";
 }

--- a/web/app/agent-packs/claude/download/route.ts
+++ b/web/app/agent-packs/claude/download/route.ts
@@ -1,0 +1,7 @@
+import { proxyBackendRequest } from "@/lib/server/backendProxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyBackendRequest(request, "/agent-packs/claude/download", {
+    requireServerApiKey: true,
+  });
+}

--- a/web/app/agent-packs/claude/route.ts
+++ b/web/app/agent-packs/claude/route.ts
@@ -1,0 +1,7 @@
+import { proxyBackendRequest } from "@/lib/server/backendProxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyBackendRequest(request, "/agent-packs/claude", {
+    requireServerApiKey: true,
+  });
+}

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import AgentPacksPage from "./page";
+
+const { apiJson, apiFetch } = vi.hoisted(() => ({
+  apiJson: vi.fn(),
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("@/config", () => ({
+  apiJson,
+  apiFetch,
+  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+}));
+
+vi.mock("../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+describe("Agent Packs page", () => {
+  beforeEach(() => {
+    apiJson.mockReset();
+    apiFetch.mockReset();
+    apiJson.mockResolvedValue({
+      provider: "claude",
+      pack_type: "pr-reviewer",
+      download_name: "saas-pr-reviewer-claude",
+      preview_order: ["claude_md", "agents", "workflow"],
+      files: [
+        { path: "CLAUDE.md", content: "# Claude PR Reviewer Memory", kind: "claude_md" },
+        { path: ".claude/agents/pr-reviewer.md", content: "review agent", kind: "agents" },
+        { path: ".github/workflows/claude.yml", content: "name: Claude", kind: "workflow" },
+      ],
+    });
+    apiFetch.mockResolvedValue(
+      new Response("zip-bytes", {
+        status: 200,
+        headers: {
+          "content-disposition": 'attachment; filename="saas-pr-reviewer-claude.zip"',
+          "content-type": "application/zip",
+        },
+      }),
+    );
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    vi.stubGlobal("URL", {
+      ...globalThis.URL,
+      createObjectURL: vi.fn(() => "blob:preview"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  test("submits the selected pack type and renders grouped preview output", async () => {
+    render(<AgentPacksPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /PR Reviewer/i }));
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "Review pull requests for secret leaks and missing tests." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /generate claude pack/i }));
+
+    await waitFor(() => expect(apiJson).toHaveBeenCalledTimes(1));
+    const [path, options] = apiJson.mock.calls[0];
+    expect(path).toBe("/agent-packs/claude");
+    expect(JSON.parse(options.body).pack_type).toBe("pr-reviewer");
+
+    expect(await screen.findByText("Pack Preview")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "agents" })).toBeTruthy();
+  });
+
+  test("downloads the generated pack through the Claude download route", async () => {
+    const clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", {
+          configurable: true,
+          value: clickSpy,
+        });
+      }
+      return element;
+    });
+
+    render(<AgentPacksPage />);
+
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "Create a full project pack." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /generate claude pack/i }));
+
+    await screen.findByText("Pack Preview");
+    fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+    const [path, options] = apiFetch.mock.calls[0];
+    expect(path).toBe("/agent-packs/claude/download");
+    expect(JSON.parse(options.body).goal).toBe("Create a full project pack.");
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -1,0 +1,457 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Bot, Copy, Download, FileCode2, FolderArchive, ShieldCheck, Sparkles } from "lucide-react";
+
+import { apiFetch, apiJson, buildGeneratorApiHeaders } from "@/config";
+import InfoButton from "../components/InfoButton";
+import { showError } from "../lib/showError";
+import { agentPackProviders } from "./providerRegistry";
+import type {
+  AgentPackFile,
+  AgentPackFileKind,
+  AgentPackManifest,
+  AgentPackRequest,
+  AgentPackRiskMode,
+  AgentPackType,
+} from "./types";
+
+const PACK_OPTIONS: { id: AgentPackType; label: string; detail: string }[] = [
+  {
+    id: "project-pack",
+    label: "Project Pack",
+    detail: "Full repo memory, settings, agents, workflow, and MCP snippet.",
+  },
+  {
+    id: "subagent",
+    label: "Subagent",
+    detail: "A focused Claude subagent bundle you can drop into a repo.",
+  },
+  {
+    id: "pr-reviewer",
+    label: "PR Reviewer",
+    detail: "A review-focused pack for code review, safety checks, and regressions.",
+  },
+  {
+    id: "mcp-tool-stub",
+    label: "MCP Tool Stub",
+    detail: "A starter MCP tool skeleton with README notes for Claude workflows.",
+  },
+];
+
+const PREVIEW_LABELS: Record<AgentPackFileKind, string> = {
+  claude_md: "CLAUDE.md",
+  settings: "settings.json",
+  agents: "agents",
+  workflow: "workflow",
+  mcp: "mcp",
+  readme: "README",
+  files: "files",
+};
+
+const RISK_OPTIONS: { id: AgentPackRiskMode; label: string; detail: string }[] = [
+  { id: "balanced", label: "Balanced", detail: "Practical defaults with guardrails." },
+  { id: "strict", label: "Strict", detail: "Tighter permissions and more defensive posture." },
+];
+
+const DEFAULT_REQUEST: AgentPackRequest = {
+  project_type: "SaaS",
+  stack: "FastAPI + Next.js",
+  goal: "",
+  pack_type: "project-pack",
+  risk_mode: "balanced",
+};
+
+function getDownloadFilename(response: Response, fallback: string): string {
+  const disposition = response.headers.get("content-disposition") || "";
+  const match = disposition.match(/filename=\"?([^"]+)\"?/i);
+  return match?.[1] || fallback;
+}
+
+function bundleFiles(files: AgentPackFile[]): string {
+  return files
+    .map((file) => `# ${file.path}\n\n${file.content.trim()}`)
+    .join("\n\n" + "=".repeat(80) + "\n\n");
+}
+
+export default function AgentPacksPage() {
+  const provider = agentPackProviders[0];
+  const [request, setRequest] = useState<AgentPackRequest>(DEFAULT_REQUEST);
+  const [manifest, setManifest] = useState<AgentPackManifest | null>(null);
+  const [activeKind, setActiveKind] = useState<AgentPackFileKind | null>(null);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedState, setCopiedState] = useState<"single" | "all" | null>(null);
+
+  const previewGroups = useMemo(() => {
+    if (!manifest) return [];
+    return manifest.preview_order
+      .map((kind) => ({
+        kind,
+        label: PREVIEW_LABELS[kind] ?? kind,
+        files: manifest.files.filter((file) => file.kind === kind),
+      }))
+      .filter((group) => group.files.length > 0);
+  }, [manifest]);
+
+  const activeGroup = previewGroups.find((group) => group.kind === activeKind) ?? previewGroups[0] ?? null;
+  const currentFile =
+    activeGroup?.files.find((file) => file.path === selectedPath) ??
+    activeGroup?.files[0] ??
+    null;
+
+  const handleFieldChange = <K extends keyof AgentPackRequest>(key: K, value: AgentPackRequest[K]) => {
+    setRequest((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleGenerate = async () => {
+    if (!request.goal.trim()) return;
+
+    setLoading(true);
+    setError(null);
+    setManifest(null);
+    setActiveKind(null);
+    setSelectedPath(null);
+
+    try {
+      const data = await apiJson<AgentPackManifest>("/agent-packs/claude", {
+        method: "POST",
+        headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(request),
+      });
+      setManifest(data);
+      setActiveKind(data.preview_order[0] ?? null);
+      setSelectedPath(data.files[0]?.path ?? null);
+    } catch (err: unknown) {
+      showError(err);
+      setError(err instanceof Error ? err.message : "Failed to generate agent pack.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopyCurrent = async () => {
+    if (!currentFile) return;
+    await navigator.clipboard.writeText(currentFile.content);
+    setCopiedState("single");
+    setTimeout(() => setCopiedState(null), 1800);
+  };
+
+  const handleCopyAll = async () => {
+    if (!manifest) return;
+    await navigator.clipboard.writeText(bundleFiles(manifest.files));
+    setCopiedState("all");
+    setTimeout(() => setCopiedState(null), 1800);
+  };
+
+  const handleDownload = async () => {
+    if (!request.goal.trim()) return;
+
+    setDownloading(true);
+    setError(null);
+    try {
+      const response = await apiFetch("/agent-packs/claude/download", {
+        method: "POST",
+        headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({ detail: response.statusText }));
+        throw new Error(payload.detail ?? "Download failed.");
+      }
+
+      const blob = await response.blob();
+      const href = URL.createObjectURL(blob);
+      const filename = getDownloadFilename(response, `${manifest?.download_name || "agent-pack"}.zip`);
+      const anchor = document.createElement("a");
+      anchor.href = href;
+      anchor.download = filename;
+      anchor.click();
+      URL.revokeObjectURL(href);
+    } catch (err: unknown) {
+      showError(err);
+      setError(err instanceof Error ? err.message : "Failed to download agent pack.");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  return (
+    <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden bg-[#050505] p-3 py-4 sm:p-4 md:h-full md:min-h-0 md:justify-center md:overflow-hidden md:p-8">
+      <div className="absolute left-[-5%] top-[-8%] h-[36vw] w-[36vw] rounded-full bg-cyan-500/10 blur-[120px] pointer-events-none" />
+      <div className="absolute bottom-[-12%] right-[-5%] h-[36vw] w-[36vw] rounded-full bg-blue-600/10 blur-[140px] pointer-events-none" />
+
+      <div className="glass flex min-h-[calc(100vh-2rem)] w-full max-w-7xl flex-col overflow-hidden rounded-2xl bg-black/40 shadow-2xl ring-1 ring-white/10 backdrop-blur-xl animate-fade-in md:h-full md:max-h-[90vh] md:rounded-3xl">
+        <header className="flex flex-col gap-3 border-b border-white/5 bg-black/20 p-4 backdrop-blur-md sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className={`flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br ${provider.accentClass} text-white shadow-lg shadow-cyan-500/20`}>
+              <FolderArchive size={18} aria-hidden="true" />
+            </div>
+            <div>
+              <h1 className="text-lg font-semibold tracking-tight text-white">Agent Packs</h1>
+              <div className="font-mono text-xs uppercase tracking-wider text-zinc-400 opacity-70">
+                One-Click Repo Assets
+              </div>
+            </div>
+            <InfoButton
+              title="Agent Packs"
+              description="Turn one short brief into runnable repo-ready assets. V1 focuses on Claude, while the architecture stays open for future providers."
+            />
+          </div>
+
+          <div className="flex items-center gap-2 self-start rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-200 sm:self-auto">
+            <Sparkles size={14} aria-hidden="true" />
+            {provider.name} {provider.badge}
+          </div>
+        </header>
+
+        <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
+          <section className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/10 p-4 sm:p-5 md:min-h-0 md:w-[38%] md:border-b-0 md:border-r md:overflow-y-auto">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div>
+                  <div className="mb-1 text-[11px] font-mono uppercase tracking-[0.25em] text-cyan-300/80">
+                    {provider.name}
+                  </div>
+                  <h2 className="text-xl font-semibold text-white">Generate runnable agent assets for your repo</h2>
+                </div>
+                <div className={`h-12 w-12 rounded-2xl ${provider.glowClass} flex items-center justify-center`}>
+                  <Bot size={22} className="text-cyan-200" aria-hidden="true" />
+                </div>
+              </div>
+              <p className="text-sm leading-relaxed text-zinc-400">{provider.summary}</p>
+            </div>
+
+            <button
+              type="button"
+              className={`group flex items-center justify-between rounded-2xl border border-white/10 p-4 text-left transition-all hover:border-cyan-400/30 hover:bg-white/[0.05] ${manifest ? "bg-white/[0.05]" : "bg-white/[0.02]"}`}
+              aria-label="Claude provider card"
+            >
+              <div>
+                <div className="mb-1 text-sm font-semibold text-white">{provider.name}</div>
+                <div className="text-xs text-zinc-500">V1 provider. More ecosystems can slot into this registry later.</div>
+              </div>
+              <div className={`rounded-xl bg-gradient-to-br ${provider.accentClass} px-3 py-2 text-xs font-semibold text-white shadow-lg shadow-cyan-500/10`}>
+                Ready
+              </div>
+            </button>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-zinc-300">Project Type</span>
+                <input
+                  value={request.project_type}
+                  onChange={(event) => handleFieldChange("project_type", event.target.value)}
+                  className="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-zinc-200 outline-none transition focus:ring-1 focus:ring-cyan-500/50"
+                  placeholder="SaaS, CLI, internal tool..."
+                />
+              </label>
+
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-zinc-300">Stack</span>
+                <input
+                  value={request.stack}
+                  onChange={(event) => handleFieldChange("stack", event.target.value)}
+                  className="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-zinc-200 outline-none transition focus:ring-1 focus:ring-cyan-500/50"
+                  placeholder="React, FastAPI, Node..."
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label htmlFor="agent-pack-goal" className="text-sm font-medium text-zinc-300">
+                What should Claude do?
+              </label>
+              <textarea
+                id="agent-pack-goal"
+                value={request.goal}
+                onChange={(event) => handleFieldChange("goal", event.target.value)}
+                className="min-h-36 rounded-2xl border border-white/10 bg-black/20 p-4 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
+                placeholder="e.g. Review PRs for prompt leakage, unsafe settings, and missing regression tests."
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-zinc-300">Pack Type</span>
+              <div className="grid gap-2">
+                {PACK_OPTIONS.map((option) => {
+                  const active = request.pack_type === option.id;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => handleFieldChange("pack_type", option.id)}
+                      className={`rounded-2xl border px-4 py-3 text-left transition-all ${
+                        active
+                          ? "border-cyan-400/50 bg-cyan-500/10 text-white shadow-lg shadow-cyan-500/10"
+                          : "border-white/8 bg-white/[0.02] text-zinc-400 hover:border-white/15 hover:bg-white/[0.04]"
+                      }`}
+                    >
+                      <div className="mb-1 text-sm font-semibold">{option.label}</div>
+                      <div className="text-xs leading-relaxed text-inherit/80">{option.detail}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-zinc-300">Risk Mode</span>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {RISK_OPTIONS.map((option) => {
+                  const active = request.risk_mode === option.id;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => handleFieldChange("risk_mode", option.id)}
+                      className={`rounded-xl border px-4 py-3 text-left transition-all ${
+                        active
+                          ? "border-cyan-400/40 bg-cyan-500/10 text-white"
+                          : "border-white/8 bg-white/[0.02] text-zinc-400 hover:border-white/15"
+                      }`}
+                    >
+                      <div className="flex items-center gap-2 text-sm font-semibold">
+                        {option.id === "strict" ? <ShieldCheck size={15} aria-hidden="true" /> : <Sparkles size={15} aria-hidden="true" />}
+                        {option.label}
+                      </div>
+                      <div className="mt-1 text-xs text-inherit/80">{option.detail}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={loading || !request.goal.trim()}
+              className={`mt-1 flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3 text-sm font-bold text-white shadow-lg transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${provider.buttonClass}`}
+            >
+              {loading ? "Generating..." : provider.ctaLabel}
+            </button>
+
+            {error && (
+              <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-xs text-red-300">
+                {error}
+              </div>
+            )}
+          </section>
+
+          <section className="relative flex min-h-[380px] w-full flex-col bg-black/20 md:min-h-0 md:w-[62%]">
+            {manifest ? (
+              <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex flex-col gap-3 border-b border-white/5 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+                  <div>
+                    <h2 className="text-sm font-semibold tracking-tight text-zinc-100">Pack Preview</h2>
+                    <p className="mt-1 text-xs text-zinc-500">
+                      {manifest.files.length} files grouped for quick review, copy, or download.
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={handleCopyCurrent}
+                      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-zinc-200 transition hover:bg-white/[0.08]"
+                    >
+                      <Copy size={14} aria-hidden="true" />
+                      {copiedState === "single" ? "Copied" : "Copy"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleCopyAll}
+                      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-zinc-200 transition hover:bg-white/[0.08]"
+                    >
+                      <FileCode2 size={14} aria-hidden="true" />
+                      {copiedState === "all" ? "Copied All" : "Copy All"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDownload}
+                      disabled={downloading}
+                      className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:opacity-60"
+                    >
+                      <Download size={14} aria-hidden="true" />
+                      {downloading ? "Preparing..." : "Download Pack"}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2 border-b border-white/5 px-4 py-3 sm:px-6">
+                  {previewGroups.map((group) => (
+                    <button
+                      key={group.kind}
+                      type="button"
+                      onClick={() => {
+                        setActiveKind(group.kind);
+                        setSelectedPath(group.files[0]?.path ?? null);
+                      }}
+                      className={`rounded-full border px-3 py-1.5 text-[11px] font-mono uppercase tracking-wide transition-all ${
+                        activeGroup?.kind === group.kind
+                          ? "border-cyan-400/40 bg-cyan-500/10 text-cyan-100"
+                          : "border-transparent bg-white/[0.03] text-zinc-500 hover:bg-white/[0.07] hover:text-zinc-300"
+                      }`}
+                    >
+                      {group.label}
+                    </button>
+                  ))}
+                </div>
+
+                {activeGroup && activeGroup.files.length > 1 && (
+                  <div className="px-4 pt-4 sm:px-6">
+                    <label htmlFor="agent-pack-file-select" className="sr-only">
+                      Preview file
+                    </label>
+                    <select
+                      id="agent-pack-file-select"
+                      value={currentFile?.path ?? activeGroup.files[0].path}
+                      onChange={(event) => setSelectedPath(event.target.value)}
+                      className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
+                    >
+                      {activeGroup.files.map((file) => (
+                        <option key={file.path} value={file.path}>
+                          {file.path}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
+                <div className="flex-1 overflow-hidden p-4 sm:p-6">
+                  <div className="relative h-full overflow-hidden rounded-2xl border border-white/8 bg-black/35">
+                    <div className="flex items-center justify-between border-b border-white/5 px-4 py-3">
+                      <div className="text-xs font-medium text-zinc-300">{currentFile?.path || "Generated file"}</div>
+                      <div className="text-[10px] font-mono uppercase tracking-wider text-zinc-500">{manifest.provider}</div>
+                    </div>
+                    <pre className="custom-scrollbar h-full overflow-auto p-4 pb-12 font-mono text-[11px] leading-relaxed text-zinc-300 whitespace-pre">
+                      <code>{currentFile?.content || "Choose a generated file to preview it here."}</code>
+                    </pre>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-1 flex-col items-center justify-center gap-6 p-8 text-center text-zinc-600 opacity-80">
+                <div className="relative">
+                  <div className="absolute inset-0 rounded-full bg-cyan-500/30 blur-[45px]" />
+                  <div className="relative flex h-24 w-24 items-center justify-center rounded-[28px] border border-white/10 bg-gradient-to-br from-zinc-900 to-black shadow-2xl">
+                    <FolderArchive size={40} className="text-cyan-300/70" aria-hidden="true" />
+                  </div>
+                </div>
+                <div className="max-w-sm space-y-2">
+                  <h3 className="text-lg font-medium text-zinc-200">Single-click pack generation</h3>
+                  <p className="text-sm leading-relaxed text-zinc-500">
+                    Pick a pack type, describe what Claude should do, then generate a ready-to-review asset bundle on the right.
+                  </p>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/app/agent-packs/providerRegistry.ts
+++ b/web/app/agent-packs/providerRegistry.ts
@@ -1,0 +1,15 @@
+import type { AgentPackProviderConfig } from "./types";
+
+export const agentPackProviders: AgentPackProviderConfig[] = [
+  {
+    id: "claude",
+    name: "Claude",
+    badge: "V1 Live",
+    summary: "Generate repo-ready Claude assets from one short brief.",
+    ctaLabel: "Generate Claude Pack",
+    accentClass: "from-sky-500 via-cyan-500 to-blue-600",
+    glowClass: "bg-cyan-500/20",
+    buttonClass:
+      "bg-gradient-to-r from-sky-500 via-cyan-500 to-blue-600 hover:from-sky-400 hover:via-cyan-400 hover:to-blue-500 focus-visible:ring-cyan-400 shadow-cyan-500/20",
+  },
+];

--- a/web/app/agent-packs/types.ts
+++ b/web/app/agent-packs/types.ts
@@ -1,0 +1,43 @@
+export type AgentPackType = "project-pack" | "subagent" | "pr-reviewer" | "mcp-tool-stub";
+export type AgentPackRiskMode = "balanced" | "strict";
+export type AgentPackFileKind =
+  | "claude_md"
+  | "settings"
+  | "agents"
+  | "workflow"
+  | "mcp"
+  | "readme"
+  | "files";
+
+export interface AgentPackRequest {
+  project_type: string;
+  stack: string;
+  goal: string;
+  pack_type: AgentPackType;
+  risk_mode: AgentPackRiskMode;
+}
+
+export interface AgentPackFile {
+  path: string;
+  content: string;
+  kind: AgentPackFileKind;
+}
+
+export interface AgentPackManifest {
+  provider: string;
+  pack_type: AgentPackType;
+  files: AgentPackFile[];
+  download_name: string;
+  preview_order: AgentPackFileKind[];
+}
+
+export interface AgentPackProviderConfig {
+  id: string;
+  name: string;
+  badge: string;
+  summary: string;
+  ctaLabel: string;
+  accentClass: string;
+  glowClass: string;
+  buttonClass: string;
+}

--- a/web/app/components/Sidebar.test.tsx
+++ b/web/app/components/Sidebar.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import Sidebar from "./Sidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/agent-packs",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.PropsWithChildren<{ href: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("Sidebar", () => {
+  test("renders Agent Packs as a top-level navigation item", () => {
+    render(<Sidebar />);
+
+    const link = screen.getByLabelText("Agent Packs");
+    expect(link.getAttribute("href")).toBe("/agent-packs");
+    expect(link.getAttribute("aria-current")).toBe("page");
+  });
+});

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Code2, Sparkles, WifiOff, Swords, Bot, Zap, type LucideIcon } from "lucide-react";
+import { Code2, Sparkles, WifiOff, Swords, Bot, Zap, FolderArchive, type LucideIcon } from "lucide-react";
 
 const navItems: { name: string; path: string; Icon: LucideIcon }[] = [
     { name: "Compiler",          path: "/",                 Icon: Code2    },
     { name: "Optimizer",         path: "/optimizer",        Icon: Sparkles },
     { name: "Offline",           path: "/offline",          Icon: WifiOff  },
     { name: "Benchmark",         path: "/benchmark",        Icon: Swords   },
+    { name: "Agent Packs",       path: "/agent-packs",      Icon: FolderArchive },
     { name: "Agent Generator",   path: "/agent-generator",  Icon: Bot      },
     { name: "Skills Generator",  path: "/skills-generator", Icon: Zap      },
 ];
@@ -18,6 +19,7 @@ const accentBarMap: Record<string, string> = {
     "/optimizer":         "bg-emerald-500",
     "/offline":           "bg-zinc-500",
     "/benchmark":         "bg-amber-500",
+    "/agent-packs":       "bg-cyan-500",
     "/agent-generator":   "bg-green-500",
     "/skills-generator":  "bg-yellow-500",
 };
@@ -27,6 +29,7 @@ const accentRingMap: Record<string, string> = {
     "/optimizer":         "ring-emerald-500/30",
     "/offline":           "ring-zinc-500/30",
     "/benchmark":         "ring-amber-500/30",
+    "/agent-packs":       "ring-cyan-500/30",
     "/agent-generator":   "ring-green-500/30",
     "/skills-generator":  "ring-yellow-500/30",
 };

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -126,6 +126,7 @@ body {
   --accent-optimizer:        #10b981;
   --accent-offline:          #71717a;
   --accent-benchmark:        #f59e0b;
+  --accent-agent-packs:      #06b6d4;
   --accent-agent-generator:  #22c55e;
   --accent-skills-generator: #eab308;
 }

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GET as healthRoute } from "./health/route";
 import { POST as compileRoute } from "./compile/route";
+import { POST as agentPacksClaudeRoute } from "./agent-packs/claude/route";
+import { POST as agentPacksClaudeDownloadRoute } from "./agent-packs/claude/download/route";
 import { POST as agentGenerateRoute } from "./agent-generator/generate/route";
 import { POST as agentExportRoute } from "./agent-generator/export/route";
 import { POST as benchmarkRunRoute } from "./benchmark/run/route";
@@ -81,6 +83,20 @@ describe("Next backend proxy route wiring", () => {
   });
 
   it.each<RouteCase>([
+    {
+      name: "agent packs",
+      handler: agentPacksClaudeRoute,
+      requestUrl: "http://localhost:3000/agent-packs/claude",
+      requestBody: { project_type: "SaaS", stack: "FastAPI", goal: "Generate a project pack", pack_type: "project-pack" },
+      expectedUrl: "https://api.memo.dev/agent-packs/claude",
+    },
+    {
+      name: "agent pack download",
+      handler: agentPacksClaudeDownloadRoute,
+      requestUrl: "http://localhost:3000/agent-packs/claude/download",
+      requestBody: { project_type: "SaaS", stack: "FastAPI", goal: "Generate a project pack", pack_type: "project-pack" },
+      expectedUrl: "https://api.memo.dev/agent-packs/claude/download",
+    },
     {
       name: "agent generation",
       handler: agentGenerateRoute,
@@ -170,6 +186,20 @@ describe("Next backend proxy route wiring", () => {
   });
 
   it.each<RouteCase>([
+    {
+      name: "agent packs",
+      handler: agentPacksClaudeRoute,
+      requestUrl: "http://localhost:3000/agent-packs/claude",
+      requestBody: { project_type: "SaaS", stack: "FastAPI", goal: "Generate a project pack", pack_type: "project-pack" },
+      expectedUrl: "https://api.memo.dev/agent-packs/claude",
+    },
+    {
+      name: "agent pack download",
+      handler: agentPacksClaudeDownloadRoute,
+      requestUrl: "http://localhost:3000/agent-packs/claude/download",
+      requestBody: { project_type: "SaaS", stack: "FastAPI", goal: "Generate a project pack", pack_type: "project-pack" },
+      expectedUrl: "https://api.memo.dev/agent-packs/claude/download",
+    },
     {
       name: "agent generation",
       handler: agentGenerateRoute,

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import SkillExportPanel from "./ExportPanel";
+
+const { apiFetch } = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("@/config", () => ({
+  apiFetch,
+}));
+
+describe("Skill ExportPanel", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        python_code: "def tool(): pass",
+        json_config: '{"name":"tool"}',
+        code: "def tool(): pass",
+        files: [],
+      }),
+    });
+  });
+
+  test("requests the Claude MCP tool export", async () => {
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Claude MCP Tool" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, options] = apiFetch.mock.calls.at(-1);
+    expect(JSON.parse(options.body).format).toBe("claude-mcp-tool-stub");
+  });
+});

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -1,346 +1,298 @@
 "use client";
 
-import { useState, useEffect, useRef, useId } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { apiFetch } from "@/config";
 
-type SkillFormat = "langchain-tool" | "claude-tool-use" | "agent-skill";
-type OutputTab = "python" | "json" | "markdown";
+type SkillTarget = "claude-tool" | "claude-mcp-tool" | "langchain-tool";
+type OutputMode = "python" | "json" | "files";
+
+interface ExportFile {
+  path: string;
+  content: string;
+}
 
 interface SkillExportResult {
-    python_code: string | null;
-    json_config: string | null;
-    markdown: string | null;
+  python_code: string | null;
+  json_config: string | null;
+  code?: string | null;
+  files?: ExportFile[];
 }
 
 interface ExportPanelProps {
-    skillDefinition: string | null;
+  skillDefinition: string | null;
 }
 
-const OUTPUT_TABS: Record<SkillFormat, { id: OutputTab; label: string }[]> = {
-    "langchain-tool": [
-        { id: "python", label: "Python Tool" },
-        { id: "json", label: "JSON Schema" },
-    ],
-    "claude-tool-use": [
-        { id: "json", label: "JSON Config" },
-        { id: "python", label: "Python Tool" },
-    ],
-    "agent-skill": [{ id: "markdown", label: "SKILL.md" }],
-};
-
-const CONTENT_KEY: Record<OutputTab, keyof SkillExportResult> = {
-    python: "python_code",
-    json: "json_config",
-    markdown: "markdown",
-};
-
-const FORMATS: {
-    id: SkillFormat;
-    label: string;
-    color: string;
-    activeColor: string;
+const TARGETS: {
+  id: SkillTarget;
+  label: string;
+  color: string;
+  activeColor: string;
 }[] = [
-    {
-        id: "langchain-tool",
-        label: "LangChain Tool",
-        color: "text-zinc-400 border-transparent hover:border-green-500/40 hover:text-green-300",
-        activeColor: "text-green-300 border-green-500/60 bg-green-500/10",
-    },
-    {
-        id: "claude-tool-use",
-        label: "Claude tool_use",
-        color: "text-zinc-400 border-transparent hover:border-orange-500/40 hover:text-orange-300",
-        activeColor: "text-orange-300 border-orange-500/60 bg-orange-500/10",
-    },
-    {
-        id: "agent-skill",
-        label: "Agent Skill",
-        color: "text-zinc-400 border-transparent hover:border-purple-500/40 hover:text-purple-300",
-        activeColor: "text-purple-300 border-purple-500/60 bg-purple-500/10",
-    },
+  {
+    id: "claude-tool",
+    label: "Claude Tool",
+    color: "text-zinc-400 border-transparent hover:border-orange-500/40 hover:text-orange-300",
+    activeColor: "text-orange-300 border-orange-500/60 bg-orange-500/10",
+  },
+  {
+    id: "claude-mcp-tool",
+    label: "Claude MCP Tool",
+    color: "text-zinc-400 border-transparent hover:border-blue-500/40 hover:text-blue-300",
+    activeColor: "text-blue-300 border-blue-500/60 bg-blue-500/10",
+  },
+  {
+    id: "langchain-tool",
+    label: "LangChain Tool",
+    color: "text-zinc-400 border-transparent hover:border-green-500/40 hover:text-green-300",
+    activeColor: "text-green-300 border-green-500/60 bg-green-500/10",
+  },
 ];
 
-export default function SkillExportPanel({
-    skillDefinition,
-}: ExportPanelProps) {
-    const [isOpen, setIsOpen] = useState(false);
-    const [format, setFormat] = useState<SkillFormat>("langchain-tool");
-    const [outputTab, setOutputTab] = useState<OutputTab>("python");
-    const [cache, setCache] = useState<
-        Partial<Record<SkillFormat, SkillExportResult>>
-    >({});
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [copied, setCopied] = useState(false);
-    const prevDefRef = useRef<string | null>(null);
-    const panelId = useId();
+const OUTPUT_OPTIONS: Record<SkillTarget, { id: OutputMode; label: string }[]> = {
+  "claude-tool": [
+    { id: "json", label: "JSON" },
+    { id: "python", label: "Python" },
+  ],
+  "claude-mcp-tool": [{ id: "files", label: "Files" }],
+  "langchain-tool": [
+    { id: "python", label: "Python" },
+    { id: "json", label: "JSON" },
+  ],
+};
 
-    // Reset cache when skill definition changes
-    useEffect(() => {
-        if (skillDefinition !== prevDefRef.current) {
-            prevDefRef.current = skillDefinition;
-            setCache({});
-            setError(null);
-        }
-    }, [skillDefinition]);
+export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [target, setTarget] = useState<SkillTarget>("claude-tool");
+  const [outputMode, setOutputMode] = useState<OutputMode>("json");
+  const [cache, setCache] = useState<Record<string, SkillExportResult>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
+  const prevDefRef = useRef<string | null>(null);
+  const panelId = useId();
 
-    const currentResult = cache[format] ?? null;
+  useEffect(() => {
+    if (skillDefinition !== prevDefRef.current) {
+      prevDefRef.current = skillDefinition;
+      setCache({});
+      setError(null);
+      setSelectedFilePath(null);
+      setTarget("claude-tool");
+      setOutputMode("json");
+    }
+  }, [skillDefinition]);
 
-    const fetchExport = async (fmt: SkillFormat) => {
-        if (!skillDefinition) return;
-        if (cache[fmt]) return;
+  const activeTarget = TARGETS.find((item) => item.id === target)!;
+  const format = resolveFormat(target);
+  const currentResult = cache[format] ?? null;
+  const visibleFiles = currentResult?.files ?? [];
 
-        setLoading(true);
-        setError(null);
-        try {
-            const res = await apiFetch("/skills-generator/export", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    skill_definition: skillDefinition,
-                    format: fmt,
-                    output_type: "both",
-                }),
-            });
+  const currentContent = useMemo(() => {
+    if (!currentResult) return null;
+    if (outputMode === "python") return currentResult.python_code;
+    if (outputMode === "json") return currentResult.json_config;
+    const files = currentResult.files ?? [];
+    if (!files.length) return null;
+    const selected = files.find((file) => file.path === selectedFilePath) ?? files[0];
+    return selected.content;
+  }, [currentResult, outputMode, selectedFilePath]);
 
-            if (!res.ok) {
-                const body = await res
-                    .json()
-                    .catch(() => ({ detail: res.statusText }));
-                throw new Error(body.detail ?? `Export failed (${res.status})`);
-            }
+  const fetchExport = async (nextTarget: SkillTarget, nextMode: OutputMode) => {
+    if (!skillDefinition) return;
+    const nextFormat = resolveFormat(nextTarget);
+    if (cache[nextFormat]) {
+      const files = cache[nextFormat].files ?? [];
+      if (files.length && !selectedFilePath) {
+        setSelectedFilePath(files[0].path);
+      }
+      return;
+    }
 
-            const data: SkillExportResult = await res.json();
-            setCache((prev) => ({ ...prev, [fmt]: data }));
-        } catch (e: unknown) {
-            setError(e instanceof Error ? e.message : "Export failed");
-        } finally {
-            setLoading(false);
-        }
-    };
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch("/skills-generator/export", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          skill_definition: skillDefinition,
+          format: nextFormat,
+          output_type: nextMode,
+        }),
+      });
 
-    const handleFormatClick = (fmt: SkillFormat) => {
-        setFormat(fmt);
-        fetchExport(fmt);
-        // Reset output tab to a valid default for the selected format
-        if (fmt === "claude-tool-use") setOutputTab("json");
-        else if (fmt === "agent-skill") setOutputTab("markdown");
-        else setOutputTab("python");
-    };
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(body.detail ?? `Export failed (${res.status})`);
+      }
 
-    const handleToggle = () => {
-        const next = !isOpen;
-        setIsOpen(next);
-        if (next && !cache[format]) {
-            fetchExport(format);
-        }
-    };
+      const data: SkillExportResult = await res.json();
+      setCache((prev) => ({ ...prev, [nextFormat]: data }));
+      const files = data.files ?? [];
+      if (files.length) {
+        setSelectedFilePath(files[0].path);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    const codeContent = currentResult?.[CONTENT_KEY[outputTab]] ?? null;
+  const handleToggle = () => {
+    const next = !isOpen;
+    setIsOpen(next);
+    if (next) {
+      void fetchExport(target, outputMode);
+    }
+  };
 
-    const handleCopy = () => {
-        const text = codeContent;
-        if (text) {
-            navigator.clipboard.writeText(text).then(() => {
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
-            });
-        }
-    };
+  const handleTargetClick = (nextTarget: SkillTarget) => {
+    const firstMode = OUTPUT_OPTIONS[nextTarget][0].id;
+    setTarget(nextTarget);
+    setOutputMode(firstMode);
+    void fetchExport(nextTarget, firstMode);
+  };
 
-    const handleDownloadSkill = () => {
-        const text = currentResult?.markdown;
-        if (!text) return;
-        const blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
-        const url = URL.createObjectURL(blob);
-        const anchor = document.createElement("a");
-        anchor.href = url;
-        anchor.download = "SKILL.md";
-        anchor.click();
-        // Revoke after a tick so the browser has time to initiate the download.
-        setTimeout(() => URL.revokeObjectURL(url), 100);
-    };
+  const handleOutputModeClick = (nextMode: OutputMode) => {
+    setOutputMode(nextMode);
+  };
 
-    const outputTabs = OUTPUT_TABS[format];
+  const handleCopy = () => {
+    if (!currentContent) return;
+    navigator.clipboard.writeText(currentContent).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
 
-    if (!skillDefinition) return null;
+  if (!skillDefinition) return null;
 
-    return (
-        <div className="mt-6 border-t border-white/5 pt-4">
-            {/* Toggle header */}
-            <button
-                type="button"
-                onClick={handleToggle}
-                aria-expanded={isOpen}
-                aria-controls={panelId}
-                className="w-full flex items-center justify-between px-2 py-1 group"
-            >
-                <div className="flex items-center gap-2">
-                    <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
-                        Export
-                    </span>
-                    <span className="text-[10px] text-zinc-600 font-mono">
-                        → framework code
-                    </span>
-                </div>
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className={`text-zinc-500 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
-                >
-                    <path d="m6 9 6 6 6-6" />
-                </svg>
-            </button>
-
-            {isOpen && (
-                <div
-                    id={panelId}
-                    className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden"
-                >
-                    {/* Format tabs */}
-                    <div className="flex gap-1 p-3 border-b border-white/5">
-                        {FORMATS.map((f) => (
-                            <button
-                                type="button"
-                                key={f.id}
-                                onClick={() => handleFormatClick(f.id)}
-                                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
-                                    format === f.id ? f.activeColor : f.color
-                                }`}
-                            >
-                                {f.label}
-                            </button>
-                        ))}
-                    </div>
-
-                    {/* Output type tabs */}
-                    <div className="flex gap-1 px-3 pt-3">
-                        {outputTabs.map((tab) => (
-                            <button
-                                type="button"
-                                key={tab.id}
-                                onClick={() => setOutputTab(tab.id)}
-                                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
-                                    outputTab === tab.id
-                                        ? "bg-white/10 text-zinc-100"
-                                        : "text-zinc-500 hover:text-zinc-300"
-                                }`}
-                            >
-                                {tab.label}
-                            </button>
-                        ))}
-                    </div>
-
-                    {/* Code area */}
-                    <div className="relative p-3">
-                        {loading ? (
-                            <div className="flex items-center justify-center h-24 text-zinc-500 text-xs animate-pulse">
-                                Generating export...
-                            </div>
-                        ) : error ? (
-                            <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                                {error}
-                            </div>
-                        ) : codeContent ? (
-                            <div className="relative group/code">
-                                <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
-                                    <code>{codeContent}</code>
-                                </pre>
-                                <div className="absolute top-3 right-3 flex gap-1.5 opacity-0 group-hover/code:opacity-100 focus-within:opacity-100 transition-opacity">
-                                    {/* Download button — only shown for SKILL.md */}
-                                    {format === "agent-skill" && (
-                                        <button
-                                            type="button"
-                                            onClick={handleDownloadSkill}
-                                            className="bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                                            aria-label="Download SKILL.md"
-                                        >
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                width="11"
-                                                height="11"
-                                                viewBox="0 0 24 24"
-                                                fill="none"
-                                                stroke="currentColor"
-                                                strokeWidth="2"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                            >
-                                                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                                                <polyline points="7 10 12 15 17 10" />
-                                                <line x1="12" y1="15" x2="12" y2="3" />
-                                            </svg>
-                                            SKILL.md
-                                        </button>
-                                    )}
-                                    {/* Copy button */}
-                                    <button
-                                        type="button"
-                                        onClick={handleCopy}
-                                        className="bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                                        aria-label="Copy code"
-                                    >
-                                        {copied ? (
-                                            <>
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    width="11"
-                                                    height="11"
-                                                    viewBox="0 0 24 24"
-                                                    fill="none"
-                                                    stroke="currentColor"
-                                                    strokeWidth="2.5"
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                >
-                                                    <path d="M20 6 9 17l-5-5" />
-                                                </svg>
-                                                Copied!
-                                            </>
-                                        ) : (
-                                            <>
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    width="11"
-                                                    height="11"
-                                                    viewBox="0 0 24 24"
-                                                    fill="none"
-                                                    stroke="currentColor"
-                                                    strokeWidth="2"
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                >
-                                                    <rect
-                                                        width="14"
-                                                        height="14"
-                                                        x="8"
-                                                        y="8"
-                                                        rx="2"
-                                                        ry="2"
-                                                    />
-                                                    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-                                                </svg>
-                                                Copy
-                                            </>
-                                        )}
-                                    </button>
-                                </div>
-                            </div>
-                        ) : (
-                            <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
-                                Select a format above to generate export code
-                            </div>
-                        )}
-                    </div>
-                </div>
-            )}
+  return (
+    <div className="mt-6 border-t border-white/5 pt-4">
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        className="w-full flex items-center justify-between px-2 py-1 group"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
+            Export
+          </span>
+          <span className="text-[10px] text-zinc-600 font-mono">
+            -&gt; runnable tool target
+          </span>
         </div>
-    );
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-zinc-500 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div id={panelId} className="mt-3 rounded-2xl border border-white/8 bg-black/30 overflow-hidden">
+          <div className="flex gap-1 p-3 border-b border-white/5 flex-wrap">
+            {TARGETS.map((item) => (
+              <button
+                type="button"
+                key={item.id}
+                onClick={() => handleTargetClick(item.id)}
+                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                  target === item.id ? item.activeColor : item.color
+                }`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex gap-1 px-3 pt-3 flex-wrap">
+            {OUTPUT_OPTIONS[target].map((tab) => (
+              <button
+                type="button"
+                key={tab.id}
+                onClick={() => handleOutputModeClick(tab.id)}
+                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
+                  outputMode === tab.id
+                    ? "bg-white/10 text-zinc-100"
+                    : "text-zinc-500 hover:text-zinc-300"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {visibleFiles.length > 1 && (
+            <div className="px-3 pt-3">
+              <label htmlFor="skill-export-file" className="sr-only">
+                Exported file
+              </label>
+              <select
+                id="skill-export-file"
+                value={selectedFilePath ?? visibleFiles[0].path}
+                onChange={(event) => setSelectedFilePath(event.target.value)}
+                className="w-full bg-black/20 border border-white/10 text-zinc-300 text-xs rounded-xl px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+              >
+                {visibleFiles.map((file) => (
+                  <option key={file.path} value={file.path}>
+                    {file.path}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="relative p-3">
+            {loading ? (
+              <div className="flex items-center justify-center h-24 text-zinc-500 text-xs animate-pulse">
+                Generating {activeTarget.label} export...
+              </div>
+            ) : error ? (
+              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
+                {error}
+              </div>
+            ) : currentContent ? (
+              <div className="relative group/code">
+                <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
+                  <code>{currentContent}</code>
+                </pre>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                  aria-label="Copy code"
+                >
+                  {copied ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
+                Select a target above to generate export code
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function resolveFormat(target: SkillTarget): string {
+  if (target === "claude-mcp-tool") return "claude-mcp-tool-stub";
+  if (target === "langchain-tool") return "langchain-tool";
+  return "claude-tool-use";
 }


### PR DESCRIPTION
## Summary
- add Claude-native export adapters, Anthropic provider wiring, and MCP bridge tools for runnable agent assets
- add a new Agent Packs sidebar section with a Claude-first one-click flow, preview tabs, copy actions, and pack downloads
- add repo-native Claude assets (`CLAUDE.md`, `.claude/settings.json`, `.claude/agents/*`, `claude.yml`) plus API/frontend tests for the new flows

## Why
This adds a self-contained side feature without changing the product's main positioning. Users can now generate runnable Claude assets from a short brief, preview them in-app, and download a ready-to-use pack while the architecture stays open for future providers like Codex or OpenCode.

## Validation
- `python -m pytest tests/test_agent_packs_api.py tests/test_export_adapters.py tests/test_llm_providers.py integrations/mcp-server/test_server.py -q`
- `cd web && npm run test -- app/agent-packs/page.test.tsx app/components/Sidebar.test.tsx app/proxy-routes.test.ts app/agent-generator/components/ExportPanel.test.tsx app/skills-generator/components/ExportPanel.test.tsx`
- `cd web && npm run build`
