### PR TITLE
ci: scope Full Test pytest to tests/ to fix main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -q --cov=app --cov=cli --cov=api --cov-report=term-missing --cov-report=xml --cov-fail-under=60
+          pytest tests/ -q --cov=app --cov=cli --cov=api --cov-report=term-missing --cov-report=xml --cov-fail-under=60
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- The Full Test job ran `pytest -q --cov=...` without a target directory, collecting every `test_*.py` from the repo root.
- After #536 brought in `integrations/mcp-server/test_server.py` (which imports the optional `mcp` package), collection failed on every OS/Python combo with `ModuleNotFoundError: No module named 'mcp'`.
- Scoping pytest to `tests/` matches the local runbook in `CLAUDE.md` and keeps MCP tests gated behind their own explicit invocation.

## Test plan
- [x] Local: `python -m pytest tests/ -q` → 1022 passed, 5 skipped
- [ ] CI Full Test matrix turns green