### PR TITLE
docs: document Claude Agent Packs section and bump to 2.0.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.46] - 2026-05-08
+### Added
+- **🤖 Claude Agent Packs**: A new first-class export surface that turns a project brief into a runnable, repo-ready Claude assets bundle.
+  - **New `Agent Packs` sidebar section** in the web app with a Claude-first one-click flow, preview tabs, copy actions, and one-shot pack download as a `.zip`.
+  - **Four pack types** under a single endpoint:
+    - **Project Pack** — emits `CLAUDE.md`, `.claude/settings.json`, and `.github/workflows/claude.yml` so a repo can adopt Claude Code with policy, deny rules, and a CI workflow on day one.
+    - **Subagent Bundle** — emits one or more `.claude/agents/<role>.md` files with frontmatter (`name`, `description`, `tools`) ready to be picked up by Claude Code's subagent dispatcher.
+    - **PR Reviewer Pack** — emits a reviewer subagent plus a `.github/workflows/claude.yml` that wires Claude into pull request review automation.
+    - **MCP Tool Stub** — emits a runnable `server.py` and `README.md` for an MCP server scaffolded from a skill definition (FastMCP-based, ready to register with Claude Code, Cursor, or Claude Desktop).
+  - **Risk-aware generation**: each request accepts `risk_mode: "balanced" | "strict"`. Strict mode tightens deny lists, narrows allowed tools, and removes optimistic defaults.
+  - **Provider-agnostic core**: a new `AgentPackAdapter` Protocol keeps Claude-specific logic (`ClaudeAgentPackAdapter` in `app/adapters/claude_code.py`) at the edge while the IR layer (`app/adapters/agent_packs.py`) stays neutral, so future Cursor/Codex/etc. adapters can plug in without touching the core.
+- **New API endpoints** (both protected by `verify_api_key`):
+  - `POST /agent-packs/claude` → returns an `AgentPackManifest` with file paths, contents, kinds, and a stable `preview_order` for the UI.
+  - `POST /agent-packs/claude/download` → streams the same manifest as a deflate-compressed `.zip` with a content-disposition filename derived from the pack type and slugified project type.
+- **New skill export format `claude-mcp-tool-stub`**: `POST /skills-generator/export` now accepts this format and returns a multi-file payload (`server.py` + `README.md`) suitable for cloning into a fresh MCP server repo.
+- **Repo-native Claude assets** committed as part of this work so the Compiler repo itself adopts the same flow it generates:
+  - `CLAUDE.md` with project summary, runbook, domain concepts, and security notes.
+  - `.claude/settings.json` with `defaultMode: acceptEdits`, deny rules for `.env*`, `secrets/**`, `users.db`, and `web/.env.local`, and ask gates for `git push`, `fly:`, and `railway:` shell commands.
+  - `.claude/agents/compiler-architect.md`, `.claude/agents/frontend-polisher.md`, `.claude/agents/mcp-integrator.md`, and `.claude/agents/prompt-safety-reviewer.md` covering the four core review/build personas the project routinely needs.
+  - `.github/workflows/claude.yml` for hosted Claude Code review on PRs.
+- **MCP bridge tool surface** updated in `integrations/mcp-server/server.py` so Claude Code, Cursor, and other MCP clients can call agent pack generation directly through the bridge alongside compile/skill/agent flows.
+- **Frontend test coverage** added for the new flows: `web/app/agent-packs/page.test.tsx`, `web/app/agent-generator/components/ExportPanel.test.tsx`, `web/app/skills-generator/components/ExportPanel.test.tsx`, and `web/app/components/Sidebar.test.tsx`.
+- **Backend test coverage** added in `tests/test_export_adapters.py` for `claude-agent-sdk-py`, `claude-agent-sdk-ts`, `claude-subagent`, `claude-project-pack`, and `claude-mcp-tool-stub` paths.
+
+### Changed
+- `app/adapters/__init__.py` now exports the new Claude Code adapters (`to_claude_mcp_tool_stub`, `to_claude_pr_reviewer_pack`, `to_claude_project_pack`, `to_claude_subagent_bundle`) alongside the existing skill adapters.
+- `api/main.py` mounts the new `agent_packs` router and the existing `export` router accepts the additional `claude-mcp-tool-stub` skill format.
+- The Skills Generator export panel now also surfaces the multi-file `files` payload (path + content) when a format returns more than a single artifact, instead of only `python_code` / `json_config`.
+- The Sidebar gains an `Agent Packs` entry pointing to `/agent-packs`, slotted next to `Agent Generator` and `Skills Generator`.
+- `agents.md` and `Makefile` updated to document the new pack flows alongside the existing compile/skill/agent recipes.
+
+### Security
+- Repo-shipped `.claude/settings.json` denies reads of `.env`, `.env.*`, `secrets/**`, `users.db`, and `web/.env.local` so an in-repo Claude Code session cannot exfiltrate local credentials, and gates `git push`, `fly:`, and `railway:` behind explicit confirmation prompts.
+- Generated `Project Pack` deny rules and ask gates mirror the same posture, so any repo that adopts the pack inherits the safe defaults rather than starting from an empty allowlist.
+
+### Notes
+- The `agent-skill` UI surface in the Skills Generator export panel will be re-added in a follow-up; the `agent-skill` format already works end-to-end through the API and remains covered by `test_export_api_endpoint_skill_agent_skill_format`.
+
 ## [2.0.45] - 2025-11-12
 ### Added
 - **⌨️ Keyboard Shortcuts Panel**: Comprehensive shortcuts reference dialog

--- a/README.md
+++ b/README.md
@@ -113,10 +113,60 @@ After generating a skill, the **Export** section can wrap the output in framewor
 |---|---|
 | **LangChain Tool** | Python `@tool` function plus JSON schema |
 | **Claude tool_use** | JSON config compatible with Anthropic's `tools` parameter |
+| **Claude MCP Tool Stub** | Runnable FastMCP `server.py` + `README.md`, ready to register with Claude Code, Cursor, or Claude Desktop |
 
 <p align="center">
   <img src="docs/images/skills_generator.png" alt="Skills Generator Interface" width="80%">
 </p>
+
+---
+
+### Claude Agent Packs
+
+The **Agent Packs** sidebar turns a short project brief (project type, stack, goal) into a **runnable, repo-ready bundle of Claude assets** — not just a prompt. Pick a pack type, preview the files, copy individual snippets, or download the whole thing as a `.zip`.
+
+Four pack types are available out of the box, all served from a single Claude-first endpoint:
+
+| Pack Type | What It Emits | Use It For |
+|---|---|---|
+| **Project Pack** | `CLAUDE.md`, `.claude/settings.json`, `.github/workflows/claude.yml` | Bootstrapping Claude Code in a new repo with policy, deny rules, and CI on day one |
+| **Subagent Bundle** | One or more `.claude/agents/<role>.md` files with `name`, `description`, and `tools` frontmatter | Giving Claude Code a team of specialized reviewers / builders that it can dispatch to |
+| **PR Reviewer Pack** | A reviewer subagent + `.github/workflows/claude.yml` | Wiring Claude into pull request review automation |
+| **MCP Tool Stub** | A FastMCP `server.py` + `README.md` scaffolded from a skill definition | Standing up an MCP server that exposes a custom tool to any MCP client |
+
+**Risk-aware generation.** Each request takes a `risk_mode`:
+
+| Mode | Behavior |
+|---|---|
+| `balanced` (default) | Sensible defaults: typical deny list, common allowed tools, gentle ask gates for destructive commands |
+| `strict` | Tightens deny lists, narrows allowed tools, drops optimistic defaults — pick this when adopting Claude Code into a repo with sensitive data or untrusted contributors |
+
+**Provider-agnostic core.** The pack generator is built around an `AgentPackAdapter` Protocol. Claude-specific logic lives in `app/adapters/claude_code.py`; the IR layer in `app/adapters/agent_packs.py` stays neutral. Cursor / Codex / other-provider adapters can plug in later without touching the core.
+
+**API surface** (both endpoints require an API key):
+
+```bash
+# Generate the manifest (preview-friendly: file paths, contents, kinds, preview order)
+curl -X POST https://api.example.com/agent-packs/claude \
+  -H "x-api-key: $PROMPTC_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "project_type": "FastAPI service",
+    "stack": "Python 3.12, FastAPI, PostgreSQL",
+    "goal": "Add a Claude-reviewed PR workflow with deny rules for .env",
+    "pack_type": "project-pack",
+    "risk_mode": "strict"
+  }'
+
+# Same payload, returns a deflate-compressed .zip ready to drop into a repo
+curl -X POST https://api.example.com/agent-packs/claude/download \
+  -H "x-api-key: $PROMPTC_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{...same body...}' \
+  --output claude-project-pack.zip
+```
+
+**Repo-native adoption.** This repo eats its own dog food: the Compiler itself ships a `CLAUDE.md`, a hardened `.claude/settings.json` (denies `.env*`, `secrets/**`, `users.db`, `web/.env.local`; gates `git push`, `fly:`, `railway:` behind explicit confirmation), four ready-to-dispatch subagents in `.claude/agents/` (`compiler-architect`, `frontend-polisher`, `mcp-integrator`, `prompt-safety-reviewer`), and a `claude.yml` workflow for hosted Claude Code review on PRs.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "promptc"
-version = "2.0.45"
+version = "2.0.46"
 description = "Prompt Compiler App: compile free-text prompts into structured IR + prompts + plan"
 authors = [ { name = "madara88645" } ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Documentation pass for the Claude Agent Packs work that landed in #536.

- **CHANGELOG.md** gains a `2.0.46` entry covering:
  - All four pack types (Project Pack, Subagent Bundle, PR Reviewer Pack, MCP Tool Stub).
  - Risk-aware generation (`balanced` vs `strict`) and the provider-agnostic `AgentPackAdapter` Protocol.
  - New API endpoints `/agent-packs/claude` and `/agent-packs/claude/download`.
  - New skill export format `claude-mcp-tool-stub`.
  - Repo-native Claude assets (`CLAUDE.md`, `.claude/settings.json`, `.claude/agents/*`, `.github/workflows/claude.yml`).
  - MCP bridge surface updates and new test coverage on both the API and frontend.
  - A note that the `agent-skill` UI tab will be re-added in a follow-up (the format already works end-to-end via the API).
- **README.md** gains a new **Claude Agent Packs** section between Skill Generator and Token Optimizer:
  - Tables for pack types and risk modes.
  - A short note on the provider-agnostic adapter design.
  - `curl` examples for both manifest and `.zip` endpoints.
  - The repo-native adoption posture (deny rules, ask gates, four shipped subagents).
- The Skills Generator export table is extended with **Claude MCP Tool Stub**.
- `pyproject.toml` version bumped `2.0.45` → `2.0.46`.

## Test plan
- [x] `python -m pytest tests/ -q` still green locally
- [ ] CI Full Test matrix is green (already fixed on main by #539)
- [ ] Reviewer skim of CHANGELOG + README sections for tone / accuracy