### PR TITLE
[codex] stabilize agent packs backend availability

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -96,6 +96,7 @@ uvicorn api.main:app --host 0.0.0.0 --port 8000
 ### Fly.io operational note
 
 - `mycompiler-api` has proven too tight at `256mb` on Fly Machines for generator/RAG-backed requests. Treat `512mb` as the minimum practical production memory size unless profiling proves otherwise.
+- Keep `min_machines_running = 1` for `mycompiler-api` in production. Letting the only machine scale down to zero causes cold-start races where Next proxy routes can return a fast 502 before Uvicorn is reachable, especially on `/compile` and `/agent-packs/claude`.
 - When Fly emails an `OOM: uvicorn killed` alert, check the current machine and recent logs first:
 
 ```bash

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ primary_region = "ams"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [http_service.concurrency]
     type = "requests"

--- a/web/app/agent-packs/claude/download/route.ts
+++ b/web/app/agent-packs/claude/download/route.ts
@@ -3,5 +3,6 @@ import { proxyBackendRequest } from "@/lib/server/backendProxy";
 export async function POST(request: Request): Promise<Response> {
   return proxyBackendRequest(request, "/agent-packs/claude/download", {
     requireServerApiKey: true,
+    retryNetworkErrors: true,
   });
 }

--- a/web/app/agent-packs/claude/route.ts
+++ b/web/app/agent-packs/claude/route.ts
@@ -3,5 +3,6 @@ import { proxyBackendRequest } from "@/lib/server/backendProxy";
 export async function POST(request: Request): Promise<Response> {
   return proxyBackendRequest(request, "/agent-packs/claude", {
     requireServerApiKey: true,
+    retryNetworkErrors: true,
   });
 }

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/config", () => ({
   buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
   describeRequestError: (error: unknown) =>
     error instanceof Error && error.message === "Failed to fetch"
-      ? "Could not reach the backend. Check the API URL or make sure the server is running."
+      ? "The service is temporarily unavailable or still waking up. Please retry in a few seconds."
       : error instanceof Error
         ? error.message
         : "Connection failed.",
@@ -122,7 +122,7 @@ describe("Agent Packs page", () => {
     fireEvent.click(screen.getByRole("button", { name: /generate claude pack/i }));
 
     expect(
-      await screen.findByText("Could not reach the backend. Check the API URL or make sure the server is running."),
+      await screen.findByText("The service is temporarily unavailable or still waking up. Please retry in a few seconds."),
     ).toBeTruthy();
   });
 });

--- a/web/app/compile/route.ts
+++ b/web/app/compile/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/compile");
+  return proxyBackendRequest(request, "/compile", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/app/hooks/useContextManager.ts
+++ b/web/app/hooks/useContextManager.ts
@@ -23,8 +23,24 @@ type FileWithRelativePath = File & {
 
 function toUserMessage(error: unknown): string {
   return describeRequestError(error, {
-    network: "Could not reach the backend. Check the API URL or make sure the server is running.",
+    network: "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
   });
+}
+
+async function readResponseDetail(response: Response): Promise<string> {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload === "object") {
+      const detail = (payload as { detail?: unknown }).detail;
+      if (typeof detail === "string" && detail.trim()) {
+        return detail.trim();
+      }
+    }
+  } catch {
+    // Ignore body parsing failures and fall back to generic copy.
+  }
+
+  return "The service is temporarily unavailable or still waking up. Please retry in a few seconds.";
 }
 
 function getUploadRelativePath(file: File): string {
@@ -57,7 +73,7 @@ export function useContextManager() {
 
       if (!response.ok) {
         setIsConnected(false);
-        setStatus("Backend health check failed. Verify the API URL and server status.");
+        setStatus(await readResponseDetail(response));
         return;
       }
 
@@ -76,10 +92,6 @@ export function useContextManager() {
   }, [refreshStats]);
 
   useEffect(() => {
-    // We intentionally ignore the rule here because `checkConnection` initializes our
-    // app connection status explicitly on mount, and we rely on `checkConnection`
-    // handling state cleanly based on async results.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void checkConnection();
   }, [checkConnection]);
 

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -82,6 +82,29 @@ describe("Next backend proxy route wiring", () => {
     await expect(response.json()).resolves.toEqual({ system_prompt: "safe" });
   });
 
+  it("retries compile requests after a transient backend connection failure", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ system_prompt: "safe" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const response = await compileRoute(
+      new Request("http://localhost:3000/compile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "summarize this" }),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(response.json()).resolves.toEqual({ system_prompt: "safe" });
+  });
+
   it.each<RouteCase>([
     {
       name: "agent packs",

--- a/web/config.test.mts
+++ b/web/config.test.mts
@@ -89,7 +89,7 @@ test("describeRequestError rewrites raw browser fetch failures into helpful copy
 
   assert.equal(
     describeRequestError(new Error("Failed to fetch")),
-    "Could not reach the backend. Check the API URL or make sure the server is running.",
+    "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
   );
 });
 

--- a/web/config.ts
+++ b/web/config.ts
@@ -1,4 +1,6 @@
 const DEFAULT_LOCAL_API_BASE = "http://127.0.0.1:8080";
+const BACKEND_WAKING_UP_MESSAGE =
+  "The service is temporarily unavailable or still waking up. Please retry in a few seconds.";
 
 type LocationLike = {
   hostname: string;
@@ -102,10 +104,7 @@ export function describeRequestError(
       normalizedMessage.includes("networkerror") ||
       normalizedMessage.includes("load failed")
     ) {
-      return (
-        copy.network ||
-        "Could not reach the backend. Check the API URL or make sure the server is running."
-      );
+      return copy.network || BACKEND_WAKING_UP_MESSAGE;
     }
 
     return error.message;

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -119,6 +119,59 @@ describe("backend proxy", () => {
     await expect(response.text()).resolves.toBe("zip-bytes");
   });
 
+  it("retries retryable JSON requests when the first backend fetch throws", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const request = new Request("http://localhost:3000/compile", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ text: "summarize this" }),
+    });
+
+    const response = await proxyBackendRequest(request, "/compile", {
+      retryNetworkErrors: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("does not retry non-retryable requests when the backend fetch throws", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch failed"));
+
+    const request = new Request("http://localhost:3000/rag/upload", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "x-api-key": "caller-key",
+      },
+      body: JSON.stringify({ filename: "README.md", content: "hello" }),
+    });
+
+    const response = await proxyBackendRequest(request, "/rag/upload", {
+      requireServerApiKey: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(502);
+  });
+
   it("returns a config error when a protected route has no server API key", async () => {
     const request = new Request("http://localhost:3000/agent-generator/generate", {
       method: "POST",

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -146,6 +146,8 @@ describe("backend proxy", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response.headers.get("x-promptc-proxy-attempts")).toBe("2");
+    expect(response.headers.get("x-promptc-proxy-duration-ms")).toBeTruthy();
     await expect(response.json()).resolves.toEqual({ ok: true });
   });
 
@@ -265,8 +267,9 @@ describe("backend proxy", () => {
     const response = await proxyBackendRequest(request, "/health", {});
 
     expect(response.status).toBe(502);
+    expect(response.headers.get("x-promptc-proxy-attempts")).toBe("1");
     await expect(response.json()).resolves.toEqual({
-      detail: "Could not reach the backend from the web server.",
+      detail: "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
     });
   });
 });

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -1,6 +1,9 @@
 const DEFAULT_BACKEND_API_BASE = "http://127.0.0.1:8080";
 const CONFIG_ERROR_DETAIL = "PROMPTC_SERVER_API_KEY is not configured on the web server.";
-const NETWORK_ERROR_DETAIL = "Could not reach the backend from the web server.";
+const NETWORK_ERROR_DETAIL =
+  "The service is temporarily unavailable or still waking up. Please retry in a few seconds.";
+const PROXY_ATTEMPTS_HEADER = "x-promptc-proxy-attempts";
+const PROXY_DURATION_HEADER = "x-promptc-proxy-duration-ms";
 
 if (!process.env.PROMPTC_SERVER_API_KEY?.trim()) {
   console.warn("PROMPTC_SERVER_API_KEY not set - protected proxy routes will forward no API key");
@@ -54,9 +57,16 @@ function shouldBufferProxyResponse(response: Response): boolean {
   return contentType.includes("application/json") || contentType.startsWith("text/");
 }
 
-async function cloneProxyResponse(response: Response): Promise<Response> {
+function addProxyDiagnostics(headers: Headers, attempts: number, durationMs: number): Headers {
+  headers.set(PROXY_ATTEMPTS_HEADER, String(attempts));
+  headers.set(PROXY_DURATION_HEADER, String(durationMs));
+  return headers;
+}
+
+async function cloneProxyResponse(response: Response, attempts: number, durationMs: number): Promise<Response> {
   const headers = new Headers(response.headers);
   headers.delete("content-length");
+  addProxyDiagnostics(headers, attempts, durationMs);
   if (shouldBufferProxyResponse(response)) {
     headers.delete("content-encoding");
     return new Response(await response.arrayBuffer(), {
@@ -83,6 +93,7 @@ export async function proxyBackendRequest(
   backendPath: string,
   options: ProxyOptions = {},
 ): Promise<Response> {
+  const requestStartedAt = Date.now();
   const serverApiKey = resolveServerApiKey();
   const callerApiKey = request.headers.get("x-api-key")?.trim() || "";
 
@@ -115,14 +126,41 @@ export async function proxyBackendRequest(
       if (init.body && !bufferedBody) init.duplex = "half";
 
       const upstreamResponse = await fetch(targetUrl, init as RequestInit);
-      return await cloneProxyResponse(upstreamResponse);
-    } catch {
-      if (attempt === retryAttempts - 1) {
-        return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502 });
+      const attemptsUsed = attempt + 1;
+      const durationMs = Date.now() - requestStartedAt;
+
+      if (attempt > 0) {
+        console.info("[backendProxy] upstream recovered after retry", {
+          attempts: attemptsUsed,
+          backendPath: path,
+          durationMs,
+        });
       }
+
+      return await cloneProxyResponse(upstreamResponse, attemptsUsed, durationMs);
+    } catch (error) {
+      if (attempt === retryAttempts - 1) {
+        const attemptsUsed = attempt + 1;
+        const durationMs = Date.now() - requestStartedAt;
+        console.error("[backendProxy] upstream unavailable", {
+          attempts: attemptsUsed,
+          backendPath: path,
+          durationMs,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        const diagnosticHeaders = addProxyDiagnostics(new Headers(), attemptsUsed, durationMs);
+        return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502, headers: diagnosticHeaders });
+      }
+
+      console.warn("[backendProxy] retrying upstream request", {
+        attempt: attempt + 1,
+        backendPath: path,
+        retryDelayMs: retryDelayMs * (attempt + 1),
+      });
       await sleep(retryDelayMs * (attempt + 1));
     }
   }
 
-  return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502 });
+  const diagnosticHeaders = addProxyDiagnostics(new Headers(), retryAttempts, Date.now() - requestStartedAt);
+  return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502, headers: diagnosticHeaders });
 }

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -19,7 +19,10 @@ const HOP_BY_HOP_HEADERS = new Set([
 ]);
 
 type ProxyOptions = {
+  networkRetryAttempts?: number;
+  networkRetryDelayMs?: number;
   requireServerApiKey?: boolean;
+  retryNetworkErrors?: boolean;
 };
 
 function resolveServerApiKey(): string {
@@ -42,6 +45,10 @@ function copyProxyHeaders(request: Request): Headers {
   return headers;
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function shouldBufferProxyResponse(response: Response): boolean {
   const contentType = response.headers.get("content-type")?.toLowerCase() || "";
   return contentType.includes("application/json") || contentType.startsWith("text/");
@@ -58,10 +65,8 @@ async function cloneProxyResponse(response: Response): Promise<Response> {
       headers,
     });
   }
-  // ⚡ Bolt Performance Optimization
-  // We forward the response.body ReadableStream directly instead of buffering the whole payload
-  // via await response.arrayBuffer(). This prevents OOM kills on machines with low memory
-  // (like Fly.io 512MB VMs) when passing through large RAG payloads.
+  // Stream large binary responses directly so download-style routes keep the
+  // lower-memory behavior from the original optimization.
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -90,28 +95,34 @@ export async function proxyBackendRequest(
     headers.set("x-api-key", serverApiKey);
   }
 
-  const base = resolveBackendApiBase().replace(/\/+$/, '');
-  const path = backendPath.startsWith('/') ? backendPath : '/' + backendPath;
+  const base = resolveBackendApiBase().replace(/\/+$/, "");
+  const path = backendPath.startsWith("/") ? backendPath : "/" + backendPath;
   const targetUrl = base + path;
+  const retryAttempts = options.retryNetworkErrors ? Math.max(1, options.networkRetryAttempts ?? 3) : 1;
+  const retryDelayMs = options.networkRetryDelayMs ?? 1000;
+  const bufferedBody =
+    !isBodylessMethod(request.method) && options.retryNetworkErrors ? await request.arrayBuffer() : null;
 
-  try {
-    // ⚡ Bolt Performance Optimization
-    // We forward the request.body ReadableStream directly instead of buffering it into memory
-    // using await request.arrayBuffer(). Streaming large requests directly to the backend
-    // reduces memory spikes and prevents OOM crashes on constrained environments.
-    const init: RequestInit & { duplex?: "half" } = {
-      method: request.method,
-      headers,
-      body: isBodylessMethod(request.method) ? undefined : request.body,
-      cache: "no-store",
-      redirect: "manual",
-    };
-    if (init.body) init.duplex = "half";
+  for (let attempt = 0; attempt < retryAttempts; attempt += 1) {
+    try {
+      const init: RequestInit & { duplex?: "half" } = {
+        method: request.method,
+        headers,
+        body: isBodylessMethod(request.method) ? undefined : bufferedBody ?? request.body,
+        cache: "no-store",
+        redirect: "manual",
+      };
+      if (init.body && !bufferedBody) init.duplex = "half";
 
-    const upstreamResponse = await fetch(targetUrl, init as RequestInit);
-
-    return await cloneProxyResponse(upstreamResponse);
-  } catch {
-    return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502 });
+      const upstreamResponse = await fetch(targetUrl, init as RequestInit);
+      return await cloneProxyResponse(upstreamResponse);
+    } catch {
+      if (attempt === retryAttempts - 1) {
+        return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502 });
+      }
+      await sleep(retryDelayMs * (attempt + 1));
+    }
   }
+
+  return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502 });
 }


### PR DESCRIPTION
## What changed
- keep the Fly backend warm by setting `min_machines_running = 1`
- preserve retry behavior for small proxy-backed requests like `/compile` and Agent Packs
- add lightweight proxy diagnostics headers/logging for retry count and total proxy time
- replace misleading backend-unreachable copy with clearer temporary-wake-up messaging
- document the Fly cold-start behavior in `agents.md`

## Why
Agent Packs and compile requests were failing on the first hit because the only Fly machine could scale to zero. When traffic returned, Fly started the machine, but the proxy sometimes reached it before Uvicorn was ready, causing fast 502-style failures even though the backend became healthy a few seconds later.

## User impact
- first-use failures should drop sharply
- the backend stays warm in production instead of sleeping completely
- transient wake-up/network failures are explained more honestly in the UI
- small proxy requests expose retry/latency diagnostics for easier debugging

## Validation
- `cd web && npm run test:contracts`
- `cd web && npm run lint`
- `cd web && npm run build`
- `fly deploy -a mycompiler-api --remote-only`
- verified `https://prcompiler.com/health` returns `200`
- verified the Fly machine remains `started` after idle time once traffic has warmed it
