### PR TITLE
[codex] clarify Agent Packs beta messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
 - **Backend test coverage** added in `tests/test_export_adapters.py` for `claude-agent-sdk-py`, `claude-agent-sdk-ts`, `claude-subagent`, `claude-project-pack`, and `claude-mcp-tool-stub` paths.
 
 ### Changed
+- Agent Packs is now presented explicitly as a **beta** across the product docs and web UI, with clearer expectations around human review, production-readiness, and early-stage limitations.
+- The Agent Packs API key helper copy in the web app is now fully English and explains the proxy behavior in detail: when the typed `x-api-key` is used, when `PROMPTC_SERVER_API_KEY` overrides it, and why the field mainly exists for local debugging or fallback calls.
 - `app/adapters/__init__.py` now exports the new Claude Code adapters (`to_claude_mcp_tool_stub`, `to_claude_pr_reviewer_pack`, `to_claude_project_pack`, `to_claude_subagent_bundle`) alongside the existing skill adapters.
 - `api/main.py` mounts the new `agent_packs` router and the existing `export` router accepts the additional `claude-mcp-tool-stub` skill format.
 - The Skills Generator export panel now also surfaces the multi-file `files` payload (path + content) when a format returns more than a single artifact, instead of only `python_code` / `json_config`.

--- a/README.md
+++ b/README.md
@@ -121,9 +121,18 @@ After generating a skill, the **Export** section can wrap the output in framewor
 
 ---
 
-### Claude Agent Packs
+### Claude Agent Packs Beta
 
 The **Agent Packs** sidebar turns a short project brief (project type, stack, goal) into a **runnable, repo-ready bundle of Claude assets** — not just a prompt. Pick a pack type, preview the files, copy individual snippets, or download the whole thing as a `.zip`.
+
+This feature is currently in **beta**: it is designed to give you a strong starting point quickly, but you should still review every generated file before using it in production.
+
+What the beta means in practice:
+
+- **Fast scaffolding, not blind automation** - expect useful repo memory, settings, agents, and workflow files, then adjust them for your own policies and edge cases.
+- **Best for early repo setup and internal experimentation** - especially when you want to bootstrap Claude Code conventions without hand-writing every asset.
+- **Human review is required** - check prompts, permissions, deny rules, CI assumptions, and generated documentation before shipping.
+- **Optional client API key fallback in the web UI** - if `PROMPTC_SERVER_API_KEY` is already configured on the web server, that server-side key wins. The UI field is mainly for local debugging or fallback calls when the proxy intentionally has no server key.
 
 Four pack types are available out of the box, all served from a single Claude-first endpoint:
 

--- a/web/README.md
+++ b/web/README.md
@@ -34,6 +34,7 @@ npm run test:contracts
 
 - Browser calls stay same-origin and hit the Next proxy layer first. Server-side proxy handlers forward to `NEXT_PUBLIC_API_URL` (or `http://127.0.0.1:8080` locally).
 - Protected proxy routes use `PROMPTC_SERVER_API_KEY` on the web server. `NEXT_PUBLIC_API_KEY` should not be used in the browser.
+- The Agent Packs page exposes an optional client-side `x-api-key` field for local debugging and fallback use. If `PROMPTC_SERVER_API_KEY` is configured, the proxy uses that server key and ignores the typed client key.
 - `/rag/search` returns canonical items shaped like `{ path, snippet, score }`.
 - `/rag/upload` returns canonical ingest metadata and may also include compatibility fields.
 - Some routes can now return `403` when API key protection is enabled on the backend.

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -61,6 +61,22 @@ describe("Agent Packs page", () => {
     });
   });
 
+  test("surfaces beta messaging and detailed API key guidance in English", () => {
+    render(<AgentPacksPage />);
+
+    const apiKeyCard = screen.getByText("Agent Packs API Key (Optional)").closest("label");
+
+    expect(screen.getAllByText("Beta").length).toBeGreaterThan(0);
+    expect(screen.getByText("Beta Notice")).toBeTruthy();
+    expect(apiKeyCard).toBeTruthy();
+    expect(apiKeyCard?.textContent).toContain(
+      "Use this only when the web server does not already provide PROMPTC_SERVER_API_KEY for protected Agent Packs requests.",
+    );
+    expect(apiKeyCard?.textContent).toContain(
+      "If the server key exists, it takes precedence and your typed key is ignored before the request leaves the proxy.",
+    );
+  });
+
   test("submits the selected pack type and renders grouped preview output", async () => {
     render(<AgentPacksPage />);
 

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -67,7 +67,6 @@ function getDownloadFilename(response: Response, fallback: string): string {
   const match = disposition.match(/filename=\"?([^"]+)\"?/i);
   return match?.[1] || fallback;
 }
-
 function bundleFiles(files: AgentPackFile[]): string {
   return files
     .map((file) => `# ${file.path}\n\n${file.content.trim()}`)
@@ -208,14 +207,19 @@ export default function AgentPacksPage() {
               <FolderArchive size={18} aria-hidden="true" />
             </div>
             <div>
-              <h1 className="text-lg font-semibold tracking-tight text-white">Agent Packs</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-lg font-semibold tracking-tight text-white">Agent Packs</h1>
+                <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-amber-200">
+                  Beta
+                </span>
+              </div>
               <div className="font-mono text-xs uppercase tracking-wider text-zinc-400 opacity-70">
                 One-Click Repo Assets
               </div>
             </div>
             <InfoButton
               title="Agent Packs"
-              description="Turn one short brief into runnable repo-ready assets. V1 focuses on Claude, while the architecture stays open for future providers."
+              description="Turn one short brief into runnable, repo-ready assets. This beta focuses on Claude first, and every generated file should be reviewed before production use."
             />
           </div>
 
@@ -233,7 +237,7 @@ export default function AgentPacksPage() {
                   <div className="mb-1 text-[11px] font-mono uppercase tracking-[0.25em] text-cyan-300/80">
                     {provider.name}
                   </div>
-                  <h2 className="text-xl font-semibold text-white">Generate runnable agent assets for your repo</h2>
+                  <h2 className="text-xl font-semibold text-white">Generate beta-stage agent assets for your repo</h2>
                 </div>
                 <div className={`h-12 w-12 rounded-2xl ${provider.glowClass} flex items-center justify-center`}>
                   <Bot size={22} className="text-cyan-200" aria-hidden="true" />
@@ -249,23 +253,32 @@ export default function AgentPacksPage() {
             >
               <div>
                 <div className="mb-1 text-sm font-semibold text-white">{provider.name}</div>
-                <div className="text-xs text-zinc-500">V1 provider. More ecosystems can slot into this registry later.</div>
+                <div className="text-xs text-zinc-500">
+                  Beta preview. Good for fast bootstrapping, but you should still review prompts, permissions,
+                  workflows, and generated files before shipping.
+                </div>
               </div>
               <div className={`rounded-xl bg-gradient-to-br ${provider.accentClass} px-3 py-2 text-xs font-semibold text-white shadow-lg shadow-cyan-500/10`}>
-                Ready
+                Beta
               </div>
             </button>
 
+            <div className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4 text-sm leading-relaxed text-amber-100/90">
+              <div className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-amber-200">Beta Notice</div>
+              Agent Packs is a strong starting point, not a finished autopilot. Expect useful scaffolding, then
+              review the output carefully for repo-specific policies, CI assumptions, and tool permissions.
+            </div>
+
             <label className="flex flex-col gap-2 rounded-2xl border border-cyan-500/20 bg-cyan-500/5 p-4">
               <span className="text-xs font-semibold uppercase tracking-wide text-cyan-200">
-                Agent Packs API Key (Opsiyonel)
+                Agent Packs API Key (Optional)
               </span>
               <input
                 type="password"
                 value={clientApiKey}
                 onChange={(event) => setClientApiKey(event.target.value)}
                 className="rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-zinc-200 outline-none transition focus:ring-1 focus:ring-cyan-500/50"
-                placeholder="x-api-key değeri"
+                placeholder="Paste an x-api-key value"
               />
               <div className="flex items-center gap-2">
                 <button
@@ -273,7 +286,7 @@ export default function AgentPacksPage() {
                   onClick={() => window.localStorage.setItem(CLIENT_AGENT_PACKS_API_KEY, clientApiKey.trim())}
                   className="rounded-lg border border-cyan-400/30 bg-cyan-500/15 px-3 py-1.5 text-xs font-medium text-cyan-100 hover:bg-cyan-500/25"
                 >
-                  Key&apos;i Kaydet
+                  Save Key
                 </button>
                 <button
                   type="button"
@@ -283,11 +296,11 @@ export default function AgentPacksPage() {
                   }}
                   className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:bg-white/10"
                 >
-                  Temizle
+                  Clear
                 </button>
               </div>
               <p className="text-xs text-zinc-400">
-                Sunucuda <code>PROMPTC_SERVER_API_KEY</code> yoksa bu anahtar istek header&apos;ına eklenir ve Agent Packs çağrılarında kullanılabilir.
+                Use this only when the web server does not already provide <code>PROMPTC_SERVER_API_KEY</code> for protected Agent Packs requests. If the server key exists, it takes precedence and your typed key is ignored before the request leaves the proxy. This field is mainly for local debugging or fallback calls when the proxy is intentionally running without a server-side key.
               </p>
             </label>
 

--- a/web/app/agent-packs/providerRegistry.ts
+++ b/web/app/agent-packs/providerRegistry.ts
@@ -4,8 +4,8 @@ export const agentPackProviders: AgentPackProviderConfig[] = [
   {
     id: "claude",
     name: "Claude",
-    badge: "V1 Live",
-    summary: "Generate repo-ready Claude assets from one short brief.",
+    badge: "Beta Preview",
+    summary: "Generate repo-ready Claude assets from one short brief, then review them before production use.",
     ctaLabel: "Generate Claude Pack",
     accentClass: "from-sky-500 via-cyan-500 to-blue-600",
     glowClass: "bg-cyan-500/20",


### PR DESCRIPTION
## Summary
- translate the Agent Packs API key helper copy to English
- add visible beta messaging to the Agent Packs page
- update README, web README, and changelog copy to introduce Agent Packs as a beta feature
- add a frontend test covering the beta notice and detailed API key guidance

## Why
The Agent Packs UI still exposed Turkish copy in a public-facing section and did not clearly explain that the feature is beta or how the optional `x-api-key` field behaves when `PROMPTC_SERVER_API_KEY` is configured on the proxy.

## Validation
- `npm run test -- app/agent-packs/page.test.tsx`
- `npm run lint`
