### PR TITLE
[codex] Harden agent packs manifest contract

### DIFF
--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, Protocol
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from .agent_ir import parse_agent_markdown
 from .claude_code import (
@@ -18,6 +18,8 @@ from .skill_ir import parse_skill_markdown
 
 PackType = Literal["project-pack", "subagent", "pr-reviewer", "mcp-tool-stub"]
 RiskMode = Literal["balanced", "strict"]
+AgentPackProvider = Literal["claude"]
+AgentPackFileKind = Literal["claude_md", "settings", "agents", "workflow", "mcp", "readme", "files"]
 
 
 class AgentPackRequest(BaseModel):
@@ -31,15 +33,24 @@ class AgentPackRequest(BaseModel):
 class AgentPackFile(BaseModel):
     path: str
     content: str
-    kind: str
+    kind: AgentPackFileKind
 
 
 class AgentPackManifest(BaseModel):
-    provider: str
+    provider: AgentPackProvider
     pack_type: PackType
     files: list[AgentPackFile]
     download_name: str
-    preview_order: list[str]
+    preview_order: list[AgentPackFileKind]
+
+    @model_validator(mode="after")
+    def validate_preview_order(self) -> "AgentPackManifest":
+        file_kinds = {file.kind for file in self.files}
+        unknown_preview_kinds = [kind for kind in self.preview_order if kind not in file_kinds]
+        if unknown_preview_kinds:
+            joined = ", ".join(unknown_preview_kinds)
+            raise ValueError(f"preview_order includes kinds without matching files: {joined}")
+        return self
 
 
 class AgentPackAdapter(Protocol):
@@ -170,7 +181,7 @@ def _build_skill_brief(req: AgentPackRequest) -> str:
     )
 
 
-def _classify_kind(path: str) -> str:
+def _classify_kind(path: str) -> AgentPackFileKind:
     normalized = path.replace("\\", "/")
     if normalized == "CLAUDE.md":
         return "claude_md"
@@ -187,7 +198,7 @@ def _classify_kind(path: str) -> str:
     return "files"
 
 
-def _preview_order() -> list[str]:
+def _preview_order() -> list[AgentPackFileKind]:
     return ["claude_md", "settings", "agents", "workflow", "mcp", "readme", "files"]
 
 

--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -5,8 +5,11 @@ import zipfile
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
+import pytest
+from pydantic import ValidationError
 
 from api.main import app
+from app.adapters.agent_packs import AgentPackManifest
 
 
 def _request_payload(pack_type: str) -> dict[str, str]:
@@ -121,3 +124,63 @@ def test_agent_packs_download_returns_plain_file_for_single_file_manifest():
         assert response.status_code == 200
         assert response.headers["content-disposition"] == 'attachment; filename="review-agent.md"'
         assert response.text == "hello"
+
+
+def test_agent_pack_manifest_rejects_unknown_provider():
+    with patch("api.main.hybrid_compiler"):
+        with pytest.raises(ValidationError):
+            AgentPackManifest.model_validate(
+                {
+                    "provider": "cursor",
+                    "pack_type": "subagent",
+                    "download_name": "demo-pack",
+                    "preview_order": ["agents"],
+                    "files": [
+                        {
+                            "path": ".claude/agents/review-agent.md",
+                            "content": "hello",
+                            "kind": "agents",
+                        }
+                    ],
+                }
+            )
+
+
+def test_agent_pack_manifest_rejects_unknown_kind_and_preview_order():
+    with patch("api.main.hybrid_compiler"):
+        with pytest.raises(ValidationError):
+            AgentPackManifest.model_validate(
+                {
+                    "provider": "claude",
+                    "pack_type": "subagent",
+                    "download_name": "demo-pack",
+                    "preview_order": ["ghost-kind"],
+                    "files": [
+                        {
+                            "path": ".claude/agents/review-agent.md",
+                            "content": "hello",
+                            "kind": "ghost-kind",
+                        }
+                    ],
+                }
+            )
+
+
+def test_agent_pack_manifest_rejects_preview_order_kinds_not_present_in_files():
+    with patch("api.main.hybrid_compiler"):
+        with pytest.raises(ValidationError):
+            AgentPackManifest.model_validate(
+                {
+                    "provider": "claude",
+                    "pack_type": "subagent",
+                    "download_name": "demo-pack",
+                    "preview_order": ["agents", "workflow"],
+                    "files": [
+                        {
+                            "path": ".claude/agents/review-agent.md",
+                            "content": "hello",
+                            "kind": "agents",
+                        }
+                    ],
+                }
+            )


### PR DESCRIPTION
## Summary
- tighten the Agent Packs manifest model so `provider`, `kind`, and `preview_order` only accept the Claude values the UI expects
- reject manifests whose `preview_order` references groups that do not exist in the returned files
- add regression tests covering invalid provider, invalid file kinds, and stale preview groups

## Why
Recent Agent Packs work added a new backend/frontend contract, but the backend model still accepted arbitrary strings for manifest fields that the frontend treats as a fixed set. That made drift easy to introduce silently and hard to catch before runtime.

## Impact
This makes contract drift fail fast during tests and model validation instead of surfacing later in the UI.

## Validation
- `python -m pytest tests/test_agent_packs_api.py -q`
