### PR TITLE
[codex] test: harden pytest runtime bootstrap fallback

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -242,7 +242,7 @@ Relevant files: `app/rag/simple_index.py`, `api/routes/rag.py`
 pytest tests/test_rag.py tests/test_rag_upload.py tests/test_rag_pipeline.py tests/test_rag_chunking.py tests/test_rag_hybrid_api.py tests/test_rag_parsers.py -v
 ```
 
-**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
+**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. `tests/runtime_bootstrap.py` also probes each freshly created session dir before using it, so Windows ACL issues that allow `mkdtemp()` but block child directories should now fall through to the next candidate root. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
 
 **RAG upload smoke (requires running backend and an API key):**
 

--- a/tests/runtime_bootstrap.py
+++ b/tests/runtime_bootstrap.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,19 @@ def _candidate_roots(preferred_root: Path, fallback_roots: Iterable[Path]) -> li
     return unique_roots
 
 
+def _create_session_dir(root: Path) -> Path:
+    session_dir = Path(tempfile.mkdtemp(prefix="pytest-", dir=str(root))).resolve()
+    probe_dir = session_dir / ".write-probe"
+
+    try:
+        probe_dir.mkdir(parents=True, exist_ok=False)
+    finally:
+        if probe_dir.exists():
+            probe_dir.rmdir()
+
+    return session_dir
+
+
 def prepare_test_runtime(
     *,
     preferred_root: Path,
@@ -36,7 +50,7 @@ def prepare_test_runtime(
     for root in _candidate_roots(preferred_root, fallback_roots):
         try:
             root.mkdir(parents=True, exist_ok=True)
-            session_dir = Path(tempfile.mkdtemp(prefix="pytest-", dir=str(root))).resolve()
+            session_dir = _create_session_dir(root)
             db_dir = (session_dir / "db").resolve()
             db_dir.mkdir(parents=True, exist_ok=True)
 
@@ -48,6 +62,8 @@ def prepare_test_runtime(
             }
             return TestRuntime(session_dir=session_dir, db_dir=db_dir, env_updates=env_updates)
         except PermissionError as exc:
+            if "session_dir" in locals():
+                shutil.rmtree(session_dir, ignore_errors=True)
             errors.append(f"{root}: {exc}")
 
     joined_errors = "; ".join(errors) if errors else "no candidate roots were provided"

--- a/tests/test_test_runtime_bootstrap.py
+++ b/tests/test_test_runtime_bootstrap.py
@@ -50,3 +50,41 @@ def test_prepare_test_runtime_sets_process_temp_environment(tmp_path):
     assert runtime.env_updates["TEMP"] == str(runtime.session_dir)
     assert runtime.env_updates["TMPDIR"] == str(runtime.session_dir)
     assert runtime.env_updates["DB_DIR"] == str(runtime.db_dir)
+
+
+def test_prepare_test_runtime_falls_back_when_session_dir_cannot_create_children(
+    tmp_path, monkeypatch
+):
+    from tests.runtime_bootstrap import prepare_test_runtime
+
+    preferred_root = tmp_path / "preferred"
+    fallback_root = tmp_path / "fallback"
+    fallback_root.mkdir()
+
+    failing_session = preferred_root / "pytest-failing"
+    working_session = fallback_root / "pytest-working"
+
+    created_session_dirs: list[Path] = []
+
+    def fake_mkdtemp(*, prefix: str, dir: str) -> str:
+        target = failing_session if not created_session_dirs else working_session
+        target.mkdir(parents=True, exist_ok=True)
+        created_session_dirs.append(target)
+        return str(target)
+
+    original_mkdir = Path.mkdir
+
+    def patched_mkdir(self: Path, parents: bool = False, exist_ok: bool = False):
+        if self == failing_session / ".write-probe":
+            raise PermissionError("simulated session dir child creation failure")
+        return original_mkdir(self, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr("tests.runtime_bootstrap.tempfile.mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(Path, "mkdir", patched_mkdir)
+
+    runtime = prepare_test_runtime(preferred_root=preferred_root, fallback_roots=[fallback_root])
+
+    assert runtime.session_dir == working_session.resolve()
+    assert runtime.db_dir == (working_session / "db").resolve()
+    assert runtime.db_dir.is_dir()
+    assert created_session_dirs == [failing_session, working_session]


### PR DESCRIPTION
## What changed
- harden `tests/runtime_bootstrap.py` so each newly created pytest session directory is write-probed before being accepted
- remove unusable session directories before falling back to the next candidate temp root
- add regression coverage for the case where `mkdtemp()` succeeds but child directory creation fails
- document the stronger Windows temp-dir fallback behavior in `agents.md`

## Why
Some Windows permission setups allow the session directory itself to be created, but then reject child directory creation inside it. The previous bootstrap only discovered that later while creating `db`, which made startup failures harder to diagnose and left unusable temp folders behind.

## Impact
Pytest startup should fall through to the next configured temp root earlier and more cleanly on Windows ACL edge cases, reducing false-start failures before the real test suite begins.

## Validation
- `python -m pytest -q tests/test_test_runtime_bootstrap.py tests/test_agent_generator.py tests/test_skills_generator.py tests/test_context_generation.py`
- `python -m pytest -q tests/test_api_hardening.py tests/test_auth_fast_path.py tests/test_rag_upload.py tests/test_benchmark_api.py`
- `python -m ruff check tests/runtime_bootstrap.py tests/test_test_runtime_bootstrap.py`
