### PR TITLE
feat: add repo-aware public GitHub generator MVP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ Prompt Compiler is a FastAPI + Next.js product that turns vague requests into st
 - Frontend tests: `cd web && npm run test`
 - Frontend build: `cd web && npm run build`
 
+## Server-side environment variables
+The Next-side proxy and the backend each need their own keys; keep them out of the bundled JS.
+
+| Env var | Side | Purpose |
+| --- | --- | --- |
+| `PROMPTC_SERVER_API_KEY` | Next.js | Forwarded as `x-api-key` to protected backend routes (generators, analyze). Without it, protected proxy routes return 500. |
+| `PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS` | Next.js | Hard upstream-fetch timeout for the proxy (default 25000). Aborts a stuck backend connection with a 504 instead of hanging the route forever. |
+| `PROMPTC_GITHUB_TOKEN` (or `GITHUB_TOKEN`) | Backend | Optional. When set, the public-repo analyzer adds `Authorization: Bearer <token>` to GitHub requests, raising the rate limit from 60 req/h (anonymous) to 5000 req/h. |
+| `PROMPTC_REPO_CONTEXT_CACHE_TTL` | Backend | Repo-brief cache TTL in seconds (default 600). Set to `0` to disable the in-memory cache. |
+
 ## Domain Concepts
 - Conservative mode should avoid hallucinated requirements and fake APIs.
 - Export surfaces should feel executable, not just prompt-pretty.

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import time
 from typing import Literal
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -12,6 +14,43 @@ from app.github_repo_context import (
     InvalidGitHubRepoUrl,
     analyze_public_github_repo,
 )
+
+
+def _safe_repo_full_name(repo_url: str) -> str | None:
+    try:
+        parsed = urlparse((repo_url or "").strip())
+        if parsed.netloc.lower() != "github.com":
+            return None
+        segments = [seg for seg in parsed.path.split("/") if seg]
+        if len(segments) < 2:
+            return None
+        return f"{segments[0]}/{segments[1]}"
+    except Exception:
+        return None
+
+
+def _log_repo_analyze_outcome(
+    *,
+    outcome: str,
+    repo_url: str,
+    started_at: float,
+    repo_full_name: str | None = None,
+    status_code: int | None = None,
+    error_message: str | None = None,
+) -> None:
+    duration_ms = round((time.monotonic() - started_at) * 1000, 2)
+    extra = {
+        "event": "repo_analyze",
+        "outcome": outcome,
+        "repo_full_name": repo_full_name or _safe_repo_full_name(repo_url),
+        "duration_ms": duration_ms,
+    }
+    if status_code is not None:
+        extra["status_code"] = status_code
+    if error_message:
+        extra["error_message"] = error_message
+    logger.info("repo_analyze outcome=%s", outcome, extra=extra)
+
 
 router = APIRouter(tags=["generators"])
 
@@ -80,16 +119,48 @@ async def analyze_github_repo_endpoint(
     api_key: APIKey = Depends(verify_api_key),
 ):
     del api_key
+    started_at = time.monotonic()
 
     try:
-        return GitHubRepoContextPayload.model_validate(analyze_public_github_repo(req.repo_url))
+        payload = analyze_public_github_repo(req.repo_url)
     except InvalidGitHubRepoUrl as exc:
+        _log_repo_analyze_outcome(
+            outcome="invalid_url",
+            repo_url=req.repo_url,
+            started_at=started_at,
+            status_code=400,
+            error_message=str(exc),
+        )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except GitHubRepoAnalysisError as exc:
+        outcome = "not_found" if exc.status_code == 404 else "upstream_error"
+        _log_repo_analyze_outcome(
+            outcome=outcome,
+            repo_url=req.repo_url,
+            started_at=started_at,
+            status_code=exc.status_code,
+            error_message=str(exc),
+        )
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
     except Exception as exc:
         logger.exception("github repo analysis failed")
+        _log_repo_analyze_outcome(
+            outcome="internal_error",
+            repo_url=req.repo_url,
+            started_at=started_at,
+            status_code=500,
+            error_message=str(exc),
+        )
         raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
+
+    _log_repo_analyze_outcome(
+        outcome="ok",
+        repo_url=req.repo_url,
+        started_at=started_at,
+        repo_full_name=payload.get("repo_full_name") if isinstance(payload, dict) else None,
+        status_code=200,
+    )
+    return GitHubRepoContextPayload.model_validate(payload)
 
 
 @router.post("/skills-generator/generate", response_model=SkillGenResponse)

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -69,6 +69,8 @@ RepoContextMode = Literal["full", "compact"]
 class GitHubRepoContextPayload(BaseModel):
     normalized_repo_url: str = Field(..., min_length=1, max_length=500)
     repo_full_name: str = Field(..., min_length=1, max_length=255)
+    requested_ref: str | None = Field(default=None, max_length=255)
+    requested_subdir: str | None = Field(default=None, max_length=500)
     default_branch: str | None = Field(default=None, max_length=255)
     summary: str = Field(..., min_length=1, max_length=1_500)
     summary_compact: str | None = Field(default=None, max_length=400)

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -5,6 +5,11 @@ from pydantic import BaseModel, Field
 
 from api.auth import APIKey, verify_api_key
 from api.shared import logger
+from app.github_repo_context import (
+    GitHubRepoAnalysisError,
+    InvalidGitHubRepoUrl,
+    analyze_public_github_repo,
+)
 
 router = APIRouter(tags=["generators"])
 
@@ -17,12 +22,27 @@ def _get_compiler():
     return api_main.get_compiler()
 
 
+class GitHubRepoContextPayload(BaseModel):
+    normalized_repo_url: str = Field(..., min_length=1, max_length=500)
+    repo_full_name: str = Field(..., min_length=1, max_length=255)
+    default_branch: str | None = Field(default=None, max_length=255)
+    summary: str = Field(..., min_length=1, max_length=1_500)
+    highlights: list[str] = Field(default_factory=list, max_length=6)
+    files_used: list[str] = Field(default_factory=list, max_length=6)
+    detected_stack: list[str] = Field(default_factory=list, max_length=6)
+
+
+class GitHubRepoContextRequest(BaseModel):
+    repo_url: str = Field(..., min_length=1, max_length=500)
+
+
 class SkillGenRequest(BaseModel):
     description: str = Field(..., min_length=1, max_length=_MAX_DESCRIPTION_CHARS)
     include_example_code: bool = Field(
         default=False,
         description="Whether generated skill definition should include implementation example code",
     )
+    repo_context: GitHubRepoContextPayload | None = None
 
 
 class SkillGenResponse(BaseModel):
@@ -33,10 +53,29 @@ class AgentGenRequest(BaseModel):
     description: str = Field(..., min_length=1, max_length=_MAX_DESCRIPTION_CHARS)
     multi_agent: bool = Field(default=False, description="Generate a multi-agent swarm if true")
     include_example_code: bool = Field(default=False, description="Include pseudo-code example")
+    repo_context: GitHubRepoContextPayload | None = None
 
 
 class AgentGenResponse(BaseModel):
     system_prompt: str
+
+
+@router.post("/repo-context/github", response_model=GitHubRepoContextPayload)
+async def analyze_github_repo_endpoint(
+    req: GitHubRepoContextRequest,
+    api_key: APIKey = Depends(verify_api_key),
+):
+    del api_key
+
+    try:
+        return GitHubRepoContextPayload.model_validate(analyze_public_github_repo(req.repo_url))
+    except InvalidGitHubRepoUrl as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except GitHubRepoAnalysisError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("github repo analysis failed")
+        raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
 
 
 @router.post("/skills-generator/generate", response_model=SkillGenResponse)
@@ -51,6 +90,7 @@ async def generate_skill_endpoint(
         result = compiler.generate_skill(
             req.description,
             include_example_code=req.include_example_code,
+            repo_context=req.repo_context.model_dump() if req.repo_context else None,
         )
         return SkillGenResponse(skill_definition=result)
     except Exception as exc:
@@ -71,6 +111,7 @@ async def generate_agent_endpoint(
             req.description,
             multi_agent=req.multi_agent,
             include_example_code=req.include_example_code,
+            repo_context=req.repo_context.model_dump() if req.repo_context else None,
         )
         return AgentGenResponse(system_prompt=result)
     except Exception as exc:

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
@@ -22,11 +24,15 @@ def _get_compiler():
     return api_main.get_compiler()
 
 
+RepoContextMode = Literal["full", "compact"]
+
+
 class GitHubRepoContextPayload(BaseModel):
     normalized_repo_url: str = Field(..., min_length=1, max_length=500)
     repo_full_name: str = Field(..., min_length=1, max_length=255)
     default_branch: str | None = Field(default=None, max_length=255)
     summary: str = Field(..., min_length=1, max_length=1_500)
+    summary_compact: str | None = Field(default=None, max_length=400)
     highlights: list[str] = Field(default_factory=list, max_length=6)
     files_used: list[str] = Field(default_factory=list, max_length=6)
     detected_stack: list[str] = Field(default_factory=list, max_length=6)
@@ -43,6 +49,10 @@ class SkillGenRequest(BaseModel):
         description="Whether generated skill definition should include implementation example code",
     )
     repo_context: GitHubRepoContextPayload | None = None
+    repo_context_mode: RepoContextMode = Field(
+        default="full",
+        description="Whether to use the full or the compact repo brief in the generator prompt.",
+    )
 
 
 class SkillGenResponse(BaseModel):
@@ -54,6 +64,10 @@ class AgentGenRequest(BaseModel):
     multi_agent: bool = Field(default=False, description="Generate a multi-agent swarm if true")
     include_example_code: bool = Field(default=False, description="Include pseudo-code example")
     repo_context: GitHubRepoContextPayload | None = None
+    repo_context_mode: RepoContextMode = Field(
+        default="full",
+        description="Whether to use the full or the compact repo brief in the generator prompt.",
+    )
 
 
 class AgentGenResponse(BaseModel):
@@ -91,6 +105,7 @@ async def generate_skill_endpoint(
             req.description,
             include_example_code=req.include_example_code,
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
+            repo_context_mode=req.repo_context_mode,
         )
         return SkillGenResponse(skill_definition=result)
     except Exception as exc:
@@ -112,6 +127,7 @@ async def generate_agent_endpoint(
             multi_agent=req.multi_agent,
             include_example_code=req.include_example_code,
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
+            repo_context_mode=req.repo_context_mode,
         )
         return AgentGenResponse(system_prompt=result)
     except Exception as exc:

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -107,13 +107,31 @@ def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
     return payload
 
 
+def _resolve_github_token() -> str | None:
+    for env_name in ("PROMPTC_GITHUB_TOKEN", "GITHUB_TOKEN"):
+        raw = os.environ.get(env_name)
+        if raw:
+            stripped = raw.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def _build_github_request_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "promptc-repo-context/1.0",
+    }
+    token = _resolve_github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
 def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) -> dict[str, Any]:
     with httpx.Client(
         base_url=GITHUB_API_BASE,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "promptc-repo-context/1.0",
-        },
+        headers=_build_github_request_headers(),
         timeout=10.0,
         follow_redirects=True,
     ) as client:

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+from cachetools import TTLCache
 
 
 GITHUB_API_BASE = "https://api.github.com"
@@ -24,6 +26,31 @@ MAX_HIGHLIGHTS = 6
 MAX_FILES_USED = 6
 MAX_STACK_ITEMS = 6
 SUMMARY_MAX_CHARS = 1200
+SUMMARY_COMPACT_MAX_CHARS = 280
+_REPO_CACHE_MAXSIZE = 128
+_REPO_CACHE_DEFAULT_TTL_SECONDS = 600
+
+
+def _resolve_repo_cache_ttl() -> int:
+    raw = os.environ.get("PROMPTC_REPO_CONTEXT_CACHE_TTL")
+    if raw is None or raw.strip() == "":
+        return _REPO_CACHE_DEFAULT_TTL_SECONDS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _REPO_CACHE_DEFAULT_TTL_SECONDS
+
+
+_REPO_CACHE: TTLCache[str, dict[str, Any]] | None = None
+_repo_cache_ttl = _resolve_repo_cache_ttl()
+if _repo_cache_ttl > 0:
+    _REPO_CACHE = TTLCache(maxsize=_REPO_CACHE_MAXSIZE, ttl=_repo_cache_ttl)
+
+
+def reset_repo_cache_for_tests() -> None:
+    global _REPO_CACHE
+    if _REPO_CACHE is not None:
+        _REPO_CACHE.clear()
 
 
 class InvalidGitHubRepoUrl(ValueError):
@@ -67,6 +94,20 @@ def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
     normalized_url = normalize_public_github_repo_url(repo_url)
     repo_full_name = normalized_url.replace("https://github.com/", "", 1)
 
+    if _REPO_CACHE is not None:
+        cached = _REPO_CACHE.get(repo_full_name)
+        if cached is not None:
+            return dict(cached)
+
+    payload = _fetch_public_github_repo_payload(normalized_url, repo_full_name)
+
+    if _REPO_CACHE is not None:
+        _REPO_CACHE[repo_full_name] = dict(payload)
+
+    return payload
+
+
+def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) -> dict[str, Any]:
     with httpx.Client(
         base_url=GITHUB_API_BASE,
         headers={
@@ -129,12 +170,18 @@ def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
             manifest_paths=list(manifests.keys()),
             readme_text=readme_text,
         )
+        summary_compact = _build_summary_compact(
+            repo_meta=repo_meta,
+            detected_stack=detected_stack,
+            top_level_dirs=top_level_dirs,
+        )
 
     return {
         "normalized_repo_url": normalized_url,
         "repo_full_name": repo_full_name,
         "default_branch": default_branch,
         "summary": summary,
+        "summary_compact": summary_compact,
         "highlights": highlights,
         "files_used": files_used,
         "detected_stack": detected_stack[:MAX_STACK_ITEMS],
@@ -327,6 +374,34 @@ def _build_summary(
     if len(summary) > SUMMARY_MAX_CHARS:
         summary = summary[: SUMMARY_MAX_CHARS - 3].rstrip() + "..."
     return summary
+
+
+def _build_summary_compact(
+    *,
+    repo_meta: dict[str, Any],
+    detected_stack: list[str],
+    top_level_dirs: list[str],
+) -> str:
+    repo_name = repo_meta.get("full_name") or "This repository"
+    description = (repo_meta.get("description") or "").strip()
+    stack_phrase = ", ".join(detected_stack[:3]) if detected_stack else "no detected stack signals"
+    shape = (
+        "multi-surface (frontend + backend dirs)"
+        if any(
+            name in {"web", "frontend", "backend", "api", "client", "server"}
+            for name in top_level_dirs
+        )
+        else "single-surface"
+    )
+    parts = [
+        f"{repo_name}: {description}" if description else f"{repo_name}.",
+        f"Stack: {stack_phrase}.",
+        f"Shape: {shape}.",
+    ]
+    compact = " ".join(part.strip() for part in parts if part.strip())
+    if len(compact) > SUMMARY_COMPACT_MAX_CHARS:
+        compact = compact[: SUMMARY_COMPACT_MAX_CHARS - 3].rstrip() + "..."
+    return compact
 
 
 def _extract_readme_signal(readme_text: str) -> str:

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -230,30 +230,12 @@ def _fetch_public_github_repo_payload(
                     if content:
                         manifests[entry["path"]] = content
                         files_used.append(entry["path"])
-
-        readme_scan_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS]
-        for directory in readme_scan_dirs:
-            if len(_dedupe(files_used)) >= MAX_FILES_USED:
-                break
-            nested_path = (
-                f"{requested_subdir.strip('/')}/{directory}" if requested_subdir else directory
-            )
-            nested_entries = _get_json(
-                client,
-                _contents_api_path(
-                    repo_full_name,
-                    requested_path=nested_path,
-                    requested_ref=requested_ref,
-                ),
-            )
-            if not isinstance(nested_entries, list):
-                continue
-            nested_readme = _find_readme(nested_entries)
-            if not nested_readme or nested_readme["path"] in files_used:
-                continue
-            nested_readme_text = _read_text_file(client, nested_readme)
-            if nested_readme_text:
-                files_used.append(nested_readme["path"])
+            if len(_dedupe(files_used)) < MAX_FILES_USED:
+                nested_readme = _find_readme(nested_entries)
+                if nested_readme and nested_readme["path"] not in files_used:
+                    nested_readme_text = _read_text_file(client, nested_readme)
+                    if nested_readme_text:
+                        files_used.append(nested_readme["path"])
 
         detected_stack = _detect_stack(repo_meta, manifests)
         files_used = _dedupe(files_used)[:MAX_FILES_USED]

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 import httpx
 from cachetools import TTLCache
@@ -41,7 +41,8 @@ def _resolve_repo_cache_ttl() -> int:
         return _REPO_CACHE_DEFAULT_TTL_SECONDS
 
 
-_REPO_CACHE: TTLCache[str, dict[str, Any]] | None = None
+RepoCacheKey = tuple[str, str, str]
+_REPO_CACHE: TTLCache[RepoCacheKey, dict[str, Any]] | None = None
 _repo_cache_ttl = _resolve_repo_cache_ttl()
 if _repo_cache_ttl > 0:
     _REPO_CACHE = TTLCache(maxsize=_REPO_CACHE_MAXSIZE, ttl=_repo_cache_ttl)
@@ -63,7 +64,7 @@ class GitHubRepoAnalysisError(RuntimeError):
         self.status_code = status_code
 
 
-def normalize_public_github_repo_url(repo_url: str) -> str:
+def normalize_public_github_repo_url(repo_url: str) -> tuple[str, str | None, str | None]:
     raw = (repo_url or "").strip()
     if not raw:
         raise InvalidGitHubRepoUrl("GitHub repo URL is required.")
@@ -76,10 +77,10 @@ def normalize_public_github_repo_url(repo_url: str) -> str:
 
     path = parsed.path.rstrip("/")
     segments = [segment for segment in path.split("/") if segment]
-    if len(segments) != 2:
+    if len(segments) < 2:
         raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
 
-    owner, repo = segments
+    owner, repo = segments[0], segments[1]
     if repo.endswith(".git"):
         raise InvalidGitHubRepoUrl("Remove the .git suffix and use the root repository URL.")
 
@@ -87,22 +88,43 @@ def normalize_public_github_repo_url(repo_url: str) -> str:
     if not allowed.match(owner) or not allowed.match(repo):
         raise InvalidGitHubRepoUrl("Repository URL contains unsupported characters.")
 
-    return f"https://github.com/{owner}/{repo}"
+    normalized_url = f"https://github.com/{owner}/{repo}"
+    if len(segments) == 2:
+        return normalized_url, None, None
+
+    if len(segments) >= 4 and segments[2] == "tree":
+        requested_ref = segments[3]
+        if not requested_ref:
+            raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
+        requested_subdir = "/".join(segments[4:]) or None
+        return normalized_url, requested_ref, requested_subdir
+
+    raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
 
 
 def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
-    normalized_url = normalize_public_github_repo_url(repo_url)
+    normalized_url, requested_ref, requested_subdir = normalize_public_github_repo_url(repo_url)
     repo_full_name = normalized_url.replace("https://github.com/", "", 1)
+    cache_key: RepoCacheKey = (
+        repo_full_name,
+        requested_ref or "",
+        requested_subdir or "",
+    )
 
     if _REPO_CACHE is not None:
-        cached = _REPO_CACHE.get(repo_full_name)
+        cached = _REPO_CACHE.get(cache_key)
         if cached is not None:
             return dict(cached)
 
-    payload = _fetch_public_github_repo_payload(normalized_url, repo_full_name)
+    payload = _fetch_public_github_repo_payload(
+        normalized_url,
+        repo_full_name,
+        requested_ref=requested_ref,
+        requested_subdir=requested_subdir,
+    )
 
     if _REPO_CACHE is not None:
-        _REPO_CACHE[repo_full_name] = dict(payload)
+        _REPO_CACHE[cache_key] = dict(payload)
 
     return payload
 
@@ -128,7 +150,28 @@ def _build_github_request_headers() -> dict[str, str]:
     return headers
 
 
-def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) -> dict[str, Any]:
+def _contents_api_path(
+    repo_full_name: str,
+    *,
+    requested_path: str | None = None,
+    requested_ref: str | None = None,
+) -> str:
+    path = f"/repos/{repo_full_name}/contents"
+    if requested_path:
+        normalized_path = quote(requested_path.strip("/"), safe="/")
+        path = f"{path}/{normalized_path}"
+    if requested_ref:
+        path = f"{path}?{urlencode({'ref': requested_ref})}"
+    return path
+
+
+def _fetch_public_github_repo_payload(
+    normalized_url: str,
+    repo_full_name: str,
+    *,
+    requested_ref: str | None,
+    requested_subdir: str | None,
+) -> dict[str, Any]:
     with httpx.Client(
         base_url=GITHUB_API_BASE,
         headers=_build_github_request_headers(),
@@ -136,12 +179,19 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
         follow_redirects=True,
     ) as client:
         repo_meta = _get_json(client, f"/repos/{repo_full_name}")
-        root_entries = _get_json(client, f"/repos/{repo_full_name}/contents")
-        if not isinstance(root_entries, list):
+        listing_entries = _get_json(
+            client,
+            _contents_api_path(
+                repo_full_name,
+                requested_path=requested_subdir,
+                requested_ref=requested_ref,
+            ),
+        )
+        if not isinstance(listing_entries, list):
             raise GitHubRepoAnalysisError("Unable to read the repository root directory.")
 
         default_branch = repo_meta.get("default_branch")
-        readme_entry = _find_readme(root_entries)
+        readme_entry = _find_readme(listing_entries)
         readme_text = _read_text_file(client, readme_entry) if readme_entry else ""
         files_used: list[str] = []
         if readme_entry:
@@ -149,18 +199,28 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
 
         manifests: dict[str, str] = {}
         for manifest_name in MANIFEST_FILES:
-            entry = _find_entry(root_entries, manifest_name)
+            entry = _find_entry(listing_entries, manifest_name)
             if entry:
                 content = _read_text_file(client, entry)
                 if content:
                     manifests[entry["path"]] = content
                     files_used.append(entry["path"])
 
-        top_level_dirs = [entry["name"] for entry in root_entries if entry.get("type") == "dir"]
+        top_level_dirs = [entry["name"] for entry in listing_entries if entry.get("type") == "dir"]
         candidate_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS][:2]
 
         for directory in candidate_dirs:
-            nested_entries = _get_json(client, f"/repos/{repo_full_name}/contents/{directory}")
+            nested_path = (
+                f"{requested_subdir.strip('/')}/{directory}" if requested_subdir else directory
+            )
+            nested_entries = _get_json(
+                client,
+                _contents_api_path(
+                    repo_full_name,
+                    requested_path=nested_path,
+                    requested_ref=requested_ref,
+                ),
+            )
             if not isinstance(nested_entries, list):
                 continue
             for manifest_name in MANIFEST_FILES:
@@ -170,6 +230,30 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
                     if content:
                         manifests[entry["path"]] = content
                         files_used.append(entry["path"])
+
+        readme_scan_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS]
+        for directory in readme_scan_dirs:
+            if len(_dedupe(files_used)) >= MAX_FILES_USED:
+                break
+            nested_path = (
+                f"{requested_subdir.strip('/')}/{directory}" if requested_subdir else directory
+            )
+            nested_entries = _get_json(
+                client,
+                _contents_api_path(
+                    repo_full_name,
+                    requested_path=nested_path,
+                    requested_ref=requested_ref,
+                ),
+            )
+            if not isinstance(nested_entries, list):
+                continue
+            nested_readme = _find_readme(nested_entries)
+            if not nested_readme or nested_readme["path"] in files_used:
+                continue
+            nested_readme_text = _read_text_file(client, nested_readme)
+            if nested_readme_text:
+                files_used.append(nested_readme["path"])
 
         detected_stack = _detect_stack(repo_meta, manifests)
         files_used = _dedupe(files_used)[:MAX_FILES_USED]
@@ -197,6 +281,8 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
     return {
         "normalized_repo_url": normalized_url,
         "repo_full_name": repo_full_name,
+        "requested_ref": requested_ref,
+        "requested_subdir": requested_subdir,
         "default_branch": default_branch,
         "summary": summary,
         "summary_compact": summary_compact,

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+
+GITHUB_API_BASE = "https://api.github.com"
+MANIFEST_FILES = [
+    "package.json",
+    "pyproject.toml",
+    "requirements.txt",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "composer.json",
+    "Gemfile",
+]
+SCANNED_APP_DIRS = ["web", "frontend", "backend", "app", "api", "server", "client"]
+MAX_HIGHLIGHTS = 6
+MAX_FILES_USED = 6
+MAX_STACK_ITEMS = 6
+SUMMARY_MAX_CHARS = 1200
+
+
+class InvalidGitHubRepoUrl(ValueError):
+    pass
+
+
+class GitHubRepoAnalysisError(RuntimeError):
+    def __init__(self, message: str, *, status_code: int = 502):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def normalize_public_github_repo_url(repo_url: str) -> str:
+    raw = (repo_url or "").strip()
+    if not raw:
+        raise InvalidGitHubRepoUrl("GitHub repo URL is required.")
+
+    parsed = urlparse(raw)
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        raise InvalidGitHubRepoUrl("Only public https://github.com/owner/repo URLs are supported.")
+    if parsed.query or parsed.fragment:
+        raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
+
+    path = parsed.path.rstrip("/")
+    segments = [segment for segment in path.split("/") if segment]
+    if len(segments) != 2:
+        raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
+
+    owner, repo = segments
+    if repo.endswith(".git"):
+        raise InvalidGitHubRepoUrl("Remove the .git suffix and use the root repository URL.")
+
+    allowed = re.compile(r"^[A-Za-z0-9_.-]+$")
+    if not allowed.match(owner) or not allowed.match(repo):
+        raise InvalidGitHubRepoUrl("Repository URL contains unsupported characters.")
+
+    return f"https://github.com/{owner}/{repo}"
+
+
+def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
+    normalized_url = normalize_public_github_repo_url(repo_url)
+    repo_full_name = normalized_url.replace("https://github.com/", "", 1)
+
+    with httpx.Client(
+        base_url=GITHUB_API_BASE,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "promptc-repo-context/1.0",
+        },
+        timeout=10.0,
+        follow_redirects=True,
+    ) as client:
+        repo_meta = _get_json(client, f"/repos/{repo_full_name}")
+        root_entries = _get_json(client, f"/repos/{repo_full_name}/contents")
+        if not isinstance(root_entries, list):
+            raise GitHubRepoAnalysisError("Unable to read the repository root directory.")
+
+        default_branch = repo_meta.get("default_branch")
+        readme_entry = _find_readme(root_entries)
+        readme_text = _read_text_file(client, readme_entry) if readme_entry else ""
+        files_used: list[str] = []
+        if readme_entry:
+            files_used.append(readme_entry["path"])
+
+        manifests: dict[str, str] = {}
+        for manifest_name in MANIFEST_FILES:
+            entry = _find_entry(root_entries, manifest_name)
+            if entry:
+                content = _read_text_file(client, entry)
+                if content:
+                    manifests[entry["path"]] = content
+                    files_used.append(entry["path"])
+
+        top_level_dirs = [entry["name"] for entry in root_entries if entry.get("type") == "dir"]
+        candidate_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS][:2]
+
+        for directory in candidate_dirs:
+            nested_entries = _get_json(client, f"/repos/{repo_full_name}/contents/{directory}")
+            if not isinstance(nested_entries, list):
+                continue
+            for manifest_name in MANIFEST_FILES:
+                entry = _find_entry(nested_entries, manifest_name)
+                if entry and entry["path"] not in manifests:
+                    content = _read_text_file(client, entry)
+                    if content:
+                        manifests[entry["path"]] = content
+                        files_used.append(entry["path"])
+
+        detected_stack = _detect_stack(repo_meta, manifests)
+        files_used = _dedupe(files_used)[:MAX_FILES_USED]
+        highlights = _build_highlights(
+            repo_meta=repo_meta,
+            detected_stack=detected_stack,
+            top_level_dirs=top_level_dirs,
+            files_used=files_used,
+            manifest_paths=list(manifests.keys()),
+        )[:MAX_HIGHLIGHTS]
+        summary = _build_summary(
+            repo_meta=repo_meta,
+            detected_stack=detected_stack,
+            top_level_dirs=top_level_dirs,
+            files_used=files_used,
+            manifest_paths=list(manifests.keys()),
+            readme_text=readme_text,
+        )
+
+    return {
+        "normalized_repo_url": normalized_url,
+        "repo_full_name": repo_full_name,
+        "default_branch": default_branch,
+        "summary": summary,
+        "highlights": highlights,
+        "files_used": files_used,
+        "detected_stack": detected_stack[:MAX_STACK_ITEMS],
+    }
+
+
+def _get_json(client: httpx.Client, path: str) -> Any:
+    try:
+        response = client.get(path)
+        if response.status_code == 404:
+            raise GitHubRepoAnalysisError(
+                "Repository not found or not public. Only public GitHub repos are supported.",
+                status_code=404,
+            )
+        response.raise_for_status()
+        return response.json()
+    except httpx.HTTPStatusError as exc:
+        status_code = exc.response.status_code if exc.response is not None else 502
+        raise GitHubRepoAnalysisError(
+            "GitHub repository analysis failed.",
+            status_code=404 if status_code == 404 else 502,
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise GitHubRepoAnalysisError("GitHub repository analysis failed.") from exc
+
+
+def _read_text_file(client: httpx.Client, entry: dict[str, Any]) -> str:
+    download_url = entry.get("download_url")
+    if not download_url:
+        return ""
+    try:
+        response = client.get(download_url)
+        response.raise_for_status()
+        return response.text
+    except httpx.HTTPError:
+        return ""
+
+
+def _find_entry(entries: list[dict[str, Any]], target_name: str) -> dict[str, Any] | None:
+    target_lower = target_name.lower()
+    for entry in entries:
+        if entry.get("name", "").lower() == target_lower:
+            return entry
+    return None
+
+
+def _find_readme(entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for entry in entries:
+        name = entry.get("name", "").lower()
+        if entry.get("type") == "file" and name.startswith("readme"):
+            return entry
+    return None
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _detect_stack(repo_meta: dict[str, Any], manifests: dict[str, str]) -> list[str]:
+    stack: list[str] = []
+    language = repo_meta.get("language")
+    if isinstance(language, str) and language.strip():
+        stack.append(language.strip())
+
+    manifest_names = {path.rsplit("/", 1)[-1] for path in manifests}
+    combined_manifest_text = "\n".join(manifests.values()).lower()
+
+    if "package.json" in manifest_names:
+        stack.append("Node.js")
+        try:
+            package_json = json.loads(
+                next(text for path, text in manifests.items() if path.endswith("package.json"))
+            )
+            deps = {
+                **(package_json.get("dependencies") or {}),
+                **(package_json.get("devDependencies") or {}),
+            }
+            dep_names = {str(name).lower() for name in deps}
+            if "next" in dep_names:
+                stack.append("Next.js")
+            if "react" in dep_names:
+                stack.append("React")
+            if "typescript" in dep_names:
+                stack.append("TypeScript")
+        except Exception:
+            pass
+
+    if "pyproject.toml" in manifest_names or "requirements.txt" in manifest_names:
+        stack.append("Python")
+    if "fastapi" in combined_manifest_text:
+        stack.append("FastAPI")
+    if "django" in combined_manifest_text:
+        stack.append("Django")
+    if "flask" in combined_manifest_text:
+        stack.append("Flask")
+    if "httpx" in combined_manifest_text:
+        stack.append("httpx")
+    if "cargo.toml" in {name.lower() for name in manifest_names}:
+        stack.append("Rust")
+    if "go.mod" in manifest_names:
+        stack.append("Go")
+    if "pom.xml" in manifest_names:
+        stack.append("Java")
+    if "composer.json" in manifest_names:
+        stack.append("PHP")
+    if "gemfile" in {name.lower() for name in manifest_names}:
+        stack.append("Ruby")
+
+    return _dedupe(stack)[:MAX_STACK_ITEMS]
+
+
+def _build_highlights(
+    *,
+    repo_meta: dict[str, Any],
+    detected_stack: list[str],
+    top_level_dirs: list[str],
+    files_used: list[str],
+    manifest_paths: list[str],
+) -> list[str]:
+    repo_name = repo_meta.get("full_name") or "This repository"
+    description = (repo_meta.get("description") or "").strip()
+    highlights: list[str] = []
+    if description:
+        highlights.append(description)
+    if detected_stack:
+        highlights.append(f"Detected stack: {', '.join(detected_stack)}.")
+    if len(top_level_dirs) >= 2:
+        highlights.append(f"Top-level directories include {', '.join(top_level_dirs[:4])}.")
+    if manifest_paths:
+        highlights.append(f"Manifest signals found in {', '.join(manifest_paths[:3])}.")
+    if files_used:
+        highlights.append(f"Brief built from {', '.join(files_used[:4])}.")
+    highlights.append(
+        f"Use existing patterns from {repo_name}; avoid inventing missing APIs or dependencies."
+    )
+    return _dedupe(highlights)
+
+
+def _build_summary(
+    *,
+    repo_meta: dict[str, Any],
+    detected_stack: list[str],
+    top_level_dirs: list[str],
+    files_used: list[str],
+    manifest_paths: list[str],
+    readme_text: str,
+) -> str:
+    repo_name = repo_meta.get("full_name") or "This repository"
+    description = (repo_meta.get("description") or "").strip()
+    shape = (
+        "a multi-surface repo with distinct app areas"
+        if any(
+            name in {"web", "frontend", "backend", "api", "client", "server"}
+            for name in top_level_dirs
+        )
+        else "a mostly single-surface repo"
+    )
+    stack_phrase = (
+        ", ".join(detected_stack) if detected_stack else "manifest-derived project tooling"
+    )
+    dir_phrase = (
+        ", ".join(top_level_dirs[:5]) if top_level_dirs else "no notable top-level directories"
+    )
+    manifest_phrase = (
+        ", ".join(manifest_paths[:4]) if manifest_paths else "no common manifests were detected"
+    )
+    files_phrase = ", ".join(files_used[:6]) if files_used else "repo metadata only"
+    readme_signal = _extract_readme_signal(readme_text)
+
+    parts = [
+        f"{repo_name} is a public GitHub repository.",
+        description
+        if description
+        else "No repository description was provided in GitHub metadata.",
+        f"Primary stack signals point to {stack_phrase}.",
+        f"The root structure suggests {shape}, with directories such as {dir_phrase}.",
+        f"The shallow analysis inspected {files_phrase} and used manifest hints from {manifest_phrase}.",
+        readme_signal,
+        "For generator output, stay aligned with the detected stack, prefer existing project conventions, and avoid assuming internal APIs that are not visible in README or manifest-level signals.",
+        "Treat this as a compact repo brief rather than a full code audit: it is suitable for tailoring an agent or skill, but not for making file-level implementation claims without further context.",
+    ]
+    summary = " ".join(part.strip() for part in parts if part.strip())
+    if len(summary) > SUMMARY_MAX_CHARS:
+        summary = summary[: SUMMARY_MAX_CHARS - 3].rstrip() + "..."
+    return summary
+
+
+def _extract_readme_signal(readme_text: str) -> str:
+    text = re.sub(r"\s+", " ", (readme_text or "")).strip()
+    if not text:
+        return "README content was unavailable, so the brief leans more heavily on GitHub metadata and manifest files."
+    compact = text[:220].strip()
+    return "README signal: " + compact + ("..." if len(text) > len(compact) else "")

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -166,18 +166,72 @@ class WorkerClient:
         return f"<{tag}>\n<![CDATA[\n{safe_content}\n]]>\n</{tag}>"
 
     def _context_message(self, *, mode: str, context: Optional[Dict[str, Any]]) -> str:
-        payload = {
+        repo_context_block = ""
+        runtime_payload: Dict[str, Any] = {
             "mode": mode,
             **(
                 context
                 or {"retrieval_status": "empty", "retrieval_note": "No runtime context supplied."}
             ),
         }
+        repo_context = runtime_payload.pop("repo_context", None)
+        if isinstance(repo_context, dict):
+            repo_context_block = self._render_repo_context_block(repo_context) + "\n\n"
+
         return (
-            "<runtime_context>\n"
-            f"<context_json><![CDATA[\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n]]></context_json>\n"
+            f"{repo_context_block}<runtime_context>\n"
+            f"<context_json><![CDATA[\n{json.dumps(runtime_payload, ensure_ascii=False, indent=2)}\n]]></context_json>\n"
             "</runtime_context>"
         )
+
+    def _render_repo_context_block(self, repo_context: Dict[str, Any]) -> str:
+        mode = str(repo_context.get("mode") or "full").strip().lower()
+        if mode not in {"full", "compact"}:
+            mode = "full"
+        repo_full_name = str(repo_context.get("repo_full_name") or "").strip()
+        normalized_url = str(repo_context.get("normalized_repo_url") or "").strip()
+        default_branch = str(repo_context.get("default_branch") or "").strip()
+        detected_stack = repo_context.get("detected_stack") or []
+        highlights = repo_context.get("highlights") or []
+        files_used = repo_context.get("files_used") or []
+        summary_full = str(repo_context.get("summary") or "").strip()
+        summary_compact = str(repo_context.get("summary_compact") or "").strip()
+        active_summary = summary_compact if mode == "compact" and summary_compact else summary_full
+
+        lines = [
+            "## Repo Context (ground truth)",
+            "Treat the facts in this section as the only verified information about the user's "
+            "repository. Only reference tools, APIs, file paths, manifests, or conventions that are "
+            "visible here. Do NOT invent libraries, endpoints, file paths, or capabilities that are "
+            "not listed below. If something is missing, mark it as a TODO or open question instead "
+            "of guessing.",
+            "",
+        ]
+        if repo_full_name:
+            lines.append(f"- Repo: {repo_full_name}")
+        if normalized_url:
+            lines.append(f"- URL: {normalized_url}")
+        if default_branch:
+            lines.append(f"- Default branch: {default_branch}")
+        if isinstance(detected_stack, list) and detected_stack:
+            lines.append(f"- Detected stack: {', '.join(str(item) for item in detected_stack)}")
+        if isinstance(files_used, list) and files_used:
+            lines.append(f"- Brief built from: {', '.join(str(item) for item in files_used)}")
+        if isinstance(highlights, list) and highlights:
+            lines.append("- Highlights:")
+            for item in highlights:
+                lines.append(f"  - {item}")
+        if active_summary:
+            lines.append("")
+            lines.append(f"### Repo brief ({mode})")
+            lines.append(active_summary)
+        lines.append("")
+        lines.append(
+            "Reminder: this brief is README + manifest level only. Do NOT make file-level "
+            'implementation claims (no "in `src/foo.py` we…" unless that file is listed in '
+            "'Brief built from'). Use TODO markers when uncertain."
+        )
+        return "\n".join(lines)
 
     def _single_agent_prompt(self, include_example_code: bool) -> str:
         prompt = (

--- a/app/llm_engine/hybrid.py
+++ b/app/llm_engine/hybrid.py
@@ -211,6 +211,7 @@ class HybridCompiler:
         multi_agent: bool = False,
         include_example_code: bool = False,
         repo_context: dict[str, Any] | None = None,
+        repo_context_mode: str = "full",
     ) -> str:
         """
         Generate a comprehensive AI Agent system prompt, aware of RAG context.
@@ -220,6 +221,7 @@ class HybridCompiler:
             rag_context = self._merge_generator_context(
                 self.context_strategist.process(text),
                 repo_context,
+                repo_context_mode,
             )
             return self.worker.generate_agent(
                 text,
@@ -236,6 +238,7 @@ class HybridCompiler:
         text: str,
         include_example_code: bool = False,
         repo_context: dict[str, Any] | None = None,
+        repo_context_mode: str = "full",
     ) -> str:
         """
         Generate a comprehensive AI Skill definition, aware of RAG context.
@@ -245,6 +248,7 @@ class HybridCompiler:
             rag_context = self._merge_generator_context(
                 self.context_strategist.process(text),
                 repo_context,
+                repo_context_mode,
             )
             return self.worker.generate_skill(
                 text,
@@ -257,13 +261,28 @@ class HybridCompiler:
 
     def _merge_generator_context(
         self,
-        rag_context: dict[str, Any] | None,
+        rag_context: Any,
         repo_context: dict[str, Any] | None,
-    ) -> dict[str, Any] | None:
-        merged: dict[str, Any] = dict(rag_context or {})
-        if repo_context:
-            merged["repo_context"] = {
-                "source": "github_public_repo",
-                **repo_context,
-            }
-        return merged or None
+        repo_context_mode: str = "full",
+    ) -> Any:
+        """
+        Merge an optional repo_context payload into the existing RAG context.
+
+        rag_context is whatever ``ContextStrategist.process`` returned and may be a
+        dict, a string, or None depending on configuration. When no repo_context
+        is supplied this method passes rag_context through unchanged so existing
+        non-dict callers keep working; only when wrapping repo_context do we coerce
+        rag_context into a dict.
+        """
+        if not repo_context:
+            return rag_context
+        merged: dict[str, Any] = dict(rag_context) if isinstance(rag_context, dict) else {}
+        mode = (repo_context_mode or "full").strip().lower()
+        if mode not in {"full", "compact"}:
+            mode = "full"
+        merged["repo_context"] = {
+            "source": "github_public_repo",
+            "mode": mode,
+            **repo_context,
+        }
+        return merged

--- a/app/llm_engine/hybrid.py
+++ b/app/llm_engine/hybrid.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Any, Optional
 from .client import WorkerClient, WorkerResponse, DEFAULT_MODEL
 from .schemas import DiagnosticItem
 from app.compiler import compile_text_v2
@@ -210,13 +210,17 @@ class HybridCompiler:
         text: str,
         multi_agent: bool = False,
         include_example_code: bool = False,
+        repo_context: dict[str, Any] | None = None,
     ) -> str:
         """
         Generate a comprehensive AI Agent system prompt, aware of RAG context.
         """
         try:
             # Retrieve relevant code context using Agent 6
-            rag_context = self.context_strategist.process(text)
+            rag_context = self._merge_generator_context(
+                self.context_strategist.process(text),
+                repo_context,
+            )
             return self.worker.generate_agent(
                 text,
                 context=rag_context,
@@ -227,13 +231,21 @@ class HybridCompiler:
             # Fallback for agent generation
             return f"# Error\n\nFailed to generate agent: {e}"
 
-    def generate_skill(self, text: str, include_example_code: bool = False) -> str:
+    def generate_skill(
+        self,
+        text: str,
+        include_example_code: bool = False,
+        repo_context: dict[str, Any] | None = None,
+    ) -> str:
         """
         Generate a comprehensive AI Skill definition, aware of RAG context.
         """
         try:
             # Retrieve relevant code context using Agent 6
-            rag_context = self.context_strategist.process(text)
+            rag_context = self._merge_generator_context(
+                self.context_strategist.process(text),
+                repo_context,
+            )
             return self.worker.generate_skill(
                 text,
                 context=rag_context,
@@ -242,3 +254,16 @@ class HybridCompiler:
         except Exception as e:
             # Fallback for skill generation
             return f"# Error\n\nFailed to generate skill: {e}"
+
+    def _merge_generator_context(
+        self,
+        rag_context: dict[str, Any] | None,
+        repo_context: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        merged: dict[str, Any] = dict(rag_context or {})
+        if repo_context:
+            merged["repo_context"] = {
+                "source": "github_public_repo",
+                **repo_context,
+            }
+        return merged or None

--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -8,9 +8,18 @@ You may be provided with a **Project Context** (snippets of code, file structure
 - Use specific filenames, class names, and architectural patterns found in the context.
 - The "Tech Stack" should reflect the actual technologies detected in the project context.
 
+### Repo Context (ground truth)
+A `## Repo Context (ground truth)` section may appear BEFORE the runtime context. When present:
+- Treat it as the only verified information about the user's repository.
+- Anchor the generated `## Tech Stack` to the listed `Detected stack`. Do not add stack items that are not visible there. If the list is empty or missing, write `- TODO: stack not detected from repo metadata` instead of guessing.
+- Reference repo-level facts (repo name, default branch, top-level dirs) only when they appear in the block.
+- Do NOT make file-level claims (no "in `src/foo.py` we…") unless that file is listed in `Brief built from`.
+- The brief is README + manifest level only — it is a *project signal*, not a code audit. Treat anything not in the brief as unknown and use `TODO` markers.
+
 ## HONESTY & RELIABILITY RULES
 - Never invent dependencies, SDKs, utilities, or modules that are not present in the provided context.
 - Never invent API contracts (fields, request/response JSON keys, or privileged write operations) when the exact shape is unknown.
+- Never invent tool names, capability labels, or integration endpoints. If the user request implies a tool but no concrete name is verifiable from context, use a clearly-named placeholder (e.g. `external_search_tool`) and add a `TODO` comment explaining what real tool/library name to substitute.
 - For uncertain implementation details, use pseudo-code and explicit `TODO` comments.
 - Do not present speculative integrations as production-ready code.
 - Self-Verification is mandatory, not optional. If any check fails, fix the response or surface the gap explicitly — do not silently ship.
@@ -78,6 +87,7 @@ The output must strictly follow this Markdown structure:
 [A 3–5 item checklist the agent runs BEFORE sending its final response. Each item must be observable, not aspirational. Tailor to the agent's purpose.]
 - [ ] Does the response answer every part of the user's question?
 - [ ] Are all referenced files / APIs / functions ones that exist in the provided context?
+- [ ] If a `## Repo Context (ground truth)` block was provided, does my Tech Stack match its `Detected stack` and do I avoid claims about files not listed in `Brief built from`?
 - [ ] Are TODO markers used wherever I'm uncertain, instead of fabricated detail?
 - [ ] If I called tools, did each call use parameters drawn from the request — not invented?
 - [ ] Have I met the Stop Conditions, or do I need to continue / escalate?

--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -14,6 +14,18 @@ You are an Expert AI Systems Architect specializing in Multi-Agent Systems (MAS)
 - If Project Context is provided, assign specific files or architectural components to the most relevant agent.
 - Ensure agents share a common understanding of the tech stack.
 
+### Repo Context (ground truth)
+A `## Repo Context (ground truth)` section may appear BEFORE the runtime context. When present:
+- Treat it as the only verified information about the user's repository.
+- Each agent's `## Tech Stack` must align with the listed `Detected stack` — do not split agents along technologies that the brief does not show. If the brief lists Python only, do not invent a "Frontend Engineer (React)" agent unless the user's mission explicitly demands it.
+- Do NOT make file-level handoff claims (no "Agent 2 reads `src/foo.py`") unless that file is listed in `Brief built from`.
+- The brief is README + manifest level only. Anything not in it is unknown — use `TODO` markers, do not invent module names, endpoints, or class boundaries.
+
+## HONESTY & RELIABILITY RULES
+- Never invent technologies, libraries, or APIs beyond what the brief shows.
+- Never invent inter-agent message schemas that reference fictional fields. Handoff arrows must reference shapes you actually declared in `## Outputs`.
+- For uncertain implementation details, mark them with `TODO` rather than fabricating confident detail.
+
 ## OUTPUT STRUCTURE
 Begin the entire output with a single topology declaration blockquote:
 > **Topology:** orchestrator-worker | peer-pipeline — [one sentence: why this topology fits the mission]

--- a/app/llm_engine/prompts/skills_generator.md
+++ b/app/llm_engine/prompts/skills_generator.md
@@ -8,6 +8,19 @@ You may be provided with a **Project Context** (snippets of code, file structure
 - Use specific types, classes, and helper functions found in the context for the "Input Schema" and "Implementation".
 - Align the "Dependencies" with the project's existing dependencies (e.g., if they use `httpx`, don't suggest `requests` unless necessary).
 
+### Repo Context (ground truth)
+A `## Repo Context (ground truth)` section may appear BEFORE the runtime context. When present:
+- Treat it as the only verified information about the user's repository.
+- Anchor `## Dependencies` to the listed `Detected stack`. Do not introduce libraries that contradict that stack. If the brief says Python, do not suggest Node-only tools, and vice versa. If the stack is empty, write `- TODO: dependencies not detected from repo metadata` rather than guessing.
+- Do NOT make file-level claims (no "use `src/foo.py`'s helper") unless that file is listed in `Brief built from`.
+- The brief is README + manifest level only. Treat anything not visible in the brief as unknown — use `TODO` markers, never invent class names, function names, or module paths.
+
+## HONESTY & RELIABILITY RULES
+- Never invent libraries, modules, or APIs that are not present in the provided context.
+- Never invent function or class names from the user's project; if you need to reference one, mark it as `TODO` with a placeholder name.
+- For uncertain details, prefer pseudo-code and explicit `TODO` comments over confident-looking guesses.
+- The skill must be idempotent and the Examples section must use inputs/outputs you can defend from the schema you defined — no decorative made-up payload values that imply data the schema does not allow.
+
 ## INSTRUCTIONS
 1. Analyze the user's request (the "Capability" or "Task") and any provided Project Context.
 2. Design a specialized AI Skill to fulfill this request, compatible with the project's codebase.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 	"ttkbootstrap>=1.20.3",
 	"pillow>=12.2.0",
 	"openai>=2.35.1",
+	"httpx<0.29",
 	"python-dotenv>=1.2.2",
 	"jinja2>=3.1.6",
 	"tiktoken>=0.12.0",
@@ -52,7 +53,6 @@ dev = [
 	"build>=1.5.0",
 	"ruff==0.15.12",
 	"pre-commit==4.6.0",
-	"httpx<0.29",
 ]
 
 openai = []

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -106,7 +106,11 @@ def test_api_generate_agent_endpoint():
         assert response.status_code == 200
         assert response.json() == {"system_prompt": "# Mock API Agent"}
         mock_compiler.generate_agent.assert_called_with(
-            "Test Agent Request", multi_agent=False, include_example_code=False
+            "Test Agent Request",
+            multi_agent=False,
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
 
@@ -123,7 +127,11 @@ def test_api_generate_agent_endpoint_with_example_code_enabled():
         assert response.status_code == 200
         assert response.json() == {"system_prompt": "# Mock API Agent"}
         mock_compiler.generate_agent.assert_called_with(
-            "Test Agent Request", multi_agent=False, include_example_code=True
+            "Test Agent Request",
+            multi_agent=False,
+            include_example_code=True,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -33,9 +33,14 @@ def test_generator_endpoints_require_api_key():
 
     agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"})
     skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"})
+    repo_resp = client.post(
+        "/repo-context/github",
+        json={"repo_url": "https://github.com/openai/openai-python"},
+    )
 
     assert agent_resp.status_code == 403
     assert skill_resp.status_code == 403
+    assert repo_resp.status_code == 403
 
 
 @pytest.mark.auth_required

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -6,6 +6,54 @@ from api.main import app
 from fastapi.testclient import TestClient
 
 
+REPO_CONTEXT_FOR_RENDER = {
+    "source": "github_public_repo",
+    "mode": "full",
+    "normalized_repo_url": "https://github.com/openai/openai-python",
+    "repo_full_name": "openai/openai-python",
+    "default_branch": "main",
+    "summary": "Python SDK repo full summary content.",
+    "summary_compact": "Python SDK repo compact summary content.",
+    "highlights": ["Python package", "README present"],
+    "files_used": ["README.md", "pyproject.toml"],
+    "detected_stack": ["Python", "httpx"],
+}
+
+
+def test_context_message_renders_repo_context_as_ground_truth_block():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    message = client._context_message(
+        mode="generator",
+        context={"repo_context": REPO_CONTEXT_FOR_RENDER},
+    )
+    assert message.startswith("## Repo Context (ground truth)")
+    assert "openai/openai-python" in message
+    assert "Detected stack: Python, httpx" in message
+    assert "Brief built from: README.md, pyproject.toml" in message
+    # Full mode picks the full summary, compact summary stays out
+    assert "Python SDK repo full summary content." in message
+    assert "Python SDK repo compact summary content." not in message
+    # repo_context is removed from runtime_context to avoid duplication
+    assert "<runtime_context>" in message
+    assert "repo_context" not in message.split("<runtime_context>")[1]
+
+
+def test_context_message_compact_mode_uses_compact_summary():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    repo_context = {**REPO_CONTEXT_FOR_RENDER, "mode": "compact"}
+    message = client._context_message(
+        mode="generator",
+        context={"repo_context": repo_context},
+    )
+    assert "Python SDK repo compact summary content." in message
+    assert "Python SDK repo full summary content." not in message
+    assert "### Repo brief (compact)" in message
+
+
 # Mock WorkerClient to avoid API calls
 @pytest.fixture
 def mock_worker_client():
@@ -63,6 +111,7 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
             "file1.py": "content",
             "repo_context": {
                 "source": "github_public_repo",
+                "mode": "full",
                 **repo_context,
             },
         },
@@ -79,11 +128,18 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
             "file1.py": "content",
             "repo_context": {
                 "source": "github_public_repo",
+                "mode": "full",
                 **repo_context,
             },
         },
         include_example_code=False,
     )
+
+    # Test compact mode threads through to the merged context.
+    mock_worker_client.generate_agent.reset_mock()
+    compiler.generate_agent("Test Agent", repo_context=repo_context, repo_context_mode="compact")
+    _, agent_kwargs = mock_worker_client.generate_agent.call_args
+    assert agent_kwargs["context"]["repo_context"]["mode"] == "compact"
 
 
 def test_api_endpoints_integration():
@@ -104,6 +160,9 @@ def test_api_endpoints_integration():
             "detected_stack": ["Python"],
         }
 
+        # Pydantic adds the optional summary_compact field on round-trip
+        normalized_repo_context = {**repo_context, "summary_compact": None}
+
         # Test Agent Generator Endpoint
         resp_agent = client.post(
             "/agent-generator/generate",
@@ -115,18 +174,24 @@ def test_api_endpoints_integration():
             "Test Agent",
             multi_agent=False,
             include_example_code=False,
-            repo_context=repo_context,
+            repo_context=normalized_repo_context,
+            repo_context_mode="full",
         )
 
-        # Test Skills Generator Endpoint
+        # Test Skills Generator Endpoint, exercising compact mode through the API
         resp_skill = client.post(
             "/skills-generator/generate",
-            json={"description": "Test Skill", "repo_context": repo_context},
+            json={
+                "description": "Test Skill",
+                "repo_context": repo_context,
+                "repo_context_mode": "compact",
+            },
         )
         assert resp_skill.status_code == 200
         assert resp_skill.json() == {"skill_definition": "# Mock API Skill"}
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill",
             include_example_code=False,
-            repo_context=repo_context,
+            repo_context=normalized_repo_context,
+            repo_context_mode="compact",
         )

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -160,8 +160,13 @@ def test_api_endpoints_integration():
             "detected_stack": ["Python"],
         }
 
-        # Pydantic adds the optional summary_compact field on round-trip
-        normalized_repo_context = {**repo_context, "summary_compact": None}
+        # Pydantic adds the optional fields on round-trip (summary_compact, requested_ref, requested_subdir)
+        normalized_repo_context = {
+            **repo_context,
+            "summary_compact": None,
+            "requested_ref": None,
+            "requested_subdir": None,
+        }
 
         # Test Agent Generator Endpoint
         resp_agent = client.post(

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -41,26 +41,47 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
     # Mock context strategist
     compiler.context_strategist = MagicMock()
     compiler.context_strategist.process.return_value = {"file1.py": "content"}
+    repo_context = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repository.",
+        "highlights": ["README present"],
+        "files_used": ["README.md"],
+        "detected_stack": ["Python"],
+    }
 
     # Manually inject the mock worker
     compiler.worker = mock_worker_client
 
     # Test generate_agent with context
-    compiler.generate_agent("Test Agent")
+    compiler.generate_agent("Test Agent", repo_context=repo_context)
     compiler.context_strategist.process.assert_called_with("Test Agent")
     mock_worker_client.generate_agent.assert_called_with(
         "Test Agent",
-        context={"file1.py": "content"},
+        context={
+            "file1.py": "content",
+            "repo_context": {
+                "source": "github_public_repo",
+                **repo_context,
+            },
+        },
         multi_agent=False,
         include_example_code=False,
     )
 
     # Test generate_skill with context
-    compiler.generate_skill("Test Skill")
+    compiler.generate_skill("Test Skill", repo_context=repo_context)
     compiler.context_strategist.process.assert_called_with("Test Skill")
     mock_worker_client.generate_skill.assert_called_with(
         "Test Skill",
-        context={"file1.py": "content"},
+        context={
+            "file1.py": "content",
+            "repo_context": {
+                "source": "github_public_repo",
+                **repo_context,
+            },
+        },
         include_example_code=False,
     )
 
@@ -70,15 +91,42 @@ def test_api_endpoints_integration():
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = "# Mock API Agent"
         mock_compiler.generate_skill.return_value = "# Mock API Skill"
+        mock_compiler.analyze_public_github_repo.return_value = None
 
         client = TestClient(app)
+        repo_context = {
+            "normalized_repo_url": "https://github.com/openai/openai-python",
+            "repo_full_name": "openai/openai-python",
+            "default_branch": "main",
+            "summary": "Python SDK repository.",
+            "highlights": ["README present"],
+            "files_used": ["README.md"],
+            "detected_stack": ["Python"],
+        }
 
         # Test Agent Generator Endpoint
-        resp_agent = client.post("/agent-generator/generate", json={"description": "Test Agent"})
+        resp_agent = client.post(
+            "/agent-generator/generate",
+            json={"description": "Test Agent", "repo_context": repo_context},
+        )
         assert resp_agent.status_code == 200
         assert resp_agent.json() == {"system_prompt": "# Mock API Agent"}
+        mock_compiler.generate_agent.assert_called_with(
+            "Test Agent",
+            multi_agent=False,
+            include_example_code=False,
+            repo_context=repo_context,
+        )
 
         # Test Skills Generator Endpoint
-        resp_skill = client.post("/skills-generator/generate", json={"description": "Test Skill"})
+        resp_skill = client.post(
+            "/skills-generator/generate",
+            json={"description": "Test Skill", "repo_context": repo_context},
+        )
         assert resp_skill.status_code == 200
         assert resp_skill.json() == {"skill_definition": "# Mock API Skill"}
+        mock_compiler.generate_skill.assert_called_with(
+            "Test Skill",
+            include_example_code=False,
+            repo_context=repo_context,
+        )

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -42,13 +42,21 @@ def test_api_multi_agent_flag():
         # Test Default (False)
         client.post("/agent-generator/generate", json={"description": "Test"})
         mock_compiler.generate_agent.assert_called_with(
-            "Test", multi_agent=False, include_example_code=False
+            "Test",
+            multi_agent=False,
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
         # Test True
         client.post("/agent-generator/generate", json={"description": "Test", "multi_agent": True})
         mock_compiler.generate_agent.assert_called_with(
-            "Test", multi_agent=True, include_example_code=False
+            "Test",
+            multi_agent=True,
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
 

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -19,16 +19,48 @@ client = TestClient(app)
 
 
 def test_normalize_public_github_repo_url_accepts_root_url():
-    normalized = normalize_public_github_repo_url("https://github.com/openai/openai-python/")
+    normalized, requested_ref, requested_subdir = normalize_public_github_repo_url(
+        "https://github.com/openai/openai-python/"
+    )
 
     assert normalized == "https://github.com/openai/openai-python"
+    assert requested_ref is None
+    assert requested_subdir is None
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "expected_root", "expected_ref", "expected_subdir"),
+    [
+        (
+            "https://github.com/openai/openai-python/tree/main",
+            "https://github.com/openai/openai-python",
+            "main",
+            None,
+        ),
+        (
+            "https://github.com/vercel/next.js/tree/canary/packages/next",
+            "https://github.com/vercel/next.js",
+            "canary",
+            "packages/next",
+        ),
+    ],
+)
+def test_normalize_public_github_repo_url_accepts_tree_variants(
+    repo_url: str,
+    expected_root: str,
+    expected_ref: str,
+    expected_subdir: str | None,
+):
+    normalized, requested_ref, requested_subdir = normalize_public_github_repo_url(repo_url)
+    assert normalized == expected_root
+    assert requested_ref == expected_ref
+    assert requested_subdir == expected_subdir
 
 
 @pytest.mark.parametrize(
     "repo_url",
     [
         "https://github.com/openai/openai-python.git",
-        "https://github.com/openai/openai-python/tree/main",
         "https://github.com/openai/openai-python/blob/main/README.md",
         "https://github.com/openai/openai-python?tab=readme-ov-file",
         "https://github.com/openai/openai-python#readme",
@@ -65,7 +97,7 @@ def test_build_summary_compact_handles_missing_metadata():
     assert "single-surface" in compact
 
 
-def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
+def test_analyze_public_github_repo_uses_ref_and_subdir_cache_key(monkeypatch):
     reset_repo_cache_for_tests()
 
     repo_meta = {
@@ -117,15 +149,134 @@ def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
 
     monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
 
-    first = analyze_public_github_repo("https://github.com/openai/openai-python")
-    second = analyze_public_github_repo("https://github.com/openai/openai-python")
+    first = analyze_public_github_repo("https://github.com/openai/openai-python/tree/main")
+    second = analyze_public_github_repo("https://github.com/openai/openai-python/tree/main")
+    third = analyze_public_github_repo("https://github.com/openai/openai-python/tree/v4")
 
     assert first == second
+    assert third["requested_ref"] == "v4"
     assert "summary_compact" in first and first["summary_compact"]
     assert (
-        call_log.count("/repos/openai/openai-python") == 1
-    ), f"expected GitHub API to be hit once, got call log: {call_log}"
+        call_log.count("/repos/openai/openai-python") == 2
+    ), f"expected GitHub API to be hit twice for two refs, got call log: {call_log}"
+    assert call_log.count("/repos/openai/openai-python/contents?ref=main") == 1
+    assert call_log.count("/repos/openai/openai-python/contents?ref=v4") == 1
 
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_forwards_ref_to_contents_api(monkeypatch):
+    reset_repo_cache_for_tests()
+    call_log: list[str] = []
+
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Python SDK for OpenAI.",
+        "default_branch": "main",
+        "language": "Python",
+    }
+    root_entries = [
+        {"name": "README.md", "path": "README.md", "type": "file", "download_url": "rd"}
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/openai/openai-python"):
+                return FakeResponse(repo_meta)
+            if path == "/repos/openai/openai-python/contents?ref=my-branch":
+                return FakeResponse(root_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# README")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+    payload = analyze_public_github_repo("https://github.com/openai/openai-python/tree/my-branch")
+    assert payload["requested_ref"] == "my-branch"
+    assert "/repos/openai/openai-python/contents?ref=my-branch" in call_log
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_walks_requested_subdir(monkeypatch):
+    reset_repo_cache_for_tests()
+    call_log: list[str] = []
+
+    repo_meta = {
+        "full_name": "vercel/next.js",
+        "description": "Next.js repo",
+        "default_branch": "canary",
+        "language": "TypeScript",
+    }
+    subdir_entries = [
+        {
+            "name": "README.md",
+            "path": "packages/next/README.md",
+            "type": "file",
+            "download_url": "rd",
+        }
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/vercel/next.js"):
+                return FakeResponse(repo_meta)
+            if path == "/repos/vercel/next.js/contents/packages/next?ref=canary":
+                return FakeResponse(subdir_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# Next package")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+    payload = analyze_public_github_repo(
+        "https://github.com/vercel/next.js/tree/canary/packages/next"
+    )
+    assert payload["requested_ref"] == "canary"
+    assert payload["requested_subdir"] == "packages/next"
+    assert "/repos/vercel/next.js/contents/packages/next?ref=canary" in call_log
+    assert "/repos/vercel/next.js/contents?ref=canary" not in call_log
     reset_repo_cache_for_tests()
 
 
@@ -275,5 +426,10 @@ def test_repo_context_endpoint_returns_analyzed_repo_summary():
 
     assert response.status_code == 200
     # Response model adds summary_compact (defaults to None when analyzer omits it).
-    assert response.json() == {**mock_payload, "summary_compact": None}
+    assert response.json() == {
+        **mock_payload,
+        "summary_compact": None,
+        "requested_ref": None,
+        "requested_subdir": None,
+    }
     mock_analyze.assert_called_once_with("https://github.com/openai/openai-python")

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
 from app.github_repo_context import (
+    GitHubRepoAnalysisError,
     InvalidGitHubRepoUrl,
     _build_summary_compact,
     analyze_public_github_repo,
@@ -125,6 +127,131 @@ def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
     ), f"expected GitHub API to be hit once, got call log: {call_log}"
 
     reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_forwards_promptc_github_token(monkeypatch):
+    reset_repo_cache_for_tests()
+    monkeypatch.setenv("PROMPTC_GITHUB_TOKEN", "ghp_test_token")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    captured_headers: dict[str, str] = {}
+
+    class HeaderCapturingClient:
+        def __init__(self, *args, **kwargs):
+            captured_headers.update(dict(kwargs.get("headers") or {}))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            raise httpx.HTTPError("stop after header capture")
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", HeaderCapturingClient)
+
+    with pytest.raises(GitHubRepoAnalysisError):
+        analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert captured_headers.get("Authorization") == "Bearer ghp_test_token"
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_omits_authorization_when_no_token(monkeypatch):
+    reset_repo_cache_for_tests()
+    monkeypatch.delenv("PROMPTC_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    captured_headers: dict[str, str] = {}
+
+    class HeaderCapturingClient:
+        def __init__(self, *args, **kwargs):
+            captured_headers.update(dict(kwargs.get("headers") or {}))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            raise httpx.HTTPError("stop after header capture")
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", HeaderCapturingClient)
+
+    with pytest.raises(GitHubRepoAnalysisError):
+        analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert "Authorization" not in captured_headers
+    reset_repo_cache_for_tests()
+
+
+def _enable_promptc_api_log_capture(caplog):
+    import logging
+
+    caplog.set_level(logging.INFO, logger="promptc.api")
+    logger = logging.getLogger("promptc.api")
+    previous_propagate = logger.propagate
+    logger.propagate = True
+    return previous_propagate
+
+
+def _restore_promptc_api_log_capture(previous_propagate):
+    import logging
+
+    logging.getLogger("promptc.api").propagate = previous_propagate
+
+
+def test_repo_context_endpoint_emits_ok_telemetry(caplog):
+    mock_payload = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repo with README-led overview and manifest-derived stack.",
+        "highlights": ["Python package", "README present"],
+        "files_used": ["README.md", "pyproject.toml"],
+        "detected_stack": ["Python", "httpx"],
+    }
+
+    previous_propagate = _enable_promptc_api_log_capture(caplog)
+    try:
+        with patch("api.routes.generators.analyze_public_github_repo", return_value=mock_payload):
+            response = client.post(
+                "/repo-context/github",
+                json={"repo_url": "https://github.com/openai/openai-python"},
+            )
+    finally:
+        _restore_promptc_api_log_capture(previous_propagate)
+
+    assert response.status_code == 200
+
+    analyze_records = [r for r in caplog.records if getattr(r, "event", None) == "repo_analyze"]
+    assert analyze_records, "expected at least one repo_analyze structured log record"
+    record = analyze_records[-1]
+    assert record.outcome == "ok"
+    assert record.repo_full_name == "openai/openai-python"
+    assert record.status_code == 200
+    assert isinstance(record.duration_ms, (int, float))
+
+
+def test_repo_context_endpoint_emits_invalid_url_telemetry(caplog):
+    previous_propagate = _enable_promptc_api_log_capture(caplog)
+    try:
+        response = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://gitlab.com/openai/openai-python"},
+        )
+    finally:
+        _restore_promptc_api_log_capture(previous_propagate)
+
+    assert response.status_code == 400
+
+    analyze_records = [r for r in caplog.records if getattr(r, "event", None) == "repo_analyze"]
+    assert analyze_records, "expected an invalid_url telemetry record"
+    record = analyze_records[-1]
+    assert record.outcome == "invalid_url"
+    assert record.status_code == 400
 
 
 def test_repo_context_endpoint_returns_analyzed_repo_summary():

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -139,7 +139,10 @@ def test_analyze_public_github_repo_uses_ref_and_subdir_cache_key(monkeypatch):
             call_log.append(path)
             if path.endswith("/repos/openai/openai-python"):
                 return FakeResponse(repo_meta)
-            if path.endswith("/repos/openai/openai-python/contents"):
+            if path in (
+                "/repos/openai/openai-python/contents?ref=main",
+                "/repos/openai/openai-python/contents?ref=v4",
+            ):
                 return FakeResponse(root_entries)
             if path == "rd":
                 return FakeResponse(None, text="# OpenAI Python\n\nOfficial SDK.")
@@ -161,6 +164,67 @@ def test_analyze_public_github_repo_uses_ref_and_subdir_cache_key(monkeypatch):
     ), f"expected GitHub API to be hit twice for two refs, got call log: {call_log}"
     assert call_log.count("/repos/openai/openai-python/contents?ref=main") == 1
     assert call_log.count("/repos/openai/openai-python/contents?ref=v4") == 1
+
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_uses_in_memory_cache_for_root_url(monkeypatch):
+    reset_repo_cache_for_tests()
+
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Python SDK for OpenAI.",
+        "default_branch": "main",
+        "language": "Python",
+    }
+    root_entries = [
+        {"name": "README.md", "path": "README.md", "type": "file", "download_url": "rd"},
+    ]
+    call_log: list[str] = []
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/openai/openai-python"):
+                return FakeResponse(repo_meta)
+            if path == "/repos/openai/openai-python/contents":
+                return FakeResponse(root_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# OpenAI Python\n\nOfficial SDK.")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+
+    first = analyze_public_github_repo("https://github.com/openai/openai-python")
+    second = analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert first == second
+    assert first["requested_ref"] is None
+    assert first["requested_subdir"] is None
+    assert (
+        call_log.count("/repos/openai/openai-python") == 1
+    ), f"expected GitHub API to be hit once for root URL, got call log: {call_log}"
 
     reset_repo_cache_for_tests()
 

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from app.github_repo_context import InvalidGitHubRepoUrl, normalize_public_github_repo_url
+
+
+client = TestClient(app)
+
+
+def test_normalize_public_github_repo_url_accepts_root_url():
+    normalized = normalize_public_github_repo_url("https://github.com/openai/openai-python/")
+
+    assert normalized == "https://github.com/openai/openai-python"
+
+
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        "https://github.com/openai/openai-python.git",
+        "https://github.com/openai/openai-python/tree/main",
+        "https://github.com/openai/openai-python/blob/main/README.md",
+        "https://github.com/openai/openai-python?tab=readme-ov-file",
+        "https://github.com/openai/openai-python#readme",
+        "https://github.com/openai/openai-python/issues",
+    ],
+)
+def test_normalize_public_github_repo_url_rejects_non_root_variants(repo_url: str):
+    with pytest.raises(InvalidGitHubRepoUrl):
+        normalize_public_github_repo_url(repo_url)
+
+
+def test_repo_context_endpoint_returns_analyzed_repo_summary():
+    mock_payload = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repo with README-led overview and manifest-derived stack.",
+        "highlights": ["Python package", "README present"],
+        "files_used": ["README.md", "pyproject.toml"],
+        "detected_stack": ["Python", "httpx"],
+    }
+
+    with patch(
+        "api.routes.generators.analyze_public_github_repo", return_value=mock_payload
+    ) as mock_analyze:
+        response = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://github.com/openai/openai-python"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == mock_payload
+    mock_analyze.assert_called_once_with("https://github.com/openai/openai-python")

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -4,7 +4,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
-from app.github_repo_context import InvalidGitHubRepoUrl, normalize_public_github_repo_url
+from app.github_repo_context import (
+    InvalidGitHubRepoUrl,
+    _build_summary_compact,
+    analyze_public_github_repo,
+    normalize_public_github_repo_url,
+    reset_repo_cache_for_tests,
+)
 
 
 client = TestClient(app)
@@ -32,6 +38,95 @@ def test_normalize_public_github_repo_url_rejects_non_root_variants(repo_url: st
         normalize_public_github_repo_url(repo_url)
 
 
+def test_build_summary_compact_truncates_to_budget():
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Official Python SDK for the OpenAI API.",
+    }
+    compact = _build_summary_compact(
+        repo_meta=repo_meta,
+        detected_stack=["Python", "httpx", "pydantic"],
+        top_level_dirs=["src", "tests"],
+    )
+    assert compact.startswith("openai/openai-python:")
+    assert "Python" in compact
+    assert len(compact) <= 280
+
+
+def test_build_summary_compact_handles_missing_metadata():
+    compact = _build_summary_compact(
+        repo_meta={},
+        detected_stack=[],
+        top_level_dirs=[],
+    )
+    assert "no detected stack" in compact
+    assert "single-surface" in compact
+
+
+def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
+    reset_repo_cache_for_tests()
+
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Python SDK for OpenAI.",
+        "default_branch": "main",
+        "language": "Python",
+    }
+    root_entries = [
+        {"name": "README.md", "path": "README.md", "type": "file", "download_url": "rd"},
+        {"name": "pyproject.toml", "path": "pyproject.toml", "type": "file", "download_url": "py"},
+    ]
+
+    call_log: list[str] = []
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/openai/openai-python"):
+                return FakeResponse(repo_meta)
+            if path.endswith("/repos/openai/openai-python/contents"):
+                return FakeResponse(root_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# OpenAI Python\n\nOfficial SDK.")
+            if path == "py":
+                return FakeResponse(None, text="[project]\nname='openai'\n")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+
+    first = analyze_public_github_repo("https://github.com/openai/openai-python")
+    second = analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert first == second
+    assert "summary_compact" in first and first["summary_compact"]
+    assert (
+        call_log.count("/repos/openai/openai-python") == 1
+    ), f"expected GitHub API to be hit once, got call log: {call_log}"
+
+    reset_repo_cache_for_tests()
+
+
 def test_repo_context_endpoint_returns_analyzed_repo_summary():
     mock_payload = {
         "normalized_repo_url": "https://github.com/openai/openai-python",
@@ -52,5 +147,6 @@ def test_repo_context_endpoint_returns_analyzed_repo_summary():
         )
 
     assert response.status_code == 200
-    assert response.json() == mock_payload
+    # Response model adds summary_compact (defaults to None when analyzer omits it).
+    assert response.json() == {**mock_payload, "summary_compact": None}
     mock_analyze.assert_called_once_with("https://github.com/openai/openai-python")

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -51,6 +51,7 @@ def test_hybrid_compiler_generate_skill(mock_worker_client):
     assert kwargs["include_example_code"] is False
     assert kwargs["context"]["repo_context"] == {
         "source": "github_public_repo",
+        "mode": "full",
         **repo_context,
     }
 
@@ -80,7 +81,8 @@ def test_api_generate_skill_endpoint():
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=False,
-            repo_context=repo_context,
+            repo_context={**repo_context, "summary_compact": None},
+            repo_context_mode="full",
         )
 
 
@@ -100,6 +102,7 @@ def test_api_generate_skill_endpoint_with_example_code_enabled():
             "Test Skill Request",
             include_example_code=True,
             repo_context=None,
+            repo_context_mode="full",
         )
 
 

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -33,28 +33,46 @@ def test_hybrid_compiler_generate_skill(mock_worker_client):
     compiler = HybridCompiler()
     # Manually inject the mock worker because HybridCompiler creates its own instance
     compiler.worker = mock_worker_client
+    repo_context = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repository.",
+        "highlights": ["README present"],
+        "files_used": ["README.md"],
+        "detected_stack": ["Python"],
+    }
 
-    result = compiler.generate_skill("Test Skill")
+    result = compiler.generate_skill("Test Skill", repo_context=repo_context)
     assert result == "# Mock Skill Definition"
-    # HybridCompiler now injects context, so we expect the context argument
-    # We can use ANY for the context content since it depends on the mock vector db
-    from unittest.mock import ANY
-
-    mock_worker_client.generate_skill.assert_called_with(
-        "Test Skill",
-        context=ANY,
-        include_example_code=False,
-    )
+    mock_worker_client.generate_skill.assert_called_once()
+    args, kwargs = mock_worker_client.generate_skill.call_args
+    assert args == ("Test Skill",)
+    assert kwargs["include_example_code"] is False
+    assert kwargs["context"]["repo_context"] == {
+        "source": "github_public_repo",
+        **repo_context,
+    }
 
 
 def test_api_generate_skill_endpoint():
     # Mock the global hybrid_compiler in api.main
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_skill.return_value = "# Mock API Skill"
+        repo_context = {
+            "normalized_repo_url": "https://github.com/openai/openai-python",
+            "repo_full_name": "openai/openai-python",
+            "default_branch": "main",
+            "summary": "Python SDK repository.",
+            "highlights": ["README present"],
+            "files_used": ["README.md"],
+            "detected_stack": ["Python"],
+        }
 
         client = TestClient(app)
         response = client.post(
-            "/skills-generator/generate", json={"description": "Test Skill Request"}
+            "/skills-generator/generate",
+            json={"description": "Test Skill Request", "repo_context": repo_context},
         )
 
         assert response.status_code == 200
@@ -62,6 +80,7 @@ def test_api_generate_skill_endpoint():
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=False,
+            repo_context=repo_context,
         )
 
 
@@ -80,6 +99,7 @@ def test_api_generate_skill_endpoint_with_example_code_enabled():
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=True,
+            repo_context=None,
         )
 
 

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -81,7 +81,12 @@ def test_api_generate_skill_endpoint():
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=False,
-            repo_context={**repo_context, "summary_compact": None},
+            repo_context={
+                **repo_context,
+                "summary_compact": None,
+                "requested_ref": None,
+                "requested_subdir": None,
+            },
             repo_context_mode="full",
         )
 

--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AgentGeneratorPage from "./page";
+import { apiJson } from "@/config";
+
+vi.mock("@/config", () => ({
+  apiJson: vi.fn(),
+  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+}));
+
+vi.mock("../components/InfoButton", () => ({
+  default: ({ title }: { title: string }) => <button type="button">{title}</button>,
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("./components/ExportPanel", () => ({
+  default: () => null,
+}));
+
+vi.mock("../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+const apiJsonMock = vi.mocked(apiJson);
+
+describe("Agent Generator page", () => {
+  beforeEach(() => {
+    apiJsonMock.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("analyzes a GitHub repo and includes repo_context in the generate request", async () => {
+    apiJsonMock
+      .mockResolvedValueOnce({
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      })
+      .mockResolvedValueOnce({
+        system_prompt: "# Repo-aware Agent",
+      });
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Review this repo and generate an agent." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+
+    await screen.findByText("openai/openai-python");
+    expect(screen.getByText("Python SDK repo with a compact README and clear manifest signals.")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+
+    expect(apiJsonMock.mock.calls[0]?.[0]).toBe("/repo-context/github");
+    expect(JSON.parse(String(apiJsonMock.mock.calls[0]?.[1]?.body))).toEqual({
+      repo_url: "https://github.com/openai/openai-python",
+    });
+
+    expect(apiJsonMock.mock.calls[1]?.[0]).toBe("/agent-generator/generate");
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Review this repo and generate an agent.",
+      multi_agent: false,
+      include_example_code: false,
+      repo_context: {
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      },
+    });
+  });
+
+  it("shows a warning when repo analysis fails but still generates without repo context", async () => {
+    apiJsonMock
+      .mockRejectedValueOnce(new Error("Repository analysis failed"))
+      .mockResolvedValueOnce({
+        system_prompt: "# Plain Agent",
+      });
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Build a safe agent." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+    expect(await screen.findByText("Repository analysis failed")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Build a safe agent.",
+      multi_agent: false,
+      include_example_code: false,
+    });
+  });
+
+  it("keeps the description textarea at a usable desktop height", () => {
+    render(<AgentGeneratorPage />);
+
+    const textarea = screen.getByLabelText("Agent Description");
+    const classes = textarea.getAttribute("class") || "";
+
+    expect(classes).toContain("md:min-h-[220px]");
+    expect(classes).not.toContain("md:min-h-0");
+  });
+});

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -4,13 +4,27 @@ import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Bot } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
+import type { GitHubRepoContextPayload } from "@/lib/api/types";
+import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
+import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
 import ExportPanel from "./components/ExportPanel";
+
+const REPO_ANALYSIS_TIMEOUT_MS = 15000;
+
+function isSupportedGitHubRepoRootUrl(value: string): boolean {
+  return /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/.test(value.trim());
+}
 
 export default function AgentGenerator() {
   const [description, setDescription] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [repoContext, setRepoContext] = useState<GitHubRepoContextPayload | null>(null);
+  const [repoAnalysisLoading, setRepoAnalysisLoading] = useState(false);
+  const [repoAnalysisWarning, setRepoAnalysisWarning] = useState<string | null>(null);
+  const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -20,6 +34,36 @@ export default function AgentGenerator() {
   const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
+  const isValidRepoUrl = isSupportedGitHubRepoRootUrl(repoUrl);
+
+  const handleAnalyzeRepo = async () => {
+    if (!isValidRepoUrl || repoAnalysisLoading) return;
+
+    setRepoAnalysisLoading(true);
+    setRepoAnalysisWarning(null);
+    setError(null);
+
+    try {
+      const data = await withTimeout(
+        apiJson<GitHubRepoContextPayload>("/repo-context/github", {
+          method: "POST",
+          headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({ repo_url: repoUrl.trim() }),
+        }),
+        REPO_ANALYSIS_TIMEOUT_MS,
+        "Repository analysis is taking too long. Please try again.",
+      );
+      setRepoContext(data);
+      setRepoContextDirty(false);
+    } catch (e: unknown) {
+      showError(e);
+      setRepoContext(null);
+      setRepoContextDirty(false);
+      setRepoAnalysisWarning(e instanceof Error ? e.message : "Repository analysis failed");
+    } finally {
+      setRepoAnalysisLoading(false);
+    }
+  };
 
   const handleGenerate = async () => {
     if (!description.trim()) return;
@@ -38,6 +82,7 @@ export default function AgentGenerator() {
           description,
           multi_agent: multiAgent,
           include_example_code: includeExampleCode,
+          ...(repoContext && !repoContextDirty ? { repo_context: repoContext } : {}),
         }),
       });
 
@@ -106,12 +151,65 @@ export default function AgentGenerator() {
               </p>
             </div>
 
-            <div className="flex-1 min-h-0 flex flex-col relative group">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="agent-repo-url" className="text-sm font-medium text-zinc-300">GitHub Repo URL</label>
+              <p className="text-xs text-zinc-500">
+                Optional. Analyze a public root repo URL to give the generator a compact project-aware brief.
+              </p>
+              <input
+                id="agent-repo-url"
+                aria-label="GitHub Repo URL"
+                className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 font-mono text-sm text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50"
+                placeholder="https://github.com/owner/repo"
+                value={repoUrl}
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+                  setRepoUrl(nextValue);
+                  setRepoAnalysisWarning(null);
+                  if (!repoContext) {
+                    return;
+                  }
+                  const normalizedNext = nextValue.trim().replace(/\/+$/, "");
+                  const normalizedCurrent = repoContext.normalized_repo_url.replace(/\/+$/, "");
+                  const isDirty = normalizedNext !== normalizedCurrent;
+                  setRepoContextDirty(isDirty);
+                  if (!isDirty) {
+                    setRepoAnalysisWarning(null);
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleAnalyzeRepo}
+                disabled={!isValidRepoUrl || repoAnalysisLoading}
+                className="w-full rounded-xl border border-green-500/20 bg-green-500/10 px-4 py-2.5 text-sm font-semibold text-green-100 transition-all hover:bg-green-500/15 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {repoAnalysisLoading ? "Analyzing Repo..." : "Analyze Repo"}
+              </button>
+            </div>
+
+            {repoContext && !repoContextDirty ? (
+              <RepoContextPreviewCard repoContext={repoContext} accent="green" />
+            ) : null}
+
+            {repoContextDirty ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                Repo URL changed. Re-analyze to attach fresh repo context.
+              </div>
+            ) : null}
+
+            {repoAnalysisWarning ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                {repoAnalysisWarning}
+              </div>
+            ) : null}
+
+            <div className="relative shrink-0 group">
               <textarea
                 id="agent-description"
                 aria-label="Agent Description"
                 aria-describedby="agent-description-help"
-                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-0"
+                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'I need an agent that reviews React code for performance bottlenecks' or 'A creative writer for sci-fi stories'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}

--- a/web/app/components/RepoContextPreviewCard.tsx
+++ b/web/app/components/RepoContextPreviewCard.tsx
@@ -1,0 +1,88 @@
+import type { GitHubRepoContextPayload } from "@/lib/api/types";
+
+type RepoContextPreviewCardProps = {
+  repoContext: GitHubRepoContextPayload;
+  accent: "green" | "yellow";
+};
+
+const accentMap = {
+  green: {
+    ring: "ring-green-500/20",
+    badge: "bg-green-500/10 text-green-200 border-green-500/20",
+    code: "text-green-300",
+  },
+  yellow: {
+    ring: "ring-yellow-500/20",
+    badge: "bg-yellow-500/10 text-yellow-200 border-yellow-500/20",
+    code: "text-yellow-300",
+  },
+} as const;
+
+export default function RepoContextPreviewCard({
+  repoContext,
+  accent,
+}: RepoContextPreviewCardProps) {
+  const styles = accentMap[accent];
+
+  return (
+    <div className={`rounded-2xl border border-white/10 bg-black/20 p-4 ring-1 ${styles.ring}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs font-mono uppercase tracking-[0.2em] text-zinc-500">
+            Repo Brief
+          </div>
+          <div className="mt-1 text-sm font-semibold text-white">{repoContext.repo_full_name}</div>
+        </div>
+        {repoContext.default_branch ? (
+          <span className={`rounded-full border px-2 py-1 text-[10px] font-mono uppercase tracking-wider ${styles.badge}`}>
+            {repoContext.default_branch}
+          </span>
+        ) : null}
+      </div>
+
+      <p className="mt-3 text-xs leading-relaxed text-zinc-300">{repoContext.summary}</p>
+
+      {repoContext.detected_stack.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {repoContext.detected_stack.map((item) => (
+            <span
+              key={item}
+              className={`rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-mono uppercase tracking-wider ${styles.code}`}
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {repoContext.highlights.length > 0 ? (
+        <div className="mt-4">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">Highlights</div>
+          <ul className="mt-2 space-y-1">
+            {repoContext.highlights.map((item) => (
+              <li key={item} className="text-xs leading-relaxed text-zinc-300">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {repoContext.files_used.length > 0 ? (
+        <div className="mt-4">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">Files Used</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {repoContext.files_used.map((item) => (
+              <span
+                key={item}
+                className="rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-mono text-zinc-300"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -14,6 +14,7 @@ import { POST as skillsGenerateRoute } from "./skills-generator/generate/route";
 import { POST as skillsExportRoute } from "./skills-generator/export/route";
 import { POST as ragUploadRoute } from "./rag/upload/route";
 import { POST as ragIngestRoute } from "./rag/ingest/route";
+import { POST as repoContextGithubRoute } from "./repo-context/github/route";
 
 type RouteCase = {
   name: string;
@@ -135,6 +136,13 @@ describe("Next backend proxy route wiring", () => {
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
     },
     {
+      name: "repo context analysis",
+      handler: repoContextGithubRoute,
+      requestUrl: "http://localhost:3000/repo-context/github",
+      requestBody: { repo_url: "https://github.com/openai/openai-python" },
+      expectedUrl: "https://api.memo.dev/repo-context/github",
+    },
+    {
       name: "RAG upload",
       handler: ragUploadRoute,
       requestUrl: "http://localhost:3000/rag/upload",
@@ -236,6 +244,13 @@ describe("Next backend proxy route wiring", () => {
       requestUrl: "http://localhost:3000/skills-generator/generate",
       requestBody: { description: "search docs" },
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
+    },
+    {
+      name: "repo context analysis",
+      handler: repoContextGithubRoute,
+      requestUrl: "http://localhost:3000/repo-context/github",
+      requestBody: { repo_url: "https://github.com/openai/openai-python" },
+      expectedUrl: "https://api.memo.dev/repo-context/github",
     },
     {
       name: "RAG upload",

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+﻿import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GET as healthRoute } from "./health/route";
 import { POST as compileRoute } from "./compile/route";
@@ -136,13 +136,6 @@ describe("Next backend proxy route wiring", () => {
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
     },
     {
-      name: "repo context analysis",
-      handler: repoContextGithubRoute,
-      requestUrl: "http://localhost:3000/repo-context/github",
-      requestBody: { repo_url: "https://github.com/openai/openai-python" },
-      expectedUrl: "https://api.memo.dev/repo-context/github",
-    },
-    {
       name: "RAG upload",
       handler: ragUploadRoute,
       requestUrl: "http://localhost:3000/rag/upload",
@@ -244,13 +237,6 @@ describe("Next backend proxy route wiring", () => {
       requestUrl: "http://localhost:3000/skills-generator/generate",
       requestBody: { description: "search docs" },
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
-    },
-    {
-      name: "repo context analysis",
-      handler: repoContextGithubRoute,
-      requestUrl: "http://localhost:3000/repo-context/github",
-      requestBody: { repo_url: "https://github.com/openai/openai-python" },
-      expectedUrl: "https://api.memo.dev/repo-context/github",
     },
     {
       name: "RAG upload",

--- a/web/app/repo-context/github/route.ts
+++ b/web/app/repo-context/github/route.ts
@@ -1,0 +1,7 @@
+import { proxyBackendRequest } from "@/lib/server/backendProxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyBackendRequest(request, "/repo-context/github", {
+    requireServerApiKey: true,
+  });
+}

--- a/web/app/repo-context/github/route.ts
+++ b/web/app/repo-context/github/route.ts
@@ -1,7 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/repo-context/github", {
-    requireServerApiKey: true,
-  });
+  return proxyBackendRequest(request, "/repo-context/github", {});
 }

--- a/web/app/skills-generator/page.test.tsx
+++ b/web/app/skills-generator/page.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SkillsGeneratorPage from "./page";
+import { apiJson } from "@/config";
+
+vi.mock("@/config", () => ({
+  apiJson: vi.fn(),
+  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+}));
+
+vi.mock("../components/InfoButton", () => ({
+  default: ({ title }: { title: string }) => <button type="button">{title}</button>,
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("./components/ExportPanel", () => ({
+  default: () => null,
+}));
+
+vi.mock("../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+const apiJsonMock = vi.mocked(apiJson);
+
+describe("Skills Generator page", () => {
+  beforeEach(() => {
+    apiJsonMock.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("analyzes a GitHub repo and includes repo_context in the skill request", async () => {
+    apiJsonMock
+      .mockResolvedValueOnce({
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      })
+      .mockResolvedValueOnce({
+        skill_definition: "# Repo-aware Skill",
+      });
+
+    render(<SkillsGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Generate a skill for this repo." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+
+    await screen.findByText("openai/openai-python");
+    expect(screen.getByText("Python SDK repo with a compact README and clear manifest signals.")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Generate a skill for this repo.",
+      include_example_code: false,
+      repo_context: {
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      },
+    });
+  });
+
+  it("requires re-analysis after the repo URL changes", async () => {
+    apiJsonMock
+      .mockResolvedValueOnce({
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package"],
+        files_used: ["README.md"],
+        detected_stack: ["Python"],
+      })
+      .mockResolvedValueOnce({
+        skill_definition: "# Plain Skill",
+      });
+
+    render(<SkillsGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Generate a skill for this repo." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+
+    await screen.findByText("openai/openai-python");
+
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/vercel/next.js" },
+    });
+
+    expect(screen.getByText("Repo URL changed. Re-analyze to attach fresh repo context.")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Generate a skill for this repo.",
+      include_example_code: false,
+    });
+  });
+
+  it("keeps the description textarea at a usable desktop height", () => {
+    render(<SkillsGeneratorPage />);
+
+    const textarea = screen.getByLabelText("Skill Description");
+    const classes = textarea.getAttribute("class") || "";
+
+    expect(classes).toContain("md:min-h-[220px]");
+    expect(classes).not.toContain("md:min-h-0");
+  });
+});

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -4,13 +4,27 @@ import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Zap } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
+import type { GitHubRepoContextPayload } from "@/lib/api/types";
+import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
 import InfoButton from "../components/InfoButton";
 import ContextManager from "../components/ContextManager";
+import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
 import SkillExportPanel from "./components/ExportPanel";
+
+const REPO_ANALYSIS_TIMEOUT_MS = 15000;
+
+function isSupportedGitHubRepoRootUrl(value: string): boolean {
+  return /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/.test(value.trim());
+}
 
 export default function SkillsGenerator() {
   const [description, setDescription] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [repoContext, setRepoContext] = useState<GitHubRepoContextPayload | null>(null);
+  const [repoAnalysisLoading, setRepoAnalysisLoading] = useState(false);
+  const [repoAnalysisWarning, setRepoAnalysisWarning] = useState<string | null>(null);
+  const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -19,6 +33,36 @@ export default function SkillsGenerator() {
   const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
+  const isValidRepoUrl = isSupportedGitHubRepoRootUrl(repoUrl);
+
+  const handleAnalyzeRepo = async () => {
+    if (!isValidRepoUrl || repoAnalysisLoading) return;
+
+    setRepoAnalysisLoading(true);
+    setRepoAnalysisWarning(null);
+    setError(null);
+
+    try {
+      const data = await withTimeout(
+        apiJson<GitHubRepoContextPayload>("/repo-context/github", {
+          method: "POST",
+          headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({ repo_url: repoUrl.trim() }),
+        }),
+        REPO_ANALYSIS_TIMEOUT_MS,
+        "Repository analysis is taking too long. Please try again.",
+      );
+      setRepoContext(data);
+      setRepoContextDirty(false);
+    } catch (e: unknown) {
+      showError(e);
+      setRepoContext(null);
+      setRepoContextDirty(false);
+      setRepoAnalysisWarning(e instanceof Error ? e.message : "Repository analysis failed");
+    } finally {
+      setRepoAnalysisLoading(false);
+    }
+  };
 
   const handleGenerate = async () => {
     if (!description.trim()) return;
@@ -36,6 +80,7 @@ export default function SkillsGenerator() {
         body: JSON.stringify({
           description,
           include_example_code: includeExampleCode,
+          ...(repoContext && !repoContextDirty ? { repo_context: repoContext } : {}),
         }),
       });
 
@@ -104,11 +149,64 @@ export default function SkillsGenerator() {
               </p>
             </div>
 
-            <div className="flex-1 min-h-0 flex flex-col relative group">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="skill-repo-url" className="text-sm font-medium text-zinc-300">GitHub Repo URL</label>
+              <p className="text-xs text-zinc-500">
+                Optional. Analyze a public root repo URL to add a compact, deterministic project brief.
+              </p>
+              <input
+                id="skill-repo-url"
+                aria-label="GitHub Repo URL"
+                className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 font-mono text-sm text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50"
+                placeholder="https://github.com/owner/repo"
+                value={repoUrl}
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+                  setRepoUrl(nextValue);
+                  setRepoAnalysisWarning(null);
+                  if (!repoContext) {
+                    return;
+                  }
+                  const normalizedNext = nextValue.trim().replace(/\/+$/, "");
+                  const normalizedCurrent = repoContext.normalized_repo_url.replace(/\/+$/, "");
+                  const isDirty = normalizedNext !== normalizedCurrent;
+                  setRepoContextDirty(isDirty);
+                  if (!isDirty) {
+                    setRepoAnalysisWarning(null);
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleAnalyzeRepo}
+                disabled={!isValidRepoUrl || repoAnalysisLoading}
+                className="w-full rounded-xl border border-yellow-500/20 bg-yellow-500/10 px-4 py-2.5 text-sm font-semibold text-yellow-100 transition-all hover:bg-yellow-500/15 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {repoAnalysisLoading ? "Analyzing Repo..." : "Analyze Repo"}
+              </button>
+            </div>
+
+            {repoContext && !repoContextDirty ? (
+              <RepoContextPreviewCard repoContext={repoContext} accent="yellow" />
+            ) : null}
+
+            {repoContextDirty ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                Repo URL changed. Re-analyze to attach fresh repo context.
+              </div>
+            ) : null}
+
+            {repoAnalysisWarning ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                {repoAnalysisWarning}
+              </div>
+            ) : null}
+
+            <div className="relative shrink-0 group">
               <textarea
                 id="skill-description"
                 aria-label="Skill Description"
-                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-0"
+                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'A skill that parses JSON and validates schemas' or 'Fetch and summarize web pages'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -138,3 +138,13 @@ export type RagStats = {
   avg_bytes?: number;
   largest?: Array<{ path: string; size: number }>;
 };
+
+export type GitHubRepoContextPayload = {
+  normalized_repo_url: string;
+  repo_full_name: string;
+  default_branch: string | null;
+  summary: string;
+  highlights: string[];
+  files_used: string[];
+  detected_stack: string[];
+};

--- a/web/lib/promise/withTimeout.test.ts
+++ b/web/lib/promise/withTimeout.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { withTimeout } from "./withTimeout";
+
+describe("withTimeout", () => {
+  it("resolves when the wrapped promise resolves in time", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), 1000, "too slow")).resolves.toBe("ok");
+  });
+
+  it("rejects with the provided message when the promise hangs", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const pending = withTimeout(new Promise(() => {}), 15000, "Repository analysis is taking too long.");
+
+      vi.advanceTimersByTime(15000);
+
+      await expect(pending).rejects.toThrow("Repository analysis is taking too long.");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/web/lib/promise/withTimeout.ts
+++ b/web/lib/promise/withTimeout.ts
@@ -1,0 +1,16 @@
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = globalThis.setTimeout(() => reject(new Error(message)), ms);
+
+    promise.then(
+      (value) => {
+        globalThis.clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        globalThis.clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -7,6 +7,7 @@ describe("backend proxy", () => {
     delete process.env.INTERNAL_API_URL;
     delete process.env.NEXT_PUBLIC_API_URL;
     delete process.env.PROMPTC_SERVER_API_KEY;
+    delete process.env.PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS;
   });
 
   afterEach(() => {
@@ -271,6 +272,45 @@ describe("backend proxy", () => {
 
     expect(url).toBe("https://api.memo.dev/agent-generator/generate");
     expect(proxiedHeaders.get("x-api-key")).toBe("server-secret");
+  });
+
+  it("returns a 504 with a timed-out diagnostic header when the upstream fetch hangs past the budget", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return new Promise((_, reject) => {
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }
+        // Never resolve — only the AbortSignal can end this promise.
+      });
+    });
+
+    const request = new Request("http://localhost:3000/repo-context/github", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo_url: "https://github.com/openai/openai-python" }),
+    });
+
+    const startedAt = Date.now();
+    const response = await proxyBackendRequest(request, "/repo-context/github", {
+      upstreamTimeoutMs: 100,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(504);
+    expect(response.headers.get("x-promptc-proxy-timed-out")).toBe("1");
+    expect(response.headers.get("x-promptc-proxy-attempts")).toBe("1");
+    expect(elapsedMs).toBeLessThan(2000);
+    await expect(response.json()).resolves.toEqual({
+      detail: "The backend did not respond within the upstream timeout. Please retry shortly.",
+    });
   });
 
   it("returns a 502 bad gateway when the upstream fetch throws a network error", async () => {

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -191,6 +191,25 @@ describe("backend proxy", () => {
     });
   });
 
+  it("drains request bodies before returning a protected-route config error", async () => {
+    const request = new Request("http://localhost:3000/repo-context/github", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo_url: "https://github.com/openai/openai-python" }),
+    });
+    const arrayBufferSpy = vi.spyOn(request, "arrayBuffer");
+
+    const response = await proxyBackendRequest(request, "/repo-context/github", {
+      requireServerApiKey: true,
+    });
+
+    expect(response.status).toBe(500);
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({
+      detail: "PROMPTC_SERVER_API_KEY is not configured on the web server.",
+    });
+  });
+
   it("allows protected routes with a caller-supplied x-api-key when server key is missing", async () => {
     process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -1,9 +1,25 @@
 const DEFAULT_BACKEND_API_BASE = "http://127.0.0.1:8080";
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 25_000;
 const CONFIG_ERROR_DETAIL = "PROMPTC_SERVER_API_KEY is not configured on the web server.";
 const NETWORK_ERROR_DETAIL =
   "The service is temporarily unavailable or still waking up. Please retry in a few seconds.";
+const TIMEOUT_ERROR_DETAIL =
+  "The backend did not respond within the upstream timeout. Please retry shortly.";
 const PROXY_ATTEMPTS_HEADER = "x-promptc-proxy-attempts";
 const PROXY_DURATION_HEADER = "x-promptc-proxy-duration-ms";
+const PROXY_TIMED_OUT_HEADER = "x-promptc-proxy-timed-out";
+
+function resolveUpstreamTimeoutMs(): number {
+  const raw = process.env.PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_UPSTREAM_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_UPSTREAM_TIMEOUT_MS;
+  return parsed;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}
 
 if (!process.env.PROMPTC_SERVER_API_KEY?.trim()) {
   console.warn("PROMPTC_SERVER_API_KEY not set - protected proxy routes will forward no API key");
@@ -26,6 +42,7 @@ type ProxyOptions = {
   networkRetryDelayMs?: number;
   requireServerApiKey?: boolean;
   retryNetworkErrors?: boolean;
+  upstreamTimeoutMs?: number;
 };
 
 function resolveServerApiKey(): string {
@@ -121,10 +138,13 @@ export async function proxyBackendRequest(
   const targetUrl = base + path;
   const retryAttempts = options.retryNetworkErrors ? Math.max(1, options.networkRetryAttempts ?? 3) : 1;
   const retryDelayMs = options.networkRetryDelayMs ?? 1000;
+  const upstreamTimeoutMs = options.upstreamTimeoutMs ?? resolveUpstreamTimeoutMs();
   const bufferedBody =
     !isBodylessMethod(request.method) && options.retryNetworkErrors ? await request.arrayBuffer() : null;
 
   for (let attempt = 0; attempt < retryAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), upstreamTimeoutMs);
     try {
       const init: RequestInit & { duplex?: "half" } = {
         method: request.method,
@@ -132,6 +152,7 @@ export async function proxyBackendRequest(
         body: isBodylessMethod(request.method) ? undefined : bufferedBody ?? request.body,
         cache: "no-store",
         redirect: "manual",
+        signal: controller.signal,
       };
       if (init.body && !bufferedBody) init.duplex = "half";
 
@@ -149,25 +170,42 @@ export async function proxyBackendRequest(
 
       return await cloneProxyResponse(upstreamResponse, attemptsUsed, durationMs);
     } catch (error) {
+      const timedOut = isAbortError(error);
       if (attempt === retryAttempts - 1) {
         const attemptsUsed = attempt + 1;
         const durationMs = Date.now() - requestStartedAt;
-        console.error("[backendProxy] upstream unavailable", {
+        const logLabel = timedOut ? "[backendProxy] upstream timed out" : "[backendProxy] upstream unavailable";
+        console.error(logLabel, {
           attempts: attemptsUsed,
           backendPath: path,
           durationMs,
+          upstreamTimeoutMs,
+          timedOut,
           error: error instanceof Error ? error.message : String(error),
         });
         const diagnosticHeaders = addProxyDiagnostics(new Headers(), attemptsUsed, durationMs);
-        return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502, headers: diagnosticHeaders });
+        if (timedOut) {
+          diagnosticHeaders.set(PROXY_TIMED_OUT_HEADER, "1");
+          return Response.json(
+            { detail: TIMEOUT_ERROR_DETAIL },
+            { status: 504, headers: diagnosticHeaders },
+          );
+        }
+        return Response.json(
+          { detail: NETWORK_ERROR_DETAIL },
+          { status: 502, headers: diagnosticHeaders },
+        );
       }
 
       console.warn("[backendProxy] retrying upstream request", {
         attempt: attempt + 1,
         backendPath: path,
         retryDelayMs: retryDelayMs * (attempt + 1),
+        timedOut,
       });
       await sleep(retryDelayMs * (attempt + 1));
+    } finally {
+      clearTimeout(timeoutHandle);
     }
   }
 

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -36,6 +36,15 @@ function isBodylessMethod(method: string): boolean {
   return method === "GET" || method === "HEAD";
 }
 
+async function drainRequestBody(request: Request): Promise<void> {
+  if (isBodylessMethod(request.method)) return;
+  try {
+    await request.arrayBuffer();
+  } catch {
+    // Best effort only; the response path should still complete even if draining fails.
+  }
+}
+
 function copyProxyHeaders(request: Request): Headers {
   const headers = new Headers();
 
@@ -98,6 +107,7 @@ export async function proxyBackendRequest(
   const callerApiKey = request.headers.get("x-api-key")?.trim() || "";
 
   if (options.requireServerApiKey && !serverApiKey && !callerApiKey) {
+    await drainRequestBody(request);
     return Response.json({ detail: CONFIG_ERROR_DETAIL }, { status: 500 });
   }
 


### PR DESCRIPTION
## Summary
- add a shallow public GitHub repo analysis endpoint for generator workflows
- pass optional `repo_context` through agent/skill generation and show a repo brief preview in the UI
- harden the Next proxy + generator pages so protected analyze requests do not get stuck in a perpetual loading state

## Testing
- `python -m pytest tests/test_repo_context.py tests/test_context_generation.py tests/test_skills_generator.py tests/test_api_hardening.py -q`
- `cd web && npm run test -- app/agent-generator/page.test.tsx app/skills-generator/page.test.tsx app/proxy-routes.test.ts lib/server/backendProxy.test.ts lib/promise/withTimeout.test.ts`
- `cd web && npm run build`

## Notes
- this is intentionally a lightweight MVP: no local clone, no recursive source scan, no branch/subdir/file URL support, and no separate LLM-powered repo analysis step
