### PR TITLE
feat(generators): tighten repo-context prompts and cache analyze results (Phase A)

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
@@ -22,11 +24,15 @@ def _get_compiler():
     return api_main.get_compiler()
 
 
+RepoContextMode = Literal["full", "compact"]
+
+
 class GitHubRepoContextPayload(BaseModel):
     normalized_repo_url: str = Field(..., min_length=1, max_length=500)
     repo_full_name: str = Field(..., min_length=1, max_length=255)
     default_branch: str | None = Field(default=None, max_length=255)
     summary: str = Field(..., min_length=1, max_length=1_500)
+    summary_compact: str | None = Field(default=None, max_length=400)
     highlights: list[str] = Field(default_factory=list, max_length=6)
     files_used: list[str] = Field(default_factory=list, max_length=6)
     detected_stack: list[str] = Field(default_factory=list, max_length=6)
@@ -43,6 +49,10 @@ class SkillGenRequest(BaseModel):
         description="Whether generated skill definition should include implementation example code",
     )
     repo_context: GitHubRepoContextPayload | None = None
+    repo_context_mode: RepoContextMode = Field(
+        default="full",
+        description="Whether to use the full or the compact repo brief in the generator prompt.",
+    )
 
 
 class SkillGenResponse(BaseModel):
@@ -54,6 +64,10 @@ class AgentGenRequest(BaseModel):
     multi_agent: bool = Field(default=False, description="Generate a multi-agent swarm if true")
     include_example_code: bool = Field(default=False, description="Include pseudo-code example")
     repo_context: GitHubRepoContextPayload | None = None
+    repo_context_mode: RepoContextMode = Field(
+        default="full",
+        description="Whether to use the full or the compact repo brief in the generator prompt.",
+    )
 
 
 class AgentGenResponse(BaseModel):
@@ -91,6 +105,7 @@ async def generate_skill_endpoint(
             req.description,
             include_example_code=req.include_example_code,
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
+            repo_context_mode=req.repo_context_mode,
         )
         return SkillGenResponse(skill_definition=result)
     except Exception as exc:
@@ -112,6 +127,7 @@ async def generate_agent_endpoint(
             multi_agent=req.multi_agent,
             include_example_code=req.include_example_code,
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
+            repo_context_mode=req.repo_context_mode,
         )
         return AgentGenResponse(system_prompt=result)
     except Exception as exc:

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+from cachetools import TTLCache
 
 
 GITHUB_API_BASE = "https://api.github.com"
@@ -24,6 +26,31 @@ MAX_HIGHLIGHTS = 6
 MAX_FILES_USED = 6
 MAX_STACK_ITEMS = 6
 SUMMARY_MAX_CHARS = 1200
+SUMMARY_COMPACT_MAX_CHARS = 280
+_REPO_CACHE_MAXSIZE = 128
+_REPO_CACHE_DEFAULT_TTL_SECONDS = 600
+
+
+def _resolve_repo_cache_ttl() -> int:
+    raw = os.environ.get("PROMPTC_REPO_CONTEXT_CACHE_TTL")
+    if raw is None or raw.strip() == "":
+        return _REPO_CACHE_DEFAULT_TTL_SECONDS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _REPO_CACHE_DEFAULT_TTL_SECONDS
+
+
+_REPO_CACHE: TTLCache[str, dict[str, Any]] | None = None
+_repo_cache_ttl = _resolve_repo_cache_ttl()
+if _repo_cache_ttl > 0:
+    _REPO_CACHE = TTLCache(maxsize=_REPO_CACHE_MAXSIZE, ttl=_repo_cache_ttl)
+
+
+def reset_repo_cache_for_tests() -> None:
+    global _REPO_CACHE
+    if _REPO_CACHE is not None:
+        _REPO_CACHE.clear()
 
 
 class InvalidGitHubRepoUrl(ValueError):
@@ -67,6 +94,20 @@ def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
     normalized_url = normalize_public_github_repo_url(repo_url)
     repo_full_name = normalized_url.replace("https://github.com/", "", 1)
 
+    if _REPO_CACHE is not None:
+        cached = _REPO_CACHE.get(repo_full_name)
+        if cached is not None:
+            return dict(cached)
+
+    payload = _fetch_public_github_repo_payload(normalized_url, repo_full_name)
+
+    if _REPO_CACHE is not None:
+        _REPO_CACHE[repo_full_name] = dict(payload)
+
+    return payload
+
+
+def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) -> dict[str, Any]:
     with httpx.Client(
         base_url=GITHUB_API_BASE,
         headers={
@@ -129,12 +170,18 @@ def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
             manifest_paths=list(manifests.keys()),
             readme_text=readme_text,
         )
+        summary_compact = _build_summary_compact(
+            repo_meta=repo_meta,
+            detected_stack=detected_stack,
+            top_level_dirs=top_level_dirs,
+        )
 
     return {
         "normalized_repo_url": normalized_url,
         "repo_full_name": repo_full_name,
         "default_branch": default_branch,
         "summary": summary,
+        "summary_compact": summary_compact,
         "highlights": highlights,
         "files_used": files_used,
         "detected_stack": detected_stack[:MAX_STACK_ITEMS],
@@ -327,6 +374,34 @@ def _build_summary(
     if len(summary) > SUMMARY_MAX_CHARS:
         summary = summary[: SUMMARY_MAX_CHARS - 3].rstrip() + "..."
     return summary
+
+
+def _build_summary_compact(
+    *,
+    repo_meta: dict[str, Any],
+    detected_stack: list[str],
+    top_level_dirs: list[str],
+) -> str:
+    repo_name = repo_meta.get("full_name") or "This repository"
+    description = (repo_meta.get("description") or "").strip()
+    stack_phrase = ", ".join(detected_stack[:3]) if detected_stack else "no detected stack signals"
+    shape = (
+        "multi-surface (frontend + backend dirs)"
+        if any(
+            name in {"web", "frontend", "backend", "api", "client", "server"}
+            for name in top_level_dirs
+        )
+        else "single-surface"
+    )
+    parts = [
+        f"{repo_name}: {description}" if description else f"{repo_name}.",
+        f"Stack: {stack_phrase}.",
+        f"Shape: {shape}.",
+    ]
+    compact = " ".join(part.strip() for part in parts if part.strip())
+    if len(compact) > SUMMARY_COMPACT_MAX_CHARS:
+        compact = compact[: SUMMARY_COMPACT_MAX_CHARS - 3].rstrip() + "..."
+    return compact
 
 
 def _extract_readme_signal(readme_text: str) -> str:

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -166,18 +166,72 @@ class WorkerClient:
         return f"<{tag}>\n<![CDATA[\n{safe_content}\n]]>\n</{tag}>"
 
     def _context_message(self, *, mode: str, context: Optional[Dict[str, Any]]) -> str:
-        payload = {
+        repo_context_block = ""
+        runtime_payload: Dict[str, Any] = {
             "mode": mode,
             **(
                 context
                 or {"retrieval_status": "empty", "retrieval_note": "No runtime context supplied."}
             ),
         }
+        repo_context = runtime_payload.pop("repo_context", None)
+        if isinstance(repo_context, dict):
+            repo_context_block = self._render_repo_context_block(repo_context) + "\n\n"
+
         return (
-            "<runtime_context>\n"
-            f"<context_json><![CDATA[\n{json.dumps(payload, ensure_ascii=False, indent=2)}\n]]></context_json>\n"
+            f"{repo_context_block}<runtime_context>\n"
+            f"<context_json><![CDATA[\n{json.dumps(runtime_payload, ensure_ascii=False, indent=2)}\n]]></context_json>\n"
             "</runtime_context>"
         )
+
+    def _render_repo_context_block(self, repo_context: Dict[str, Any]) -> str:
+        mode = str(repo_context.get("mode") or "full").strip().lower()
+        if mode not in {"full", "compact"}:
+            mode = "full"
+        repo_full_name = str(repo_context.get("repo_full_name") or "").strip()
+        normalized_url = str(repo_context.get("normalized_repo_url") or "").strip()
+        default_branch = str(repo_context.get("default_branch") or "").strip()
+        detected_stack = repo_context.get("detected_stack") or []
+        highlights = repo_context.get("highlights") or []
+        files_used = repo_context.get("files_used") or []
+        summary_full = str(repo_context.get("summary") or "").strip()
+        summary_compact = str(repo_context.get("summary_compact") or "").strip()
+        active_summary = summary_compact if mode == "compact" and summary_compact else summary_full
+
+        lines = [
+            "## Repo Context (ground truth)",
+            "Treat the facts in this section as the only verified information about the user's "
+            "repository. Only reference tools, APIs, file paths, manifests, or conventions that are "
+            "visible here. Do NOT invent libraries, endpoints, file paths, or capabilities that are "
+            "not listed below. If something is missing, mark it as a TODO or open question instead "
+            "of guessing.",
+            "",
+        ]
+        if repo_full_name:
+            lines.append(f"- Repo: {repo_full_name}")
+        if normalized_url:
+            lines.append(f"- URL: {normalized_url}")
+        if default_branch:
+            lines.append(f"- Default branch: {default_branch}")
+        if isinstance(detected_stack, list) and detected_stack:
+            lines.append(f"- Detected stack: {', '.join(str(item) for item in detected_stack)}")
+        if isinstance(files_used, list) and files_used:
+            lines.append(f"- Brief built from: {', '.join(str(item) for item in files_used)}")
+        if isinstance(highlights, list) and highlights:
+            lines.append("- Highlights:")
+            for item in highlights:
+                lines.append(f"  - {item}")
+        if active_summary:
+            lines.append("")
+            lines.append(f"### Repo brief ({mode})")
+            lines.append(active_summary)
+        lines.append("")
+        lines.append(
+            "Reminder: this brief is README + manifest level only. Do NOT make file-level "
+            'implementation claims (no "in `src/foo.py` we…" unless that file is listed in '
+            "'Brief built from'). Use TODO markers when uncertain."
+        )
+        return "\n".join(lines)
 
     def _single_agent_prompt(self, include_example_code: bool) -> str:
         prompt = (

--- a/app/llm_engine/hybrid.py
+++ b/app/llm_engine/hybrid.py
@@ -211,6 +211,7 @@ class HybridCompiler:
         multi_agent: bool = False,
         include_example_code: bool = False,
         repo_context: dict[str, Any] | None = None,
+        repo_context_mode: str = "full",
     ) -> str:
         """
         Generate a comprehensive AI Agent system prompt, aware of RAG context.
@@ -220,6 +221,7 @@ class HybridCompiler:
             rag_context = self._merge_generator_context(
                 self.context_strategist.process(text),
                 repo_context,
+                repo_context_mode,
             )
             return self.worker.generate_agent(
                 text,
@@ -236,6 +238,7 @@ class HybridCompiler:
         text: str,
         include_example_code: bool = False,
         repo_context: dict[str, Any] | None = None,
+        repo_context_mode: str = "full",
     ) -> str:
         """
         Generate a comprehensive AI Skill definition, aware of RAG context.
@@ -245,6 +248,7 @@ class HybridCompiler:
             rag_context = self._merge_generator_context(
                 self.context_strategist.process(text),
                 repo_context,
+                repo_context_mode,
             )
             return self.worker.generate_skill(
                 text,
@@ -257,13 +261,28 @@ class HybridCompiler:
 
     def _merge_generator_context(
         self,
-        rag_context: dict[str, Any] | None,
+        rag_context: Any,
         repo_context: dict[str, Any] | None,
-    ) -> dict[str, Any] | None:
-        merged: dict[str, Any] = dict(rag_context or {})
-        if repo_context:
-            merged["repo_context"] = {
-                "source": "github_public_repo",
-                **repo_context,
-            }
-        return merged or None
+        repo_context_mode: str = "full",
+    ) -> Any:
+        """
+        Merge an optional repo_context payload into the existing RAG context.
+
+        rag_context is whatever ``ContextStrategist.process`` returned and may be a
+        dict, a string, or None depending on configuration. When no repo_context
+        is supplied this method passes rag_context through unchanged so existing
+        non-dict callers keep working; only when wrapping repo_context do we coerce
+        rag_context into a dict.
+        """
+        if not repo_context:
+            return rag_context
+        merged: dict[str, Any] = dict(rag_context) if isinstance(rag_context, dict) else {}
+        mode = (repo_context_mode or "full").strip().lower()
+        if mode not in {"full", "compact"}:
+            mode = "full"
+        merged["repo_context"] = {
+            "source": "github_public_repo",
+            "mode": mode,
+            **repo_context,
+        }
+        return merged

--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -8,9 +8,18 @@ You may be provided with a **Project Context** (snippets of code, file structure
 - Use specific filenames, class names, and architectural patterns found in the context.
 - The "Tech Stack" should reflect the actual technologies detected in the project context.
 
+### Repo Context (ground truth)
+A `## Repo Context (ground truth)` section may appear BEFORE the runtime context. When present:
+- Treat it as the only verified information about the user's repository.
+- Anchor the generated `## Tech Stack` to the listed `Detected stack`. Do not add stack items that are not visible there. If the list is empty or missing, write `- TODO: stack not detected from repo metadata` instead of guessing.
+- Reference repo-level facts (repo name, default branch, top-level dirs) only when they appear in the block.
+- Do NOT make file-level claims (no "in `src/foo.py` we…") unless that file is listed in `Brief built from`.
+- The brief is README + manifest level only — it is a *project signal*, not a code audit. Treat anything not in the brief as unknown and use `TODO` markers.
+
 ## HONESTY & RELIABILITY RULES
 - Never invent dependencies, SDKs, utilities, or modules that are not present in the provided context.
 - Never invent API contracts (fields, request/response JSON keys, or privileged write operations) when the exact shape is unknown.
+- Never invent tool names, capability labels, or integration endpoints. If the user request implies a tool but no concrete name is verifiable from context, use a clearly-named placeholder (e.g. `external_search_tool`) and add a `TODO` comment explaining what real tool/library name to substitute.
 - For uncertain implementation details, use pseudo-code and explicit `TODO` comments.
 - Do not present speculative integrations as production-ready code.
 - Self-Verification is mandatory, not optional. If any check fails, fix the response or surface the gap explicitly — do not silently ship.
@@ -78,6 +87,7 @@ The output must strictly follow this Markdown structure:
 [A 3–5 item checklist the agent runs BEFORE sending its final response. Each item must be observable, not aspirational. Tailor to the agent's purpose.]
 - [ ] Does the response answer every part of the user's question?
 - [ ] Are all referenced files / APIs / functions ones that exist in the provided context?
+- [ ] If a `## Repo Context (ground truth)` block was provided, does my Tech Stack match its `Detected stack` and do I avoid claims about files not listed in `Brief built from`?
 - [ ] Are TODO markers used wherever I'm uncertain, instead of fabricated detail?
 - [ ] If I called tools, did each call use parameters drawn from the request — not invented?
 - [ ] Have I met the Stop Conditions, or do I need to continue / escalate?

--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -14,6 +14,18 @@ You are an Expert AI Systems Architect specializing in Multi-Agent Systems (MAS)
 - If Project Context is provided, assign specific files or architectural components to the most relevant agent.
 - Ensure agents share a common understanding of the tech stack.
 
+### Repo Context (ground truth)
+A `## Repo Context (ground truth)` section may appear BEFORE the runtime context. When present:
+- Treat it as the only verified information about the user's repository.
+- Each agent's `## Tech Stack` must align with the listed `Detected stack` — do not split agents along technologies that the brief does not show. If the brief lists Python only, do not invent a "Frontend Engineer (React)" agent unless the user's mission explicitly demands it.
+- Do NOT make file-level handoff claims (no "Agent 2 reads `src/foo.py`") unless that file is listed in `Brief built from`.
+- The brief is README + manifest level only. Anything not in it is unknown — use `TODO` markers, do not invent module names, endpoints, or class boundaries.
+
+## HONESTY & RELIABILITY RULES
+- Never invent technologies, libraries, or APIs beyond what the brief shows.
+- Never invent inter-agent message schemas that reference fictional fields. Handoff arrows must reference shapes you actually declared in `## Outputs`.
+- For uncertain implementation details, mark them with `TODO` rather than fabricating confident detail.
+
 ## OUTPUT STRUCTURE
 Begin the entire output with a single topology declaration blockquote:
 > **Topology:** orchestrator-worker | peer-pipeline — [one sentence: why this topology fits the mission]

--- a/app/llm_engine/prompts/skills_generator.md
+++ b/app/llm_engine/prompts/skills_generator.md
@@ -8,6 +8,19 @@ You may be provided with a **Project Context** (snippets of code, file structure
 - Use specific types, classes, and helper functions found in the context for the "Input Schema" and "Implementation".
 - Align the "Dependencies" with the project's existing dependencies (e.g., if they use `httpx`, don't suggest `requests` unless necessary).
 
+### Repo Context (ground truth)
+A `## Repo Context (ground truth)` section may appear BEFORE the runtime context. When present:
+- Treat it as the only verified information about the user's repository.
+- Anchor `## Dependencies` to the listed `Detected stack`. Do not introduce libraries that contradict that stack. If the brief says Python, do not suggest Node-only tools, and vice versa. If the stack is empty, write `- TODO: dependencies not detected from repo metadata` rather than guessing.
+- Do NOT make file-level claims (no "use `src/foo.py`'s helper") unless that file is listed in `Brief built from`.
+- The brief is README + manifest level only. Treat anything not visible in the brief as unknown — use `TODO` markers, never invent class names, function names, or module paths.
+
+## HONESTY & RELIABILITY RULES
+- Never invent libraries, modules, or APIs that are not present in the provided context.
+- Never invent function or class names from the user's project; if you need to reference one, mark it as `TODO` with a placeholder name.
+- For uncertain details, prefer pseudo-code and explicit `TODO` comments over confident-looking guesses.
+- The skill must be idempotent and the Examples section must use inputs/outputs you can defend from the schema you defined — no decorative made-up payload values that imply data the schema does not allow.
+
 ## INSTRUCTIONS
 1. Analyze the user's request (the "Capability" or "Task") and any provided Project Context.
 2. Design a specialized AI Skill to fulfill this request, compatible with the project's codebase.

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -106,7 +106,11 @@ def test_api_generate_agent_endpoint():
         assert response.status_code == 200
         assert response.json() == {"system_prompt": "# Mock API Agent"}
         mock_compiler.generate_agent.assert_called_with(
-            "Test Agent Request", multi_agent=False, include_example_code=False
+            "Test Agent Request",
+            multi_agent=False,
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
 
@@ -123,7 +127,11 @@ def test_api_generate_agent_endpoint_with_example_code_enabled():
         assert response.status_code == 200
         assert response.json() == {"system_prompt": "# Mock API Agent"}
         mock_compiler.generate_agent.assert_called_with(
-            "Test Agent Request", multi_agent=False, include_example_code=True
+            "Test Agent Request",
+            multi_agent=False,
+            include_example_code=True,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
 

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -6,6 +6,54 @@ from api.main import app
 from fastapi.testclient import TestClient
 
 
+REPO_CONTEXT_FOR_RENDER = {
+    "source": "github_public_repo",
+    "mode": "full",
+    "normalized_repo_url": "https://github.com/openai/openai-python",
+    "repo_full_name": "openai/openai-python",
+    "default_branch": "main",
+    "summary": "Python SDK repo full summary content.",
+    "summary_compact": "Python SDK repo compact summary content.",
+    "highlights": ["Python package", "README present"],
+    "files_used": ["README.md", "pyproject.toml"],
+    "detected_stack": ["Python", "httpx"],
+}
+
+
+def test_context_message_renders_repo_context_as_ground_truth_block():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    message = client._context_message(
+        mode="generator",
+        context={"repo_context": REPO_CONTEXT_FOR_RENDER},
+    )
+    assert message.startswith("## Repo Context (ground truth)")
+    assert "openai/openai-python" in message
+    assert "Detected stack: Python, httpx" in message
+    assert "Brief built from: README.md, pyproject.toml" in message
+    # Full mode picks the full summary, compact summary stays out
+    assert "Python SDK repo full summary content." in message
+    assert "Python SDK repo compact summary content." not in message
+    # repo_context is removed from runtime_context to avoid duplication
+    assert "<runtime_context>" in message
+    assert "repo_context" not in message.split("<runtime_context>")[1]
+
+
+def test_context_message_compact_mode_uses_compact_summary():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    repo_context = {**REPO_CONTEXT_FOR_RENDER, "mode": "compact"}
+    message = client._context_message(
+        mode="generator",
+        context={"repo_context": repo_context},
+    )
+    assert "Python SDK repo compact summary content." in message
+    assert "Python SDK repo full summary content." not in message
+    assert "### Repo brief (compact)" in message
+
+
 # Mock WorkerClient to avoid API calls
 @pytest.fixture
 def mock_worker_client():
@@ -63,6 +111,7 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
             "file1.py": "content",
             "repo_context": {
                 "source": "github_public_repo",
+                "mode": "full",
                 **repo_context,
             },
         },
@@ -79,11 +128,18 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
             "file1.py": "content",
             "repo_context": {
                 "source": "github_public_repo",
+                "mode": "full",
                 **repo_context,
             },
         },
         include_example_code=False,
     )
+
+    # Test compact mode threads through to the merged context.
+    mock_worker_client.generate_agent.reset_mock()
+    compiler.generate_agent("Test Agent", repo_context=repo_context, repo_context_mode="compact")
+    _, agent_kwargs = mock_worker_client.generate_agent.call_args
+    assert agent_kwargs["context"]["repo_context"]["mode"] == "compact"
 
 
 def test_api_endpoints_integration():
@@ -104,6 +160,9 @@ def test_api_endpoints_integration():
             "detected_stack": ["Python"],
         }
 
+        # Pydantic adds the optional summary_compact field on round-trip
+        normalized_repo_context = {**repo_context, "summary_compact": None}
+
         # Test Agent Generator Endpoint
         resp_agent = client.post(
             "/agent-generator/generate",
@@ -115,18 +174,24 @@ def test_api_endpoints_integration():
             "Test Agent",
             multi_agent=False,
             include_example_code=False,
-            repo_context=repo_context,
+            repo_context=normalized_repo_context,
+            repo_context_mode="full",
         )
 
-        # Test Skills Generator Endpoint
+        # Test Skills Generator Endpoint, exercising compact mode through the API
         resp_skill = client.post(
             "/skills-generator/generate",
-            json={"description": "Test Skill", "repo_context": repo_context},
+            json={
+                "description": "Test Skill",
+                "repo_context": repo_context,
+                "repo_context_mode": "compact",
+            },
         )
         assert resp_skill.status_code == 200
         assert resp_skill.json() == {"skill_definition": "# Mock API Skill"}
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill",
             include_example_code=False,
-            repo_context=repo_context,
+            repo_context=normalized_repo_context,
+            repo_context_mode="compact",
         )

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -42,13 +42,21 @@ def test_api_multi_agent_flag():
         # Test Default (False)
         client.post("/agent-generator/generate", json={"description": "Test"})
         mock_compiler.generate_agent.assert_called_with(
-            "Test", multi_agent=False, include_example_code=False
+            "Test",
+            multi_agent=False,
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
         # Test True
         client.post("/agent-generator/generate", json={"description": "Test", "multi_agent": True})
         mock_compiler.generate_agent.assert_called_with(
-            "Test", multi_agent=True, include_example_code=False
+            "Test",
+            multi_agent=True,
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
         )
 
 

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -4,7 +4,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
-from app.github_repo_context import InvalidGitHubRepoUrl, normalize_public_github_repo_url
+from app.github_repo_context import (
+    InvalidGitHubRepoUrl,
+    _build_summary_compact,
+    analyze_public_github_repo,
+    normalize_public_github_repo_url,
+    reset_repo_cache_for_tests,
+)
 
 
 client = TestClient(app)
@@ -32,6 +38,95 @@ def test_normalize_public_github_repo_url_rejects_non_root_variants(repo_url: st
         normalize_public_github_repo_url(repo_url)
 
 
+def test_build_summary_compact_truncates_to_budget():
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Official Python SDK for the OpenAI API.",
+    }
+    compact = _build_summary_compact(
+        repo_meta=repo_meta,
+        detected_stack=["Python", "httpx", "pydantic"],
+        top_level_dirs=["src", "tests"],
+    )
+    assert compact.startswith("openai/openai-python:")
+    assert "Python" in compact
+    assert len(compact) <= 280
+
+
+def test_build_summary_compact_handles_missing_metadata():
+    compact = _build_summary_compact(
+        repo_meta={},
+        detected_stack=[],
+        top_level_dirs=[],
+    )
+    assert "no detected stack" in compact
+    assert "single-surface" in compact
+
+
+def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
+    reset_repo_cache_for_tests()
+
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Python SDK for OpenAI.",
+        "default_branch": "main",
+        "language": "Python",
+    }
+    root_entries = [
+        {"name": "README.md", "path": "README.md", "type": "file", "download_url": "rd"},
+        {"name": "pyproject.toml", "path": "pyproject.toml", "type": "file", "download_url": "py"},
+    ]
+
+    call_log: list[str] = []
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/openai/openai-python"):
+                return FakeResponse(repo_meta)
+            if path.endswith("/repos/openai/openai-python/contents"):
+                return FakeResponse(root_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# OpenAI Python\n\nOfficial SDK.")
+            if path == "py":
+                return FakeResponse(None, text="[project]\nname='openai'\n")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+
+    first = analyze_public_github_repo("https://github.com/openai/openai-python")
+    second = analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert first == second
+    assert "summary_compact" in first and first["summary_compact"]
+    assert (
+        call_log.count("/repos/openai/openai-python") == 1
+    ), f"expected GitHub API to be hit once, got call log: {call_log}"
+
+    reset_repo_cache_for_tests()
+
+
 def test_repo_context_endpoint_returns_analyzed_repo_summary():
     mock_payload = {
         "normalized_repo_url": "https://github.com/openai/openai-python",
@@ -52,5 +147,6 @@ def test_repo_context_endpoint_returns_analyzed_repo_summary():
         )
 
     assert response.status_code == 200
-    assert response.json() == mock_payload
+    # Response model adds summary_compact (defaults to None when analyzer omits it).
+    assert response.json() == {**mock_payload, "summary_compact": None}
     mock_analyze.assert_called_once_with("https://github.com/openai/openai-python")

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -51,6 +51,7 @@ def test_hybrid_compiler_generate_skill(mock_worker_client):
     assert kwargs["include_example_code"] is False
     assert kwargs["context"]["repo_context"] == {
         "source": "github_public_repo",
+        "mode": "full",
         **repo_context,
     }
 
@@ -80,7 +81,8 @@ def test_api_generate_skill_endpoint():
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=False,
-            repo_context=repo_context,
+            repo_context={**repo_context, "summary_compact": None},
+            repo_context_mode="full",
         )
 
 
@@ -100,6 +102,7 @@ def test_api_generate_skill_endpoint_with_example_code_enabled():
             "Test Skill Request",
             include_example_code=True,
             repo_context=None,
+            repo_context_mode="full",
         )
 
 


### PR DESCRIPTION
## Summary
Phase A of the [PR #552 follow-up plan](https://github.com/madara88645/Compiler/pull/552#issuecomment-): tighten generator prompts so the repo brief is treated as ground truth, render that brief as a delimited markdown section instead of burying it in JSON context, cache analyzer responses, and expose a compact-brief mode for small models.

This PR **stacks on top of #552** — it targets `codex/repo-aware-generator-mvp` so its diff stays focused on Phase A. Once #552 merges to `main`, this PR will auto-rebase to just the Phase A changes.

## What changed
- **Prompt fidelity (gaps 1, 8)** — `agent_generator.md`, `skills_generator.md`, `multi_agent_planner.md` now have a "Repo Context (ground truth)" subsection plus tightened HONESTY rules. Generated Tech Stack is bound to `detected_stack`; file-level claims about files not listed in `Brief built from` are forbidden; new self-verification checkbox enforces this.
- **Prompt rendering (gap 1)** — `WorkerClient._context_message` lifts `repo_context` out of the JSON `<runtime_context>` block and renders it as a clearly delimited `## Repo Context (ground truth)` markdown section. Smaller models pick up the framing far more reliably than nested JSON keys.
- **Compact brief (gap 7)** — Analyzer now returns `summary_compact` (≤ 280 chars). New `repo_context_mode: "full" | "compact"` field on `SkillGenRequest`/`AgentGenRequest` (defaults to `"full"`, no behavior change for existing callers).
- **Caching (gap 4)** — Module-level `TTLCache(maxsize=128, ttl=600)` keyed on `repo_full_name`, env-overridable via `PROMPTC_REPO_CONTEXT_CACHE_TTL` (`0` to disable). Reduces GitHub API churn under load.

## Side-fix included
PR #552 introduced `_merge_generator_context` with `dict(rag_context or {})` — that crashes when `ContextStrategist.process` returns a non-dict (e.g. a string). Six pre-existing tests (`test_hybrid::test_generate_agent_success`, `test_generate_skill_success`, `test_multi_agent::test_hybrid_compiler_multi_agent`, `test_api_multi_agent_flag`, `test_agent_generator::test_api_generate_agent_endpoint*`) silently regressed because the targeted suite #552 ran didn't cover those code paths.

The merger now passes `rag_context` through unchanged when no `repo_context` is supplied, restoring pre-#552 behavior on that path. All six tests pass on this branch.

## Test plan
- [x] `python -m pytest tests/test_repo_context.py tests/test_context_generation.py tests/test_skills_generator.py tests/test_api_hardening.py tests/test_agent_generator.py tests/test_multi_agent.py tests/test_hybrid.py -q` → 53 passed
- [x] Pre-commit (ruff + ruff-format) clean
- [x] New tests added: `_build_summary_compact` budget + missing-metadata, cache hit assertion, repo block render assertion (full + compact modes)
- [ ] Manual smoke once merged: hit `/repo-context/github` twice for the same URL, second call should not hit GitHub API (verifiable via PROMPTC_REPO_CONTEXT_CACHE_TTL or by tail-logging the httpx client)

## Operator-facing knobs
- `PROMPTC_REPO_CONTEXT_CACHE_TTL` (env, seconds; default 600; set `0` to disable cache).
- `repo_context_mode` (request body field; defaults to `"full"`).

## Locked plan decisions (from approved plan)
- 3 separate PRs (A, B, C). This is **A**.
- Compact-brief: knob exposed only — no auto-pick by model size yet.
- Authenticated GitHub: deferred to **Phase B**.

## Out of scope (Phase B / C)
- Authenticated GitHub requests (`PROMPTC_GITHUB_TOKEN`) — Phase B.
- Server-side proxy upstream timeout (`backendProxy.ts`) — Phase B.
- Structured analyze-failure telemetry — Phase B.
- Branch / subdir URL acceptance — Phase C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
