### PR TITLE
feat(generators): add GitHub auth, proxy timeout, and analyze telemetry (Phase B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ Prompt Compiler is a FastAPI + Next.js product that turns vague requests into st
 - Frontend tests: `cd web && npm run test`
 - Frontend build: `cd web && npm run build`
 
+## Server-side environment variables
+The Next-side proxy and the backend each need their own keys; keep them out of the bundled JS.
+
+| Env var | Side | Purpose |
+| --- | --- | --- |
+| `PROMPTC_SERVER_API_KEY` | Next.js | Forwarded as `x-api-key` to protected backend routes (generators, analyze). Without it, protected proxy routes return 500. |
+| `PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS` | Next.js | Hard upstream-fetch timeout for the proxy (default 25000). Aborts a stuck backend connection with a 504 instead of hanging the route forever. |
+| `PROMPTC_GITHUB_TOKEN` (or `GITHUB_TOKEN`) | Backend | Optional. When set, the public-repo analyzer adds `Authorization: Bearer <token>` to GitHub requests, raising the rate limit from 60 req/h (anonymous) to 5000 req/h. |
+| `PROMPTC_REPO_CONTEXT_CACHE_TTL` | Backend | Repo-brief cache TTL in seconds (default 600). Set to `0` to disable the in-memory cache. |
+
 ## Domain Concepts
 - Conservative mode should avoid hallucinated requirements and fake APIs.
 - Export surfaces should feel executable, not just prompt-pretty.

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import time
 from typing import Literal
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -12,6 +14,43 @@ from app.github_repo_context import (
     InvalidGitHubRepoUrl,
     analyze_public_github_repo,
 )
+
+
+def _safe_repo_full_name(repo_url: str) -> str | None:
+    try:
+        parsed = urlparse((repo_url or "").strip())
+        if parsed.netloc.lower() != "github.com":
+            return None
+        segments = [seg for seg in parsed.path.split("/") if seg]
+        if len(segments) < 2:
+            return None
+        return f"{segments[0]}/{segments[1]}"
+    except Exception:
+        return None
+
+
+def _log_repo_analyze_outcome(
+    *,
+    outcome: str,
+    repo_url: str,
+    started_at: float,
+    repo_full_name: str | None = None,
+    status_code: int | None = None,
+    error_message: str | None = None,
+) -> None:
+    duration_ms = round((time.monotonic() - started_at) * 1000, 2)
+    extra = {
+        "event": "repo_analyze",
+        "outcome": outcome,
+        "repo_full_name": repo_full_name or _safe_repo_full_name(repo_url),
+        "duration_ms": duration_ms,
+    }
+    if status_code is not None:
+        extra["status_code"] = status_code
+    if error_message:
+        extra["error_message"] = error_message
+    logger.info("repo_analyze outcome=%s", outcome, extra=extra)
+
 
 router = APIRouter(tags=["generators"])
 
@@ -80,16 +119,48 @@ async def analyze_github_repo_endpoint(
     api_key: APIKey = Depends(verify_api_key),
 ):
     del api_key
+    started_at = time.monotonic()
 
     try:
-        return GitHubRepoContextPayload.model_validate(analyze_public_github_repo(req.repo_url))
+        payload = analyze_public_github_repo(req.repo_url)
     except InvalidGitHubRepoUrl as exc:
+        _log_repo_analyze_outcome(
+            outcome="invalid_url",
+            repo_url=req.repo_url,
+            started_at=started_at,
+            status_code=400,
+            error_message=str(exc),
+        )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except GitHubRepoAnalysisError as exc:
+        outcome = "not_found" if exc.status_code == 404 else "upstream_error"
+        _log_repo_analyze_outcome(
+            outcome=outcome,
+            repo_url=req.repo_url,
+            started_at=started_at,
+            status_code=exc.status_code,
+            error_message=str(exc),
+        )
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
     except Exception as exc:
         logger.exception("github repo analysis failed")
+        _log_repo_analyze_outcome(
+            outcome="internal_error",
+            repo_url=req.repo_url,
+            started_at=started_at,
+            status_code=500,
+            error_message=str(exc),
+        )
         raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
+
+    _log_repo_analyze_outcome(
+        outcome="ok",
+        repo_url=req.repo_url,
+        started_at=started_at,
+        repo_full_name=payload.get("repo_full_name") if isinstance(payload, dict) else None,
+        status_code=200,
+    )
+    return GitHubRepoContextPayload.model_validate(payload)
 
 
 @router.post("/skills-generator/generate", response_model=SkillGenResponse)

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -107,13 +107,31 @@ def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
     return payload
 
 
+def _resolve_github_token() -> str | None:
+    for env_name in ("PROMPTC_GITHUB_TOKEN", "GITHUB_TOKEN"):
+        raw = os.environ.get(env_name)
+        if raw:
+            stripped = raw.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def _build_github_request_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "promptc-repo-context/1.0",
+    }
+    token = _resolve_github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
 def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) -> dict[str, Any]:
     with httpx.Client(
         base_url=GITHUB_API_BASE,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "promptc-repo-context/1.0",
-        },
+        headers=_build_github_request_headers(),
         timeout=10.0,
         follow_redirects=True,
     ) as client:

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
 from app.github_repo_context import (
+    GitHubRepoAnalysisError,
     InvalidGitHubRepoUrl,
     _build_summary_compact,
     analyze_public_github_repo,
@@ -125,6 +127,131 @@ def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
     ), f"expected GitHub API to be hit once, got call log: {call_log}"
 
     reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_forwards_promptc_github_token(monkeypatch):
+    reset_repo_cache_for_tests()
+    monkeypatch.setenv("PROMPTC_GITHUB_TOKEN", "ghp_test_token")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    captured_headers: dict[str, str] = {}
+
+    class HeaderCapturingClient:
+        def __init__(self, *args, **kwargs):
+            captured_headers.update(dict(kwargs.get("headers") or {}))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            raise httpx.HTTPError("stop after header capture")
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", HeaderCapturingClient)
+
+    with pytest.raises(GitHubRepoAnalysisError):
+        analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert captured_headers.get("Authorization") == "Bearer ghp_test_token"
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_omits_authorization_when_no_token(monkeypatch):
+    reset_repo_cache_for_tests()
+    monkeypatch.delenv("PROMPTC_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    captured_headers: dict[str, str] = {}
+
+    class HeaderCapturingClient:
+        def __init__(self, *args, **kwargs):
+            captured_headers.update(dict(kwargs.get("headers") or {}))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            raise httpx.HTTPError("stop after header capture")
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", HeaderCapturingClient)
+
+    with pytest.raises(GitHubRepoAnalysisError):
+        analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert "Authorization" not in captured_headers
+    reset_repo_cache_for_tests()
+
+
+def _enable_promptc_api_log_capture(caplog):
+    import logging
+
+    caplog.set_level(logging.INFO, logger="promptc.api")
+    logger = logging.getLogger("promptc.api")
+    previous_propagate = logger.propagate
+    logger.propagate = True
+    return previous_propagate
+
+
+def _restore_promptc_api_log_capture(previous_propagate):
+    import logging
+
+    logging.getLogger("promptc.api").propagate = previous_propagate
+
+
+def test_repo_context_endpoint_emits_ok_telemetry(caplog):
+    mock_payload = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repo with README-led overview and manifest-derived stack.",
+        "highlights": ["Python package", "README present"],
+        "files_used": ["README.md", "pyproject.toml"],
+        "detected_stack": ["Python", "httpx"],
+    }
+
+    previous_propagate = _enable_promptc_api_log_capture(caplog)
+    try:
+        with patch("api.routes.generators.analyze_public_github_repo", return_value=mock_payload):
+            response = client.post(
+                "/repo-context/github",
+                json={"repo_url": "https://github.com/openai/openai-python"},
+            )
+    finally:
+        _restore_promptc_api_log_capture(previous_propagate)
+
+    assert response.status_code == 200
+
+    analyze_records = [r for r in caplog.records if getattr(r, "event", None) == "repo_analyze"]
+    assert analyze_records, "expected at least one repo_analyze structured log record"
+    record = analyze_records[-1]
+    assert record.outcome == "ok"
+    assert record.repo_full_name == "openai/openai-python"
+    assert record.status_code == 200
+    assert isinstance(record.duration_ms, (int, float))
+
+
+def test_repo_context_endpoint_emits_invalid_url_telemetry(caplog):
+    previous_propagate = _enable_promptc_api_log_capture(caplog)
+    try:
+        response = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://gitlab.com/openai/openai-python"},
+        )
+    finally:
+        _restore_promptc_api_log_capture(previous_propagate)
+
+    assert response.status_code == 400
+
+    analyze_records = [r for r in caplog.records if getattr(r, "event", None) == "repo_analyze"]
+    assert analyze_records, "expected an invalid_url telemetry record"
+    record = analyze_records[-1]
+    assert record.outcome == "invalid_url"
+    assert record.status_code == 400
 
 
 def test_repo_context_endpoint_returns_analyzed_repo_summary():

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -7,6 +7,7 @@ describe("backend proxy", () => {
     delete process.env.INTERNAL_API_URL;
     delete process.env.NEXT_PUBLIC_API_URL;
     delete process.env.PROMPTC_SERVER_API_KEY;
+    delete process.env.PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS;
   });
 
   afterEach(() => {
@@ -271,6 +272,45 @@ describe("backend proxy", () => {
 
     expect(url).toBe("https://api.memo.dev/agent-generator/generate");
     expect(proxiedHeaders.get("x-api-key")).toBe("server-secret");
+  });
+
+  it("returns a 504 with a timed-out diagnostic header when the upstream fetch hangs past the budget", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return new Promise((_, reject) => {
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        }
+        // Never resolve — only the AbortSignal can end this promise.
+      });
+    });
+
+    const request = new Request("http://localhost:3000/repo-context/github", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo_url: "https://github.com/openai/openai-python" }),
+    });
+
+    const startedAt = Date.now();
+    const response = await proxyBackendRequest(request, "/repo-context/github", {
+      upstreamTimeoutMs: 100,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(504);
+    expect(response.headers.get("x-promptc-proxy-timed-out")).toBe("1");
+    expect(response.headers.get("x-promptc-proxy-attempts")).toBe("1");
+    expect(elapsedMs).toBeLessThan(2000);
+    await expect(response.json()).resolves.toEqual({
+      detail: "The backend did not respond within the upstream timeout. Please retry shortly.",
+    });
   });
 
   it("returns a 502 bad gateway when the upstream fetch throws a network error", async () => {

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -1,9 +1,25 @@
 const DEFAULT_BACKEND_API_BASE = "http://127.0.0.1:8080";
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 25_000;
 const CONFIG_ERROR_DETAIL = "PROMPTC_SERVER_API_KEY is not configured on the web server.";
 const NETWORK_ERROR_DETAIL =
   "The service is temporarily unavailable or still waking up. Please retry in a few seconds.";
+const TIMEOUT_ERROR_DETAIL =
+  "The backend did not respond within the upstream timeout. Please retry shortly.";
 const PROXY_ATTEMPTS_HEADER = "x-promptc-proxy-attempts";
 const PROXY_DURATION_HEADER = "x-promptc-proxy-duration-ms";
+const PROXY_TIMED_OUT_HEADER = "x-promptc-proxy-timed-out";
+
+function resolveUpstreamTimeoutMs(): number {
+  const raw = process.env.PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_UPSTREAM_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_UPSTREAM_TIMEOUT_MS;
+  return parsed;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}
 
 if (!process.env.PROMPTC_SERVER_API_KEY?.trim()) {
   console.warn("PROMPTC_SERVER_API_KEY not set - protected proxy routes will forward no API key");
@@ -26,6 +42,7 @@ type ProxyOptions = {
   networkRetryDelayMs?: number;
   requireServerApiKey?: boolean;
   retryNetworkErrors?: boolean;
+  upstreamTimeoutMs?: number;
 };
 
 function resolveServerApiKey(): string {
@@ -121,10 +138,13 @@ export async function proxyBackendRequest(
   const targetUrl = base + path;
   const retryAttempts = options.retryNetworkErrors ? Math.max(1, options.networkRetryAttempts ?? 3) : 1;
   const retryDelayMs = options.networkRetryDelayMs ?? 1000;
+  const upstreamTimeoutMs = options.upstreamTimeoutMs ?? resolveUpstreamTimeoutMs();
   const bufferedBody =
     !isBodylessMethod(request.method) && options.retryNetworkErrors ? await request.arrayBuffer() : null;
 
   for (let attempt = 0; attempt < retryAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), upstreamTimeoutMs);
     try {
       const init: RequestInit & { duplex?: "half" } = {
         method: request.method,
@@ -132,6 +152,7 @@ export async function proxyBackendRequest(
         body: isBodylessMethod(request.method) ? undefined : bufferedBody ?? request.body,
         cache: "no-store",
         redirect: "manual",
+        signal: controller.signal,
       };
       if (init.body && !bufferedBody) init.duplex = "half";
 
@@ -149,25 +170,42 @@ export async function proxyBackendRequest(
 
       return await cloneProxyResponse(upstreamResponse, attemptsUsed, durationMs);
     } catch (error) {
+      const timedOut = isAbortError(error);
       if (attempt === retryAttempts - 1) {
         const attemptsUsed = attempt + 1;
         const durationMs = Date.now() - requestStartedAt;
-        console.error("[backendProxy] upstream unavailable", {
+        const logLabel = timedOut ? "[backendProxy] upstream timed out" : "[backendProxy] upstream unavailable";
+        console.error(logLabel, {
           attempts: attemptsUsed,
           backendPath: path,
           durationMs,
+          upstreamTimeoutMs,
+          timedOut,
           error: error instanceof Error ? error.message : String(error),
         });
         const diagnosticHeaders = addProxyDiagnostics(new Headers(), attemptsUsed, durationMs);
-        return Response.json({ detail: NETWORK_ERROR_DETAIL }, { status: 502, headers: diagnosticHeaders });
+        if (timedOut) {
+          diagnosticHeaders.set(PROXY_TIMED_OUT_HEADER, "1");
+          return Response.json(
+            { detail: TIMEOUT_ERROR_DETAIL },
+            { status: 504, headers: diagnosticHeaders },
+          );
+        }
+        return Response.json(
+          { detail: NETWORK_ERROR_DETAIL },
+          { status: 502, headers: diagnosticHeaders },
+        );
       }
 
       console.warn("[backendProxy] retrying upstream request", {
         attempt: attempt + 1,
         backendPath: path,
         retryDelayMs: retryDelayMs * (attempt + 1),
+        timedOut,
       });
       await sleep(retryDelayMs * (attempt + 1));
+    } finally {
+      clearTimeout(timeoutHandle);
     }
   }
 


### PR DESCRIPTION
﻿## Summary

- **B1 - GitHub token auth**: Reads `PROMPTC_GITHUB_TOKEN` (fallback `GITHUB_TOKEN`) and injects `Authorization: Bearer <token>` on all GitHub API requests inside `analyze_public_github_repo`. Unauthenticated path still works; when a token is present the rate limit rises from 60 to 5000 req/h.
- **B2 - Server-side fetch timeout**: Every upstream `fetch` in `proxyBackendRequest` now runs under an `AbortController` with a 25 s budget (override via `PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS`). Timed-out requests return **504** with `x-promptc-proxy-timed-out: 1`; plain network errors keep returning **502**. This makes `withTimeout.ts` defense-in-depth instead of the only safeguard.
- **B3 - Structured analyze telemetry**: Replaced the bare `logger.exception` in `analyze_github_repo_endpoint` with `extra=`-keyed records covering all five outcome branches (`ok`, `invalid_url`, `not_found`, `upstream_error`, `internal_error`). Fields: `event`, `outcome`, `repo_full_name`, `duration_ms`, `status_code`.
- **B4 - Operational docs**: Added a server-side environment variable table to `CLAUDE.md` documenting `PROMPTC_SERVER_API_KEY`, `PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS`, `PROMPTC_GITHUB_TOKEN`, and `PROMPTC_REPO_CONTEXT_CACHE_TTL`.

## Test plan

- [ ] `python -m pytest tests/test_repo_context.py -q` - 15 tests, all passing (token present, token absent, cache hit assertions)
- [ ] `cd web && npm run test -- lib/server/backendProxy.test.ts` - 13 tests, all passing (504 timeout, 502 network error, retry, drain-body, API-key injection/override)
- [ ] Manual: set `PROMPTC_PROXY_UPSTREAM_TIMEOUT_MS=2000`, point backend at a black-hole port, confirm page surfaces a 502 within ~3 s instead of hanging
- [ ] Manual: set `PROMPTC_GITHUB_TOKEN=<pat>`, hit `/repo-context/github`, confirm `Authorization` header is forwarded

Generated with [Claude Code](https://claude.com/claude-code)
