### PR TITLE
feat(generators): accept branch/subdir URLs and deeper README pickup (Phase C)

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -69,6 +69,8 @@ RepoContextMode = Literal["full", "compact"]
 class GitHubRepoContextPayload(BaseModel):
     normalized_repo_url: str = Field(..., min_length=1, max_length=500)
     repo_full_name: str = Field(..., min_length=1, max_length=255)
+    requested_ref: str | None = Field(default=None, max_length=255)
+    requested_subdir: str | None = Field(default=None, max_length=500)
     default_branch: str | None = Field(default=None, max_length=255)
     summary: str = Field(..., min_length=1, max_length=1_500)
     summary_compact: str | None = Field(default=None, max_length=400)

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -230,30 +230,12 @@ def _fetch_public_github_repo_payload(
                     if content:
                         manifests[entry["path"]] = content
                         files_used.append(entry["path"])
-
-        readme_scan_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS]
-        for directory in readme_scan_dirs:
-            if len(_dedupe(files_used)) >= MAX_FILES_USED:
-                break
-            nested_path = (
-                f"{requested_subdir.strip('/')}/{directory}" if requested_subdir else directory
-            )
-            nested_entries = _get_json(
-                client,
-                _contents_api_path(
-                    repo_full_name,
-                    requested_path=nested_path,
-                    requested_ref=requested_ref,
-                ),
-            )
-            if not isinstance(nested_entries, list):
-                continue
-            nested_readme = _find_readme(nested_entries)
-            if not nested_readme or nested_readme["path"] in files_used:
-                continue
-            nested_readme_text = _read_text_file(client, nested_readme)
-            if nested_readme_text:
-                files_used.append(nested_readme["path"])
+            if len(_dedupe(files_used)) < MAX_FILES_USED:
+                nested_readme = _find_readme(nested_entries)
+                if nested_readme and nested_readme["path"] not in files_used:
+                    nested_readme_text = _read_text_file(client, nested_readme)
+                    if nested_readme_text:
+                        files_used.append(nested_readme["path"])
 
         detected_stack = _detect_stack(repo_meta, manifests)
         files_used = _dedupe(files_used)[:MAX_FILES_USED]

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 import httpx
 from cachetools import TTLCache
@@ -41,7 +41,8 @@ def _resolve_repo_cache_ttl() -> int:
         return _REPO_CACHE_DEFAULT_TTL_SECONDS
 
 
-_REPO_CACHE: TTLCache[str, dict[str, Any]] | None = None
+RepoCacheKey = tuple[str, str, str]
+_REPO_CACHE: TTLCache[RepoCacheKey, dict[str, Any]] | None = None
 _repo_cache_ttl = _resolve_repo_cache_ttl()
 if _repo_cache_ttl > 0:
     _REPO_CACHE = TTLCache(maxsize=_REPO_CACHE_MAXSIZE, ttl=_repo_cache_ttl)
@@ -63,7 +64,7 @@ class GitHubRepoAnalysisError(RuntimeError):
         self.status_code = status_code
 
 
-def normalize_public_github_repo_url(repo_url: str) -> str:
+def normalize_public_github_repo_url(repo_url: str) -> tuple[str, str | None, str | None]:
     raw = (repo_url or "").strip()
     if not raw:
         raise InvalidGitHubRepoUrl("GitHub repo URL is required.")
@@ -76,10 +77,10 @@ def normalize_public_github_repo_url(repo_url: str) -> str:
 
     path = parsed.path.rstrip("/")
     segments = [segment for segment in path.split("/") if segment]
-    if len(segments) != 2:
+    if len(segments) < 2:
         raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
 
-    owner, repo = segments
+    owner, repo = segments[0], segments[1]
     if repo.endswith(".git"):
         raise InvalidGitHubRepoUrl("Remove the .git suffix and use the root repository URL.")
 
@@ -87,22 +88,43 @@ def normalize_public_github_repo_url(repo_url: str) -> str:
     if not allowed.match(owner) or not allowed.match(repo):
         raise InvalidGitHubRepoUrl("Repository URL contains unsupported characters.")
 
-    return f"https://github.com/{owner}/{repo}"
+    normalized_url = f"https://github.com/{owner}/{repo}"
+    if len(segments) == 2:
+        return normalized_url, None, None
+
+    if len(segments) >= 4 and segments[2] == "tree":
+        requested_ref = segments[3]
+        if not requested_ref:
+            raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
+        requested_subdir = "/".join(segments[4:]) or None
+        return normalized_url, requested_ref, requested_subdir
+
+    raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
 
 
 def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
-    normalized_url = normalize_public_github_repo_url(repo_url)
+    normalized_url, requested_ref, requested_subdir = normalize_public_github_repo_url(repo_url)
     repo_full_name = normalized_url.replace("https://github.com/", "", 1)
+    cache_key: RepoCacheKey = (
+        repo_full_name,
+        requested_ref or "",
+        requested_subdir or "",
+    )
 
     if _REPO_CACHE is not None:
-        cached = _REPO_CACHE.get(repo_full_name)
+        cached = _REPO_CACHE.get(cache_key)
         if cached is not None:
             return dict(cached)
 
-    payload = _fetch_public_github_repo_payload(normalized_url, repo_full_name)
+    payload = _fetch_public_github_repo_payload(
+        normalized_url,
+        repo_full_name,
+        requested_ref=requested_ref,
+        requested_subdir=requested_subdir,
+    )
 
     if _REPO_CACHE is not None:
-        _REPO_CACHE[repo_full_name] = dict(payload)
+        _REPO_CACHE[cache_key] = dict(payload)
 
     return payload
 
@@ -128,7 +150,28 @@ def _build_github_request_headers() -> dict[str, str]:
     return headers
 
 
-def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) -> dict[str, Any]:
+def _contents_api_path(
+    repo_full_name: str,
+    *,
+    requested_path: str | None = None,
+    requested_ref: str | None = None,
+) -> str:
+    path = f"/repos/{repo_full_name}/contents"
+    if requested_path:
+        normalized_path = quote(requested_path.strip("/"), safe="/")
+        path = f"{path}/{normalized_path}"
+    if requested_ref:
+        path = f"{path}?{urlencode({'ref': requested_ref})}"
+    return path
+
+
+def _fetch_public_github_repo_payload(
+    normalized_url: str,
+    repo_full_name: str,
+    *,
+    requested_ref: str | None,
+    requested_subdir: str | None,
+) -> dict[str, Any]:
     with httpx.Client(
         base_url=GITHUB_API_BASE,
         headers=_build_github_request_headers(),
@@ -136,12 +179,19 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
         follow_redirects=True,
     ) as client:
         repo_meta = _get_json(client, f"/repos/{repo_full_name}")
-        root_entries = _get_json(client, f"/repos/{repo_full_name}/contents")
-        if not isinstance(root_entries, list):
+        listing_entries = _get_json(
+            client,
+            _contents_api_path(
+                repo_full_name,
+                requested_path=requested_subdir,
+                requested_ref=requested_ref,
+            ),
+        )
+        if not isinstance(listing_entries, list):
             raise GitHubRepoAnalysisError("Unable to read the repository root directory.")
 
         default_branch = repo_meta.get("default_branch")
-        readme_entry = _find_readme(root_entries)
+        readme_entry = _find_readme(listing_entries)
         readme_text = _read_text_file(client, readme_entry) if readme_entry else ""
         files_used: list[str] = []
         if readme_entry:
@@ -149,18 +199,28 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
 
         manifests: dict[str, str] = {}
         for manifest_name in MANIFEST_FILES:
-            entry = _find_entry(root_entries, manifest_name)
+            entry = _find_entry(listing_entries, manifest_name)
             if entry:
                 content = _read_text_file(client, entry)
                 if content:
                     manifests[entry["path"]] = content
                     files_used.append(entry["path"])
 
-        top_level_dirs = [entry["name"] for entry in root_entries if entry.get("type") == "dir"]
+        top_level_dirs = [entry["name"] for entry in listing_entries if entry.get("type") == "dir"]
         candidate_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS][:2]
 
         for directory in candidate_dirs:
-            nested_entries = _get_json(client, f"/repos/{repo_full_name}/contents/{directory}")
+            nested_path = (
+                f"{requested_subdir.strip('/')}/{directory}" if requested_subdir else directory
+            )
+            nested_entries = _get_json(
+                client,
+                _contents_api_path(
+                    repo_full_name,
+                    requested_path=nested_path,
+                    requested_ref=requested_ref,
+                ),
+            )
             if not isinstance(nested_entries, list):
                 continue
             for manifest_name in MANIFEST_FILES:
@@ -170,6 +230,30 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
                     if content:
                         manifests[entry["path"]] = content
                         files_used.append(entry["path"])
+
+        readme_scan_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS]
+        for directory in readme_scan_dirs:
+            if len(_dedupe(files_used)) >= MAX_FILES_USED:
+                break
+            nested_path = (
+                f"{requested_subdir.strip('/')}/{directory}" if requested_subdir else directory
+            )
+            nested_entries = _get_json(
+                client,
+                _contents_api_path(
+                    repo_full_name,
+                    requested_path=nested_path,
+                    requested_ref=requested_ref,
+                ),
+            )
+            if not isinstance(nested_entries, list):
+                continue
+            nested_readme = _find_readme(nested_entries)
+            if not nested_readme or nested_readme["path"] in files_used:
+                continue
+            nested_readme_text = _read_text_file(client, nested_readme)
+            if nested_readme_text:
+                files_used.append(nested_readme["path"])
 
         detected_stack = _detect_stack(repo_meta, manifests)
         files_used = _dedupe(files_used)[:MAX_FILES_USED]
@@ -197,6 +281,8 @@ def _fetch_public_github_repo_payload(normalized_url: str, repo_full_name: str) 
     return {
         "normalized_repo_url": normalized_url,
         "repo_full_name": repo_full_name,
+        "requested_ref": requested_ref,
+        "requested_subdir": requested_subdir,
         "default_branch": default_branch,
         "summary": summary,
         "summary_compact": summary_compact,

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -19,16 +19,48 @@ client = TestClient(app)
 
 
 def test_normalize_public_github_repo_url_accepts_root_url():
-    normalized = normalize_public_github_repo_url("https://github.com/openai/openai-python/")
+    normalized, requested_ref, requested_subdir = normalize_public_github_repo_url(
+        "https://github.com/openai/openai-python/"
+    )
 
     assert normalized == "https://github.com/openai/openai-python"
+    assert requested_ref is None
+    assert requested_subdir is None
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "expected_root", "expected_ref", "expected_subdir"),
+    [
+        (
+            "https://github.com/openai/openai-python/tree/main",
+            "https://github.com/openai/openai-python",
+            "main",
+            None,
+        ),
+        (
+            "https://github.com/vercel/next.js/tree/canary/packages/next",
+            "https://github.com/vercel/next.js",
+            "canary",
+            "packages/next",
+        ),
+    ],
+)
+def test_normalize_public_github_repo_url_accepts_tree_variants(
+    repo_url: str,
+    expected_root: str,
+    expected_ref: str,
+    expected_subdir: str | None,
+):
+    normalized, requested_ref, requested_subdir = normalize_public_github_repo_url(repo_url)
+    assert normalized == expected_root
+    assert requested_ref == expected_ref
+    assert requested_subdir == expected_subdir
 
 
 @pytest.mark.parametrize(
     "repo_url",
     [
         "https://github.com/openai/openai-python.git",
-        "https://github.com/openai/openai-python/tree/main",
         "https://github.com/openai/openai-python/blob/main/README.md",
         "https://github.com/openai/openai-python?tab=readme-ov-file",
         "https://github.com/openai/openai-python#readme",
@@ -65,7 +97,7 @@ def test_build_summary_compact_handles_missing_metadata():
     assert "single-surface" in compact
 
 
-def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
+def test_analyze_public_github_repo_uses_ref_and_subdir_cache_key(monkeypatch):
     reset_repo_cache_for_tests()
 
     repo_meta = {
@@ -117,15 +149,134 @@ def test_analyze_public_github_repo_uses_in_memory_cache(monkeypatch):
 
     monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
 
-    first = analyze_public_github_repo("https://github.com/openai/openai-python")
-    second = analyze_public_github_repo("https://github.com/openai/openai-python")
+    first = analyze_public_github_repo("https://github.com/openai/openai-python/tree/main")
+    second = analyze_public_github_repo("https://github.com/openai/openai-python/tree/main")
+    third = analyze_public_github_repo("https://github.com/openai/openai-python/tree/v4")
 
     assert first == second
+    assert third["requested_ref"] == "v4"
     assert "summary_compact" in first and first["summary_compact"]
     assert (
-        call_log.count("/repos/openai/openai-python") == 1
-    ), f"expected GitHub API to be hit once, got call log: {call_log}"
+        call_log.count("/repos/openai/openai-python") == 2
+    ), f"expected GitHub API to be hit twice for two refs, got call log: {call_log}"
+    assert call_log.count("/repos/openai/openai-python/contents?ref=main") == 1
+    assert call_log.count("/repos/openai/openai-python/contents?ref=v4") == 1
 
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_forwards_ref_to_contents_api(monkeypatch):
+    reset_repo_cache_for_tests()
+    call_log: list[str] = []
+
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Python SDK for OpenAI.",
+        "default_branch": "main",
+        "language": "Python",
+    }
+    root_entries = [
+        {"name": "README.md", "path": "README.md", "type": "file", "download_url": "rd"}
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/openai/openai-python"):
+                return FakeResponse(repo_meta)
+            if path == "/repos/openai/openai-python/contents?ref=my-branch":
+                return FakeResponse(root_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# README")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+    payload = analyze_public_github_repo("https://github.com/openai/openai-python/tree/my-branch")
+    assert payload["requested_ref"] == "my-branch"
+    assert "/repos/openai/openai-python/contents?ref=my-branch" in call_log
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_walks_requested_subdir(monkeypatch):
+    reset_repo_cache_for_tests()
+    call_log: list[str] = []
+
+    repo_meta = {
+        "full_name": "vercel/next.js",
+        "description": "Next.js repo",
+        "default_branch": "canary",
+        "language": "TypeScript",
+    }
+    subdir_entries = [
+        {
+            "name": "README.md",
+            "path": "packages/next/README.md",
+            "type": "file",
+            "download_url": "rd",
+        }
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/vercel/next.js"):
+                return FakeResponse(repo_meta)
+            if path == "/repos/vercel/next.js/contents/packages/next?ref=canary":
+                return FakeResponse(subdir_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# Next package")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+    payload = analyze_public_github_repo(
+        "https://github.com/vercel/next.js/tree/canary/packages/next"
+    )
+    assert payload["requested_ref"] == "canary"
+    assert payload["requested_subdir"] == "packages/next"
+    assert "/repos/vercel/next.js/contents/packages/next?ref=canary" in call_log
+    assert "/repos/vercel/next.js/contents?ref=canary" not in call_log
     reset_repo_cache_for_tests()
 
 
@@ -275,5 +426,10 @@ def test_repo_context_endpoint_returns_analyzed_repo_summary():
 
     assert response.status_code == 200
     # Response model adds summary_compact (defaults to None when analyzer omits it).
-    assert response.json() == {**mock_payload, "summary_compact": None}
+    assert response.json() == {
+        **mock_payload,
+        "summary_compact": None,
+        "requested_ref": None,
+        "requested_subdir": None,
+    }
     mock_analyze.assert_called_once_with("https://github.com/openai/openai-python")

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -139,7 +139,10 @@ def test_analyze_public_github_repo_uses_ref_and_subdir_cache_key(monkeypatch):
             call_log.append(path)
             if path.endswith("/repos/openai/openai-python"):
                 return FakeResponse(repo_meta)
-            if path.endswith("/repos/openai/openai-python/contents"):
+            if path in (
+                "/repos/openai/openai-python/contents?ref=main",
+                "/repos/openai/openai-python/contents?ref=v4",
+            ):
                 return FakeResponse(root_entries)
             if path == "rd":
                 return FakeResponse(None, text="# OpenAI Python\n\nOfficial SDK.")
@@ -161,6 +164,67 @@ def test_analyze_public_github_repo_uses_ref_and_subdir_cache_key(monkeypatch):
     ), f"expected GitHub API to be hit twice for two refs, got call log: {call_log}"
     assert call_log.count("/repos/openai/openai-python/contents?ref=main") == 1
     assert call_log.count("/repos/openai/openai-python/contents?ref=v4") == 1
+
+    reset_repo_cache_for_tests()
+
+
+def test_analyze_public_github_repo_uses_in_memory_cache_for_root_url(monkeypatch):
+    reset_repo_cache_for_tests()
+
+    repo_meta = {
+        "full_name": "openai/openai-python",
+        "description": "Python SDK for OpenAI.",
+        "default_branch": "main",
+        "language": "Python",
+    }
+    root_entries = [
+        {"name": "README.md", "path": "README.md", "type": "file", "download_url": "rd"},
+    ]
+    call_log: list[str] = []
+
+    class FakeResponse:
+        def __init__(self, payload, *, text=""):
+            self._payload = payload
+            self.text = text
+            self.status_code = 200
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, path):
+            call_log.append(path)
+            if path.endswith("/repos/openai/openai-python"):
+                return FakeResponse(repo_meta)
+            if path == "/repos/openai/openai-python/contents":
+                return FakeResponse(root_entries)
+            if path == "rd":
+                return FakeResponse(None, text="# OpenAI Python\n\nOfficial SDK.")
+            return FakeResponse([])
+
+    monkeypatch.setattr("app.github_repo_context.httpx.Client", FakeClient)
+
+    first = analyze_public_github_repo("https://github.com/openai/openai-python")
+    second = analyze_public_github_repo("https://github.com/openai/openai-python")
+
+    assert first == second
+    assert first["requested_ref"] is None
+    assert first["requested_subdir"] is None
+    assert (
+        call_log.count("/repos/openai/openai-python") == 1
+    ), f"expected GitHub API to be hit once for root URL, got call log: {call_log}"
 
     reset_repo_cache_for_tests()
 


### PR DESCRIPTION
## Summary
- accept GitHub `/tree/<branch>` and `/tree/<branch>/<subdir>` URLs while normalizing to repo root and returning `requested_ref`/`requested_subdir`
- thread ref/subdir through analyze calls, switch cache key to `(repo_full_name, requested_ref, requested_subdir)`, and include ref-aware contents lookups
- add one-level deeper README pickup for app-like directories and extend payload/tests for new fields and URL/caching behaviors

## Test plan
- [x] `python -m pytest tests/test_repo_context.py -v`