### PR TITLE
﻿fix(repo-context): remove requireServerApiKey from proxy route

### DIFF
--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -14,6 +14,7 @@ import { POST as skillsGenerateRoute } from "./skills-generator/generate/route";
 import { POST as skillsExportRoute } from "./skills-generator/export/route";
 import { POST as ragUploadRoute } from "./rag/upload/route";
 import { POST as ragIngestRoute } from "./rag/ingest/route";
+import { POST as repoContextGithubRoute } from "./repo-context/github/route";
 
 type RouteCase = {
   name: string;
@@ -236,6 +237,13 @@ describe("Next backend proxy route wiring", () => {
       requestUrl: "http://localhost:3000/skills-generator/generate",
       requestBody: { description: "search docs" },
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
+    },
+    {
+      name: "repo context analysis",
+      handler: repoContextGithubRoute,
+      requestUrl: "http://localhost:3000/repo-context/github",
+      requestBody: { repo_url: "https://github.com/openai/openai-python" },
+      expectedUrl: "https://api.memo.dev/repo-context/github",
     },
     {
       name: "RAG upload",

--- a/web/app/repo-context/github/route.ts
+++ b/web/app/repo-context/github/route.ts
@@ -1,0 +1,5 @@
+import { proxyBackendRequest } from "@/lib/server/backendProxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyBackendRequest(request, "/repo-context/github", {});
+}


### PR DESCRIPTION
The repo-context endpoint now uses the same auth pattern as the other generator routes - the server key is forwarded when available but the request is never blocked client-side for its absence. Remove the now- stale test case that expected a 500 when the key was missing.