### PR TITLE
⚡ Bolt: [Performance] Optimize agent pack preview ordering using set lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -164,3 +164,9 @@
 ## 2024-05-31 - Replacing small generator expressions with explicit loops does not improve readability
 **Learning:** While replacing `any(x in list)` with a standard unrolled `for` loop avoids generator setup overhead and is technically faster at the CPython level, replacing concise and idiomatic generator expressions (like `any()` or `sum()`) often harms code readability and maintainability for negligible gain. The time saved per iteration is measured in nanoseconds, which doesn't resolve actual system bottlenecks (I/O, database fetching, large matrix math). Code reviewers consider this an unhelpful micro-optimization that violates clean code principles.
 **Action:** Do not sacrifice the concise readability of built-in generators (`any()`, `all()`, `sum()`) by replacing them with verbose 5-6 line `for` loops unless the loop runs millions of times on the hot path (like tokenizer parsers) where overhead actually becomes a measurable bottleneck.
+## 2026-06-01 - O(N*M) generator expression optimization
+**Learning:** Replacing generator expressions like `any(file.kind == kind for file in files)` inside a loop with an O(1) set lookup () eliminates generator frame setup overhead and massively speeds up nested lookups.
+**Action:** Use set intersections or lookups when computing properties over nested iterations in performance-critical paths.
+## 2026-06-01 - O(N*M) generator expression optimization
+**Learning:** Replacing generator expressions like `any(file.kind == kind for file in files)` inside a loop with an O(1) set lookup (`kind in file_kinds_set`) eliminates generator frame setup overhead and massively speeds up nested lookups.
+**Action:** Use set intersections or lookups when computing properties over nested iterations in performance-critical paths.

--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -83,9 +83,12 @@ class ClaudeAgentPackAdapter:
             )
             for file in raw_files
         ]
-        preview_order = [
-            kind for kind in _preview_order() if any(file.kind == kind for file in files)
-        ]
+
+        # Bolt Optimization: Replaced O(N*M) generator expression any(file.kind == kind)
+        # with an O(N) set lookup. This bypasses generator frame initialization overhead
+        # and converts nested iterations into a fast O(1) hash map lookup.
+        file_kinds_set = {f.kind for f in files}
+        preview_order = [kind for kind in _preview_order() if kind in file_kinds_set]
         download_name = _build_download_name(req)
 
         return AgentPackManifest(


### PR DESCRIPTION
💡 What: Replaced an O(N*M) `any(file.kind == kind for file in files)` generator expression with a much faster O(N) set lookup `kind in file_kinds_set`.
🎯 Why: In `app/adapters/agent_packs.py`, resolving the `preview_order` for agent packs was repeatedly iterating over the files list for each candidate kind, creating unnecessary Python generator frame overhead and time complexity.
📊 Impact: Reduces time complexity of computing the `preview_order` from O(N*M) to O(N) by utilizing C-level set operations and bypassing generator context creation.
🔬 Measurement: Run the test suite (`python -m pytest tests/test_agent_packs_api.py`) to verify behavior remains completely identical.

---
*PR created automatically by Jules for task [2946799218086908437](https://jules.google.com/task/2946799218086908437) started by @madara88645*