### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits for lists to prevent DoS

### DIFF
--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import anyio
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.auth import APIKey, verify_api_key, verify_api_key_if_required
 from api.shared import logger
@@ -34,6 +34,24 @@ class RagIngestRequest(BaseModel):
     embed: bool = Field(default=False)
     embed_dim: int = Field(default=64, ge=8, le=1024)
     chunking_strategy: str = Field(default="paragraph", pattern="^(fixed|paragraph|semantic)$")
+
+    @field_validator("paths")
+    @classmethod
+    def validate_paths_length(cls, paths: List[str]) -> List[str]:
+        for path in paths:
+            if len(path) > 1024:
+                raise ValueError("path exceeds maximum length of 1024 characters")
+        return paths
+
+    @field_validator("exts")
+    @classmethod
+    def validate_exts_length(cls, exts: Optional[List[str]]) -> Optional[List[str]]:
+        if exts is None:
+            return None
+        for ext in exts:
+            if len(ext) > 50:
+                raise ValueError("extension exceeds maximum length of 50 characters")
+        return exts
 
 
 class RagIngestResponse(BaseModel):

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,5 +1,8 @@
 import pytest
+from pydantic import ValidationError
 from unittest.mock import MagicMock, patch
+
+from api.routes.rag import RagIngestRequest
 from app.llm_engine.rag import ContextStrategist, Snippet, MockVectorDB, SQLiteVectorDB
 
 
@@ -106,6 +109,26 @@ def test_process_end_to_end(strategist):
 def test_mock_vector_db():
     db = MockVectorDB()
     assert db.search("anything") == []
+
+
+def test_rag_ingest_request_validates_path_length():
+    with pytest.raises(ValidationError) as exc:
+        RagIngestRequest(paths=["a" * 1025])
+    assert "path exceeds maximum length of 1024 characters" in str(exc.value)
+
+    # Valid path should not raise
+    req = RagIngestRequest(paths=["a" * 1024])
+    assert req.paths == ["a" * 1024]
+
+
+def test_rag_ingest_request_validates_exts_length():
+    with pytest.raises(ValidationError) as exc:
+        RagIngestRequest(paths=["valid"], exts=["a" * 51])
+    assert "extension exceeds maximum length of 50 characters" in str(exc.value)
+
+    # Valid ext should not raise
+    req = RagIngestRequest(paths=["valid"], exts=["a" * 50])
+    assert req.exts == ["a" * 50]
 
 
 @patch("app.llm_engine.rag.search_hybrid")


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unbounded string lengths inside Pydantic `List[str]` schemas. Pydantic `Field(max_length=...)` on a `List[str]` only limits the *number of items* in the list, not the length of individual strings. This means an attacker could send a payload containing an extremely long string inside the list to bypass standard payload length caps and consume unbounded memory, leading to a potential Denial of Service (DoS) attack.
🎯 **Impact:** Unbounded memory consumption and possible Denial of Service (DoS) vulnerabilities on the API endpoint `/rag/ingest`.
🔧 **Fix:** Implemented custom `@field_validator` functions for `paths` and `exts` in `api/routes/rag.py` that check the string length of each element in the list, returning a `ValueError` for elements exceeding reasonable limits (`1024` for paths and `50` for extensions). 
✅ **Verification:** Unit tests have been added to `tests/test_rag.py` to ensure that extremely large payloads properly trigger `ValidationError` and valid payloads parse properly. Verified by running the test suite (`python3 -m pytest tests/test_rag.py`).

---
*PR created automatically by Jules for task [10772834408174329847](https://jules.google.com/task/10772834408174329847) started by @madara88645*