### PR TITLE
🎨 Palette: Add toast feedback to copy to clipboard actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,6 @@
 ## 2024-05-15 - [Add aria-controls to ExportPanel buttons]
 **Learning:** For collapsible content, buttons with `aria-expanded` must also have an `aria-controls` attribute linking them to the content container's ID for screen readers.
 **Action:** When creating expanding/collapsing UI panels, generate a unique ID (e.g. via `useId`) to link the toggle control directly to its target content.
+## 2025-05-10 - Consistent Copy Feedback
+**Learning:** Copy to clipboard actions often lack visual feedback, leaving users uncertain if the action succeeded. The `toast.success` pattern used in other components (like `RagSearchPanel`) should be consistently applied to all copy actions across the app to provide a unified and reassuring UX.
+**Action:** When adding copy to clipboard functionality, always include a brief visual confirmation notification (like `toast.success("Copied to clipboard")`) to ensure the user knows the action was successful.

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useId } from "react";
+import { toast } from "sonner";
 import { apiFetch } from "@/config";
 
 type Framework = "claude-sdk" | "langchain" | "langgraph";
@@ -125,6 +126,7 @@ export default function ExportPanel({
             navigator.clipboard.writeText(text).then(() => {
                 setCopied(true);
                 setTimeout(() => setCopied(false), 2000);
+                toast.success("Copied to clipboard");
             });
         }
     };

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -7,6 +7,7 @@ import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import { showError } from "../lib/showError";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
+import { toast } from "sonner";
 import ExportPanel from "./components/ExportPanel";
 
 export default function AgentGenerator() {
@@ -63,6 +64,7 @@ export default function AgentGenerator() {
       navigator.clipboard.writeText(result);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      toast.success("Copied to clipboard");
     }
   };
 

--- a/web/app/components/BenchmarkResults.tsx
+++ b/web/app/components/BenchmarkResults.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, memo } from "react";
+import { toast } from "sonner";
 
 export type BenchmarkData = {
     raw_output: string;
@@ -131,6 +132,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
                                 navigator.clipboard.writeText(data.raw_output);
                                 setCopiedRaw(true);
                                 setTimeout(() => setCopiedRaw(false), 2000);
+                                toast.success("Copied to clipboard");
                             }}
                             className="text-zinc-600 hover:text-zinc-400 transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             title={copiedRaw ? "Copied!" : "Copy raw output"}
@@ -161,6 +163,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
                                 navigator.clipboard.writeText(data.compiled_output);
                                 setCopiedCompiled(true);
                                 setTimeout(() => setCopiedCompiled(false), 2000);
+                                toast.success("Copied to clipboard");
                             }}
                             className="text-zinc-600 hover:text-zinc-400 transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             title={copiedCompiled ? "Copied!" : "Copy compiled output"}

--- a/web/app/components/context/ContextSuggestions.tsx
+++ b/web/app/components/context/ContextSuggestions.tsx
@@ -1,3 +1,4 @@
+import { toast } from "sonner";
 import type { ContextSuggestion } from "../../../lib/api/types";
 
 type ContextSuggestionsProps = {
@@ -16,7 +17,10 @@ export default function ContextSuggestions({ suggestions, onInsertContext }: Con
                     <button
                         key={suggestion.path}
                         type="button"
-                        onClick={() => onInsertContext(`[File: ${suggestion.name}]\n(Reason: ${suggestion.reason})`)}
+                        onClick={() => {
+                            onInsertContext(`[File: ${suggestion.name}]\n(Reason: ${suggestion.reason})`);
+                            toast.success(`Inserted ${suggestion.name} into prompt`);
+                        }}
                         className="group flex items-center gap-2 px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 hover:border-blue-500/40 rounded-full transition-all text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                         title={`Add ${suggestion.path} to context`}
                         aria-label={`Add ${suggestion.path} to context`}

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { WifiOff } from "lucide-react";
+import { toast } from "sonner";
 import ContextManager from "../components/ContextManager";
 import { describeRequestError } from "@/config";
 import { compilePrompt } from "../../lib/api/promptc";
@@ -223,7 +224,10 @@ export default function OfflinePage() {
                                             />
                                             <button
                                                 type="button"
-                                                onClick={() => navigator.clipboard.writeText(getOfflineTabContent(result, activeTab))}
+                                                onClick={() => {
+                                                    navigator.clipboard.writeText(getOfflineTabContent(result, activeTab));
+                                                    toast.success("Copied to clipboard");
+                                                }}
                                                 className="absolute bottom-6 right-6 bg-zinc-700 hover:bg-zinc-600 text-white p-3 rounded-xl shadow-lg transition-all hover:scale-105 active:scale-95 z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500"
                                                 title="Copy"
                                                 aria-label="Copy to Clipboard"

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { Sparkles } from "lucide-react";
 import { apiJson } from "@/config";
 import { showError } from "../lib/showError";
@@ -158,7 +159,9 @@ export default function OptimizerPage() {
 
     const copyText = (text: string) => {
         if (!text) return;
-        void navigator.clipboard?.writeText(text).catch(() => {});
+        void navigator.clipboard?.writeText(text)
+            .then(() => toast.success("Copied to clipboard"))
+            .catch(() => {});
     };
 
     return (

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useId, useState } from "react";
+import { toast } from "sonner";
 import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
@@ -421,6 +422,7 @@ export default function Home() {
                             navigator.clipboard.writeText(getTabContent(result, tab));
                             setCopied(true);
                             setTimeout(() => setCopied(false), 2000);
+                            toast.success("Copied to clipboard");
                           }}
                           className="absolute bottom-6 right-6 bg-blue-600 hover:bg-blue-500 text-white p-3 rounded-xl shadow-lg shadow-blue-500/20 transition-all hover:scale-105 active:scale-95 z-20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                           title={copied ? "Copied!" : "Copy to Clipboard"}

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useId } from "react";
+import { toast } from "sonner";
 import { apiFetch } from "@/config";
 
 type SkillFormat = "langchain-tool" | "claude-tool-use" | "agent-skill";
@@ -144,6 +145,7 @@ export default function SkillExportPanel({
             navigator.clipboard.writeText(text).then(() => {
                 setCopied(true);
                 setTimeout(() => setCopied(false), 2000);
+                toast.success("Copied to clipboard");
             });
         }
     };

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import { Zap } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
@@ -61,6 +62,7 @@ export default function SkillsGenerator() {
       navigator.clipboard.writeText(result);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      toast.success("Copied to clipboard");
     }
   };
 


### PR DESCRIPTION
💡 What: Added toast.success("Copied to clipboard") to all copy-to-clipboard interactions across the application (BenchmarkResults, ContextSuggestions, OfflinePage, OptimizerPage, Home page, Agent/Skill Generator pages).
🎯 Why: To ensure users receive clear, consistent visual feedback when they successfully copy content to their clipboard, eliminating uncertainty.
♿ Accessibility: Provides a clear, non-intrusive notification (sonner toast) that is accessible and conforms to existing application notification patterns.

---
*PR created automatically by Jules for task [3793645499160876982](https://jules.google.com/task/3793645499160876982) started by @madara88645*