### PR TITLE
🎨 Palette: Add focus states to Generator Export Panels

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -145,7 +145,7 @@ export default function ExportPanel({
                 onClick={handleToggle}
                 aria-expanded={isOpen}
                 aria-controls={panelId}
-                className="w-full flex items-center justify-between px-2 py-1 group"
+                className="w-full flex items-center justify-between px-2 py-1 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
             >
                 <div className="flex items-center gap-2">
                     <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
@@ -183,7 +183,7 @@ export default function ExportPanel({
                                 type="button"
                                 key={fw.id}
                                 onClick={() => handleFrameworkClick(fw.id)}
-                                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                                     framework === fw.id
                                         ? fw.activeColor
                                         : fw.color
@@ -201,7 +201,7 @@ export default function ExportPanel({
                                 type="button"
                                 key={tab}
                                 onClick={() => setOutputTab(tab)}
-                                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
+                                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                                     outputTab === tab
                                         ? "bg-white/10 text-zinc-100"
                                         : "text-zinc-500 hover:text-zinc-300"

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -173,7 +173,7 @@ export default function SkillExportPanel({
                 onClick={handleToggle}
                 aria-expanded={isOpen}
                 aria-controls={panelId}
-                className="w-full flex items-center justify-between px-2 py-1 group"
+                className="w-full flex items-center justify-between px-2 py-1 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
             >
                 <div className="flex items-center gap-2">
                     <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest group-hover:text-zinc-200 transition-colors">
@@ -211,7 +211,7 @@ export default function SkillExportPanel({
                                 type="button"
                                 key={f.id}
                                 onClick={() => handleFormatClick(f.id)}
-                                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                                className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                                     format === f.id ? f.activeColor : f.color
                                 }`}
                             >
@@ -227,7 +227,7 @@ export default function SkillExportPanel({
                                 type="button"
                                 key={tab.id}
                                 onClick={() => setOutputTab(tab.id)}
-                                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
+                                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                                     outputTab === tab.id
                                         ? "bg-white/10 text-zinc-100"
                                         : "text-zinc-500 hover:text-zinc-300"


### PR DESCRIPTION
💡 What: Added `focus-visible` styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`) to the utility toggle and format/language tab buttons in the `ExportPanel` components for both the Agent Generator and Skills Generator.
🎯 Why: Without these explicit styles, keyboard users navigating via Tab could not easily see which utility button was currently focused, causing a confusing and inaccessible experience.
📸 Before/After: Added blue focus rings when navigating via keyboard.
♿ Accessibility: Ensures that keyboard-only users have a distinct visual indicator for active interactive elements within the export menus.

---
*PR created automatically by Jules for task [10577643212024394770](https://jules.google.com/task/10577643212024394770) started by @madara88645*