### PR TITLE
[codex] fix: align RAG proxy auth with backend optional routes

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -34,6 +34,7 @@ npm run test:contracts
 
 - Browser calls stay same-origin and hit the Next proxy layer first. Server-side proxy handlers forward to `NEXT_PUBLIC_API_URL` (or `http://127.0.0.1:8080` locally).
 - Protected proxy routes use `PROMPTC_SERVER_API_KEY` on the web server. `NEXT_PUBLIC_API_KEY` should not be used in the browser.
+- Routes backed by optional backend auth, such as `/rag/search` and `/rag/stats`, should stay callable without `PROMPTC_SERVER_API_KEY` unless backend-wide auth enforcement is enabled.
 - The Agent Packs page exposes an optional client-side `x-api-key` field for local debugging and fallback use. If `PROMPTC_SERVER_API_KEY` is configured, the proxy uses that server key and ignores the typed client key.
 - `/rag/search` returns canonical items shaped like `{ path, snippet, score }`.
 - `/rag/upload` returns canonical ingest metadata and may also include compatibility fields.

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -14,7 +14,6 @@ import { POST as skillsGenerateRoute } from "./skills-generator/generate/route";
 import { POST as skillsExportRoute } from "./skills-generator/export/route";
 import { POST as ragUploadRoute } from "./rag/upload/route";
 import { POST as ragIngestRoute } from "./rag/ingest/route";
-import { POST as repoContextGithubRoute } from "./repo-context/github/route";
 
 type RouteCase = {
   name: string;
@@ -108,6 +107,50 @@ describe("Next backend proxy route wiring", () => {
 
   it.each<RouteCase>([
     {
+      name: "RAG search",
+      handler: ragSearchRoute,
+      requestUrl: "http://localhost:3000/rag/search",
+      requestBody: { query: "test" },
+      expectedUrl: "http://127.0.0.1:8080/rag/search",
+    },
+    {
+      name: "RAG stats",
+      handler: ragStatsRoute as (request: Request) => Promise<Response>,
+      requestUrl: "http://localhost:3000/rag/stats",
+      requestMethod: "GET",
+      expectedUrl: "http://127.0.0.1:8080/rag/stats",
+    },
+  ])("forwards optional-auth $name requests without requiring a server API key", async ({ handler, requestUrl, requestMethod, requestBody, expectedUrl }) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const response = await handler(
+      new Request(requestUrl, {
+        method: requestMethod || "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: requestBody ? JSON.stringify(requestBody) : undefined,
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    const proxiedHeaders = new Headers(init?.headers);
+
+    expect(url).toBe(expectedUrl);
+    expect(proxiedHeaders.has("x-api-key")).toBe(false);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it.each<RouteCase>([
+    {
       name: "agent packs",
       handler: agentPacksClaudeRoute,
       requestUrl: "http://localhost:3000/agent-packs/claude",
@@ -169,20 +212,6 @@ describe("Next backend proxy route wiring", () => {
       requestUrl: "http://localhost:3000/optimize",
       requestBody: { system_prompt: "hello" },
       expectedUrl: "https://api.memo.dev/optimize",
-    },
-    {
-      name: "RAG search",
-      handler: ragSearchRoute,
-      requestUrl: "http://localhost:3000/rag/search",
-      requestBody: { query: "test" },
-      expectedUrl: "https://api.memo.dev/rag/search",
-    },
-    {
-      name: "RAG stats",
-      handler: ragStatsRoute as (request: Request) => Promise<Response>,
-      requestUrl: "http://localhost:3000/rag/stats",
-      requestMethod: "GET",
-      expectedUrl: "https://api.memo.dev/rag/stats",
     },
     {
       name: "skills export",
@@ -272,20 +301,6 @@ describe("Next backend proxy route wiring", () => {
       requestUrl: "http://localhost:3000/optimize",
       requestBody: { system_prompt: "hello" },
       expectedUrl: "https://api.memo.dev/optimize",
-    },
-    {
-      name: "RAG search",
-      handler: ragSearchRoute,
-      requestUrl: "http://localhost:3000/rag/search",
-      requestBody: { query: "test" },
-      expectedUrl: "https://api.memo.dev/rag/search",
-    },
-    {
-      name: "RAG stats",
-      handler: ragStatsRoute as (request: Request) => Promise<Response>,
-      requestUrl: "http://localhost:3000/rag/stats",
-      requestMethod: "GET",
-      expectedUrl: "https://api.memo.dev/rag/stats",
     },
     {
       name: "skills export",

--- a/web/app/rag/search/route.ts
+++ b/web/app/rag/search/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/rag/search", { requireServerApiKey: true });
+  return proxyBackendRequest(request, "/rag/search");
 }

--- a/web/app/rag/stats/route.ts
+++ b/web/app/rag/stats/route.ts
@@ -1,5 +1,5 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function GET(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/rag/stats", { requireServerApiKey: true });
+  return proxyBackendRequest(request, "/rag/stats");
 }


### PR DESCRIPTION
## What changed
- removed the unnecessary server API key requirement from the Next proxy handlers for `/rag/search` and `/rag/stats`
- added regression coverage proving those optional-auth routes still proxy correctly without `PROMPTC_SERVER_API_KEY`
- documented that optional-auth proxy routes should stay callable unless backend-wide auth enforcement is enabled

## Why
The backend already treats `/rag/search` and `/rag/stats` as optional-auth routes, but the web proxy layer had drifted into requiring a server key. That made local and lightly configured environments stricter than the backend contract and could block valid requests before they reached the API.

## Impact
- RAG search and stats now behave consistently across backend and Next proxy layers
- local setups without `PROMPTC_SERVER_API_KEY` can still use the optional-auth RAG routes
- the contract is pinned by tests so the mismatch is less likely to come back

## Verification
- `cd web && npm run test:contracts`
- `cd web && npm run lint` *(1 pre-existing warning remains in `app/hooks/useContextManager.ts` for an unused eslint-disable directive)*
- `cd web && npm run build`
