### PR TITLE
fix: salvage remaining safe PR changes

### DIFF
--- a/api/routes/export.py
+++ b/api/routes/export.py
@@ -5,7 +5,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from api.auth import APIKey, verify_api_key_if_required
+from api.auth import APIKey, verify_api_key
 
 router = APIRouter(tags=["export"])
 
@@ -21,7 +21,7 @@ class ExportRequest(BaseModel):
 @router.post("/agent-generator/export")
 async def export_agent(
     req: ExportRequest,
-    api_key: APIKey | None = Depends(verify_api_key_if_required),
+    api_key: APIKey = Depends(verify_api_key),
 ):
     del api_key
     if req.format not in [
@@ -100,7 +100,7 @@ _SKILL_EXPORT_FORMATS = frozenset(
 @router.post("/skills-generator/export")
 async def export_skill(
     req: ExportRequest,
-    api_key: APIKey | None = Depends(verify_api_key_if_required),
+    api_key: APIKey = Depends(verify_api_key),
 ):
     del api_key
     if req.format not in _SKILL_EXPORT_FORMATS:

--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import anyio
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.auth import APIKey, verify_api_key, verify_api_key_if_required
 from api.shared import logger
@@ -34,6 +34,24 @@ class RagIngestRequest(BaseModel):
     embed: bool = Field(default=False)
     embed_dim: int = Field(default=64, ge=8, le=1024)
     chunking_strategy: str = Field(default="paragraph", pattern="^(fixed|paragraph|semantic)$")
+
+    @field_validator("paths")
+    @classmethod
+    def validate_paths_length(cls, paths: List[str]) -> List[str]:
+        for path in paths:
+            if len(path) > 1024:
+                raise ValueError("path exceeds maximum length of 1024 characters")
+        return paths
+
+    @field_validator("exts")
+    @classmethod
+    def validate_exts_length(cls, exts: Optional[List[str]]) -> Optional[List[str]]:
+        if exts is None:
+            return None
+        for ext in exts:
+            if len(ext) > 50:
+                raise ValueError("extension exceeds maximum length of 50 characters")
+        return exts
 
 
 class RagIngestResponse(BaseModel):

--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, Protocol
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from .agent_ir import parse_agent_markdown
 from .claude_code import (
@@ -18,6 +18,8 @@ from .skill_ir import parse_skill_markdown
 
 PackType = Literal["project-pack", "subagent", "pr-reviewer", "mcp-tool-stub"]
 RiskMode = Literal["balanced", "strict"]
+AgentPackProvider = Literal["claude"]
+AgentPackFileKind = Literal["claude_md", "settings", "agents", "workflow", "mcp", "readme", "files"]
 
 
 class AgentPackRequest(BaseModel):
@@ -31,15 +33,24 @@ class AgentPackRequest(BaseModel):
 class AgentPackFile(BaseModel):
     path: str
     content: str
-    kind: str
+    kind: AgentPackFileKind
 
 
 class AgentPackManifest(BaseModel):
-    provider: str
+    provider: AgentPackProvider
     pack_type: PackType
     files: list[AgentPackFile]
     download_name: str
-    preview_order: list[str]
+    preview_order: list[AgentPackFileKind]
+
+    @model_validator(mode="after")
+    def validate_preview_order(self) -> "AgentPackManifest":
+        file_kinds = {file.kind for file in self.files}
+        unknown_preview_kinds = [kind for kind in self.preview_order if kind not in file_kinds]
+        if unknown_preview_kinds:
+            joined = ", ".join(unknown_preview_kinds)
+            raise ValueError(f"preview_order includes kinds without matching files: {joined}")
+        return self
 
 
 class AgentPackAdapter(Protocol):
@@ -170,7 +181,7 @@ def _build_skill_brief(req: AgentPackRequest) -> str:
     )
 
 
-def _classify_kind(path: str) -> str:
+def _classify_kind(path: str) -> AgentPackFileKind:
     normalized = path.replace("\\", "/")
     if normalized == "CLAUDE.md":
         return "claude_md"
@@ -187,7 +198,7 @@ def _classify_kind(path: str) -> str:
     return "files"
 
 
-def _preview_order() -> list[str]:
+def _preview_order() -> list[AgentPackFileKind]:
     return ["claude_md", "settings", "agents", "workflow", "mcp", "readme", "files"]
 
 

--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -4,9 +4,12 @@ import io
 import zipfile
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from api.main import app
+from app.adapters.agent_packs import AgentPackManifest
 
 
 def _request_payload(pack_type: str) -> dict[str, str]:
@@ -209,3 +212,60 @@ def test_agent_packs_download_media_types():
 
             assert response.status_code == 200
             assert response.headers["content-type"] == "text/x-python; charset=utf-8"
+
+
+def test_agent_pack_manifest_rejects_unknown_provider():
+    with pytest.raises(ValidationError):
+        AgentPackManifest.model_validate(
+            {
+                "provider": "cursor",
+                "pack_type": "subagent",
+                "download_name": "demo-pack",
+                "preview_order": ["agents"],
+                "files": [
+                    {
+                        "path": ".claude/agents/review-agent.md",
+                        "content": "hello",
+                        "kind": "agents",
+                    }
+                ],
+            }
+        )
+
+
+def test_agent_pack_manifest_rejects_unknown_kind():
+    with pytest.raises(ValidationError):
+        AgentPackManifest.model_validate(
+            {
+                "provider": "claude",
+                "pack_type": "subagent",
+                "download_name": "demo-pack",
+                "preview_order": ["ghost-kind"],
+                "files": [
+                    {
+                        "path": ".claude/agents/review-agent.md",
+                        "content": "hello",
+                        "kind": "ghost-kind",
+                    }
+                ],
+            }
+        )
+
+
+def test_agent_pack_manifest_rejects_preview_order_kinds_not_present_in_files():
+    with pytest.raises(ValidationError):
+        AgentPackManifest.model_validate(
+            {
+                "provider": "claude",
+                "pack_type": "subagent",
+                "download_name": "demo-pack",
+                "preview_order": ["agents", "workflow"],
+                "files": [
+                    {
+                        "path": ".claude/agents/review-agent.md",
+                        "content": "hello",
+                        "kind": "agents",
+                    }
+                ],
+            }
+        )

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -525,10 +525,8 @@ def test_optional_auth_routes_accept_valid_key_when_global_enforcement_enabled(
         ),
     ],
 )
-def test_export_routes_follow_global_auth_enforcement(
-    path, payload, expected_key, test_key, monkeypatch
-):
-    monkeypatch.setenv("PROMPTC_REQUIRE_API_KEY_FOR_ALL", "true")
+def test_export_routes_always_require_api_key(path, payload, expected_key, test_key, monkeypatch):
+    monkeypatch.setenv("PROMPTC_REQUIRE_API_KEY_FOR_ALL", "false")
 
     unauthorized_response = client.post(path, json=payload)
     assert unauthorized_response.status_code == 403

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,5 +1,9 @@
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.rag import RagIngestRequest
 from app.llm_engine.rag import ContextStrategist, Snippet, MockVectorDB, SQLiteVectorDB
 
 
@@ -106,6 +110,32 @@ def test_process_end_to_end(strategist):
 def test_mock_vector_db():
     db = MockVectorDB()
     assert db.search("anything") == []
+
+
+def test_rag_ingest_request_rejects_overlong_path_items():
+    with pytest.raises(ValidationError) as exc:
+        RagIngestRequest(paths=["a" * 1025])
+
+    assert "path exceeds maximum length of 1024 characters" in str(exc.value)
+
+
+def test_rag_ingest_request_accepts_max_length_path_item():
+    request = RagIngestRequest(paths=["a" * 1024])
+
+    assert request.paths == ["a" * 1024]
+
+
+def test_rag_ingest_request_rejects_overlong_extension_items():
+    with pytest.raises(ValidationError) as exc:
+        RagIngestRequest(paths=["valid"], exts=["a" * 51])
+
+    assert "extension exceeds maximum length of 50 characters" in str(exc.value)
+
+
+def test_rag_ingest_request_accepts_max_length_extension_item():
+    request = RagIngestRequest(paths=["valid"], exts=["a" * 50])
+
+    assert request.exts == ["a" * 50]
 
 
 @patch("app.llm_engine.rag.search_hybrid")


### PR DESCRIPTION
## Summary
- salvage the safe part of #561 by validating per-item lengths in RAG ingest requests
- salvage the safe part of #546 by locking the agent-pack manifest contract to the Claude schema the frontend expects
- narrow #562 to a balanced auth fix by requiring API keys only for export routes while keeping local compile/validate/optimize and optional RAG read routes open

## Verification
- python -m pytest tests/test_rag.py -q
- python -m pytest tests/test_agent_packs_api.py -q
- python -m pytest tests/test_auth_fast_path.py -q
- python -m pytest -q tests/test_api_hardening.py tests/test_auth_fast_path.py tests/test_rag_upload.py tests/test_benchmark_api.py
- python -m pytest tests/test_export_adapters.py -q
- cd web && npm run test -- --run app/proxy-routes.test.ts
- cd web && npm run test -- --run lib/server/backendProxy.test.ts

## Supersedes
- #546
- #561
- #562