### PR TITLE
test: Fix CLI output format regression in json-path

### DIFF
--- a/cli/commands/core.py
+++ b/cli/commands/core.py
@@ -1051,8 +1051,7 @@ def json_path(
     elif raw and isinstance(cur, str):
         typer.echo(cur)
     else:
-        # Bolt Optimization: orjson.dumps is significantly faster than json.dumps for CLI output serialization
-        typer.echo(orjson.dumps(cur).decode("utf-8"))
+        typer.echo(json.dumps(cur, ensure_ascii=False))
 
 
 @app.command("diff")

--- a/tests/test_cli_output_format.py
+++ b/tests/test_cli_output_format.py
@@ -1,0 +1,36 @@
+import pytest
+from typer.testing import CliRunner
+from cli.main import app
+import json
+
+runner = CliRunner()
+
+def test_json_path_output_formatting(tmp_path):
+    test_file = tmp_path / "test.json"
+    data = {"hello": "world", "nested": {"key": "value"}}
+    test_file.write_text(json.dumps(data, ensure_ascii=False))
+
+    result = runner.invoke(app, ["json-path", str(test_file), "nested"])
+    assert result.exit_code == 0
+    # Expected behavior: json.dumps will format it exactly with a space after colon
+    assert '{"key": "value"}' in result.stdout
+
+def test_json_path_string_output(tmp_path):
+    test_file = tmp_path / "test.json"
+    data = {"greeting": "hello world"}
+    test_file.write_text(json.dumps(data, ensure_ascii=False))
+
+    result = runner.invoke(app, ["json-path", str(test_file), "greeting"])
+    assert result.exit_code == 0
+    # json.dumps of string will be "hello world" with quotes
+    assert '"hello world"' in result.stdout
+
+def test_diff_json_output(tmp_path):
+    f1 = tmp_path / "1.json"
+    f2 = tmp_path / "2.json"
+    f1.write_text('{"a": 1, "b": 2}')
+    f2.write_text('{"a": 1, "b": 3}')
+    result = runner.invoke(app, ["diff", str(f1), str(f2)])
+    assert result.exit_code == 0
+    # We should see difflib output formatted exactly with indent 2 because of orjson OPT_INDENT_2
+    assert '-  "b": 2' in result.stdout or '-  "b": 2,' in result.stdout


### PR DESCRIPTION
**What:**
Fixed output format regressions caused by replacing `json.dumps` with `orjson.dumps` in the CLI tools. Specifically, the `json-path` command output formatting (which prints scalar objects and inline dicts without pretty printing) has been restored to `json.dumps` to strictly preserve exact spacing (e.g., `{"a": 1}` instead of `orjson`'s `{"a":1}`). 

**Why:**
The PR replacing `json.dumps` with `orjson.dumps` speeds up CLI JSON serialization. However, `orjson` doesn't support an exact equivalent to `json.dumps` defaults (with a space after separators), and it output bytes instead of a string. This breaks strict CLI string format compatibility for raw outputs.

**Testing/Verification:**
Added `tests/test_cli_output_format.py` which strictly tests `json-path` and `diff` command format compatibility. The test suite has been run to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [9012968528006677860](https://jules.google.com/task/9012968528006677860) started by @madara88645*