### PR TITLE
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -56,3 +56,8 @@
 **Vulnerability:** Found a potential crash/XSS vulnerability in `extension/popup.js`. The `escapeHtml` function did not explicitly cast its argument to a string and handle null/undefined values before calling string methods (`.replaceAll()`).
 **Learning:** When dynamically constructing HTML using template literals and injecting it into `innerHTML` (e.g., in vanilla JS browser extensions), it is critical to ensure all external or derived variables are sanitized. If a function like `escapeHtml` does not explicitly cast to a string (e.g., using `String(value ?? "")`), it may crash if `null` or `undefined` is passed, or it could potentially be bypassed if an object with a crafted `toString` is passed.
 **Prevention:** A robust `escapeHtml` implementation must explicitly cast values to strings (e.g., `String(value ?? "")`) to prevent crashes or bypasses from null/undefined inputs, and replace `&`, `<`, `>`, `"`, and `'`.
+## 2025-06-25 - Prevent Unauthorized LLM Prompt Optimization
+
+**Vulnerability:** The `/optimize` endpoint used `verify_api_key_if_required` instead of `verify_api_key`, allowing unauthenticated users to trigger cost-incurring LLM generation when global key requirements were disabled.
+**Learning:** Endpoints that trigger cost-incurring actions (like LLM calls) must strictly enforce standard authentication and avoid relying on fallback or optional dependencies, preventing unauthorized resource exhaustion.
+**Prevention:** Always verify that endpoints triggering cost-incurring actions explicitly include standard authentication dependencies (e.g., `Depends(verify_api_key)`) in their signature.

--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -459,7 +459,7 @@ def validate_endpoint(
 @router.post("/optimize", response_model=OptimizeResponse)
 async def optimize_endpoint(
     req: OptimizeRequest,
-    api_key: APIKey | None = Depends(verify_api_key_if_required),
+    api_key: APIKey = Depends(verify_api_key),
 ):
     del api_key
     compiler = _get_compiler()

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -388,7 +388,7 @@ def test_optimize_no_key():
 
         resp = client.post("/optimize", json={"text": "a much longer prompt"})
 
-    assert resp.status_code == 200
+    assert resp.status_code == 403
 
 
 def test_rag_stats_no_key():


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix authorization bypass in API

🚨 Severity: HIGH
💡 Vulnerability: The `/optimize` endpoint used `verify_api_key_if_required` instead of `verify_api_key`, allowing unauthenticated users to trigger cost-incurring LLM generation when global key requirements were disabled.
🎯 Impact: This allowed unauthorized users to exhaust LLM usage resources and incur costs unexpectedly.
🔧 Fix: Changed the dependency on the `/optimize` endpoint to enforce strict authentication with `verify_api_key`.
✅ Verification: Tested the API `/optimize` endpoint returns a `403` instead of `200` without a key, run all python backend tests which passed.

---
*PR created automatically by Jules for task [18384390278034130074](https://jules.google.com/task/18384390278034130074) started by @madara88645*