### PR TITLE
[codex] fix: align repo context proxy auth

### DIFF
--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -180,6 +180,13 @@ describe("Next backend proxy route wiring", () => {
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
     },
     {
+      name: "repo context analysis",
+      handler: repoContextGithubRoute,
+      requestUrl: "http://localhost:3000/repo-context/github",
+      requestBody: { repo_url: "https://github.com/openai/openai-python" },
+      expectedUrl: "https://api.memo.dev/repo-context/github",
+    },
+    {
       name: "RAG upload",
       handler: ragUploadRoute,
       requestUrl: "http://localhost:3000/rag/upload",

--- a/web/app/repo-context/github/route.ts
+++ b/web/app/repo-context/github/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/repo-context/github", {});
+  return proxyBackendRequest(request, "/repo-context/github", {
+    requireServerApiKey: true,
+  });
 }


### PR DESCRIPTION
## Summary
- require the same server-side API key protection on `/repo-context/github` as the other generator proxy routes
- add proxy route coverage that proves repo-context returns the config error instead of leaking through to the backend when the server key is missing

## Why
The backend repo-context endpoint already requires an API key, but the Next proxy route had drifted into the optional-auth path. That created inconsistent behavior in deploys without `PROMPTC_SERVER_API_KEY`: the repo analysis request tried to reach the backend and failed later instead of stopping immediately with the expected config error.

## Validation
- `cd web && npm run test -- app/proxy-routes.test.ts`
- `cd web && npm run test -- lib/server/backendProxy.test.ts`
- `cd web && npm run build`
