### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to GitHubRepoContextPayload list items

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -5,7 +5,7 @@ from typing import Literal
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.auth import APIKey, verify_api_key, verify_api_key_if_required
 from api.shared import logger
@@ -77,6 +77,17 @@ class GitHubRepoContextPayload(BaseModel):
     highlights: list[str] = Field(default_factory=list, max_length=6)
     files_used: list[str] = Field(default_factory=list, max_length=6)
     detected_stack: list[str] = Field(default_factory=list, max_length=6)
+
+    # Security: Enforce strict length limits on list elements to prevent DoS via massive strings
+    @field_validator("highlights", "files_used", "detected_stack", mode="after")
+    @classmethod
+    def validate_list_items_length(cls, items: list[str]) -> list[str]:
+        if not items:
+            return items
+        for item in items:
+            if len(item) > 1024:
+                raise ValueError("Item in list exceeds maximum length of 1024 characters")
+        return items
 
 
 class GitHubRepoContextRequest(BaseModel):


### PR DESCRIPTION
🚨 Severity: MEDIUM

💡 Vulnerability: The `GitHubRepoContextPayload` model used in `/repo-context/github` and related generator endpoints restricted the maximum number of items in the `highlights`, `files_used`, and `detected_stack` lists (via `max_length=6`), but failed to limit the length of the strings *inside* those lists. This allowed an attacker to submit massive strings (e.g., 10MB+) inside these arrays, causing excessive memory consumption and potential application crashes (Denial of Service).

🎯 Impact: A malicious actor could repeatedly trigger memory exhaustion on the server, resulting in a Denial of Service for all users by submitting a small array filled with extremely large strings to the unprotected payload fields.

🔧 Fix: Added a custom Pydantic `@field_validator` with `mode="after"` that explicitly iterates through the elements of `highlights`, `files_used`, and `detected_stack`, enforcing a strict maximum length of 1024 characters per string and raising a `ValueError` if the limit is exceeded. 

✅ Verification: 
- Local test scripts verified that 10MB strings inside the list fields are actively rejected with a Pydantic `ValidationError`.
- Full backend test suite (`pytest -n 4 tests/`) passed successfully with 1060 passing tests and 0 failures, ensuring no regressions.

---
*PR created automatically by Jules for task [10790539735619883031](https://jules.google.com/task/10790539735619883031) started by @madara88645*