### PR TITLE
[codex] fix: harden agent pack manifest file validation

### DIFF
--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import re
 from typing import Any, Literal, Protocol
 from zipfile import ZIP_DEFLATED, ZipFile
 
@@ -50,6 +51,12 @@ class AgentPackManifest(BaseModel):
         if unknown_preview_kinds:
             joined = ", ".join(unknown_preview_kinds)
             raise ValueError(f"preview_order includes kinds without matching files: {joined}")
+        normalized_paths: set[str] = set()
+        for file in self.files:
+            normalized_path = _normalize_pack_path(file.path)
+            if normalized_path in normalized_paths:
+                raise ValueError(f"duplicate file path in manifest: {file.path}")
+            normalized_paths.add(normalized_path)
         return self
 
 
@@ -223,3 +230,19 @@ def _media_type_for_path(path: str) -> str:
     if path.endswith(".py"):
         return "text/x-python; charset=utf-8"
     return "text/plain; charset=utf-8"
+
+
+def _normalize_pack_path(path: str) -> str:
+    trimmed = path.strip()
+    if not trimmed:
+        raise ValueError("manifest file paths must not be empty")
+
+    normalized = trimmed.replace("\\", "/")
+    if normalized.startswith("/") or re.match(r"^[A-Za-z]:/", normalized):
+        raise ValueError(f"manifest file path must be relative: {path}")
+
+    parts = normalized.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"manifest file path contains unsafe segments: {path}")
+
+    return normalized

--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -269,3 +269,58 @@ def test_agent_pack_manifest_rejects_preview_order_kinds_not_present_in_files():
                 ],
             }
         )
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "",
+        "   ",
+        "../secrets.txt",
+        "..\\secrets.txt",
+        "/etc/passwd",
+        "C:/windows/system32/config",
+        ".claude/../secrets.txt",
+    ],
+)
+def test_agent_pack_manifest_rejects_unsafe_file_paths(bad_path: str):
+    with pytest.raises(ValidationError):
+        AgentPackManifest.model_validate(
+            {
+                "provider": "claude",
+                "pack_type": "subagent",
+                "download_name": "demo-pack",
+                "preview_order": ["agents"],
+                "files": [
+                    {
+                        "path": bad_path,
+                        "content": "hello",
+                        "kind": "agents",
+                    }
+                ],
+            }
+        )
+
+
+def test_agent_pack_manifest_rejects_duplicate_file_paths():
+    with pytest.raises(ValidationError):
+        AgentPackManifest.model_validate(
+            {
+                "provider": "claude",
+                "pack_type": "subagent",
+                "download_name": "demo-pack",
+                "preview_order": ["agents"],
+                "files": [
+                    {
+                        "path": ".claude/agents/review-agent.md",
+                        "content": "hello",
+                        "kind": "agents",
+                    },
+                    {
+                        "path": ".claude\\agents\\review-agent.md",
+                        "content": "world",
+                        "kind": "agents",
+                    },
+                ],
+            }
+        )


### PR DESCRIPTION
## Summary
- reject unsafe relative, absolute, and empty agent-pack file paths before preview/download
- reject duplicate manifest paths after slash normalization so the same file cannot be emitted twice
- add regression coverage for unsafe and duplicate manifest entries

## Why
Agent pack manifests are generated content that later become downloadable files. Before this change, path traversal-like segments, absolute paths, and duplicate paths could pass validation and reach export flows.

## Validation
- C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m pytest tests/test_agent_packs_api.py -q
- C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m pytest tests/test_agent_packs_api.py tests/test_api_hardening.py -q
- C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m ruff check app\adapters\agent_packs.py tests\test_agent_packs_api.py
