### PR TITLE
[codex] fix: add repo-aware generator context

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -5,6 +5,11 @@ from pydantic import BaseModel, Field
 
 from api.auth import APIKey, verify_api_key
 from api.shared import logger
+from app.github_repo_context import (
+    GitHubRepoAnalysisError,
+    InvalidGitHubRepoUrl,
+    analyze_public_github_repo,
+)
 
 router = APIRouter(tags=["generators"])
 
@@ -17,12 +22,27 @@ def _get_compiler():
     return api_main.get_compiler()
 
 
+class GitHubRepoContextPayload(BaseModel):
+    normalized_repo_url: str = Field(..., min_length=1, max_length=500)
+    repo_full_name: str = Field(..., min_length=1, max_length=255)
+    default_branch: str | None = Field(default=None, max_length=255)
+    summary: str = Field(..., min_length=1, max_length=1_500)
+    highlights: list[str] = Field(default_factory=list, max_length=6)
+    files_used: list[str] = Field(default_factory=list, max_length=6)
+    detected_stack: list[str] = Field(default_factory=list, max_length=6)
+
+
+class GitHubRepoContextRequest(BaseModel):
+    repo_url: str = Field(..., min_length=1, max_length=500)
+
+
 class SkillGenRequest(BaseModel):
     description: str = Field(..., min_length=1, max_length=_MAX_DESCRIPTION_CHARS)
     include_example_code: bool = Field(
         default=False,
         description="Whether generated skill definition should include implementation example code",
     )
+    repo_context: GitHubRepoContextPayload | None = None
 
 
 class SkillGenResponse(BaseModel):
@@ -33,10 +53,29 @@ class AgentGenRequest(BaseModel):
     description: str = Field(..., min_length=1, max_length=_MAX_DESCRIPTION_CHARS)
     multi_agent: bool = Field(default=False, description="Generate a multi-agent swarm if true")
     include_example_code: bool = Field(default=False, description="Include pseudo-code example")
+    repo_context: GitHubRepoContextPayload | None = None
 
 
 class AgentGenResponse(BaseModel):
     system_prompt: str
+
+
+@router.post("/repo-context/github", response_model=GitHubRepoContextPayload)
+async def analyze_github_repo_endpoint(
+    req: GitHubRepoContextRequest,
+    api_key: APIKey = Depends(verify_api_key),
+):
+    del api_key
+
+    try:
+        return GitHubRepoContextPayload.model_validate(analyze_public_github_repo(req.repo_url))
+    except InvalidGitHubRepoUrl as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except GitHubRepoAnalysisError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("github repo analysis failed")
+        raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
 
 
 @router.post("/skills-generator/generate", response_model=SkillGenResponse)
@@ -51,6 +90,7 @@ async def generate_skill_endpoint(
         result = compiler.generate_skill(
             req.description,
             include_example_code=req.include_example_code,
+            repo_context=req.repo_context.model_dump() if req.repo_context else None,
         )
         return SkillGenResponse(skill_definition=result)
     except Exception as exc:
@@ -71,6 +111,7 @@ async def generate_agent_endpoint(
             req.description,
             multi_agent=req.multi_agent,
             include_example_code=req.include_example_code,
+            repo_context=req.repo_context.model_dump() if req.repo_context else None,
         )
         return AgentGenResponse(system_prompt=result)
     except Exception as exc:

--- a/app/github_repo_context.py
+++ b/app/github_repo_context.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+
+GITHUB_API_BASE = "https://api.github.com"
+MANIFEST_FILES = [
+    "package.json",
+    "pyproject.toml",
+    "requirements.txt",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "composer.json",
+    "Gemfile",
+]
+SCANNED_APP_DIRS = ["web", "frontend", "backend", "app", "api", "server", "client"]
+MAX_HIGHLIGHTS = 6
+MAX_FILES_USED = 6
+MAX_STACK_ITEMS = 6
+SUMMARY_MAX_CHARS = 1200
+
+
+class InvalidGitHubRepoUrl(ValueError):
+    pass
+
+
+class GitHubRepoAnalysisError(RuntimeError):
+    def __init__(self, message: str, *, status_code: int = 502):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def normalize_public_github_repo_url(repo_url: str) -> str:
+    raw = (repo_url or "").strip()
+    if not raw:
+        raise InvalidGitHubRepoUrl("GitHub repo URL is required.")
+
+    parsed = urlparse(raw)
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        raise InvalidGitHubRepoUrl("Only public https://github.com/owner/repo URLs are supported.")
+    if parsed.query or parsed.fragment:
+        raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
+
+    path = parsed.path.rstrip("/")
+    segments = [segment for segment in path.split("/") if segment]
+    if len(segments) != 2:
+        raise InvalidGitHubRepoUrl("Only root repository URLs are supported.")
+
+    owner, repo = segments
+    if repo.endswith(".git"):
+        raise InvalidGitHubRepoUrl("Remove the .git suffix and use the root repository URL.")
+
+    allowed = re.compile(r"^[A-Za-z0-9_.-]+$")
+    if not allowed.match(owner) or not allowed.match(repo):
+        raise InvalidGitHubRepoUrl("Repository URL contains unsupported characters.")
+
+    return f"https://github.com/{owner}/{repo}"
+
+
+def analyze_public_github_repo(repo_url: str) -> dict[str, Any]:
+    normalized_url = normalize_public_github_repo_url(repo_url)
+    repo_full_name = normalized_url.replace("https://github.com/", "", 1)
+
+    with httpx.Client(
+        base_url=GITHUB_API_BASE,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "promptc-repo-context/1.0",
+        },
+        timeout=10.0,
+        follow_redirects=True,
+    ) as client:
+        repo_meta = _get_json(client, f"/repos/{repo_full_name}")
+        root_entries = _get_json(client, f"/repos/{repo_full_name}/contents")
+        if not isinstance(root_entries, list):
+            raise GitHubRepoAnalysisError("Unable to read the repository root directory.")
+
+        default_branch = repo_meta.get("default_branch")
+        readme_entry = _find_readme(root_entries)
+        readme_text = _read_text_file(client, readme_entry) if readme_entry else ""
+        files_used: list[str] = []
+        if readme_entry:
+            files_used.append(readme_entry["path"])
+
+        manifests: dict[str, str] = {}
+        for manifest_name in MANIFEST_FILES:
+            entry = _find_entry(root_entries, manifest_name)
+            if entry:
+                content = _read_text_file(client, entry)
+                if content:
+                    manifests[entry["path"]] = content
+                    files_used.append(entry["path"])
+
+        top_level_dirs = [entry["name"] for entry in root_entries if entry.get("type") == "dir"]
+        candidate_dirs = [name for name in top_level_dirs if name in SCANNED_APP_DIRS][:2]
+
+        for directory in candidate_dirs:
+            nested_entries = _get_json(client, f"/repos/{repo_full_name}/contents/{directory}")
+            if not isinstance(nested_entries, list):
+                continue
+            for manifest_name in MANIFEST_FILES:
+                entry = _find_entry(nested_entries, manifest_name)
+                if entry and entry["path"] not in manifests:
+                    content = _read_text_file(client, entry)
+                    if content:
+                        manifests[entry["path"]] = content
+                        files_used.append(entry["path"])
+
+        detected_stack = _detect_stack(repo_meta, manifests)
+        files_used = _dedupe(files_used)[:MAX_FILES_USED]
+        highlights = _build_highlights(
+            repo_meta=repo_meta,
+            detected_stack=detected_stack,
+            top_level_dirs=top_level_dirs,
+            files_used=files_used,
+            manifest_paths=list(manifests.keys()),
+        )[:MAX_HIGHLIGHTS]
+        summary = _build_summary(
+            repo_meta=repo_meta,
+            detected_stack=detected_stack,
+            top_level_dirs=top_level_dirs,
+            files_used=files_used,
+            manifest_paths=list(manifests.keys()),
+            readme_text=readme_text,
+        )
+
+    return {
+        "normalized_repo_url": normalized_url,
+        "repo_full_name": repo_full_name,
+        "default_branch": default_branch,
+        "summary": summary,
+        "highlights": highlights,
+        "files_used": files_used,
+        "detected_stack": detected_stack[:MAX_STACK_ITEMS],
+    }
+
+
+def _get_json(client: httpx.Client, path: str) -> Any:
+    try:
+        response = client.get(path)
+        if response.status_code == 404:
+            raise GitHubRepoAnalysisError(
+                "Repository not found or not public. Only public GitHub repos are supported.",
+                status_code=404,
+            )
+        response.raise_for_status()
+        return response.json()
+    except httpx.HTTPStatusError as exc:
+        status_code = exc.response.status_code if exc.response is not None else 502
+        raise GitHubRepoAnalysisError(
+            "GitHub repository analysis failed.",
+            status_code=404 if status_code == 404 else 502,
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise GitHubRepoAnalysisError("GitHub repository analysis failed.") from exc
+
+
+def _read_text_file(client: httpx.Client, entry: dict[str, Any]) -> str:
+    download_url = entry.get("download_url")
+    if not download_url:
+        return ""
+    try:
+        response = client.get(download_url)
+        response.raise_for_status()
+        return response.text
+    except httpx.HTTPError:
+        return ""
+
+
+def _find_entry(entries: list[dict[str, Any]], target_name: str) -> dict[str, Any] | None:
+    target_lower = target_name.lower()
+    for entry in entries:
+        if entry.get("name", "").lower() == target_lower:
+            return entry
+    return None
+
+
+def _find_readme(entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for entry in entries:
+        name = entry.get("name", "").lower()
+        if entry.get("type") == "file" and name.startswith("readme"):
+            return entry
+    return None
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _detect_stack(repo_meta: dict[str, Any], manifests: dict[str, str]) -> list[str]:
+    stack: list[str] = []
+    language = repo_meta.get("language")
+    if isinstance(language, str) and language.strip():
+        stack.append(language.strip())
+
+    manifest_names = {path.rsplit("/", 1)[-1] for path in manifests}
+    combined_manifest_text = "\n".join(manifests.values()).lower()
+
+    if "package.json" in manifest_names:
+        stack.append("Node.js")
+        try:
+            package_json = json.loads(
+                next(text for path, text in manifests.items() if path.endswith("package.json"))
+            )
+            deps = {
+                **(package_json.get("dependencies") or {}),
+                **(package_json.get("devDependencies") or {}),
+            }
+            dep_names = {str(name).lower() for name in deps}
+            if "next" in dep_names:
+                stack.append("Next.js")
+            if "react" in dep_names:
+                stack.append("React")
+            if "typescript" in dep_names:
+                stack.append("TypeScript")
+        except Exception:
+            pass
+
+    if "pyproject.toml" in manifest_names or "requirements.txt" in manifest_names:
+        stack.append("Python")
+    if "fastapi" in combined_manifest_text:
+        stack.append("FastAPI")
+    if "django" in combined_manifest_text:
+        stack.append("Django")
+    if "flask" in combined_manifest_text:
+        stack.append("Flask")
+    if "httpx" in combined_manifest_text:
+        stack.append("httpx")
+    if "cargo.toml" in {name.lower() for name in manifest_names}:
+        stack.append("Rust")
+    if "go.mod" in manifest_names:
+        stack.append("Go")
+    if "pom.xml" in manifest_names:
+        stack.append("Java")
+    if "composer.json" in manifest_names:
+        stack.append("PHP")
+    if "gemfile" in {name.lower() for name in manifest_names}:
+        stack.append("Ruby")
+
+    return _dedupe(stack)[:MAX_STACK_ITEMS]
+
+
+def _build_highlights(
+    *,
+    repo_meta: dict[str, Any],
+    detected_stack: list[str],
+    top_level_dirs: list[str],
+    files_used: list[str],
+    manifest_paths: list[str],
+) -> list[str]:
+    repo_name = repo_meta.get("full_name") or "This repository"
+    description = (repo_meta.get("description") or "").strip()
+    highlights: list[str] = []
+    if description:
+        highlights.append(description)
+    if detected_stack:
+        highlights.append(f"Detected stack: {', '.join(detected_stack)}.")
+    if len(top_level_dirs) >= 2:
+        highlights.append(f"Top-level directories include {', '.join(top_level_dirs[:4])}.")
+    if manifest_paths:
+        highlights.append(f"Manifest signals found in {', '.join(manifest_paths[:3])}.")
+    if files_used:
+        highlights.append(f"Brief built from {', '.join(files_used[:4])}.")
+    highlights.append(
+        f"Use existing patterns from {repo_name}; avoid inventing missing APIs or dependencies."
+    )
+    return _dedupe(highlights)
+
+
+def _build_summary(
+    *,
+    repo_meta: dict[str, Any],
+    detected_stack: list[str],
+    top_level_dirs: list[str],
+    files_used: list[str],
+    manifest_paths: list[str],
+    readme_text: str,
+) -> str:
+    repo_name = repo_meta.get("full_name") or "This repository"
+    description = (repo_meta.get("description") or "").strip()
+    shape = (
+        "a multi-surface repo with distinct app areas"
+        if any(
+            name in {"web", "frontend", "backend", "api", "client", "server"}
+            for name in top_level_dirs
+        )
+        else "a mostly single-surface repo"
+    )
+    stack_phrase = (
+        ", ".join(detected_stack) if detected_stack else "manifest-derived project tooling"
+    )
+    dir_phrase = (
+        ", ".join(top_level_dirs[:5]) if top_level_dirs else "no notable top-level directories"
+    )
+    manifest_phrase = (
+        ", ".join(manifest_paths[:4]) if manifest_paths else "no common manifests were detected"
+    )
+    files_phrase = ", ".join(files_used[:6]) if files_used else "repo metadata only"
+    readme_signal = _extract_readme_signal(readme_text)
+
+    parts = [
+        f"{repo_name} is a public GitHub repository.",
+        description
+        if description
+        else "No repository description was provided in GitHub metadata.",
+        f"Primary stack signals point to {stack_phrase}.",
+        f"The root structure suggests {shape}, with directories such as {dir_phrase}.",
+        f"The shallow analysis inspected {files_phrase} and used manifest hints from {manifest_phrase}.",
+        readme_signal,
+        "For generator output, stay aligned with the detected stack, prefer existing project conventions, and avoid assuming internal APIs that are not visible in README or manifest-level signals.",
+        "Treat this as a compact repo brief rather than a full code audit: it is suitable for tailoring an agent or skill, but not for making file-level implementation claims without further context.",
+    ]
+    summary = " ".join(part.strip() for part in parts if part.strip())
+    if len(summary) > SUMMARY_MAX_CHARS:
+        summary = summary[: SUMMARY_MAX_CHARS - 3].rstrip() + "..."
+    return summary
+
+
+def _extract_readme_signal(readme_text: str) -> str:
+    text = re.sub(r"\s+", " ", (readme_text or "")).strip()
+    if not text:
+        return "README content was unavailable, so the brief leans more heavily on GitHub metadata and manifest files."
+    compact = text[:220].strip()
+    return "README signal: " + compact + ("..." if len(text) > len(compact) else "")

--- a/app/llm_engine/hybrid.py
+++ b/app/llm_engine/hybrid.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Any, Optional
 from .client import WorkerClient, WorkerResponse, DEFAULT_MODEL
 from .schemas import DiagnosticItem
 from app.compiler import compile_text_v2
@@ -210,13 +210,17 @@ class HybridCompiler:
         text: str,
         multi_agent: bool = False,
         include_example_code: bool = False,
+        repo_context: dict[str, Any] | None = None,
     ) -> str:
         """
         Generate a comprehensive AI Agent system prompt, aware of RAG context.
         """
         try:
             # Retrieve relevant code context using Agent 6
-            rag_context = self.context_strategist.process(text)
+            rag_context = self._merge_generator_context(
+                self.context_strategist.process(text),
+                repo_context,
+            )
             return self.worker.generate_agent(
                 text,
                 context=rag_context,
@@ -227,13 +231,21 @@ class HybridCompiler:
             # Fallback for agent generation
             return f"# Error\n\nFailed to generate agent: {e}"
 
-    def generate_skill(self, text: str, include_example_code: bool = False) -> str:
+    def generate_skill(
+        self,
+        text: str,
+        include_example_code: bool = False,
+        repo_context: dict[str, Any] | None = None,
+    ) -> str:
         """
         Generate a comprehensive AI Skill definition, aware of RAG context.
         """
         try:
             # Retrieve relevant code context using Agent 6
-            rag_context = self.context_strategist.process(text)
+            rag_context = self._merge_generator_context(
+                self.context_strategist.process(text),
+                repo_context,
+            )
             return self.worker.generate_skill(
                 text,
                 context=rag_context,
@@ -242,3 +254,16 @@ class HybridCompiler:
         except Exception as e:
             # Fallback for skill generation
             return f"# Error\n\nFailed to generate skill: {e}"
+
+    def _merge_generator_context(
+        self,
+        rag_context: dict[str, Any] | None,
+        repo_context: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        merged: dict[str, Any] = dict(rag_context or {})
+        if repo_context:
+            merged["repo_context"] = {
+                "source": "github_public_repo",
+                **repo_context,
+            }
+        return merged or None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 	"ttkbootstrap>=1.20.3",
 	"pillow>=12.2.0",
 	"openai>=2.35.1",
+	"httpx<0.29",
 	"python-dotenv>=1.2.2",
 	"jinja2>=3.1.6",
 	"tiktoken>=0.12.0",
@@ -52,7 +53,6 @@ dev = [
 	"build>=1.5.0",
 	"ruff==0.15.12",
 	"pre-commit==4.6.0",
-	"httpx<0.29",
 ]
 
 openai = []

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -33,9 +33,14 @@ def test_generator_endpoints_require_api_key():
 
     agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"})
     skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"})
+    repo_resp = client.post(
+        "/repo-context/github",
+        json={"repo_url": "https://github.com/openai/openai-python"},
+    )
 
     assert agent_resp.status_code == 403
     assert skill_resp.status_code == 403
+    assert repo_resp.status_code == 403
 
 
 @pytest.mark.auth_required

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -41,26 +41,47 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
     # Mock context strategist
     compiler.context_strategist = MagicMock()
     compiler.context_strategist.process.return_value = {"file1.py": "content"}
+    repo_context = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repository.",
+        "highlights": ["README present"],
+        "files_used": ["README.md"],
+        "detected_stack": ["Python"],
+    }
 
     # Manually inject the mock worker
     compiler.worker = mock_worker_client
 
     # Test generate_agent with context
-    compiler.generate_agent("Test Agent")
+    compiler.generate_agent("Test Agent", repo_context=repo_context)
     compiler.context_strategist.process.assert_called_with("Test Agent")
     mock_worker_client.generate_agent.assert_called_with(
         "Test Agent",
-        context={"file1.py": "content"},
+        context={
+            "file1.py": "content",
+            "repo_context": {
+                "source": "github_public_repo",
+                **repo_context,
+            },
+        },
         multi_agent=False,
         include_example_code=False,
     )
 
     # Test generate_skill with context
-    compiler.generate_skill("Test Skill")
+    compiler.generate_skill("Test Skill", repo_context=repo_context)
     compiler.context_strategist.process.assert_called_with("Test Skill")
     mock_worker_client.generate_skill.assert_called_with(
         "Test Skill",
-        context={"file1.py": "content"},
+        context={
+            "file1.py": "content",
+            "repo_context": {
+                "source": "github_public_repo",
+                **repo_context,
+            },
+        },
         include_example_code=False,
     )
 
@@ -70,15 +91,42 @@ def test_api_endpoints_integration():
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = "# Mock API Agent"
         mock_compiler.generate_skill.return_value = "# Mock API Skill"
+        mock_compiler.analyze_public_github_repo.return_value = None
 
         client = TestClient(app)
+        repo_context = {
+            "normalized_repo_url": "https://github.com/openai/openai-python",
+            "repo_full_name": "openai/openai-python",
+            "default_branch": "main",
+            "summary": "Python SDK repository.",
+            "highlights": ["README present"],
+            "files_used": ["README.md"],
+            "detected_stack": ["Python"],
+        }
 
         # Test Agent Generator Endpoint
-        resp_agent = client.post("/agent-generator/generate", json={"description": "Test Agent"})
+        resp_agent = client.post(
+            "/agent-generator/generate",
+            json={"description": "Test Agent", "repo_context": repo_context},
+        )
         assert resp_agent.status_code == 200
         assert resp_agent.json() == {"system_prompt": "# Mock API Agent"}
+        mock_compiler.generate_agent.assert_called_with(
+            "Test Agent",
+            multi_agent=False,
+            include_example_code=False,
+            repo_context=repo_context,
+        )
 
         # Test Skills Generator Endpoint
-        resp_skill = client.post("/skills-generator/generate", json={"description": "Test Skill"})
+        resp_skill = client.post(
+            "/skills-generator/generate",
+            json={"description": "Test Skill", "repo_context": repo_context},
+        )
         assert resp_skill.status_code == 200
         assert resp_skill.json() == {"skill_definition": "# Mock API Skill"}
+        mock_compiler.generate_skill.assert_called_with(
+            "Test Skill",
+            include_example_code=False,
+            repo_context=repo_context,
+        )

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from app.github_repo_context import InvalidGitHubRepoUrl, normalize_public_github_repo_url
+
+
+client = TestClient(app)
+
+
+def test_normalize_public_github_repo_url_accepts_root_url():
+    normalized = normalize_public_github_repo_url("https://github.com/openai/openai-python/")
+
+    assert normalized == "https://github.com/openai/openai-python"
+
+
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        "https://github.com/openai/openai-python.git",
+        "https://github.com/openai/openai-python/tree/main",
+        "https://github.com/openai/openai-python/blob/main/README.md",
+        "https://github.com/openai/openai-python?tab=readme-ov-file",
+        "https://github.com/openai/openai-python#readme",
+        "https://github.com/openai/openai-python/issues",
+    ],
+)
+def test_normalize_public_github_repo_url_rejects_non_root_variants(repo_url: str):
+    with pytest.raises(InvalidGitHubRepoUrl):
+        normalize_public_github_repo_url(repo_url)
+
+
+def test_repo_context_endpoint_returns_analyzed_repo_summary():
+    mock_payload = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repo with README-led overview and manifest-derived stack.",
+        "highlights": ["Python package", "README present"],
+        "files_used": ["README.md", "pyproject.toml"],
+        "detected_stack": ["Python", "httpx"],
+    }
+
+    with patch(
+        "api.routes.generators.analyze_public_github_repo", return_value=mock_payload
+    ) as mock_analyze:
+        response = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://github.com/openai/openai-python"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == mock_payload
+    mock_analyze.assert_called_once_with("https://github.com/openai/openai-python")

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -33,28 +33,46 @@ def test_hybrid_compiler_generate_skill(mock_worker_client):
     compiler = HybridCompiler()
     # Manually inject the mock worker because HybridCompiler creates its own instance
     compiler.worker = mock_worker_client
+    repo_context = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repository.",
+        "highlights": ["README present"],
+        "files_used": ["README.md"],
+        "detected_stack": ["Python"],
+    }
 
-    result = compiler.generate_skill("Test Skill")
+    result = compiler.generate_skill("Test Skill", repo_context=repo_context)
     assert result == "# Mock Skill Definition"
-    # HybridCompiler now injects context, so we expect the context argument
-    # We can use ANY for the context content since it depends on the mock vector db
-    from unittest.mock import ANY
-
-    mock_worker_client.generate_skill.assert_called_with(
-        "Test Skill",
-        context=ANY,
-        include_example_code=False,
-    )
+    mock_worker_client.generate_skill.assert_called_once()
+    args, kwargs = mock_worker_client.generate_skill.call_args
+    assert args == ("Test Skill",)
+    assert kwargs["include_example_code"] is False
+    assert kwargs["context"]["repo_context"] == {
+        "source": "github_public_repo",
+        **repo_context,
+    }
 
 
 def test_api_generate_skill_endpoint():
     # Mock the global hybrid_compiler in api.main
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_skill.return_value = "# Mock API Skill"
+        repo_context = {
+            "normalized_repo_url": "https://github.com/openai/openai-python",
+            "repo_full_name": "openai/openai-python",
+            "default_branch": "main",
+            "summary": "Python SDK repository.",
+            "highlights": ["README present"],
+            "files_used": ["README.md"],
+            "detected_stack": ["Python"],
+        }
 
         client = TestClient(app)
         response = client.post(
-            "/skills-generator/generate", json={"description": "Test Skill Request"}
+            "/skills-generator/generate",
+            json={"description": "Test Skill Request", "repo_context": repo_context},
         )
 
         assert response.status_code == 200
@@ -62,6 +80,7 @@ def test_api_generate_skill_endpoint():
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=False,
+            repo_context=repo_context,
         )
 
 
@@ -80,6 +99,7 @@ def test_api_generate_skill_endpoint_with_example_code_enabled():
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=True,
+            repo_context=None,
         )
 
 

--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AgentGeneratorPage from "./page";
+import { apiJson } from "@/config";
+
+vi.mock("@/config", () => ({
+  apiJson: vi.fn(),
+  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+}));
+
+vi.mock("../components/InfoButton", () => ({
+  default: ({ title }: { title: string }) => <button type="button">{title}</button>,
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("./components/ExportPanel", () => ({
+  default: () => null,
+}));
+
+vi.mock("../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+const apiJsonMock = vi.mocked(apiJson);
+
+describe("Agent Generator page", () => {
+  beforeEach(() => {
+    apiJsonMock.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("analyzes a GitHub repo and includes repo_context in the generate request", async () => {
+    apiJsonMock
+      .mockResolvedValueOnce({
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      })
+      .mockResolvedValueOnce({
+        system_prompt: "# Repo-aware Agent",
+      });
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Review this repo and generate an agent." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+
+    await screen.findByText("openai/openai-python");
+    expect(screen.getByText("Python SDK repo with a compact README and clear manifest signals.")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+
+    expect(apiJsonMock.mock.calls[0]?.[0]).toBe("/repo-context/github");
+    expect(JSON.parse(String(apiJsonMock.mock.calls[0]?.[1]?.body))).toEqual({
+      repo_url: "https://github.com/openai/openai-python",
+    });
+
+    expect(apiJsonMock.mock.calls[1]?.[0]).toBe("/agent-generator/generate");
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Review this repo and generate an agent.",
+      multi_agent: false,
+      include_example_code: false,
+      repo_context: {
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      },
+    });
+  });
+
+  it("shows a warning when repo analysis fails but still generates without repo context", async () => {
+    apiJsonMock
+      .mockRejectedValueOnce(new Error("Repository analysis failed"))
+      .mockResolvedValueOnce({
+        system_prompt: "# Plain Agent",
+      });
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Build a safe agent." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+    expect(await screen.findByText("Repository analysis failed")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Build a safe agent.",
+      multi_agent: false,
+      include_example_code: false,
+    });
+  });
+
+  it("keeps the description textarea at a usable desktop height", () => {
+    render(<AgentGeneratorPage />);
+
+    const textarea = screen.getByLabelText("Agent Description");
+    const classes = textarea.getAttribute("class") || "";
+
+    expect(classes).toContain("md:min-h-[220px]");
+    expect(classes).not.toContain("md:min-h-0");
+  });
+});

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -4,13 +4,27 @@ import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Bot } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
+import type { GitHubRepoContextPayload } from "@/lib/api/types";
+import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
+import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
 import ExportPanel from "./components/ExportPanel";
+
+const REPO_ANALYSIS_TIMEOUT_MS = 15000;
+
+function isSupportedGitHubRepoRootUrl(value: string): boolean {
+  return /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/.test(value.trim());
+}
 
 export default function AgentGenerator() {
   const [description, setDescription] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [repoContext, setRepoContext] = useState<GitHubRepoContextPayload | null>(null);
+  const [repoAnalysisLoading, setRepoAnalysisLoading] = useState(false);
+  const [repoAnalysisWarning, setRepoAnalysisWarning] = useState<string | null>(null);
+  const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -20,6 +34,36 @@ export default function AgentGenerator() {
   const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
+  const isValidRepoUrl = isSupportedGitHubRepoRootUrl(repoUrl);
+
+  const handleAnalyzeRepo = async () => {
+    if (!isValidRepoUrl || repoAnalysisLoading) return;
+
+    setRepoAnalysisLoading(true);
+    setRepoAnalysisWarning(null);
+    setError(null);
+
+    try {
+      const data = await withTimeout(
+        apiJson<GitHubRepoContextPayload>("/repo-context/github", {
+          method: "POST",
+          headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({ repo_url: repoUrl.trim() }),
+        }),
+        REPO_ANALYSIS_TIMEOUT_MS,
+        "Repository analysis is taking too long. Please try again.",
+      );
+      setRepoContext(data);
+      setRepoContextDirty(false);
+    } catch (e: unknown) {
+      showError(e);
+      setRepoContext(null);
+      setRepoContextDirty(false);
+      setRepoAnalysisWarning(e instanceof Error ? e.message : "Repository analysis failed");
+    } finally {
+      setRepoAnalysisLoading(false);
+    }
+  };
 
   const handleGenerate = async () => {
     if (!description.trim()) return;
@@ -38,6 +82,7 @@ export default function AgentGenerator() {
           description,
           multi_agent: multiAgent,
           include_example_code: includeExampleCode,
+          ...(repoContext && !repoContextDirty ? { repo_context: repoContext } : {}),
         }),
       });
 
@@ -106,12 +151,65 @@ export default function AgentGenerator() {
               </p>
             </div>
 
-            <div className="flex-1 min-h-0 flex flex-col relative group">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="agent-repo-url" className="text-sm font-medium text-zinc-300">GitHub Repo URL</label>
+              <p className="text-xs text-zinc-500">
+                Optional. Analyze a public root repo URL to give the generator a compact project-aware brief.
+              </p>
+              <input
+                id="agent-repo-url"
+                aria-label="GitHub Repo URL"
+                className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 font-mono text-sm text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50"
+                placeholder="https://github.com/owner/repo"
+                value={repoUrl}
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+                  setRepoUrl(nextValue);
+                  setRepoAnalysisWarning(null);
+                  if (!repoContext) {
+                    return;
+                  }
+                  const normalizedNext = nextValue.trim().replace(/\/+$/, "");
+                  const normalizedCurrent = repoContext.normalized_repo_url.replace(/\/+$/, "");
+                  const isDirty = normalizedNext !== normalizedCurrent;
+                  setRepoContextDirty(isDirty);
+                  if (!isDirty) {
+                    setRepoAnalysisWarning(null);
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleAnalyzeRepo}
+                disabled={!isValidRepoUrl || repoAnalysisLoading}
+                className="w-full rounded-xl border border-green-500/20 bg-green-500/10 px-4 py-2.5 text-sm font-semibold text-green-100 transition-all hover:bg-green-500/15 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {repoAnalysisLoading ? "Analyzing Repo..." : "Analyze Repo"}
+              </button>
+            </div>
+
+            {repoContext && !repoContextDirty ? (
+              <RepoContextPreviewCard repoContext={repoContext} accent="green" />
+            ) : null}
+
+            {repoContextDirty ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                Repo URL changed. Re-analyze to attach fresh repo context.
+              </div>
+            ) : null}
+
+            {repoAnalysisWarning ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                {repoAnalysisWarning}
+              </div>
+            ) : null}
+
+            <div className="relative shrink-0 group">
               <textarea
                 id="agent-description"
                 aria-label="Agent Description"
                 aria-describedby="agent-description-help"
-                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-0"
+                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'I need an agent that reviews React code for performance bottlenecks' or 'A creative writer for sci-fi stories'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}

--- a/web/app/components/RepoContextPreviewCard.tsx
+++ b/web/app/components/RepoContextPreviewCard.tsx
@@ -1,0 +1,88 @@
+import type { GitHubRepoContextPayload } from "@/lib/api/types";
+
+type RepoContextPreviewCardProps = {
+  repoContext: GitHubRepoContextPayload;
+  accent: "green" | "yellow";
+};
+
+const accentMap = {
+  green: {
+    ring: "ring-green-500/20",
+    badge: "bg-green-500/10 text-green-200 border-green-500/20",
+    code: "text-green-300",
+  },
+  yellow: {
+    ring: "ring-yellow-500/20",
+    badge: "bg-yellow-500/10 text-yellow-200 border-yellow-500/20",
+    code: "text-yellow-300",
+  },
+} as const;
+
+export default function RepoContextPreviewCard({
+  repoContext,
+  accent,
+}: RepoContextPreviewCardProps) {
+  const styles = accentMap[accent];
+
+  return (
+    <div className={`rounded-2xl border border-white/10 bg-black/20 p-4 ring-1 ${styles.ring}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs font-mono uppercase tracking-[0.2em] text-zinc-500">
+            Repo Brief
+          </div>
+          <div className="mt-1 text-sm font-semibold text-white">{repoContext.repo_full_name}</div>
+        </div>
+        {repoContext.default_branch ? (
+          <span className={`rounded-full border px-2 py-1 text-[10px] font-mono uppercase tracking-wider ${styles.badge}`}>
+            {repoContext.default_branch}
+          </span>
+        ) : null}
+      </div>
+
+      <p className="mt-3 text-xs leading-relaxed text-zinc-300">{repoContext.summary}</p>
+
+      {repoContext.detected_stack.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {repoContext.detected_stack.map((item) => (
+            <span
+              key={item}
+              className={`rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-mono uppercase tracking-wider ${styles.code}`}
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {repoContext.highlights.length > 0 ? (
+        <div className="mt-4">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">Highlights</div>
+          <ul className="mt-2 space-y-1">
+            {repoContext.highlights.map((item) => (
+              <li key={item} className="text-xs leading-relaxed text-zinc-300">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {repoContext.files_used.length > 0 ? (
+        <div className="mt-4">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">Files Used</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {repoContext.files_used.map((item) => (
+              <span
+                key={item}
+                className="rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-mono text-zinc-300"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -14,6 +14,7 @@ import { POST as skillsGenerateRoute } from "./skills-generator/generate/route";
 import { POST as skillsExportRoute } from "./skills-generator/export/route";
 import { POST as ragUploadRoute } from "./rag/upload/route";
 import { POST as ragIngestRoute } from "./rag/ingest/route";
+import { POST as repoContextGithubRoute } from "./repo-context/github/route";
 
 type RouteCase = {
   name: string;
@@ -236,6 +237,13 @@ describe("Next backend proxy route wiring", () => {
       requestUrl: "http://localhost:3000/skills-generator/generate",
       requestBody: { description: "search docs" },
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
+    },
+    {
+      name: "repo context analysis",
+      handler: repoContextGithubRoute,
+      requestUrl: "http://localhost:3000/repo-context/github",
+      requestBody: { repo_url: "https://github.com/openai/openai-python" },
+      expectedUrl: "https://api.memo.dev/repo-context/github",
     },
     {
       name: "RAG upload",

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -136,6 +136,13 @@ describe("Next backend proxy route wiring", () => {
       expectedUrl: "https://api.memo.dev/skills-generator/generate",
     },
     {
+      name: "repo context analysis",
+      handler: repoContextGithubRoute,
+      requestUrl: "http://localhost:3000/repo-context/github",
+      requestBody: { repo_url: "https://github.com/openai/openai-python" },
+      expectedUrl: "https://api.memo.dev/repo-context/github",
+    },
+    {
       name: "RAG upload",
       handler: ragUploadRoute,
       requestUrl: "http://localhost:3000/rag/upload",

--- a/web/app/repo-context/github/route.ts
+++ b/web/app/repo-context/github/route.ts
@@ -1,0 +1,5 @@
+import { proxyBackendRequest } from "@/lib/server/backendProxy";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyBackendRequest(request, "/repo-context/github", {});
+}

--- a/web/app/repo-context/github/route.ts
+++ b/web/app/repo-context/github/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/repo-context/github", {});
+  return proxyBackendRequest(request, "/repo-context/github", {
+    requireServerApiKey: true,
+  });
 }

--- a/web/app/skills-generator/page.test.tsx
+++ b/web/app/skills-generator/page.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SkillsGeneratorPage from "./page";
+import { apiJson } from "@/config";
+
+vi.mock("@/config", () => ({
+  apiJson: vi.fn(),
+  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+}));
+
+vi.mock("../components/InfoButton", () => ({
+  default: ({ title }: { title: string }) => <button type="button">{title}</button>,
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("./components/ExportPanel", () => ({
+  default: () => null,
+}));
+
+vi.mock("../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+const apiJsonMock = vi.mocked(apiJson);
+
+describe("Skills Generator page", () => {
+  beforeEach(() => {
+    apiJsonMock.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("analyzes a GitHub repo and includes repo_context in the skill request", async () => {
+    apiJsonMock
+      .mockResolvedValueOnce({
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      })
+      .mockResolvedValueOnce({
+        skill_definition: "# Repo-aware Skill",
+      });
+
+    render(<SkillsGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Generate a skill for this repo." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+
+    await screen.findByText("openai/openai-python");
+    expect(screen.getByText("Python SDK repo with a compact README and clear manifest signals.")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Generate a skill for this repo.",
+      include_example_code: false,
+      repo_context: {
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package", "README present"],
+        files_used: ["README.md", "pyproject.toml"],
+        detected_stack: ["Python", "httpx"],
+      },
+    });
+  });
+
+  it("requires re-analysis after the repo URL changes", async () => {
+    apiJsonMock
+      .mockResolvedValueOnce({
+        normalized_repo_url: "https://github.com/openai/openai-python",
+        repo_full_name: "openai/openai-python",
+        default_branch: "main",
+        summary: "Python SDK repo with a compact README and clear manifest signals.",
+        highlights: ["Python package"],
+        files_used: ["README.md"],
+        detected_stack: ["Python"],
+      })
+      .mockResolvedValueOnce({
+        skill_definition: "# Plain Skill",
+      });
+
+    render(<SkillsGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Generate a skill for this repo." },
+    });
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/openai/openai-python" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
+
+    await screen.findByText("openai/openai-python");
+
+    fireEvent.change(screen.getByLabelText("GitHub Repo URL"), {
+      target: { value: "https://github.com/vercel/next.js" },
+    });
+
+    expect(screen.getByText("Repo URL changed. Re-analyze to attach fresh repo context.")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
+      description: "Generate a skill for this repo.",
+      include_example_code: false,
+    });
+  });
+
+  it("keeps the description textarea at a usable desktop height", () => {
+    render(<SkillsGeneratorPage />);
+
+    const textarea = screen.getByLabelText("Skill Description");
+    const classes = textarea.getAttribute("class") || "";
+
+    expect(classes).toContain("md:min-h-[220px]");
+    expect(classes).not.toContain("md:min-h-0");
+  });
+});

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -4,13 +4,27 @@ import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Zap } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
+import type { GitHubRepoContextPayload } from "@/lib/api/types";
+import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
 import InfoButton from "../components/InfoButton";
 import ContextManager from "../components/ContextManager";
+import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
 import SkillExportPanel from "./components/ExportPanel";
+
+const REPO_ANALYSIS_TIMEOUT_MS = 15000;
+
+function isSupportedGitHubRepoRootUrl(value: string): boolean {
+  return /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/.test(value.trim());
+}
 
 export default function SkillsGenerator() {
   const [description, setDescription] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [repoContext, setRepoContext] = useState<GitHubRepoContextPayload | null>(null);
+  const [repoAnalysisLoading, setRepoAnalysisLoading] = useState(false);
+  const [repoAnalysisWarning, setRepoAnalysisWarning] = useState<string | null>(null);
+  const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -19,6 +33,36 @@ export default function SkillsGenerator() {
   const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
+  const isValidRepoUrl = isSupportedGitHubRepoRootUrl(repoUrl);
+
+  const handleAnalyzeRepo = async () => {
+    if (!isValidRepoUrl || repoAnalysisLoading) return;
+
+    setRepoAnalysisLoading(true);
+    setRepoAnalysisWarning(null);
+    setError(null);
+
+    try {
+      const data = await withTimeout(
+        apiJson<GitHubRepoContextPayload>("/repo-context/github", {
+          method: "POST",
+          headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({ repo_url: repoUrl.trim() }),
+        }),
+        REPO_ANALYSIS_TIMEOUT_MS,
+        "Repository analysis is taking too long. Please try again.",
+      );
+      setRepoContext(data);
+      setRepoContextDirty(false);
+    } catch (e: unknown) {
+      showError(e);
+      setRepoContext(null);
+      setRepoContextDirty(false);
+      setRepoAnalysisWarning(e instanceof Error ? e.message : "Repository analysis failed");
+    } finally {
+      setRepoAnalysisLoading(false);
+    }
+  };
 
   const handleGenerate = async () => {
     if (!description.trim()) return;
@@ -36,6 +80,7 @@ export default function SkillsGenerator() {
         body: JSON.stringify({
           description,
           include_example_code: includeExampleCode,
+          ...(repoContext && !repoContextDirty ? { repo_context: repoContext } : {}),
         }),
       });
 
@@ -104,11 +149,64 @@ export default function SkillsGenerator() {
               </p>
             </div>
 
-            <div className="flex-1 min-h-0 flex flex-col relative group">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="skill-repo-url" className="text-sm font-medium text-zinc-300">GitHub Repo URL</label>
+              <p className="text-xs text-zinc-500">
+                Optional. Analyze a public root repo URL to add a compact, deterministic project brief.
+              </p>
+              <input
+                id="skill-repo-url"
+                aria-label="GitHub Repo URL"
+                className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 font-mono text-sm text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50"
+                placeholder="https://github.com/owner/repo"
+                value={repoUrl}
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+                  setRepoUrl(nextValue);
+                  setRepoAnalysisWarning(null);
+                  if (!repoContext) {
+                    return;
+                  }
+                  const normalizedNext = nextValue.trim().replace(/\/+$/, "");
+                  const normalizedCurrent = repoContext.normalized_repo_url.replace(/\/+$/, "");
+                  const isDirty = normalizedNext !== normalizedCurrent;
+                  setRepoContextDirty(isDirty);
+                  if (!isDirty) {
+                    setRepoAnalysisWarning(null);
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleAnalyzeRepo}
+                disabled={!isValidRepoUrl || repoAnalysisLoading}
+                className="w-full rounded-xl border border-yellow-500/20 bg-yellow-500/10 px-4 py-2.5 text-sm font-semibold text-yellow-100 transition-all hover:bg-yellow-500/15 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {repoAnalysisLoading ? "Analyzing Repo..." : "Analyze Repo"}
+              </button>
+            </div>
+
+            {repoContext && !repoContextDirty ? (
+              <RepoContextPreviewCard repoContext={repoContext} accent="yellow" />
+            ) : null}
+
+            {repoContextDirty ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                Repo URL changed. Re-analyze to attach fresh repo context.
+              </div>
+            ) : null}
+
+            {repoAnalysisWarning ? (
+              <div className="rounded-xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                {repoAnalysisWarning}
+              </div>
+            ) : null}
+
+            <div className="relative shrink-0 group">
               <textarea
                 id="skill-description"
                 aria-label="Skill Description"
-                className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-0"
+                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'A skill that parses JSON and validates schemas' or 'Fetch and summarize web pages'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -138,3 +138,13 @@ export type RagStats = {
   avg_bytes?: number;
   largest?: Array<{ path: string; size: number }>;
 };
+
+export type GitHubRepoContextPayload = {
+  normalized_repo_url: string;
+  repo_full_name: string;
+  default_branch: string | null;
+  summary: string;
+  highlights: string[];
+  files_used: string[];
+  detected_stack: string[];
+};

--- a/web/lib/promise/withTimeout.test.ts
+++ b/web/lib/promise/withTimeout.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { withTimeout } from "./withTimeout";
+
+describe("withTimeout", () => {
+  it("resolves when the wrapped promise resolves in time", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), 1000, "too slow")).resolves.toBe("ok");
+  });
+
+  it("rejects with the provided message when the promise hangs", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const pending = withTimeout(new Promise(() => {}), 15000, "Repository analysis is taking too long.");
+
+      vi.advanceTimersByTime(15000);
+
+      await expect(pending).rejects.toThrow("Repository analysis is taking too long.");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/web/lib/promise/withTimeout.ts
+++ b/web/lib/promise/withTimeout.ts
@@ -1,0 +1,16 @@
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = globalThis.setTimeout(() => reject(new Error(message)), ms);
+
+    promise.then(
+      (value) => {
+        globalThis.clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        globalThis.clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+}

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -191,6 +191,25 @@ describe("backend proxy", () => {
     });
   });
 
+  it("drains request bodies before returning a protected-route config error", async () => {
+    const request = new Request("http://localhost:3000/repo-context/github", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo_url: "https://github.com/openai/openai-python" }),
+    });
+    const arrayBufferSpy = vi.spyOn(request, "arrayBuffer");
+
+    const response = await proxyBackendRequest(request, "/repo-context/github", {
+      requireServerApiKey: true,
+    });
+
+    expect(response.status).toBe(500);
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({
+      detail: "PROMPTC_SERVER_API_KEY is not configured on the web server.",
+    });
+  });
+
   it("allows protected routes with a caller-supplied x-api-key when server key is missing", async () => {
     process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -36,6 +36,15 @@ function isBodylessMethod(method: string): boolean {
   return method === "GET" || method === "HEAD";
 }
 
+async function drainRequestBody(request: Request): Promise<void> {
+  if (isBodylessMethod(request.method)) return;
+  try {
+    await request.arrayBuffer();
+  } catch {
+    // Best effort only; the response path should still complete even if draining fails.
+  }
+}
+
 function copyProxyHeaders(request: Request): Headers {
   const headers = new Headers();
 
@@ -98,6 +107,7 @@ export async function proxyBackendRequest(
   const callerApiKey = request.headers.get("x-api-key")?.trim() || "";
 
   if (options.requireServerApiKey && !serverApiKey && !callerApiKey) {
+    await drainRequestBody(request);
     return Response.json({ detail: CONFIG_ERROR_DETAIL }, { status: 500 });
   }
 


### PR DESCRIPTION
## What changed
- add a backend `repo-context/github` endpoint that analyzes a public GitHub repository URL and returns a compact repo brief
- allow Agent Generator and Skills Generator flows to attach that repo brief to generation requests
- add a shared repo preview card and timeout helper on the web side
- harden the proxy path so protected repo-context requests drain request bodies before returning config errors

## Why this changed
Generator prompts were missing an easy way to stay grounded in an existing public repository. This adds a shallow, deterministic repo brief that can guide agent and skill generation without requiring full code ingestion.

## User impact
Users can paste a public GitHub repo URL into the generator pages, review the analyzed brief, and generate repo-aware agent or skill output. If the repo URL changes, the UI requires a fresh analysis before reusing context.

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest -q tests/test_api_hardening.py tests/test_context_generation.py tests/test_skills_generator.py tests/test_repo_context.py`
- `cd web && npm run test -- app/proxy-routes.test.ts lib/server/backendProxy.test.ts app/agent-generator/page.test.tsx app/skills-generator/page.test.tsx lib/promise/withTimeout.test.ts`
