### PR TITLE
[codex] docs: sync agent packs auth docs and llm env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 OPENAI_API_KEY=sk-your-key-here
 OPENAI_BASE_URL=https://api.openai.com
 GROQ_API_KEY=gsk-your-key-here
+LLM_AGENT_MAX_TOKENS=2048
+LLM_SKILL_MAX_TOKENS=2048
 
 # Compiler behavior
 PROMPT_COMPILER_MODE=conservative

--- a/agents.md
+++ b/agents.md
@@ -34,6 +34,8 @@ You do **not** need to commit `.env`. It is gitignored and only needed for local
 | `OPENAI_API_KEY` | LLM compile, optimize, benchmark | No default — must be set for LLM paths |
 | `OPENAI_BASE_URL` | LLM provider URL | `https://api.openai.com` |
 | `GROQ_API_KEY` | Groq-backed LLM paths | Optional; LLM routes fall back to OpenAI |
+| `LLM_AGENT_MAX_TOKENS` | Agent generator response cap | `2048`; lower it to reduce token usage or raise it for longer generated packs |
+| `LLM_SKILL_MAX_TOKENS` | Skill generator response cap | `2048`; mirrors the agent cap for MCP/skill output generation |
 | `PROMPT_COMPILER_MODE` | Compiler aggressiveness | `conservative` (default) or `default` |
 | `ADMIN_API_KEY` | Master API key (skip DB lookup) | Optional; leave blank for local dev |
 | `PROMPTC_REQUIRE_API_KEY_FOR_ALL` | Force API keys everywhere | `false` for local dev, `true` for hardened deploys |
@@ -67,6 +69,8 @@ NEXT_PUBLIC_API_URL=http://127.0.0.1:8080
 
 The codebase is designed so that offline heuristics in `app/heuristics/` run without any LLM key. Set `PROMPT_COMPILER_MODE=conservative` and simply omit `OPENAI_API_KEY` / `GROQ_API_KEY`; the compiler falls back to local heuristics for most operations. Test files under `tests/` do the same — no live LLM calls are made.
 
+If agent-pack or skill exports are getting truncated, adjust `LLM_AGENT_MAX_TOKENS` or `LLM_SKILL_MAX_TOKENS` in `.env` before retrying.
+
 ---
 
 ## 3. Starting the Application
@@ -83,7 +87,7 @@ cd web && npm run dev
 
 Open http://localhost:3000 in a browser.
 
-Protected frontend routes now use same-origin Next proxy handlers. For local generator/RAG upload testing through the web UI, set `PROMPTC_SERVER_API_KEY` to a valid backend API key (or the same value as `ADMIN_API_KEY`) in the Next.js environment if backend auth is enabled.
+Protected frontend routes now use same-origin Next proxy handlers. For local generator/RAG upload testing through the web UI, set `PROMPTC_SERVER_API_KEY` to a valid backend API key (or the same value as `ADMIN_API_KEY`) in the Next.js environment if backend auth is enabled. The Agent Packs page no longer exposes a browser-side API-key input, so authenticated generator requests must come through that server-side proxy key.
 
 Backend is available at http://127.0.0.1:8080 and exposes an OpenAPI spec at http://127.0.0.1:8080/docs.
 

--- a/web/README.md
+++ b/web/README.md
@@ -35,7 +35,7 @@ npm run test:contracts
 - Browser calls stay same-origin and hit the Next proxy layer first. Server-side proxy handlers forward to `NEXT_PUBLIC_API_URL` (or `http://127.0.0.1:8080` locally).
 - Protected proxy routes use `PROMPTC_SERVER_API_KEY` on the web server. `NEXT_PUBLIC_API_KEY` should not be used in the browser.
 - Routes backed by optional backend auth, such as `/rag/search` and `/rag/stats`, should stay callable without `PROMPTC_SERVER_API_KEY` unless backend-wide auth enforcement is enabled.
-- The Agent Packs page exposes an optional client-side `x-api-key` field for local debugging and fallback use. If `PROMPTC_SERVER_API_KEY` is configured, the proxy uses that server key and ignores the typed client key.
+- The Agent Packs page now relies on the same-origin proxy flow and does not expose a browser API-key input. Configure `PROMPTC_SERVER_API_KEY` on the web server when the backend requires authenticated generator requests.
 - `/rag/search` returns canonical items shaped like `{ path, snippet, score }`.
 - `/rag/upload` returns canonical ingest metadata and may also include compatibility fields.
 - Some routes can now return `403` when API key protection is enabled on the backend.


### PR DESCRIPTION
## What changed
- updated Agent Packs frontend docs to reflect the current same-origin proxy flow
- documented `LLM_AGENT_MAX_TOKENS` and `LLM_SKILL_MAX_TOKENS` in `.env.example`
- synced `agents.md` with the new env vars and current server-side auth expectation

## Why
Recent cleanup removed the browser-side Agent Packs API key input, and the LLM client now supports token-cap env vars. The docs and setup examples had drifted behind the code, which makes local setup and deploy expectations harder to understand.

## Validation
- `rg -n "LLM_AGENT_MAX_TOKENS|LLM_SKILL_MAX_TOKENS|browser API-key input|API Key \(Optional\)" .env.example agents.md web/README.md web/app/agent-packs/page.test.tsx`
- `cd web && npm run test -- app/agent-packs/page.test.tsx`
