### PR TITLE
ux: reduce first-5-minute friction for new users

### DIFF
--- a/web/app/benchmark/modelCatalog.ts
+++ b/web/app/benchmark/modelCatalog.ts
@@ -16,7 +16,7 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     label: "Llama 3.1 8B Instant",
     badge: "cheap",
     availability: "production",
-    helperText: "Lowest-cost baseline on Groq for fast A/B checks.",
+    helperText: "Cheapest model. Use this for a quick sanity check — runs in a second or two.",
     group: "Cheap",
   },
   {
@@ -24,7 +24,7 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     label: "GPT-OSS 20B",
     badge: "cheap",
     availability: "production",
-    helperText: "Cheap open model with a strong quality-to-cost ratio.",
+    helperText: "Cheap and surprisingly capable. Good default for everyday tests.",
     group: "Cheap",
   },
   {
@@ -32,7 +32,7 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     label: "Mistral Saba 24B",
     badge: "cheap",
     availability: "production",
-    helperText: "Affordable multilingual option for broader prompt coverage.",
+    helperText: "Affordable and works well in multiple languages — handy if your prompt isn't in English.",
     group: "Cheap",
   },
   {
@@ -40,7 +40,7 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     label: "Llama 3.3 70B Versatile",
     badge: "balanced",
     availability: "production",
-    helperText: "Balanced quality model for richer benchmark comparisons.",
+    helperText: "Smarter model. Slower and pricier, but answers are more thoughtful.",
     group: "Balanced",
   },
   {
@@ -48,7 +48,7 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     label: "GPT-OSS 120B",
     badge: "balanced",
     availability: "production",
-    helperText: "Stronger reference model when you want a higher-quality comparison.",
+    helperText: "Bigger and stronger. Use this when you want the most polished comparison.",
     group: "Balanced",
   },
   {
@@ -56,7 +56,7 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     label: "Llama 4 Scout 17B 16E",
     badge: "preview",
     availability: "preview",
-    helperText: "Preview Meta model with modern context handling and multimodal lineage.",
+    helperText: "Newer model. Still being evaluated — try it if you want to compare cutting-edge results.",
     group: "Preview",
   },
   {
@@ -64,7 +64,7 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     label: "Qwen 3 32B",
     badge: "preview",
     availability: "preview",
-    helperText: "Preview Qwen model for alternative reasoning and response style checks.",
+    helperText: "Newer model with a different reasoning style. Useful for a second opinion on your prompt.",
     group: "Preview",
   },
 ];

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -158,11 +158,15 @@ export default function BenchmarkPage() {
                 <div className="font-mono text-xs uppercase tracking-wider text-zinc-500">
                   Compare raw vs compiled output
                 </div>
+                <div className="mt-1 text-xs text-zinc-400">
+                  <span className="font-semibold text-amber-300">Raw</span> = your prompt as-is &nbsp;·&nbsp;{" "}
+                  <span className="font-semibold text-emerald-300">Compiled</span> = Prompt Compiler&apos;s polished version
+                </div>
               </div>
             </div>
             <InfoButton
-              title="Benchmark Suite"
-              description="Run automated tests across multiple LLM models to evaluate the effectiveness and token efficiency of your compiled prompts."
+              title="What this page does"
+              description="We send your prompt to a real AI model twice: once exactly as you wrote it (the Raw version) and once after Prompt Compiler rewrites it (the Compiled version). The radar chart and winner banner show whose answer was clearer, safer, and more concise."
             />
           </div>
 
@@ -207,6 +211,11 @@ export default function BenchmarkPage() {
                 {selectedModel === "mock"
                   ? "No model is called. Numbers below are randomized for UI preview only — pick a real model to run an actual benchmark."
                   : selectedModelMeta?.helperText}
+              </p>
+              <p className="px-2 pb-2 text-[10px] leading-relaxed text-zinc-600">
+                <span className="font-mono text-zinc-500">[cheap]</span> runs fast and costs little.{" "}
+                <span className="font-mono text-zinc-500">[balanced]</span> is smarter but slower.{" "}
+                <span className="font-mono text-zinc-500">[preview]</span> is a newer model still being tested.
               </p>
             </div>
 
@@ -275,6 +284,9 @@ export default function BenchmarkPage() {
                     <h3 className="absolute left-4 top-4 text-xs font-semibold uppercase text-zinc-500">
                       Performance Radar
                     </h3>
+                    <p className="absolute left-4 top-9 text-[10px] text-zinc-500">
+                      Higher = better. The bigger shape wins.
+                    </p>
                     <div className="h-full w-full max-w-[400px]">
                       <ResponsiveContainer width="100%" height="100%">
                         <RadarChart outerRadius="70%" data={chartData}>

--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -45,18 +45,30 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
     } = useContextManager();
 
     const connectionBadge = getConnectionBadge(isConnected);
+    const hasDocs = (indexStats?.docs ?? 0) > 0;
 
     return (
         <div className="mt-2 flex shrink-0 flex-col gap-3 border-t border-white/5 pt-3">
             <h3 className="flex items-center justify-between gap-2 text-[10px] font-bold uppercase tracking-widest text-zinc-500">
                 <div className="flex items-center gap-2">
                     <span>Context Manager</span>
-                    <span className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 text-[9px]">RAG</span>
+                    <span
+                        title="Retrieval-Augmented Generation — fancy name for: the AI can quote from files you upload."
+                        className="px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 text-[9px] cursor-help"
+                    >
+                        RAG
+                    </span>
                 </div>
                 <span className={`text-[9px] px-1.5 py-0.5 rounded ${connectionBadge.tone}`}>
                     {connectionBadge.label}
                 </span>
             </h3>
+
+            {!hasDocs && (
+                <p className="text-[11px] leading-relaxed text-zinc-400 normal-case">
+                    Upload your own docs (README, design notes, examples). The AI will quote from them when it writes your prompt.
+                </p>
+            )}
 
             <ContextSuggestions suggestions={suggestions} onInsertContext={onInsertContext} />
 
@@ -85,44 +97,48 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                 </div>
             )}
 
-            <details className="group">
-                <summary className="text-[10px] text-zinc-600 cursor-pointer hover:text-zinc-400 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded">
-                    Advanced: Index by path
-                </summary>
-                <div className="flex flex-col gap-2 mt-2 pl-2 border-l border-white/5">
-                    <input
-                        type="text"
-                        aria-label="Path to file or folder..."
-                        className="w-full rounded-lg border border-white/5 bg-black/30 p-2 text-xs font-mono transition-colors placeholder-zinc-600 focus:border-blue-500/30 focus:outline-none"
-                        placeholder="Path to file or folder..."
-                        value={filePath}
-                        onChange={(e) => setFilePath(e.target.value)}
-                        onKeyDown={(e) => {
-                            if (e.key === "Enter" && !ingesting && filePath) {
-                                void ingestPath(filePath);
-                            }
-                        }}
-                    />
-                    <button
-                        type="button"
-                        onClick={() => void ingestPath(filePath)}
-                        disabled={ingesting || !filePath}
-                        title={!filePath ? "Enter a file path first to ingest" : "Ingest Path"}
-                        className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/5 bg-zinc-800/50 py-2 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700/50 disabled:opacity-50"
-                    >
-                        {ingesting ? <span className="animate-pulse">Indexing...</span> : "Ingest Path"}
-                    </button>
-                </div>
-            </details>
+            <div className="flex flex-col gap-2">
+                <p className="text-[10px] uppercase tracking-widest text-zinc-500 font-semibold">
+                    …or paste a path to a local file/folder
+                </p>
+                <input
+                    type="text"
+                    aria-label="Path to file or folder..."
+                    className="w-full rounded-lg border border-white/5 bg-black/30 p-2 text-xs font-mono transition-colors placeholder-zinc-600 focus:border-blue-500/30 focus:outline-none"
+                    placeholder="e.g. ./docs or C:\Users\me\notes.md"
+                    value={filePath}
+                    onChange={(e) => setFilePath(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter" && !ingesting && filePath) {
+                            void ingestPath(filePath);
+                        }
+                    }}
+                />
+                <button
+                    type="button"
+                    onClick={() => void ingestPath(filePath)}
+                    disabled={ingesting || !filePath}
+                    title={!filePath ? "Enter a file path first to ingest" : "Ingest Path"}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/5 bg-zinc-800/50 py-2 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700/50 disabled:opacity-50"
+                >
+                    {ingesting ? <span className="animate-pulse">Indexing...</span> : "Ingest Path"}
+                </button>
+            </div>
 
-            <RagSearchPanel
-                query={query}
-                setQuery={setQuery}
-                searching={searching}
-                results={results}
-                onRunSearch={() => void runSearch()}
-                onInsertContext={onInsertContext}
-            />
+            {hasDocs ? (
+                <RagSearchPanel
+                    query={query}
+                    setQuery={setQuery}
+                    searching={searching}
+                    results={results}
+                    onRunSearch={() => void runSearch()}
+                    onInsertContext={onInsertContext}
+                />
+            ) : (
+                <div className="rounded-lg border border-dashed border-white/10 bg-black/20 px-3 py-2 text-[10px] text-zinc-500 normal-case">
+                    Upload something above first, then you can search through it here.
+                </div>
+            )}
         </div>
     );
 }

--- a/web/app/components/QualityCoach.tsx
+++ b/web/app/components/QualityCoach.tsx
@@ -19,6 +19,36 @@ type QualityCoachProps = {
     onUpdatePrompt: (newPrompt: string) => void;
 };
 
+const SCORE_LABELS: Record<string, { title: string; help: string }> = {
+    clarity: {
+        title: "Clarity",
+        help: "Is the prompt easy to understand? Short, clear sentences score higher.",
+    },
+    specificity: {
+        title: "Specificity",
+        help: "Does it spell out what you want? Vague asks score lower.",
+    },
+    completeness: {
+        title: "Completeness",
+        help: "Did you include everything the AI needs (inputs, format, constraints)?",
+    },
+    consistency: {
+        title: "Consistency",
+        help: "Do the instructions agree with each other (no conflicting rules)?",
+    },
+};
+
+function prettyLabel(key: string): string {
+    return (
+        SCORE_LABELS[key]?.title ??
+        key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+    );
+}
+
+function labelHelp(key: string): string {
+    return SCORE_LABELS[key]?.help ?? "";
+}
+
 export default function QualityCoach({ prompt }: QualityCoachProps) {
     const [analyzing, setAnalyzing] = useState(false);
     const [report, setReport] = useState<ValidationResponse | null>(null);
@@ -97,10 +127,17 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
             {report && (
                 <div className="space-y-8 animate-fade-in pb-10">
                     {/* Category Scores */}
+                    <p className="text-xs text-zinc-400">
+                        Your prompt was scored in {Object.keys(report.category_scores).length} areas. Hover any card to see what it measures.
+                    </p>
                     <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
                         {Object.entries(report.category_scores).map(([cat, score]) => (
-                            <div key={cat} className="glass-panel p-4 rounded-xl relative overflow-hidden group hover:bg-white/5 transition-colors">
-                                <div className="text-[10px] text-zinc-500 uppercase tracking-widest mb-2 font-semibold">{cat}</div>
+                            <div
+                                key={cat}
+                                title={labelHelp(cat)}
+                                className="glass-panel p-4 rounded-xl relative overflow-hidden group hover:bg-white/5 transition-colors"
+                            >
+                                <div className="text-[10px] text-zinc-500 uppercase tracking-widest mb-2 font-semibold">{prettyLabel(cat)}</div>
                                 <div className="flex items-end gap-2 mb-3">
                                     <div className="text-2xl font-bold text-white tracking-tight">
                                         {typeof score === 'number' ? score.toFixed(0) : score}


### PR DESCRIPTION
## Summary

Walked through Prompt Compiler as a brand-new "vibe coder" (non-technical creative dev) and found three places in the first 5 minutes where the UI assumes the user already knows the tool's vocabulary. This PR fixes them with copy + small render helpers — no backend changes, no new deps, no new components.

## The 3 friction points & fixes

### 1. Quality Scores looked like raw database fields
**File:** `web/app/components/QualityCoach.tsx`

`<div>{cat}</div>` rendered the API field names verbatim — users saw `clarity`, `specificity`, `completeness`, `consistency` (lowercase, no spaces). Added a `SCORE_LABELS` map → cards now show titled labels with hover tooltips explaining what each one measures. Falls back gracefully if the backend adds new keys later.

### 2. Benchmark page never explained "raw vs compiled"
**Files:** `web/app/benchmark/page.tsx`, `web/app/benchmark/modelCatalog.ts`

The whole product premise was hidden behind a 4-word subtitle, and the model picker leaked jargon like "A/B checks" and "quality-to-cost ratio."

- Expanded the InfoButton with a plain-English explainer
- Added a `Raw = your prompt as-is · Compiled = Prompt Compiler's polished version` legend under the title
- Rewrote all 7 model `helperText` strings in everyday language
- Added a `[cheap]/[balanced]/[preview]` badge legend under the dropdown
- Added "Higher = better. The bigger shape wins." above the radar chart

### 3. RAG Context Manager had zero onboarding
**File:** `web/app/components/ContextManager.tsx`

Empty state was just an upload zone + a search box that returned "No results found." "RAG" was unexplained, and "Index by path" was hidden behind an `<details>` accordion labeled "Advanced:".

- Added a one-liner ("Upload your own docs… The AI will quote from them…") shown only when no docs exist
- Added a hover tooltip on the `RAG` tag defining the acronym
- Pulled "Index by path" out of the accordion and gave it a plain-English heading
- Replaced the search box with a friendly "Upload something above first" placeholder until docs are indexed

## What was preserved on purpose

Existing tests assert on `aria-label="Path to file or folder..."`, button text `"Ingest Path"`, and the section heading `"Context Manager"`. All kept intact so the 3 ContextManager tests still pass.

## Test plan

- [x] `cd web && npm run test` — 93/93 pass (19 files)
- [x] `cd web && npm run build` — all 25 routes compile clean
- [x] `npx eslint` on all 4 touched files — no warnings
- [ ] Manual: hover any Quality Score card → tooltip shows
- [ ] Manual: open `/benchmark` without typing → see Raw/Compiled legend + badge explainer
- [ ] Manual: open `/agent-generator` → Context Manager shows the one-liner intro and the path input is visible without expanding anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)