### PR TITLE
⚡ Bolt: Fix SQLite host parameter limit in vector search

### DIFF
--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -991,7 +991,7 @@ def _search_embed_with_conn(
     BATCH_SIZE = 999
 
     for i in range(0, len(chunk_ids), BATCH_SIZE):
-        batch_ids = chunk_ids[i:i + BATCH_SIZE]
+        batch_ids = chunk_ids[i : i + BATCH_SIZE]
         placeholders = ",".join("?" for _ in batch_ids)
 
         cur = conn.execute(

--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -984,28 +984,34 @@ def _search_embed_with_conn(
         return []
 
     chunk_ids = [c for _, _, c in scores]
-    placeholders = ",".join("?" for _ in chunk_ids)
 
-    # Step 2: Fetch full metadata only for the matching chunks
-    cur = conn.execute(
-        f"""
-        SELECT c.id, c.doc_id, d.path, c.chunk_index, c.content
-        FROM chunks c
-        JOIN docs d ON d.id = c.doc_id
-        WHERE c.id IN ({placeholders})
-        """,
-        chunk_ids,
-    )
-
+    # Step 2: Fetch full metadata only for the matching chunks in batches
+    # Bolt Optimization: Batch queries to avoid SQLite host parameter limits (max 999/32766)
     metadata = {}
-    for row in cur.fetchall():
-        c_id, doc_id, path, chunk_index, content = row
-        metadata[c_id] = {
-            "doc_id": doc_id,
-            "path": path,
-            "chunk_index": chunk_index,
-            "content": content,
-        }
+    BATCH_SIZE = 999
+
+    for i in range(0, len(chunk_ids), BATCH_SIZE):
+        batch_ids = chunk_ids[i:i + BATCH_SIZE]
+        placeholders = ",".join("?" for _ in batch_ids)
+
+        cur = conn.execute(
+            f"""
+            SELECT c.id, c.doc_id, d.path, c.chunk_index, c.content
+            FROM chunks c
+            JOIN docs d ON d.id = c.doc_id
+            WHERE c.id IN ({placeholders})
+            """,
+            batch_ids,
+        )
+
+        for row in cur.fetchall():
+            c_id, doc_id, path, chunk_index, content = row
+            metadata[c_id] = {
+                "doc_id": doc_id,
+                "path": path,
+                "chunk_index": chunk_index,
+                "content": content,
+            }
 
     results = []
     for score, sim, chunk_id in scores:


### PR DESCRIPTION
💡 **What:** 
Updated `_search_embed_with_conn` in `app/rag/simple_index.py` to fetch document chunk metadata in batches of 999 when querying the `chunks` table.

🎯 **Why:** 
SQLite has a strict host parameter limit for statements containing `IN (?)` placeholders. The default limit is either 999 or 32,766 depending on the build. By directly interpolating the matched `chunk_ids` into the `IN` clause during vector similarity search retrieval, a large enough vector search space would cause `sqlite3.OperationalError: too many SQL variables`, crashing the RAG querying pipeline. Batching ensures the system remains scalable.

📊 **Impact:** 
Prevents application crashes during RAG retrieval on large indexes while maintaining the current performance profile, resolving the SQLite variable limit bottleneck.

🔬 **Measurement:** 
Run `make test-backend` to verify semantic search correctness. Verified via synthetic SQLite stress tests locally that query sizes `> 33000` now safely iterate over the batches without raising the `too many SQL variables` operational error.

---
*PR created automatically by Jules for task [18260869652898535655](https://jules.google.com/task/18260869652898535655) started by @madara88645*