### PR TITLE
[codex] docs: sync root readme with agent packs proxy auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ What the beta means in practice:
 - **Fast scaffolding, not blind automation** - expect useful repo memory, settings, agents, and workflow files, then adjust them for your own policies and edge cases.
 - **Best for early repo setup and internal experimentation** - especially when you want to bootstrap Claude Code conventions without hand-writing every asset.
 - **Human review is required** - check prompts, permissions, deny rules, CI assumptions, and generated documentation before shipping.
-- **Optional client API key fallback in the web UI** - if `PROMPTC_SERVER_API_KEY` is already configured on the web server, that server-side key wins. The UI field is mainly for local debugging or fallback calls when the proxy intentionally has no server key.
+- **Server-side proxy auth for protected requests** - the web app sends Agent Packs requests through the same-origin proxy. When backend auth is enabled, configure `PROMPTC_SERVER_API_KEY` on the web server so protected Agent Packs calls succeed without exposing API keys in the browser UI.
 
 Four pack types are available out of the box, all served from a single Claude-first endpoint:
 


### PR DESCRIPTION
## What changed
- updated the root README Agent Packs beta section to describe the current same-origin proxy auth flow
- removed the stale wording that implied the page still exposes an optional browser API key field

## Why
The UI no longer renders a client-side API key input, but the root README still documented that older flow. That drift can mislead anyone trying the feature from the main project guide.

## Impact
- docs now match the current Agent Packs UI and proxy behavior
- local/deploy setup guidance points readers toward `PROMPTC_SERVER_API_KEY` instead of a browser field

## Verification
- `cd web && npm run test -- app/agent-packs/page.test.tsx`
- `rg -n "Optional client API key fallback|API Key \(Optional\)|typed client key|same-origin proxy|PROMPTC_SERVER_API_KEY" README.md web/app/agent-packs/page.tsx web/app/agent-packs/page.test.tsx`
