### PR TITLE
[codex] test: lock repo-context prompt composition

### DIFF
--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -93,6 +93,47 @@ def test_worker_client_requests_example_code_section_when_enabled():
         )
 
 
+def test_worker_client_preserves_repo_context_when_example_code_is_disabled():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+        captured = {}
+        repo_context = {
+            "source": "github_public_repo",
+            "mode": "full",
+            "normalized_repo_url": "https://github.com/openai/openai-python",
+            "repo_full_name": "openai/openai-python",
+            "default_branch": "main",
+            "summary": "Python SDK repository.",
+            "highlights": ["README present"],
+            "files_used": ["README.md"],
+            "detected_stack": ["Python"],
+        }
+
+        def fake_call_api(messages, max_tokens, json_mode):
+            captured["messages"] = messages
+            return "# Agent System Prompt"
+
+        with patch.object(client, "_call_api", side_effect=fake_call_api):
+            result = client.generate_agent(
+                "Test Agent",
+                context={"repo_context": repo_context},
+                include_example_code=False,
+            )
+
+        assert result == "# Agent System Prompt"
+        system_messages = [
+            msg["content"] for msg in captured["messages"] if msg["role"] == "system"
+        ]
+        assert "## Example Code (Pseudo-code Skeleton)" not in system_messages[0]
+        assert any("## Repo Context (ground truth)" in message for message in system_messages)
+        assert any("openai/openai-python" in message for message in system_messages)
+        assert any(
+            "Omit the entire `## Example Code (Pseudo-code Skeleton)` section" in message
+            for message in system_messages
+        )
+
+
 def test_api_generate_agent_endpoint():
     # Mock the global hybrid_compiler in api.main
     with patch("api.main.hybrid_compiler") as mock_compiler:

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -54,6 +54,18 @@ def test_context_message_compact_mode_uses_compact_summary():
     assert "### Repo brief (compact)" in message
 
 
+def test_context_message_does_not_emit_mojibake():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    message = client._context_message(
+        mode="generator",
+        context={"repo_context": REPO_CONTEXT_FOR_RENDER},
+    )
+
+    assert "â" not in message
+
+
 # Mock WorkerClient to avoid API calls
 @pytest.fixture
 def mock_worker_client():


### PR DESCRIPTION
## What changed
- adds a regression test that exercises `WorkerClient.generate_agent(...)` with `repo_context` and `include_example_code=False`
- keeps a focused context-rendering assertion alongside the existing repo-context tests

## Why
PR #559 is now stale relative to `main`: the regex precompile idea already landed in a safer shape, but a naive conflict resolution could still drop the repo-context ground-truth block or reintroduce disabled example-code sections. This PR locks down the combined behavior without changing production code.

## Impact
- safer future conflict resolution around the prompt-generator surface
- better regression coverage for a recently changed LLM prompt path
- no runtime behavior change

## Verification
- `C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m pytest tests/test_agent_generator.py tests/test_context_generation.py tests/test_multi_agent.py tests/test_skills_generator.py -q`

## Notes
- this supersedes the risky part of PR #559 by protecting the current `main` behavior instead of replaying the stale branch diff
