### PR TITLE
ux: surface policy verdict at the top of compiled output

### DIFF
--- a/app/emitters.py
+++ b/app/emitters.py
@@ -415,6 +415,27 @@ def _policy_check_lines_v2(ir: IRv2) -> List[str]:
     return lines
 
 
+def _is_benign_policy_v2(ir: IRv2) -> bool:
+    policy = ir.policy
+    return (
+        policy.execution_mode == "auto_ok"
+        and policy.risk_level == "low"
+        and policy.data_sensitivity == "public"
+        and not policy.risk_domains
+        and not policy.forbidden_tools
+        and not policy.sanitization_rules
+    )
+
+
+def _emit_policy_header_v2(ir: IRv2) -> List[str]:
+    if _is_benign_policy_v2(ir):
+        return []
+    summary = _policy_summary_text_v2(ir)
+    if not summary:
+        return []
+    return ["Policy: " + summary]
+
+
 def _clean_domain_suggestion_text(text: str) -> str:
     value = " ".join((text or "").strip().split())
     for marker in ("Include ", "Add ", "Review ", "Use ", "Follow ", "Consider ", "Handle "):
@@ -603,9 +624,6 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
             + ": "
             + c_line
         )
-    policy_line = _policy_summary_text_v2(ir)
-    if policy_line:
-        ctx_lines.append("Policy: " + policy_line)
     policy_checks = _policy_check_lines_v2(ir)
     if policy_checks:
         ctx_lines.append("Policy Checks:")
@@ -677,10 +695,12 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
         )
     )
     orig = (ir.metadata or {}).get("original_text") or ""
+    policy_header = _emit_policy_header_v2(ir)
     prompt: List[str] = [
         f"{title}",
         intro,
         "",
+        *([*policy_header, ""] if policy_header else []),
         ("Girdi" if lang == "tr" else ("Entrada" if lang == "es" else "Input")) + f": {orig}",
         "",
         ("Bağlam" if lang == "tr" else ("Contexto" if lang == "es" else "Context")) + ":",

--- a/tests/test_expanded_prompt.py
+++ b/tests/test_expanded_prompt.py
@@ -82,6 +82,63 @@ def test_expanded_prompt_v2_includes_policy_summary_without_inventing_requiremen
     assert "Missing details will be filled" not in ep
 
 
+def _split_above_input(ep: str) -> str:
+    head, _, _ = ep.partition("\nInput:")
+    return head
+
+
+def test_expanded_prompt_v2_emits_policy_header_for_high_risk_financial():
+    ir2 = compile_text_v2(
+        "Analyze my stock portfolio allocation and recommend rebalancing trades.",
+        offline_only=True,
+    )
+
+    ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
+
+    head = _split_above_input(ep)
+    assert "Policy:" in head
+    assert "human_approval_required" in head
+    assert "domains=financial" in head
+
+
+def test_expanded_prompt_v2_omits_policy_header_for_benign_educational(monkeypatch):
+    monkeypatch.setenv("PROMPT_COMPILER_MODE", "default")
+    ir2 = compile_text_v2(
+        "Explain how photosynthesis works to a curious ten year old.",
+        offline_only=True,
+    )
+
+    ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
+
+    assert ir2.policy.execution_mode == "auto_ok"
+    assert ir2.policy.risk_level == "low"
+    head = _split_above_input(ep)
+    assert "Policy:" not in head
+
+
+def test_expanded_prompt_v2_omits_policy_header_on_trivial_greeting(monkeypatch):
+    monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+    ir2 = compile_text_v2("hi", offline_only=True)
+
+    ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
+
+    assert "Policy:" not in ep
+    assert "Expanded Prompt" not in ep
+
+
+def test_expanded_prompt_v2_emits_policy_header_for_medium_risk_debug():
+    ir2 = compile_text_v2(
+        "Help me debug this Python stack trace from production logs.",
+        offline_only=True,
+    )
+
+    ep = emit_expanded_prompt_v2(ir2, diagnostics=False)
+
+    head = _split_above_input(ep)
+    assert "Policy:" in head
+    assert "execution=human_approval_required" in head
+
+
 def test_prompt_templates_discourage_invented_project_details():
     prompts_dir = Path("app/llm_engine/prompts")
     query_expansion = (prompts_dir / "query_expansion.md").read_text(encoding="utf-8").lower()

--- a/web/app/components/PolicyBadge.tsx
+++ b/web/app/components/PolicyBadge.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { CompileResponse } from "../../lib/api/types";
+import { humanizeIntentPolicyValue, normalizeIntentPolicy } from "./intent-policy-utils";
+
+type PolicyBadgeProps = {
+  result: CompileResponse;
+};
+
+type Tone = "green" | "amber" | "blue" | "zinc";
+
+const TONE_CLASSES: Record<Tone, string> = {
+  green: "border-emerald-400/40 bg-emerald-400/10 text-emerald-200",
+  amber: "border-amber-400/40 bg-amber-400/10 text-amber-200",
+  blue: "border-sky-400/40 bg-sky-400/10 text-sky-200",
+  zinc: "border-zinc-400/30 bg-zinc-400/10 text-zinc-200",
+};
+
+const DOT_CLASSES: Record<Tone, string> = {
+  green: "bg-emerald-400",
+  amber: "bg-amber-400",
+  blue: "bg-sky-400",
+  zinc: "bg-zinc-400",
+};
+
+type ModeView = { label: string; tone: Tone };
+
+function viewForMode(mode: string): ModeView {
+  switch (mode) {
+    case "auto_ok":
+      return { label: "Auto OK", tone: "green" };
+    case "human_approval_required":
+      return { label: "Approval Required", tone: "amber" };
+    case "advice_only":
+      return { label: "Advice Only", tone: "blue" };
+    default:
+      return { label: humanizeIntentPolicyValue(mode), tone: "zinc" };
+  }
+}
+
+export default function PolicyBadge({ result }: PolicyBadgeProps) {
+  const policy = result?.ir_v2?.policy ?? result?.ir?.policy;
+  if (!policy) {
+    return null;
+  }
+
+  const { executionMode, riskLevel, riskDomains } = normalizeIntentPolicy(result);
+  const { label, tone } = viewForMode(executionMode);
+  const domainText = riskDomains.length > 0 ? riskDomains.slice(0, 2).join(", ") : "none";
+  const tooltip = `Risk: ${riskLevel} · Domains: ${domainText}`;
+
+  return (
+    <div
+      role="status"
+      aria-label={`Policy verdict: ${label}`}
+      title={tooltip}
+      data-testid="policy-badge"
+      data-tone={tone}
+      className={`ml-auto inline-flex shrink-0 items-center gap-1.5 self-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${TONE_CLASSES[tone]}`}
+    >
+      <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${DOT_CLASSES[tone]}`} />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/web/app/components/PolicyBadge.tsx
+++ b/web/app/components/PolicyBadge.tsx
@@ -51,12 +51,11 @@ export default function PolicyBadge({ result }: PolicyBadgeProps) {
 
   return (
     <div
-      role="status"
       aria-label={`Policy verdict: ${label}`}
       title={tooltip}
       data-testid="policy-badge"
       data-tone={tone}
-      className={`ml-auto inline-flex shrink-0 items-center gap-1.5 self-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${TONE_CLASSES[tone]}`}
+      className={`inline-flex shrink-0 items-center gap-1.5 self-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${TONE_CLASSES[tone]}`}
     >
       <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${DOT_CLASSES[tone]}`} />
       <span>{label}</span>

--- a/web/app/components/__tests__/PolicyBadge.test.tsx
+++ b/web/app/components/__tests__/PolicyBadge.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PolicyBadge from "../PolicyBadge";
+import type { CompilePolicy, CompileResponse } from "../../../lib/api/types";
+
+function makeResult(policy: Partial<CompilePolicy> | undefined): CompileResponse {
+  const base = {
+    system_prompt: "",
+    user_prompt: "",
+    plan: "",
+    expanded_prompt: "",
+    processing_ms: 0,
+  };
+  if (!policy) {
+    return { ...base, ir: { metadata: {} } } as CompileResponse;
+  }
+  const fullPolicy: CompilePolicy = {
+    risk_level: "low",
+    risk_domains: [],
+    allowed_tools: [],
+    forbidden_tools: [],
+    sanitization_rules: [],
+    data_sensitivity: "public",
+    execution_mode: "auto_ok",
+    ...policy,
+  };
+  return {
+    ...base,
+    ir: { metadata: {}, policy: fullPolicy },
+    ir_v2: { metadata: {}, policy: fullPolicy },
+  } as CompileResponse;
+}
+
+describe("PolicyBadge", () => {
+  it("renders the green Auto OK badge for auto_ok mode", () => {
+    render(<PolicyBadge result={makeResult({ execution_mode: "auto_ok" })} />);
+
+    const badge = screen.getByTestId("policy-badge");
+    expect(badge.textContent).toContain("Auto OK");
+    expect(badge.getAttribute("data-tone")).toBe("green");
+  });
+
+  it("renders the amber Approval Required badge for human_approval_required mode", () => {
+    render(
+      <PolicyBadge
+        result={makeResult({
+          execution_mode: "human_approval_required",
+          risk_level: "high",
+          risk_domains: ["financial"],
+        })}
+      />,
+    );
+
+    const badge = screen.getByTestId("policy-badge");
+    expect(badge.textContent).toContain("Approval Required");
+    expect(badge.getAttribute("data-tone")).toBe("amber");
+  });
+
+  it("renders the blue Advice Only badge for advice_only mode", () => {
+    render(<PolicyBadge result={makeResult({ execution_mode: "advice_only" })} />);
+
+    const badge = screen.getByTestId("policy-badge");
+    expect(badge.textContent).toContain("Advice Only");
+    expect(badge.getAttribute("data-tone")).toBe("blue");
+  });
+
+  it("renders nothing when neither ir nor ir_v2 has a policy", () => {
+    const { container } = render(<PolicyBadge result={makeResult(undefined)} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("exposes risk level and top risk domain in the tooltip", () => {
+    render(
+      <PolicyBadge
+        result={makeResult({
+          execution_mode: "human_approval_required",
+          risk_level: "medium",
+          risk_domains: ["legal", "privacy"],
+        })}
+      />,
+    );
+
+    const badge = screen.getByTestId("policy-badge");
+    const tooltip = badge.getAttribute("title") ?? "";
+    expect(tooltip).toContain("medium");
+    expect(tooltip).toContain("legal");
+  });
+});

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,6 +7,7 @@ import QualityCoach from "./components/QualityCoach";
 import SecurityAlert from "./components/SecurityAlert";
 import IntentPolicyPanel from "./components/IntentPolicyPanel";
 import OutputSkeleton from "./components/OutputSkeleton";
+import PolicyBadge from "./components/PolicyBadge";
 import { useCompiler } from "./hooks/useCompiler";
 import { describeRequestError } from "../config";
 import type { CompileMode, CompileResponse } from "../lib/api/types";
@@ -319,6 +320,7 @@ export default function Home() {
                       onSelect={setActiveTab}
                     />
                   ))}
+                  <PolicyBadge result={result} />
                 </div>
 
                 {/* Content — one stable tabpanel per tab, hidden when inactive */}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -297,29 +297,31 @@ export default function Home() {
               <OutputSkeleton />
             ) : result ? (
               <>
-                {/* Tabs */}
-                <div role="tablist" aria-label="Output views" className="flex gap-1 overflow-x-auto scroll-smooth border-b border-white/5 px-4 pt-4 pb-1" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
-                  {(
-                    [
-                      { key: "user", label: "User Prompt", hint: "The prompt to copy and send to your model. Most users want this tab.", primary: true },
-                      { key: "system", label: "System Prompt", hint: "Role and behavior rules for the model — paste this into a system message.", primary: false },
-                      { key: "plan", label: "Execution Plan", hint: "Step-by-step plan the compiler suggests for carrying out the request.", primary: false },
-                      { key: "expanded", label: "Long-form", hint: "Verbose, fully expanded version of the prompt with all context inlined.", primary: false },
-                      { key: "intent", label: "Intent", hint: "Detected intent and safety policy for this request.", primary: false },
-                      { key: "json", label: "JSON", hint: "Raw machine-readable compile output — useful for piping into other tools.", primary: false },
-                      { key: "quality", label: "Quality Scores", hint: "Quality, clarity, and safety scores the compiler assigned to the result.", primary: false },
-                    ] satisfies ReadonlyArray<{ key: OutputTab; label: string; hint: string; primary: boolean }>
-                  ).map(({ key, label, hint, primary }) => (
-                    <TabButton
-                      key={key}
-                      tabKey={key}
-                      label={label}
-                      hint={hint}
-                      isActive={activeTab === key}
-                      primary={primary}
-                      onSelect={setActiveTab}
-                    />
-                  ))}
+                {/* Tabs + policy verdict */}
+                <div className="flex items-center gap-3 border-b border-white/5 px-4 pt-4 pb-1">
+                  <div role="tablist" aria-label="Output views" className="flex min-w-0 flex-1 gap-1 overflow-x-auto scroll-smooth" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
+                    {(
+                      [
+                        { key: "user", label: "User Prompt", hint: "The prompt to copy and send to your model. Most users want this tab.", primary: true },
+                        { key: "system", label: "System Prompt", hint: "Role and behavior rules for the model — paste this into a system message.", primary: false },
+                        { key: "plan", label: "Execution Plan", hint: "Step-by-step plan the compiler suggests for carrying out the request.", primary: false },
+                        { key: "expanded", label: "Long-form", hint: "Verbose, fully expanded version of the prompt with all context inlined.", primary: false },
+                        { key: "intent", label: "Intent", hint: "Detected intent and safety policy for this request.", primary: false },
+                        { key: "json", label: "JSON", hint: "Raw machine-readable compile output — useful for piping into other tools.", primary: false },
+                        { key: "quality", label: "Quality Scores", hint: "Quality, clarity, and safety scores the compiler assigned to the result.", primary: false },
+                      ] satisfies ReadonlyArray<{ key: OutputTab; label: string; hint: string; primary: boolean }>
+                    ).map(({ key, label, hint, primary }) => (
+                      <TabButton
+                        key={key}
+                        tabKey={key}
+                        label={label}
+                        hint={hint}
+                        isActive={activeTab === key}
+                        primary={primary}
+                        onSelect={setActiveTab}
+                      />
+                    ))}
+                  </div>
                   <PolicyBadge result={result} />
                 </div>
 


### PR DESCRIPTION
## Summary

The compiler already infers a per-prompt policy — risk level, execution mode (auto OK / human approval / advice only), allowed and forbidden tools, data sensitivity — but the verdict was buried mid-`Context:` in the expanded prompt and tucked under a non-primary "Intent" tab in the UI. A reader couldn't tell at a glance whether an output is auto-runnable, needs human approval, or is advice-only.

This is the smallest change that raises the policy layer from "metadata" to "executable signal" on both surfaces.

### Backend (`app/emitters.py`)
- Hoist the existing `Policy:` line from inside the `Context:` block to a top-of-output header (above `Input:`) in `emit_expanded_prompt_v2`.
- New helper `_emit_policy_header_v2` skips the header entirely when policy is fully benign (`auto_ok` + low risk + public sensitivity + no risk domains / forbidden tools / sanitization rules), so casual prompts stay clean.
- The trivial-greeting early return is preserved — `hi`-style inputs still get the minimal greeting prompt with no policy header.
- `Policy Checks:` (the detailed bullet drill-down) stays where it is inside Context.

### Frontend (`web/app/components/PolicyBadge.tsx`, `web/app/page.tsx`)
- New `PolicyBadge` pill in the result tab strip: green "Auto OK", amber "Approval Required", blue "Advice Only", gray fallback for unknown modes.
- Native tooltip carries `Risk: <level> · Domains: <first 2>`.
- Consumes the existing `normalizeIntentPolicy()` helper — no new types.
- `IntentPolicyPanel` is untouched; it stays the drill-down under the "Intent" tab.

## Test plan

- [x] `python -m pytest tests/ -q` — **1073 passed, 7 skipped** (1069 before + 4 new). New pytest cases:
  - `test_expanded_prompt_v2_emits_policy_header_for_high_risk_financial`
  - `test_expanded_prompt_v2_omits_policy_header_for_benign_educational`
  - `test_expanded_prompt_v2_omits_policy_header_on_trivial_greeting`
  - `test_expanded_prompt_v2_emits_policy_header_for_medium_risk_debug`
- [x] `cd web && npm run test` — **98 passed across 20 files** (93 before + 5 new). New Vitest cases in `web/app/components/__tests__/PolicyBadge.test.tsx`:
  - renders green "Auto OK" for `auto_ok`
  - renders amber "Approval Required" for `human_approval_required`
  - renders blue "Advice Only" for `advice_only`
  - renders nothing when no policy on either `ir` or `ir_v2`
  - tooltip carries risk level and top risk domain
- [x] Manual sanity in the dev servers:
  - High-risk input ("Analyze my stock portfolio allocation…") → amber badge in tab strip; `Policy:` line at the top of the expanded prompt above `Input:`.
  - Benign input ("Explain photosynthesis…") in default mode → green badge; no `Policy:` header at top.
  - `hi` in conservative mode → minimal greeting output, no badge, no header.

## Out of scope (deferred)

- `POLICY.md` inside the Claude project pack export.
- Per-constraint origin tagging ("which heuristic added each constraint").
- "Why was this detected?" trace popovers on domain/persona.
- Starter-example chips on the compile page.

https://claude.ai/code/session_01EDgA6b2gF1VnZ6wDNCdCWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDgA6b2gF1VnZ6wDNCdCWQ)_