### PR TITLE
🎨 Palette: Add success toast for clipboard copy action

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-18 - Visual feedback for successful inline actions
 **Learning:** When a user executes a localized, inline action (like clicking "Insert into Prompt" on a context suggestion), they expect immediate confirmation. Without it, they might click multiple times or check the resulting state manually, breaking their flow.
 **Action:** Always ensure interactive elements that don't have obvious immediate visual state changes trigger a brief visual confirmation (like a toast notification) indicating success.
+
+## 2024-05-18 - Copy to clipboard feedback
+**Learning:** When users click a utility copy button without a toast, they often have to double-check their clipboard because the visual change (e.g. icon swap) is too subtle. A success toast provides definitive feedback.
+**Action:** Always include a `toast.success` notification when implementing copy-to-clipboard functionality to ensure users are confident the action succeeded.

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useId, useState } from "react";
+import { toast } from "sonner";
 import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
@@ -419,6 +420,7 @@ export default function Home() {
                           type="button"
                           onClick={() => {
                             navigator.clipboard.writeText(getTabContent(result, tab));
+                            toast.success("Copied to clipboard");
                             setCopied(true);
                             setTimeout(() => setCopied(false), 2000);
                           }}


### PR DESCRIPTION
### 💡 What:
Added a `toast.success` notification when users copy their compiled prompt to the clipboard on the main page.

### 🎯 Why:
The copy button previously only provided a subtle visual change (an icon swap from copy to a checkmark) and internal state update. This can easily be missed or feel unassuring. Adding a toast notification provides definitive, centralized feedback that the action succeeded, adhering to the learnings in `.jules/palette.md` to ensure users are confident the action succeeded.

### 📸 Before/After:
**Before:** Clicking "Copy" swapped the icon briefly. No toast appeared.
**After:** Clicking "Copy" swaps the icon *and* triggers a clear "Copied to clipboard" toast notification via Sonner at the bottom right.

### ♿ Accessibility:
The `sonner` toast system used is accessible by default and ensures screen reader users are also informed of the successful copy action dynamically without relying purely on a visual icon change.

---
*PR created automatically by Jules for task [6936916677855900289](https://jules.google.com/task/6936916677855900289) started by @madara88645*