### PR TITLE
[codex] fix: harden windows pytest runtime bootstrap

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -246,7 +246,7 @@ Relevant files: `app/rag/simple_index.py`, `api/routes/rag.py`
 pytest tests/test_rag.py tests/test_rag_upload.py tests/test_rag_pipeline.py tests/test_rag_chunking.py tests/test_rag_hybrid_api.py tests/test_rag_parsers.py -v
 ```
 
-**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. `tests/runtime_bootstrap.py` also probes each freshly created session dir before using it, so Windows ACL issues that allow `mkdtemp()` but block child directories should now fall through to the next candidate root. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
+**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. `tests/runtime_bootstrap.py` creates the pytest session directory directly under the candidate root and probes it before use, which avoids Windows environments where `mkdtemp()` succeeds but the returned directory still rejects child file or folder creation. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
 
 **RAG upload smoke (requires running backend and an API key):**
 

--- a/tests/runtime_bootstrap.py
+++ b/tests/runtime_bootstrap.py
@@ -4,6 +4,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
+from uuid import uuid4
 
 
 @dataclass(frozen=True)
@@ -28,7 +29,8 @@ def _candidate_roots(preferred_root: Path, fallback_roots: Iterable[Path]) -> li
 
 
 def _create_session_dir(root: Path) -> Path:
-    session_dir = Path(tempfile.mkdtemp(prefix="pytest-", dir=str(root))).resolve()
+    session_dir = (root / f"pytest-{uuid4().hex[:8]}").resolve()
+    session_dir.mkdir(parents=False, exist_ok=False)
     probe_dir = session_dir / ".write-probe"
 
     try:

--- a/tests/test_test_runtime_bootstrap.py
+++ b/tests/test_test_runtime_bootstrap.py
@@ -8,33 +8,20 @@ def test_prepare_test_runtime_falls_back_when_db_dir_is_not_writable(tmp_path, m
     fallback_root = tmp_path / "fallback"
     fallback_root.mkdir()
 
-    failing_session = preferred_root / "pytest-failing"
-    working_session = fallback_root / "pytest-working"
-
-    created_session_dirs: list[Path] = []
-
-    def fake_mkdtemp(*, prefix: str, dir: str) -> str:
-        target = failing_session if not created_session_dirs else working_session
-        target.mkdir(parents=True, exist_ok=True)
-        created_session_dirs.append(target)
-        return str(target)
-
     original_mkdir = Path.mkdir
 
     def patched_mkdir(self: Path, parents: bool = False, exist_ok: bool = False):
-        if self == failing_session / "db":
+        if self.name == "db" and self.parent.parent.resolve() == preferred_root.resolve():
             raise PermissionError("simulated db dir failure")
         return original_mkdir(self, parents=parents, exist_ok=exist_ok)
 
-    monkeypatch.setattr("tests.runtime_bootstrap.tempfile.mkdtemp", fake_mkdtemp)
     monkeypatch.setattr(Path, "mkdir", patched_mkdir)
 
     runtime = prepare_test_runtime(preferred_root=preferred_root, fallback_roots=[fallback_root])
 
-    assert runtime.session_dir == working_session.resolve()
-    assert runtime.db_dir == (working_session / "db").resolve()
+    assert runtime.session_dir.parent == fallback_root.resolve()
+    assert runtime.db_dir == (runtime.session_dir / "db").resolve()
     assert runtime.db_dir.is_dir()
-    assert created_session_dirs == [failing_session, working_session]
 
 
 def test_prepare_test_runtime_sets_process_temp_environment(tmp_path):
@@ -61,22 +48,44 @@ def test_prepare_test_runtime_falls_back_when_session_dir_cannot_create_children
     fallback_root = tmp_path / "fallback"
     fallback_root.mkdir()
 
-    failing_session = preferred_root / "pytest-failing"
-    working_session = fallback_root / "pytest-working"
+    original_mkdir = Path.mkdir
 
-    created_session_dirs: list[Path] = []
+    def patched_mkdir(self: Path, parents: bool = False, exist_ok: bool = False):
+        if self.name == ".write-probe" and self.parent.parent.resolve() == preferred_root.resolve():
+            raise PermissionError("simulated session dir child creation failure")
+        return original_mkdir(self, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", patched_mkdir)
+
+    runtime = prepare_test_runtime(preferred_root=preferred_root, fallback_roots=[fallback_root])
+
+    assert runtime.session_dir.parent == fallback_root.resolve()
+    assert runtime.db_dir == (runtime.session_dir / "db").resolve()
+    assert runtime.db_dir.is_dir()
+
+
+def test_prepare_test_runtime_avoids_mkdtemp_dirs_that_cannot_create_children(
+    tmp_path, monkeypatch
+):
+    from tests.runtime_bootstrap import prepare_test_runtime
+
+    preferred_root = tmp_path / "preferred"
+    fallback_root = tmp_path / "fallback"
+
+    blocked_session_dirs: set[Path] = set()
 
     def fake_mkdtemp(*, prefix: str, dir: str) -> str:
-        target = failing_session if not created_session_dirs else working_session
+        root = Path(dir)
+        target = root / f"{prefix}blocked-{len(blocked_session_dirs)}"
         target.mkdir(parents=True, exist_ok=True)
-        created_session_dirs.append(target)
+        blocked_session_dirs.add(target.resolve())
         return str(target)
 
     original_mkdir = Path.mkdir
 
     def patched_mkdir(self: Path, parents: bool = False, exist_ok: bool = False):
-        if self == failing_session / ".write-probe":
-            raise PermissionError("simulated session dir child creation failure")
+        if self.parent.resolve() in blocked_session_dirs:
+            raise PermissionError("simulated child creation failure inside mkdtemp session dir")
         return original_mkdir(self, parents=parents, exist_ok=exist_ok)
 
     monkeypatch.setattr("tests.runtime_bootstrap.tempfile.mkdtemp", fake_mkdtemp)
@@ -84,7 +93,10 @@ def test_prepare_test_runtime_falls_back_when_session_dir_cannot_create_children
 
     runtime = prepare_test_runtime(preferred_root=preferred_root, fallback_roots=[fallback_root])
 
-    assert runtime.session_dir == working_session.resolve()
-    assert runtime.db_dir == (working_session / "db").resolve()
+    assert runtime.session_dir.parent in {
+        preferred_root.resolve(),
+        fallback_root.resolve(),
+    }
+    assert runtime.session_dir.resolve() not in blocked_session_dirs
+    assert runtime.db_dir == (runtime.session_dir / "db").resolve()
     assert runtime.db_dir.is_dir()
-    assert created_session_dirs == [failing_session, working_session]


### PR DESCRIPTION
## What changed
- switched pytest runtime bootstrap to create its session directory directly under the candidate root instead of relying on `tempfile.mkdtemp()`
- kept the child-write probe and updated runtime bootstrap tests to assert behavior rather than the old implementation detail
- synced the Windows temp-dir note in `agents.md` with the new bootstrap behavior

## Why
On this Windows workspace, `mkdtemp()` could return a directory that exists but still rejects child file/folder creation. That caused pytest to fail during `tests/conftest.py` import before the actual test suite could start.

## Impact
- pytest startup is resilient in Windows environments with this directory-shape quirk
- the regression is covered by a focused bootstrap test plus the existing API/auth smoke tests

## Validation
- `C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m pytest -q tests/test_test_runtime_bootstrap.py tests/test_api_hardening.py tests/test_auth_fast_path.py`
- direct bootstrap repro script using `prepare_test_runtime(...)`
