### PR TITLE
🎨 Palette: [UX improvement] Add aria-label and keyboard focus states to agent packs page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,14 +15,18 @@
 ## 2025-04-10 - Explicit Button Types
 **Learning:** Buttons without explicit `type` attributes default to `type="submit"` in standard HTML parsing. This can inadvertently trigger unexpected page reloads or form submissions across the application when a simple interactive button is clicked.
 **Action:** Always add `type="button"` to any `<button>` component in the frontend unless it is explicitly intended to submit a form.
+
 ## 2024-04-20 - Adding Keyboard Focus States to Buttons
 **Learning:** Several utility buttons in the Context Manager components lacked `focus-visible` styles, making keyboard navigation difficult to track. Using Tailwind's `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` is an effective, reusable pattern for resolving this across the application without breaking custom hover styles.
 **Action:** Next time I build or refactor interactive elements (especially text-based links acting as buttons or small UI toggles), I should proactively add the standard focus rings so keyboard users aren't left guessing where they are.
+
 ## 2025-04-24 - Accessibility for input elements without visible labels
 **Learning:** For interactive elements like `<textarea>` that function as central input areas in full-page editors but lack a dedicated `<label>`, it is crucial to manually add an `aria-label` attribute. Without this, screen readers will announce the element generically (e.g., "text area, blank"), leaving visually impaired users without context on what the input is for.
 **Action:** When creating or reviewing form inputs without explicit visible `<label>` tags, proactively add an `aria-label` to provide the necessary context.
 
-## 2026-04-24 - Added Keyboard Focus States to Floating Copy Buttons\n**Learning:** Floating copy buttons that appear conditionally or use absolute positioning often lack `focus-visible` states, rendering them inaccessible to keyboard-only users who cannot easily discover them via tab navigation.\n**Action:** When adding utility or floating buttons, always explicitly define `focus-visible:outline-none` and `focus-visible:ring-2` (or `ring-1`) with the appropriate brand color.
+## 2026-04-24 - Added Keyboard Focus States to Floating Copy Buttons
+**Learning:** Floating copy buttons that appear conditionally or use absolute positioning often lack `focus-visible` states, rendering them inaccessible to keyboard-only users who cannot easily discover them via tab navigation.
+**Action:** When adding utility or floating buttons, always explicitly define `focus-visible:outline-none` and `focus-visible:ring-2` (or `ring-1`) with the appropriate brand color.
 
 ## 2024-05-15 - [Add aria-controls to ExportPanel buttons]
 **Learning:** For collapsible content, buttons with `aria-expanded` must also have an `aria-controls` attribute linking them to the content container's ID for screen readers.
@@ -31,3 +35,7 @@
 ## 2026-04-24 - Empty States with Actions
 **Learning:** Empty states without Call-to-Action (CTA) buttons create friction, especially when the required action button is visually distant (e.g., in a top-right corner). Adding an inline CTA directly in the empty state significantly improves UX by making the next step obvious and easily accessible.
 **Action:** When designing or refactoring empty states, always include a clear CTA button inline if the state requires user action to change. Ensure the CTA has descriptive disabled states/tooltips if conditions aren't met (e.g., missing input).
+
+## $(date +%Y-%m-%d) - Focus states for interactive lists
+**Learning:** Custom tab-like interfaces constructed with `<button>` elements mapped from an array often omit focus states, breaking keyboard navigation. These interactive lists require standard focus indicators.
+**Action:** When mapping over items to generate interactive `<button>` elements (e.g., tabs, tags, categories), ensure the base class string includes `focus-visible` styles matching the active state color scheme.

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -286,6 +286,7 @@ export default function AgentPacksPage() {
               </label>
               <textarea
                 id="agent-pack-goal"
+                aria-label="Agent Pack Goal"
                 value={request.goal}
                 onChange={(event) => handleFieldChange("goal", event.target.value)}
                 className="min-h-36 rounded-2xl border border-white/10 bg-black/20 p-4 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
@@ -375,7 +376,7 @@ export default function AgentPacksPage() {
                     <button
                       type="button"
                       onClick={handleCopyCurrent}
-                      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-zinc-200 transition hover:bg-white/[0.08]"
+                      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-zinc-200 transition hover:bg-white/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
                     >
                       <Copy size={14} aria-hidden="true" />
                       {copiedState === "single" ? "Copied" : "Copy"}
@@ -383,7 +384,7 @@ export default function AgentPacksPage() {
                     <button
                       type="button"
                       onClick={handleCopyAll}
-                      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-zinc-200 transition hover:bg-white/[0.08]"
+                      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-zinc-200 transition hover:bg-white/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
                     >
                       <FileCode2 size={14} aria-hidden="true" />
                       {copiedState === "all" ? "Copied All" : "Copy All"}
@@ -392,7 +393,7 @@ export default function AgentPacksPage() {
                       type="button"
                       onClick={handleDownload}
                       disabled={downloading}
-                      className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:opacity-60"
+                      className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
                     >
                       <Download size={14} aria-hidden="true" />
                       {downloading ? "Preparing..." : "Download Pack"}
@@ -409,7 +410,7 @@ export default function AgentPacksPage() {
                         setActiveKind(group.kind);
                         setSelectedPath(group.files[0]?.path ?? null);
                       }}
-                      className={`rounded-full border px-3 py-1.5 text-[11px] font-mono uppercase tracking-wide transition-all ${
+                      className={`rounded-full border px-3 py-1.5 text-[11px] font-mono uppercase tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 ${
                         activeGroup?.kind === group.kind
                           ? "border-cyan-400/40 bg-cyan-500/10 text-cyan-100"
                           : "border-transparent bg-white/[0.03] text-zinc-500 hover:bg-white/[0.07] hover:text-zinc-300"


### PR DESCRIPTION
💡 What: Added `aria-label="Agent Pack Goal"` to the goal textarea and added explicit `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500` styles to the Copy, Copy All, Download, and preview group tab buttons on the Agent Packs page.

🎯 Why: To improve accessibility. The textarea previously lacked screen reader context, and the utility buttons were inaccessible via keyboard navigation because they did not display a focus ring when tabbed into.

📸 Before/After: N/A (Visual changes only apply when navigating via keyboard).

♿ Accessibility: Ensures screen readers announce the text area correctly and guarantees keyboard users can see which utility action has focus.

---
*PR created automatically by Jules for task [8981127379065830655](https://jules.google.com/task/8981127379065830655) started by @madara88645*