### PR TITLE
feat(api): add IP-based rate-limit on public routes (closes #607)

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import time
 import secrets
@@ -70,15 +71,89 @@ RATE_LIMIT_LOCK = Lock()
 RATE_LIMIT_WINDOW = 60  # seconds
 RATE_LIMIT_MAX_REQUESTS = 10
 HEAVY_RATE_LIMIT_MAX_REQUESTS = 2
+PUBLIC_HEAVY_RATE_LIMIT = 20
+PUBLIC_DEFAULT_RATE_LIMIT = 60
+
+_rate_limit_cleanup_counter = 0
+
+
+def _get_route_group(path: str) -> str:
+    heavy_routes = ["/compile", "/optimize", "/run", "/agent-generator", "/skills-generator"]
+    for r in heavy_routes:
+        if path.startswith(r):
+            return "heavy"
+    return "default"
 
 
 def _get_route_group_and_limit(path: str) -> tuple[str, int]:
-    heavy_routes = ["/compile", "/optimize", "/run", "/agent-generator", "/skills-generator"]
-    # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
-    for r in heavy_routes:
-        if path.startswith(r):
-            return "heavy", HEAVY_RATE_LIMIT_MAX_REQUESTS
-    return "default", RATE_LIMIT_MAX_REQUESTS
+    group = _get_route_group(path)
+    if group == "heavy":
+        return group, HEAVY_RATE_LIMIT_MAX_REQUESTS
+    return group, RATE_LIMIT_MAX_REQUESTS
+
+
+def _is_plausible_ip(value: str) -> bool:
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        candidate = forwarded.split(",")[0].strip()
+        if _is_plausible_ip(candidate):
+            return candidate
+    if request.client and request.client.host:
+        host = request.client.host.strip()
+        if _is_plausible_ip(host):
+            return host
+    return "anon"
+
+
+def _maybe_cleanup_rate_limit_store(now: float) -> None:
+    stale_keys = []
+    for k, v in list(RATE_LIMIT_STORE.items()):
+        valid_ts = [t for t in v if t > now - RATE_LIMIT_WINDOW]
+        if not valid_ts:
+            stale_keys.append(k)
+        else:
+            RATE_LIMIT_STORE[k] = valid_ts
+    for k in stale_keys:
+        RATE_LIMIT_STORE.pop(k, None)
+
+
+def _enforce_rate_limit(store_key: str, max_requests: int, now: float) -> None:
+    global _rate_limit_cleanup_counter
+
+    with RATE_LIMIT_LOCK:
+        _rate_limit_cleanup_counter += 1
+        if _rate_limit_cleanup_counter > 1000:
+            _rate_limit_cleanup_counter = 0
+            _maybe_cleanup_rate_limit_store(now)
+
+        history = RATE_LIMIT_STORE.get(store_key, [])
+        history = [t for t in history if t > now - RATE_LIMIT_WINDOW]
+
+        if len(history) >= max_requests:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Rate limit exceeded"
+            )
+
+        history.append(now)
+        RATE_LIMIT_STORE[store_key] = history
+
+
+def rate_limit_by_ip(request: Request) -> None:
+    """Public-route rate limiter keyed by (client_ip, route_group)."""
+    now = time.time()
+    route_group = _get_route_group(request.url.path)
+    max_requests = PUBLIC_HEAVY_RATE_LIMIT if route_group == "heavy" else PUBLIC_DEFAULT_RATE_LIMIT
+    client_ip = _resolve_client_ip(request)
+    store_key = f"ip:{client_ip}:{route_group}"
+    _enforce_rate_limit(store_key, max_requests, now)
 
 
 def _matches_admin_api_key(provided_key: str, admin_key: str) -> bool:
@@ -127,34 +202,7 @@ def verify_api_key(
     now = time.time()
     route_group, max_requests = _get_route_group_and_limit(request.url.path)
     store_key = f"{api_key}:{route_group}"
-
-    with RATE_LIMIT_LOCK:
-        # Periodically clean up stale rate limit entries to prevent memory leaks
-        if getattr(verify_api_key, "_cleanup_counter", 0) > 1000:
-            verify_api_key._cleanup_counter = 0
-            stale_keys = []
-            for k, v in list(RATE_LIMIT_STORE.items()):
-                valid_ts = [t for t in v if t > now - RATE_LIMIT_WINDOW]
-                if not valid_ts:
-                    stale_keys.append(k)
-                else:
-                    RATE_LIMIT_STORE[k] = valid_ts
-            for k in stale_keys:
-                RATE_LIMIT_STORE.pop(k, None)
-        else:
-            verify_api_key._cleanup_counter = getattr(verify_api_key, "_cleanup_counter", 0) + 1
-
-        history = RATE_LIMIT_STORE.get(store_key, [])
-        # Filter out timestamps older than window
-        history = [t for t in history if t > now - RATE_LIMIT_WINDOW]
-
-        if len(history) >= max_requests:
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Rate limit exceeded"
-            )
-
-        history.append(now)
-        RATE_LIMIT_STORE[store_key] = history
+    _enforce_rate_limit(store_key, max_requests, now)
 
     request.state.api_key_owner = key_record.owner
     return key_record

--- a/api/auth.py
+++ b/api/auth.py
@@ -78,7 +78,14 @@ _rate_limit_cleanup_counter = 0
 
 
 def _get_route_group(path: str) -> str:
-    heavy_routes = ["/compile", "/optimize", "/run", "/agent-generator", "/skills-generator"]
+    heavy_routes = [
+        "/compile",
+        "/optimize",
+        "/run",
+        "/agent-generator",
+        "/skills-generator",
+        "/repo-context",
+    ]
     for r in heavy_routes:
         if path.startswith(r):
             return "heavy"

--- a/api/routes/agent_packs.py
+++ b/api/routes/agent_packs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.auth import rate_limit_by_ip
 
 from api.shared import logger
 from app.adapters.agent_packs import (
@@ -22,6 +24,7 @@ def _get_compiler():
 @router.post("/agent-packs/claude", response_model=AgentPackManifest)
 async def build_claude_agent_pack(
     req: AgentPackRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()
     adapter = AGENT_PACK_ADAPTERS["claude"]
@@ -38,6 +41,7 @@ async def build_claude_agent_pack(
 @router.post("/agent-packs/claude/download")
 async def download_claude_agent_pack(
     req: AgentPackRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()
     adapter = AGENT_PACK_ADAPTERS["claude"]

--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -6,7 +6,9 @@ import uuid
 import anyio
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import forced_minimal_expanded_prompt, is_meta_leaked, logger, resolve_mode
@@ -335,6 +337,7 @@ def _build_offline_quality_report(req: ValidateRequest) -> QualityReport:
 def compile_endpoint(
     req: CompileRequest,
     request: Request,
+    _: None = Depends(rate_limit_by_ip),
 ):
     t0 = time.time()
     rid = uuid.uuid4().hex[:12]
@@ -428,6 +431,7 @@ def compile_endpoint(
 async def compile_fast(
     req: CompileRequest,
     request: Request,
+    _: None = Depends(rate_limit_by_ip),
 ):
     start = time.time()
     compiler = _get_compiler()
@@ -456,6 +460,7 @@ async def compile_fast(
 @router.post("/validate", response_model=QualityReport)
 def validate_endpoint(
     req: ValidateRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     try:
         try:
@@ -499,6 +504,7 @@ def validate_endpoint(
 @router.post("/optimize", response_model=OptimizeResponse)
 async def optimize_endpoint(
     req: OptimizeRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()
 

--- a/api/routes/export.py
+++ b/api/routes/export.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field
 
 from api.shared import logger
@@ -21,6 +23,7 @@ class ExportRequest(BaseModel):
 @router.post("/agent-generator/export")
 async def export_agent(
     req: ExportRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     if req.format not in [
         "claude-sdk",
@@ -102,6 +105,7 @@ _SKILL_EXPORT_FORMATS = frozenset(
 @router.post("/skills-generator/export")
 async def export_skill(
     req: ExportRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     if req.format not in _SKILL_EXPORT_FORMATS:
         raise HTTPException(status_code=400, detail=f"Unsupported format: {req.format}")

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -4,7 +4,9 @@ import time
 from typing import Literal
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -128,6 +130,7 @@ class AgentGenResponse(BaseModel):
 @router.post("/repo-context/github", response_model=GitHubRepoContextPayload)
 async def analyze_github_repo_endpoint(
     req: GitHubRepoContextRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     started_at = time.monotonic()
 
@@ -176,6 +179,7 @@ async def analyze_github_repo_endpoint(
 @router.post("/skills-generator/generate", response_model=SkillGenResponse)
 async def generate_skill_endpoint(
     req: SkillGenRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()
 
@@ -195,6 +199,7 @@ async def generate_skill_endpoint(
 @router.post("/agent-generator/generate", response_model=AgentGenResponse)
 async def generate_agent_endpoint(
     req: AgentGenRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()
 

--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -4,7 +4,9 @@ import functools
 from typing import List, Optional
 
 import anyio
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -135,6 +137,7 @@ def _secure_ingest_paths(paths: list[str]) -> list[str]:
 @router.post("/rag/ingest", response_model=RagIngestResponse)
 async def rag_ingest(
     req: RagIngestRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     try:
         secure_paths = _secure_ingest_paths(req.paths)
@@ -158,6 +161,7 @@ async def rag_ingest(
 @router.post("/rag/query", response_model=RagQueryResponse)
 def rag_query(
     req: RagQueryRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     if req.method == "embed":
         results = rag_search_embed(req.query, k=req.k, embed_dim=req.embed_dim)
@@ -176,6 +180,7 @@ def rag_query(
 @router.post("/rag/pack")
 def rag_pack(
     req: RagPackRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     if req.method == "embed":
         results = rag_search_embed(req.query, k=req.k, embed_dim=req.embed_dim)
@@ -203,6 +208,7 @@ def rag_pack(
 @router.post("/rag/upload", response_model=RagUploadResponse)
 async def rag_upload(
     req: RagUploadRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     try:
         display_name = normalize_display_name(req.filename)
@@ -232,7 +238,7 @@ async def rag_upload(
 
 
 @router.get("/rag/stats")
-def rag_stats_endpoint():
+def rag_stats_endpoint(_: None = Depends(rate_limit_by_ip)):
     """
     Bolt: Avoid blocking event loop for SQLite query by removing async
     FastAPI handles sync endpoints in a threadpool automatically.
@@ -243,6 +249,7 @@ def rag_stats_endpoint():
 @router.post("/rag/search", response_model=List[RagSearchResult])
 def rag_search_endpoint(
     req: RagSearchRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     """
     Bolt: Avoid blocking event loop for SQLite query by removing async.

--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -18,7 +18,9 @@ import re
 import time
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -273,6 +275,7 @@ def _heuristic_judge(raw_output: str, compiled_output: str) -> dict:
 @router.post("/run", response_model=BenchmarkResponse)
 async def benchmark_run(
     req: BenchmarkRequest,
+    _: None = Depends(rate_limit_by_ip),
 ):
     """
     Run an A/B benchmark comparing raw vs compiled prompt quality.

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -140,6 +140,72 @@ def test_per_ip_buckets_isolated(monkeypatch):
 
 
 @pytest.mark.auth_required
+def test_repo_context_endpoint_uses_heavy_public_rate_limit(monkeypatch):
+    monkeypatch.setattr("api.auth.PUBLIC_HEAVY_RATE_LIMIT", 1)
+    client = TestClient(app)
+    payload = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repo summary.",
+        "highlights": ["Python package"],
+        "files_used": ["README.md"],
+        "detected_stack": ["Python"],
+    }
+
+    with patch("api.routes.generators.analyze_public_github_repo", return_value=payload):
+        first = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://github.com/openai/openai-python"},
+            headers={"X-Forwarded-For": "1.1.1.1"},
+        )
+        second = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://github.com/openai/openai-python"},
+            headers={"X-Forwarded-For": "1.1.1.1"},
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+@pytest.mark.auth_required
+def test_repo_context_endpoint_keeps_per_ip_buckets_isolated(monkeypatch):
+    monkeypatch.setattr("api.auth.PUBLIC_HEAVY_RATE_LIMIT", 1)
+    client = TestClient(app)
+    payload = {
+        "normalized_repo_url": "https://github.com/openai/openai-python",
+        "repo_full_name": "openai/openai-python",
+        "default_branch": "main",
+        "summary": "Python SDK repo summary.",
+        "highlights": ["Python package"],
+        "files_used": ["README.md"],
+        "detected_stack": ["Python"],
+    }
+
+    with patch("api.routes.generators.analyze_public_github_repo", return_value=payload):
+        first = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://github.com/openai/openai-python"},
+            headers={"X-Forwarded-For": "1.1.1.1"},
+        )
+        second = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://github.com/openai/openai-python"},
+            headers={"X-Forwarded-For": "1.1.1.1"},
+        )
+        third = client.post(
+            "/repo-context/github",
+            json={"repo_url": "https://github.com/openai/openai-python"},
+            headers={"X-Forwarded-For": "2.2.2.2"},
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert third.status_code == 200
+
+
+@pytest.mark.auth_required
 def test_benchmark_works_without_api_key():
     client = TestClient(app)
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -74,6 +74,69 @@ def test_optimize_works_without_api_key():
         response = client.post("/optimize", json={"text": "a much longer prompt"})
 
     assert response.status_code == 200
+
+
+@pytest.mark.auth_required
+def test_public_routes_rate_limited_by_ip(monkeypatch):
+    """A burst from a single IP hits 429 after 20 heavy requests in 60s."""
+    monkeypatch.setattr("api.auth.PUBLIC_HEAVY_RATE_LIMIT", 3)
+    client = TestClient(app)
+
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_res = MagicMock()
+        mock_res.ir.model_dump.return_value = {}
+        mock_res.system_prompt = "sys"
+        mock_res.user_prompt = "user"
+        mock_res.plan = "plan"
+        mock_res.optimized_content = "opt"
+        mock_compiler.worker.process.return_value = mock_res
+        mock_compiler.cache = {}
+
+        for _ in range(3):
+            assert client.post("/compile/fast", json={"text": "h"}).status_code == 200
+        assert client.post("/compile/fast", json={"text": "h"}).status_code == 429
+
+
+@pytest.mark.auth_required
+def test_per_ip_buckets_isolated(monkeypatch):
+    """Two different X-Forwarded-For headers get separate buckets."""
+    monkeypatch.setattr("api.auth.PUBLIC_HEAVY_RATE_LIMIT", 1)
+    client = TestClient(app)
+
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_res = MagicMock()
+        mock_res.ir.model_dump.return_value = {}
+        mock_res.system_prompt = "sys"
+        mock_res.user_prompt = "user"
+        mock_res.plan = "plan"
+        mock_res.optimized_content = "opt"
+        mock_compiler.worker.process.return_value = mock_res
+        mock_compiler.cache = {}
+
+        assert (
+            client.post(
+                "/compile/fast",
+                json={"text": "h"},
+                headers={"X-Forwarded-For": "1.1.1.1"},
+            ).status_code
+            == 200
+        )
+        assert (
+            client.post(
+                "/compile/fast",
+                json={"text": "h"},
+                headers={"X-Forwarded-For": "1.1.1.1"},
+            ).status_code
+            == 429
+        )
+        assert (
+            client.post(
+                "/compile/fast",
+                json={"text": "h"},
+                headers={"X-Forwarded-For": "2.2.2.2"},
+            ).status_code
+            == 200
+        )
 
 
 @pytest.mark.auth_required

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -325,7 +325,7 @@ def test_verify_api_key_rate_limit_is_atomic(monkeypatch):
     monkeypatch.setattr("api.auth.RATE_LIMIT_STORE", rate_limit_store)
     monkeypatch.setattr("api.auth.RATE_LIMIT_MAX_REQUESTS", 1)
     monkeypatch.setattr("api.auth.RATE_LIMIT_WINDOW", 60)
-    monkeypatch.setattr(verify_api_key, "_cleanup_counter", 0, raising=False)
+    monkeypatch.setattr("api.auth._rate_limit_cleanup_counter", 0)
 
     def run_check():
         mock_request = MagicMock(spec=Request)


### PR DESCRIPTION
## Summary

Closes #607.

After #605 made the public API surface authentication-less, rate limiting disappeared because it only ran inside `verify_api_key`. This PR adds a separate `rate_limit_by_ip` FastAPI dependency on all public routes without reintroducing `x-api-key`.

- **Heavy routes** (`/compile`, `/optimize`, `/run`, `/agent-generator`, `/skills-generator`): **20 requests / 60s / IP**
- **Default routes** (RAG, validate, benchmark, agent-packs, etc.): **60 requests / 60s / IP**
- **API-key buckets** (Jules/admin paths): unchanged at 2/min heavy and 10/min default

## Implementation

- Shared sliding-window logic in `api/auth.py` (`_enforce_rate_limit`, `_maybe_cleanup_rate_limit_store`)
- Store keys: `ip:{client_ip}:{route_group}` (coexists with `{api_key}:{route_group}`)
- Client IP: first plausible hop in `X-Forwarded-For`, else `request.client.host`, else shared `anon` bucket
- In-process memory store with existing cleanup pass (no Redis/slowapi)

## Test plan

- [x] `pytest tests/test_api_hardening.py tests/test_auth_fast_path.py -q` (44 passed)
- [x] `pytest tests/ -q` (1084 passed)
- [ ] Manual: burst 25× `POST /compile/fast` → ~20× 200 then 429