### PR TITLE
⚡ Bolt: Optimize L2 normalization for Python 3.12+ in _simple_embed

### DIFF
--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -477,7 +477,11 @@ def _simple_embed(text: str, dim: int = 64) -> List[float]:
         idx = h % dim
         vec[idx] += 1.0
     # L2 normalize
-    norm = math.hypot(*vec) or 1.0
+    # Bolt Optimization: math.sqrt(math.sumprod(v, v)) is faster than math.hypot(*v) for sequence unpacking overhead
+    if hasattr(math, "sumprod"):
+        norm = math.sqrt(math.sumprod(vec, vec)) or 1.0
+    else:
+        norm = math.hypot(*vec) or 1.0
     vec = [v / norm for v in vec]
     return vec
 


### PR DESCRIPTION
💡 What: Replaced `math.hypot(*vec)` with `math.sqrt(math.sumprod(vec, vec))` for Python 3.12+ in the `_simple_embed` L2 normalization step.
🎯 Why: Calling `math.hypot(*vec)` incurs sequence unpacking overhead as the dynamic argument list needs to be unpacked before executing in C. `math.sumprod` executes in C and consumes the iterables directly, avoiding this overhead for dot products.
📊 Impact: The optimization increases vector norm calculation performance. In local synthetic benchmarks, it reduces vector norm computation time over large dimensional inputs.
🔬 Measurement: Verify by executing performance timing over the L2 normalization loop or by running `python test_perf.py` on vector normalization operations. Tests executed via `python3 -m pytest tests/` confirm correctness and mathematical parity.

---
*PR created automatically by Jules for task [14094056288941250358](https://jules.google.com/task/14094056288941250358) started by @madara88645*