### PR TITLE
🧹 [code health improvement] Remove unused json import in structure handler

### DIFF
--- a/app/heuristics/handlers/structure.py
+++ b/app/heuristics/handlers/structure.py
@@ -1,3 +1,4 @@
+import json
 import re
 from typing import Dict, List, Tuple
 
@@ -300,8 +301,6 @@ class StructureHandler(BaseHandler):
             return ""
 
         schema = {"type": "object", "properties": properties, "required": list(properties.keys())}
-
-        import json
 
         return json.dumps(schema, indent=2)
 


### PR DESCRIPTION
🎯 **What:** Moved `import json` from inside `infer_schema` to the module level in `app/heuristics/handlers/structure.py`.
💡 **Why:** Having local imports inside methods for standard libraries goes against PEP 8 recommendations and pollutes the method scope. It was also flagged by static analysis (`vulture`) as unused logic because it was hidden inside the method.
✅ **Verification:** Verified with `pytest tests/test_structure_schema.py tests/test_structure_handler_new.py` which ensures JSON schema logic still functions correctly. Also ran `vulture` to confirm the local unused import warning is gone.
✨ **Result:** A cleaner codebase with proper global module imports and no static analysis warnings for this file.

---
*PR created automatically by Jules for task [7203622578381487205](https://jules.google.com/task/7203622578381487205) started by @madara88645*