### PR TITLE
[codex] Retry transient backend failures for safe proxy routes

### DIFF
--- a/web/app/agent-generator/export/route.ts
+++ b/web/app/agent-generator/export/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/agent-generator/export");
+  return proxyBackendRequest(request, "/agent-generator/export", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/app/agent-generator/generate/route.ts
+++ b/web/app/agent-generator/generate/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/agent-generator/generate");
+  return proxyBackendRequest(request, "/agent-generator/generate", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/app/benchmark/run/route.ts
+++ b/web/app/benchmark/run/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/benchmark/run");
+  return proxyBackendRequest(request, "/benchmark/run", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/app/optimize/route.ts
+++ b/web/app/optimize/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/optimize");
+  return proxyBackendRequest(request, "/optimize", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -107,6 +107,89 @@ describe("Next backend proxy route wiring", () => {
 
   it.each<RouteCase>([
     {
+      name: "repo context analysis",
+      handler: repoContextGithubRoute,
+      requestUrl: "http://localhost:3000/repo-context/github",
+      requestBody: { repo_url: "https://github.com/openai/openai-python" },
+      expectedUrl: "http://127.0.0.1:8080/repo-context/github",
+    },
+    {
+      name: "agent generation",
+      handler: agentGenerateRoute,
+      requestUrl: "http://localhost:3000/agent-generator/generate",
+      requestBody: { description: "review this PR" },
+      expectedUrl: "http://127.0.0.1:8080/agent-generator/generate",
+    },
+    {
+      name: "skills generation",
+      handler: skillsGenerateRoute,
+      requestUrl: "http://localhost:3000/skills-generator/generate",
+      requestBody: { description: "search docs" },
+      expectedUrl: "http://127.0.0.1:8080/skills-generator/generate",
+    },
+    {
+      name: "benchmark run",
+      handler: benchmarkRunRoute,
+      requestUrl: "http://localhost:3000/benchmark/run",
+      requestBody: { model: "gpt-4" },
+      expectedUrl: "http://127.0.0.1:8080/benchmark/run",
+    },
+    {
+      name: "optimize",
+      handler: optimizeRoute,
+      requestUrl: "http://localhost:3000/optimize",
+      requestBody: { system_prompt: "hello" },
+      expectedUrl: "http://127.0.0.1:8080/optimize",
+    },
+    {
+      name: "agent export",
+      handler: agentExportRoute,
+      requestUrl: "http://localhost:3000/agent-generator/export",
+      requestBody: { type: "code" },
+      expectedUrl: "http://127.0.0.1:8080/agent-generator/export",
+    },
+    {
+      name: "skills export",
+      handler: skillsExportRoute,
+      requestUrl: "http://localhost:3000/skills-generator/export",
+      requestBody: { type: "code" },
+      expectedUrl: "http://127.0.0.1:8080/skills-generator/export",
+    },
+  ])("retries $name requests after a transient backend connection failure", async ({
+    handler,
+    requestUrl,
+    requestMethod,
+    requestBody,
+    expectedUrl,
+  }) => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const response = await handler(
+      new Request(requestUrl, {
+        method: requestMethod || "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: requestBody ? JSON.stringify(requestBody) : undefined,
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(expectedUrl);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it.each<RouteCase>([
+    {
       name: "RAG search",
       handler: ragSearchRoute,
       requestUrl: "http://localhost:3000/rag/search",

--- a/web/app/repo-context/github/route.ts
+++ b/web/app/repo-context/github/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/repo-context/github");
+  return proxyBackendRequest(request, "/repo-context/github", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/app/skills-generator/export/route.ts
+++ b/web/app/skills-generator/export/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/skills-generator/export");
+  return proxyBackendRequest(request, "/skills-generator/export", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/app/skills-generator/generate/route.ts
+++ b/web/app/skills-generator/generate/route.ts
@@ -1,5 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/skills-generator/generate");
+  return proxyBackendRequest(request, "/skills-generator/generate", {
+    retryNetworkErrors: true,
+  });
 }

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -130,6 +130,36 @@ describe("backend proxy", () => {
     expect(response.status).toBe(502);
   });
 
+  it("returns a 502 after exhausting retryable network attempts", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch failed"));
+
+    const response = await proxyBackendRequest(
+      new Request("http://localhost:3000/agent-generator/generate", {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ description: "review code" }),
+      }),
+      "/agent-generator/generate",
+      {
+        retryNetworkErrors: true,
+        networkRetryAttempts: 2,
+        networkRetryDelayMs: 1,
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(502);
+    expect(response.headers.get("x-promptc-proxy-attempts")).toBe("2");
+    await expect(response.json()).resolves.toEqual({
+      detail: "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
+    });
+  });
+
 
 
   it("allows proxying with a caller-supplied x-api-key", async () => {


### PR DESCRIPTION
## Summary
- enable transient network retries for the remaining safe public proxy POST routes
- cover the retry behavior at the route layer for repo context, generators, exports, benchmark, and optimize
- add a backend proxy regression test for exhausted retry attempts so diagnostics stay locked in

## Why
Some public compute-heavy routes were still failing fast on temporary upstream wake-up or connection issues even though the shared proxy already supports retries. This aligns those routes with the existing `compile` and agent-pack behavior so users see fewer avoidable 502s during cold starts.

## Validation
- `cmd /c npm run test -- proxy-routes.test.ts lib/server/backendProxy.test.ts`
- `cmd /c npm run build`
- `cmd /c npm run lint` (existing warning remains in `web/app/benchmark/page.tsx` for an unused import)
