### PR TITLE
🔒 [security fix] Fix Information Exposure in Repo Context Endpoint

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -144,7 +144,7 @@ async def analyze_github_repo_endpoint(
             status_code=400,
             error_message=str(exc),
         )
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail="Invalid GitHub repository URL.") from exc
     except GitHubRepoAnalysisError as exc:
         outcome = "not_found" if exc.status_code == 404 else "upstream_error"
         _log_repo_analyze_outcome(


### PR DESCRIPTION
🎯 **What:** Fixed an Information Exposure vulnerability (CWE-200) in the GitHub repository context endpoint.
⚠️ **Risk:** The previous implementation returned raw exception details to the client when an invalid GitHub repository URL was provided. This could potentially leak internal system information, paths, or upstream API structures if the underlying exception object was not carefully constructed.
🛡️ **Solution:** Replaced the `detail=str(exc)` argument in the raised `HTTPException` with a generic string `"Invalid GitHub repository URL."`. The detailed error message is still preserved in the server-side logs via `_log_repo_analyze_outcome` for debugging purposes.

Tests passed successfully, confirming the fix does not break existing functionality.

---
*PR created automatically by Jules for task [3258570660168021887](https://jules.google.com/task/3258570660168021887) started by @madara88645*