### PR TITLE
fix(web): preserve query params in backend proxy

### DIFF
--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -247,4 +247,26 @@ describe("backend proxy", () => {
       detail: "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
     });
   });
+
+  it("preserves query parameters when proxying to the backend", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const request = new Request("http://localhost:3000/health?verbose=1&source=web", {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+
+    const response = await proxyBackendRequest(request, "/health");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.memo.dev/health?verbose=1&source=web");
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
 });

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -104,10 +104,12 @@ export async function proxyBackendRequest(
 ): Promise<Response> {
   const requestStartedAt = Date.now();
   const headers = copyProxyHeaders(request);
+  const incomingUrl = new URL(request.url);
 
   const base = resolveBackendApiBase().replace(/\/+$/, "");
   const path = backendPath.startsWith("/") ? backendPath : "/" + backendPath;
-  const targetUrl = base + path;
+  const targetUrl = new URL(base + path);
+  targetUrl.search = incomingUrl.search;
   const retryAttempts = options.retryNetworkErrors ? Math.max(1, options.networkRetryAttempts ?? 3) : 1;
   const retryDelayMs = options.networkRetryDelayMs ?? 1000;
   const upstreamTimeoutMs = options.upstreamTimeoutMs ?? resolveUpstreamTimeoutMs();
@@ -128,7 +130,7 @@ export async function proxyBackendRequest(
       };
       if (init.body && !bufferedBody) init.duplex = "half";
 
-      const upstreamResponse = await fetch(targetUrl, init as RequestInit);
+      const upstreamResponse = await fetch(targetUrl.toString(), init as RequestInit);
       const attemptsUsed = attempt + 1;
       const durationMs = Date.now() - requestStartedAt;
 


### PR DESCRIPTION
## What changed
- preserve the original request query string when Next proxy routes forward requests to the backend
- add a regression test covering proxied requests with query parameters

## Why this helps
Some proxied requests were silently dropping the ?query=value part of the URL. For users, that means filters, flags, or paging values can disappear on the way to the backend.

## Risk
Low. The change only affects how the proxy builds the upstream URL and is covered by focused tests.

## Verification
- cd web && npm run test -- --run lib/server/backendProxy.test.ts
- cd web && npm run test -- --run app/proxy-routes.test.ts
- cd web && npm run lint
