### PR TITLE
fix(compile): preserve error context across compile flow

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -6,7 +6,7 @@ import uuid
 import anyio
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
@@ -254,6 +254,7 @@ def _fast_compile_payload(
     mode: str,
     start: float,
     fallback_reason: str | None = None,
+    request_id: str | None = None,
 ) -> tuple[dict, bool]:
     ir2, used_fallback = _coerce_fast_ir(req.text, worker_res, fallback_reason)
 
@@ -286,7 +287,7 @@ def _fast_compile_payload(
             "plan_v2": plan,
             "expanded_prompt_v2": expanded_prompt,
             "processing_ms": int((time.time() - start) * 1000),
-            "request_id": "fast_" + uuid.uuid4().hex[:12],
+            "request_id": request_id or ("fast_" + uuid.uuid4().hex[:12]),
             "heuristic_version": "v2-fast",
             "heuristic2_version": "v2-fast",
             "trace": [],
@@ -364,8 +365,12 @@ def compile_endpoint(
             user_v2 = _safe_worker_text(worker_res, "user_prompt") or user_v2
             plan_v2 = _safe_worker_text(worker_res, "plan") or plan_v2
             exp_v2 = _safe_worker_text(worker_res, "optimized_content") or exp_v2
-        except Exception as exc:
-            logger.warning("LLM compile failed; falling back to local v2 heuristics: %s", exc)
+        except Exception:
+            logger.warning(
+                "LLM compile failed; falling back to local v2 heuristics",
+                exc_info=True,
+                extra={"request_id": rid, "mode": mode, "text_length": len(req.text)},
+            )
 
     if mode != "default":
         forced_expanded = forced_minimal_expanded_prompt(req.text, ir2, req.diagnostics)
@@ -398,8 +403,12 @@ def compile_endpoint(
                 system_prompt=sys_v2,
                 context=context_str,
             ).model_dump()
-        except Exception as exc:
-            logger.debug("Critique generation skipped: %s", exc)
+        except Exception:
+            logger.warning(
+                "Critique generation skipped",
+                exc_info=True,
+                extra={"request_id": rid},
+            )
 
     elapsed = int((time.time() - t0) * 1000)
 
@@ -431,29 +440,42 @@ def compile_endpoint(
 async def compile_fast(
     req: CompileRequest,
     request: Request,
+    response: Response,
     _: None = Depends(rate_limit_by_ip),
 ):
     start = time.time()
+    rid = "fast_" + uuid.uuid4().hex[:12]
+    response.headers["X-Request-Id"] = rid
     compiler = _get_compiler()
+    phase = "init"
 
     try:
+        phase = "resolve_mode"
         mode = resolve_mode(req.mode, request)
         cache_key = (req.text, mode)
         cache_hit = cache_key in compiler.cache
         fallback_reason = None
-        if cache_key in compiler.cache:
+        if cache_hit:
+            phase = "cache_lookup"
             res = compiler.cache[cache_key]
         else:
+            phase = "worker_call"
             res, fallback_reason = await _run_fast_worker_with_retry(compiler, req.text, mode)
 
-        payload, used_fallback = _fast_compile_payload(req, res, mode, start, fallback_reason)
+        phase = "payload_build"
+        payload, used_fallback = _fast_compile_payload(
+            req, res, mode, start, fallback_reason, request_id=rid
+        )
         if not cache_hit and not used_fallback:
             compiler.cache[cache_key] = res
         elif cache_hit and used_fallback:
             compiler.cache.pop(cache_key, None)
         return payload
     except Exception as exc:
-        logger.exception("compile_fast failed")
+        logger.exception(
+            "compile_fast failed",
+            extra={"request_id": rid, "phase": phase, "text_length": len(req.text)},
+        )
         raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
 
 
@@ -466,8 +488,12 @@ def validate_endpoint(
         try:
             compiler = _get_compiler()
             report = compiler.worker.analyze_prompt(req.text)
-        except Exception as exc:
-            logger.warning("validate endpoint falling back to offline analysis: %s", exc)
+        except Exception:
+            logger.warning(
+                "validate endpoint falling back to offline analysis",
+                exc_info=True,
+                extra={"text_length": len(req.text)},
+            )
             report = _build_offline_quality_report(req)
 
         from app.heuristics.handlers.safety import SafetyHandler

--- a/web/app/hooks/useCompiler.ts
+++ b/web/app/hooks/useCompiler.ts
@@ -77,6 +77,11 @@ export function useCompiler() {
       if (controller.signal.aborted && controllerRef.current !== controller) {
         return;
       }
+      console.error("Compile request failed", {
+        mode,
+        textLength: text.length,
+        aborted: controller.signal.aborted,
+      });
       setLastError(error);
       showError(error);
       setStatus("Error");

--- a/web/app/lib/showError.ts
+++ b/web/app/lib/showError.ts
@@ -1,6 +1,28 @@
 import { toast } from "sonner";
-import { describeRequestError } from "../../config";
+import { ApiError, describeRequestError } from "../../config";
+
+function summarizeForConsole(error: unknown): Record<string, unknown> {
+  if (error instanceof ApiError) {
+    const requestId =
+      error.payload && typeof error.payload === "object"
+        ? (error.payload as { request_id?: unknown }).request_id
+        : undefined;
+    return {
+      kind: "ApiError",
+      status: error.status,
+      detail: error.detail,
+      requestId,
+      payload: error.payload,
+    };
+  }
+  if (error instanceof Error) {
+    return { kind: error.name || "Error", message: error.message };
+  }
+  return { kind: "unknown", value: error };
+}
 
 export function showError(error: unknown): void {
-  toast.error(describeRequestError(error));
+  const userMessage = describeRequestError(error);
+  console.error("[showError]", userMessage, summarizeForConsole(error), error);
+  toast.error(userMessage);
 }


### PR DESCRIPTION
## Summary
- Frontend (`showError.ts` + `useCompiler.ts`): log the full error object — unwrapping `ApiError` into `status` / `requestId` / `payload` — to `console.error` before showing the toast, so the user-facing message and the underlying error are correlatable in DevTools.
- Backend (`api/routes/compile.py`): three `logger.warning(...: %s, exc)` calls (LLM worker fallback, critic agent failure, validate offline fallback) now use `exc_info=True` with structured `extra` (`request_id`, `mode`, `text_length`). Critic-agent failure elevated from `debug` to `warning` so it is no longer invisible in production.
- Backend (`compile_fast`): mints `request_id` upfront, threads it through `_fast_compile_payload`, tracks a `phase` variable across the four stages (resolve_mode → cache_lookup / worker_call → payload_build), attaches `phase` + `request_id` to the `logger.exception` call, and sets `X-Request-Id` on the response header so a user-reported failure can be matched to server logs.

## Why
A triage audit of the compile flow found that the happy path is well-guarded (proxy retry, IR coercion, `_safe_worker_text`) but every failure path **loses information**: stringified `%s, exc` logs drop tracebacks, the browser console never sees the real error object, and a generic 500 in `compile_fast` gives no signal about which stage failed. Net effect: any compile incident is unreproducible.

These three changes are the highest-leverage fixes from the audit — they cost almost nothing and make incidents debuggable without changing any API shape or UI.

## What a reviewer should know
- **No behaviour change for users.** No API response shape changes (the new `X-Request-Id` is an additive header), no UI changes, no new dependencies. Only log lines, console output, and one response header are different.
- **`_fast_compile_payload` signature** gained an optional `request_id` keyword. Defaults preserve old behaviour when called without it.
- **Critic-agent log level was raised** from `debug` to `warning`. If this becomes noisy in practice, the right next step is to surface it as a `warnings[]` field in the response, not to drop the level back to debug.
- **Out of scope** (deferred to follow-ups, captured in the triage plan): LLM provider `Error:` sentinel string in `app/llm/providers.py`, brittle `entry['type']` access in PII safety formatting, `emitters.py` path-split assumption, and `describeRequestError` collapsing all errors to one message.

## Test plan
- [x] `py -3 -m pytest tests/test_export_adapters.py tests/test_llm_providers.py -q` — 44 passed
- [x] `py -3 -m pytest tests/ -q -k "compile or route"` — 67 passed
- [x] `cd web && npm run test` — 94 passed across 21 files
- [x] `cd web && npm run build` — succeeded (TypeScript clean)
- [ ] Manual: stop backend mid-compile, click Compile in the UI, confirm DevTools console shows `[showError]` + the full error object alongside the toast
- [ ] Manual: trigger a `/compile/fast` 500, confirm server log line includes `phase=...` and `request_id=fast_...`, and the response carries `X-Request-Id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)