### PR TITLE
🎨 Palette: Add `cursor-not-allowed` to disabled buttons

### DIFF
--- a/web/app/components/ContextManager.tsx
+++ b/web/app/components/ContextManager.tsx
@@ -136,7 +136,7 @@ export default function ContextManager({ onInsertContext, suggestions = [] }: Co
                     onClick={() => void ingestPath(filePath)}
                     disabled={ingesting || !filePath}
                     title={!filePath ? "Enter a file path first to ingest" : "Ingest Path"}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/5 bg-zinc-800/50 py-2 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700/50 disabled:opacity-50"
+                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/5 bg-zinc-800/50 py-2 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-700/50 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                     {ingesting ? <span className="animate-pulse">Indexing...</span> : "Ingest Path"}
                 </button>

--- a/web/app/components/QualityCoach.tsx
+++ b/web/app/components/QualityCoach.tsx
@@ -94,7 +94,7 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                         aria-label="Run quality analysis"
                         disabled={analyzing || !prompt.trim()}
                         title={!prompt.trim() ? "Enter a prompt first to run analysis" : "Run quality analysis"}
-                        className="px-4 py-2 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-xl hover:bg-blue-500/20 text-xs font-semibold uppercase tracking-wider disabled:opacity-50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        className="px-4 py-2 bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-xl hover:bg-blue-500/20 text-xs font-semibold uppercase tracking-wider disabled:opacity-50 disabled:cursor-not-allowed transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     >
                         {analyzing ? <span className="animate-pulse">Analyzing...</span> : "Run Analysis"}
                     </button>
@@ -113,7 +113,7 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                         aria-label="Run quality analysis"
                         disabled={analyzing || !prompt.trim()}
                         title={!prompt.trim() ? "Enter a prompt first to run analysis" : "Run quality analysis"}
-                        className="px-6 py-2 bg-blue-600/20 text-blue-300 border border-blue-500/30 rounded-xl hover:bg-blue-600/30 text-sm font-medium transition-all disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex items-center gap-2"
+                        className="px-6 py-2 bg-blue-600/20 text-blue-300 border border-blue-500/30 rounded-xl hover:bg-blue-600/30 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 flex items-center gap-2"
                     >
                         {analyzing ? (
                             <><span className="w-4 h-4 border-2 border-blue-400 border-t-transparent rounded-full animate-spin"></span> Analyzing...</>

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -49,7 +49,7 @@ export default function RagSearchPanel({
                     onClick={onRunSearch}
                     disabled={searching || !query.trim()}
                     title={!query.trim() ? "Enter a query first to search" : "Search"}
-                    className="rounded-lg border border-blue-500/20 bg-blue-500/10 px-3 text-xs font-medium text-blue-400 transition-all hover:bg-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 disabled:opacity-50"
+                    className="rounded-lg border border-blue-500/20 bg-blue-500/10 px-3 text-xs font-medium text-blue-400 transition-all hover:bg-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                     Search
                 </button>


### PR DESCRIPTION
💡 What: Added the `disabled:cursor-not-allowed` Tailwind CSS class to disabled buttons in `QualityCoach`, `ContextManager`, and `RagSearchPanel` components.
🎯 Why: To provide a clear visual indicator via the mouse cursor that the button is currently inactive and cannot be interacted with, bringing these components inline with other parts of the application (like `page.tsx`).
📸 Before/After: Before, the buttons only faded out via `opacity-50`. After, they fade out AND the mouse cursor changes to a 'not-allowed' symbol.
♿ Accessibility: Improves visual feedback for mouse users encountering disabled states, clarifying system status.

---
*PR created automatically by Jules for task [2570132192890866711](https://jules.google.com/task/2570132192890866711) started by @madara88645*