### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing authentication on benchmark endpoint

### DIFF
--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from api.auth import rate_limit_by_ip
+from api.auth import APIKey, rate_limit_by_ip, verify_api_key
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -275,6 +275,7 @@ def _heuristic_judge(raw_output: str, compiled_output: str) -> dict:
 @router.post("/run", response_model=BenchmarkResponse)
 async def benchmark_run(
     req: BenchmarkRequest,
+    api_key: APIKey = Depends(verify_api_key),
     _: None = Depends(rate_limit_by_ip),
 ):
     """

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -206,7 +206,7 @@ def test_repo_context_endpoint_keeps_per_ip_buckets_isolated(monkeypatch):
 
 
 @pytest.mark.auth_required
-def test_benchmark_works_without_api_key():
+def test_benchmark_requires_api_key():
     client = TestClient(app)
 
     with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
@@ -218,7 +218,8 @@ def test_benchmark_works_without_api_key():
             json={"text": "Explain Python", "model": "llama-3.1-8b-instant"},
         )
 
-    assert response.status_code == 200
+    # Now it should be forbidden without an API key
+    assert response.status_code == 403
 
 
 @pytest.mark.auth_required


### PR DESCRIPTION
🎯 What: The `/benchmark/run` API endpoint was entirely unauthenticated, allowing unauthenticated usage of cost-incurring LLM routes.
⚠️ Risk: This allowed unauthenticated users to trigger LLM generations, leading to potential resource exhaustion and financial impact.
🛡️ Solution: Added `verify_api_key` as a dependency to the `benchmark_run` route in `app/routers/benchmark.py`. Updated the corresponding unit test `test_benchmark_requires_api_key` in `tests/test_api_hardening.py` to assert a `403 Forbidden` response without an API key.

---
*PR created automatically by Jules for task [5030042817426729150](https://jules.google.com/task/5030042817426729150) started by @madara88645*