### PR TITLE
[codex] chore(web): remove stale lint suppression

### DIFF
--- a/web/app/hooks/useContextManager.ts
+++ b/web/app/hooks/useContextManager.ts
@@ -92,7 +92,6 @@ export function useContextManager() {
   }, [refreshStats]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void checkConnection();
   }, [checkConnection]);
 


### PR DESCRIPTION
## What changed
- removed an unused eslint suppression from `useContextManager`

## Why
- the frontend lint job was clean except for one stale suppression comment
- keeping an empty suppression hides signal and makes future lint noise easier to miss

## Product impact
- no user-facing behavior change
- keeps CI and local frontend checks cleaner and easier to trust

## Validation
- `cd web && npm run lint`
- `cd web && npm run test -- --run lib/server/backendProxy.test.ts app/proxy-routes.test.ts`
- `cd web && npm run build`
