### PR TITLE
🎨 Palette: [UX improvement] Add disabled:cursor-not-allowed to download button

### DIFF
--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -393,7 +393,7 @@ export default function AgentPacksPage() {
                       type="button"
                       onClick={handleDownload}
                       disabled={downloading}
-                      className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
+                      className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
                     >
                       <Download size={14} aria-hidden="true" />
                       {downloading ? "Preparing..." : "Download Pack"}


### PR DESCRIPTION
💡 What: Added the `disabled:cursor-not-allowed` utility class to the "Download Pack" button in the Agent Packs page.
🎯 Why: Ensures that when the button is disabled (during a download), the cursor accurately reflects its non-interactive state, improving user feedback and consistency with other disabled elements in the app.
📸 Before/After: N/A (Visual cursor change on hover)
♿ Accessibility: Provides a clearer visual cue to users relying on mouse interactions that the button is temporarily disabled.

---
*PR created automatically by Jules for task [13912197614911771169](https://jules.google.com/task/13912197614911771169) started by @madara88645*