### PR TITLE
[codex] chore(web): remove unused context manager lint disable

### DIFF
--- a/web/app/hooks/useContextManager.ts
+++ b/web/app/hooks/useContextManager.ts
@@ -92,7 +92,6 @@ export function useContextManager() {
   }, [refreshStats]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void checkConnection();
   }, [checkConnection]);
 


### PR DESCRIPTION
## What changed
- removed an unused lint suppression comment from `useContextManager`

## Why
- the frontend lint run was clean except for one avoidable warning
- removing the stale suppression keeps the hook file easier to trust and maintain

## Product impact
- no user-facing behavior changes
- this only cleans up the code path so local and CI lint checks stay quiet

## Validation
- `npm run lint`
- `npm run build`
