### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing authentication on cost-incurring generator endpoints

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from api.auth import rate_limit_by_ip
+from api.auth import rate_limit_by_ip, APIKey, verify_api_key
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -179,6 +179,7 @@ async def analyze_github_repo_endpoint(
 @router.post("/skills-generator/generate", response_model=SkillGenResponse)
 async def generate_skill_endpoint(
     req: SkillGenRequest,
+    api_key: APIKey = Depends(verify_api_key),
     _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()
@@ -199,6 +200,7 @@ async def generate_skill_endpoint(
 @router.post("/agent-generator/generate", response_model=AgentGenResponse)
 async def generate_agent_endpoint(
     req: AgentGenRequest,
+    api_key: APIKey = Depends(verify_api_key),
     _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -35,8 +35,16 @@ def test_generator_endpoints_require_api_key(test_key):
         mock_compiler.generate_agent.return_value = "# Mock API Agent"
         mock_compiler.generate_skill.return_value = "# Mock API Skill"
 
-        agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"}, headers={"x-api-key": test_key})
-        skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"}, headers={"x-api-key": test_key})
+        agent_resp = client.post(
+            "/agent-generator/generate",
+            json={"description": "Test Agent"},
+            headers={"x-api-key": test_key},
+        )
+        skill_resp = client.post(
+            "/skills-generator/generate",
+            json={"description": "Test Skill"},
+            headers={"x-api-key": test_key},
+        )
 
     assert agent_resp.status_code == 200
     assert agent_resp.json() == {"system_prompt": "# Mock API Agent"}
@@ -328,7 +336,7 @@ def test_worker_client_wraps_user_input_and_context_with_tags():
 def test_generator_endpoints_reject_without_api_key():
     client = TestClient(app)
 
-    with patch("api.main.hybrid_compiler") as mock_compiler:
+    with patch("api.main.hybrid_compiler") as _mock_compiler:  # noqa: F841
         agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"})
         skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"})
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -28,15 +28,15 @@ def test_key():
 
 
 @pytest.mark.auth_required
-def test_generator_endpoints_work_without_api_key():
+def test_generator_endpoints_require_api_key(test_key):
     client = TestClient(app)
 
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = "# Mock API Agent"
         mock_compiler.generate_skill.return_value = "# Mock API Skill"
 
-        agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"})
-        skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"})
+        agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"}, headers={"x-api-key": test_key})
+        skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"}, headers={"x-api-key": test_key})
 
     assert agent_resp.status_code == 200
     assert agent_resp.json() == {"system_prompt": "# Mock API Agent"}
@@ -322,3 +322,15 @@ def test_worker_client_wraps_user_input_and_context_with_tags():
             "<runtime_context>" in message and "</runtime_context>" in message
             for message in system_messages
         )
+
+
+@pytest.mark.auth_required
+def test_generator_endpoints_reject_without_api_key():
+    client = TestClient(app)
+
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"})
+        skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"})
+
+    assert agent_resp.status_code == 403
+    assert skill_resp.status_code == 403


### PR DESCRIPTION
🎯 What:
The `generate_skill_endpoint` and `generate_agent_endpoint` routes in `api/routes/generators.py` were missing the `verify_api_key` dependency.
This allowed unauthenticated requests to trigger cost-incurring LLM operations, leading to potential resource exhaustion and unauthorized access.

⚠️ Risk:
Leaving these endpoints unauthenticated allows malicious actors or automated scripts to repeatedly call the LLM compilation APIs, exhausting the application's API budget and causing a Denial of Service (DoS).

🛡️ Solution:
- Added `api_key: APIKey = Depends(verify_api_key)` to the `generate_skill_endpoint` and `generate_agent_endpoint` route signatures.
- Imported `APIKey` and `verify_api_key` in `api/routes/generators.py`.
- Updated `tests/test_api_hardening.py` to pass the `test_key` to the existing generator endpoints test (`test_generator_endpoints_require_api_key`).
- Added a negative test case (`test_generator_endpoints_reject_without_api_key`) to confirm that missing keys properly return a `403` status.

---
*PR created automatically by Jules for task [3294749913705520886](https://jules.google.com/task/3294749913705520886) started by @madara88645*