### PR TITLE
🛡️ Sentinel: Fix information exposure in repository analysis error

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -63,3 +63,8 @@
 **Vulnerability:** The `/benchmark/run` endpoint lacked the `verify_api_key` dependency entirely, allowing any unauthenticated user to trigger cost-incurring LLM generation via the benchmark route.
 **Learning:** Endpoints added later in the lifecycle (like benchmark routers) can sometimes be missed when applying global or required authentication patterns used in core routers.
 **Prevention:** Always verify that newly added routers or endpoints that trigger cost-incurring actions (like LLM calls) explicitly include standard authentication dependencies (e.g., `Depends(verify_api_key)`) in their signature, matching the pattern used in the rest of the application.
+
+## 2025-05-26 - Prevent Information Leakage in API Routing
+**Vulnerability:** Information Exposure (CWE-200) in FastAPI error handling. An endpoint raised an `HTTPException` where the `detail` parameter was populated dynamically with the raw exception string (`str(exc)`).
+**Learning:** Returning `str(exc)` directly to the client can inadvertently expose sensitive internal paths, downstream API details, or error contexts meant only for developers. The exception must be logged securely on the backend while a sanitized generic message is returned to the user.
+**Prevention:** When raising `HTTPException` inside a `try...except` block, never pass the stringified exception `str(exc)` directly to the `detail` parameter. Instead, provide a generic, safe error message to the client, and rely on `logger.exception()` or explicit backend logging (e.g., `_log_repo_analyze_outcome`) to record the raw exception for internal troubleshooting.

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -154,7 +154,7 @@ async def analyze_github_repo_endpoint(
             status_code=exc.status_code,
             error_message=str(exc),
         )
-        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+        raise HTTPException(status_code=exc.status_code, detail="GitHub repository analysis failed.") from exc
     except Exception as exc:
         logger.exception("github repo analysis failed")
         _log_repo_analyze_outcome(

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -154,7 +154,9 @@ async def analyze_github_repo_endpoint(
             status_code=exc.status_code,
             error_message=str(exc),
         )
-        raise HTTPException(status_code=exc.status_code, detail="GitHub repository analysis failed.") from exc
+        raise HTTPException(
+            status_code=exc.status_code, detail="GitHub repository analysis failed."
+        ) from exc
     except Exception as exc:
         logger.exception("github repo analysis failed")
         _log_repo_analyze_outcome(


### PR DESCRIPTION
🎯 What: Fixed an information exposure vulnerability (CWE-200) in the GitHub repository analysis endpoint (`api/routes/generators.py`).
⚠️ Risk: Previously, if the repository analysis failed with an HTTP error, the endpoint would raise an `HTTPException` returning the raw `str(exc)` string directly to the client via the `detail` property. This could inadvertently leak downstream error messages, paths, or other internal contexts to untrusted users.
🛡️ Solution: Updated the error handler to pass a generic, hardcoded message (`"GitHub repository analysis failed."`) to the client. The original exception data remains safely captured on the backend via the existing telemetry logger (`_log_repo_analyze_outcome`) for debugging purposes.

---
*PR created automatically by Jules for task [15987071227065421759](https://jules.google.com/task/15987071227065421759) started by @madara88645*