### PR TITLE
[codex] test(web): move contract tests to vitest

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -19,7 +19,7 @@ npm run build
 npm run test:contracts
 ```
 
-`test:contracts` runs the lightweight Node-based contract tests for the shared API layer.
+`test:contracts` runs the lightweight Vitest contract tests for the shared API layer and Next proxy routes.
 
 ## Frontend Architecture
 

--- a/web/config.test.mts
+++ b/web/config.test.mts
@@ -1,5 +1,4 @@
-import test from "node:test";
-import assert from "node:assert/strict";
+import { afterAll, expect, test } from "vitest";
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalApiKey = process.env.NEXT_PUBLIC_API_KEY;
@@ -11,8 +10,8 @@ test("buildApiHeaders does not inject x-api-key from NEXT_PUBLIC_API_KEY", async
   const headers = buildApiHeaders({ "Content-Type": "application/json" });
   const normalizedHeaders = new Headers(headers);
 
-  assert.equal(normalizedHeaders.get("content-type"), "application/json");
-  assert.equal(normalizedHeaders.has("x-api-key"), false);
+  expect(normalizedHeaders.get("content-type")).toBe("application/json");
+  expect(normalizedHeaders.has("x-api-key")).toBe(false);
 });
 
 test("buildApiHeaders leaves headers unchanged when NEXT_PUBLIC_API_KEY is empty", async () => {
@@ -22,8 +21,8 @@ test("buildApiHeaders leaves headers unchanged when NEXT_PUBLIC_API_KEY is empty
   const headers = buildApiHeaders({ Accept: "application/json" });
   const normalizedHeaders = new Headers(headers);
 
-  assert.equal(normalizedHeaders.get("accept"), "application/json");
-  assert.equal(normalizedHeaders.has("x-api-key"), false);
+  expect(normalizedHeaders.get("accept")).toBe("application/json");
+  expect(normalizedHeaders.has("x-api-key")).toBe(false);
 });
 
 test("buildGeneratorApiHeaders does not inject x-api-key from NEXT_PUBLIC_API_KEY", async () => {
@@ -33,8 +32,8 @@ test("buildGeneratorApiHeaders does not inject x-api-key from NEXT_PUBLIC_API_KE
   const headers = buildGeneratorApiHeaders({ "Content-Type": "application/json" });
   const normalizedHeaders = new Headers(headers);
 
-  assert.equal(normalizedHeaders.get("content-type"), "application/json");
-  assert.equal(normalizedHeaders.has("x-api-key"), false);
+  expect(normalizedHeaders.get("content-type")).toBe("application/json");
+  expect(normalizedHeaders.has("x-api-key")).toBe(false);
 });
 
 test("buildGeneratorApiHeaders leaves x-api-key unset when NEXT_PUBLIC_API_KEY is empty", async () => {
@@ -44,8 +43,8 @@ test("buildGeneratorApiHeaders leaves x-api-key unset when NEXT_PUBLIC_API_KEY i
   const headers = buildGeneratorApiHeaders({ Accept: "application/json" });
   const normalizedHeaders = new Headers(headers);
 
-  assert.equal(normalizedHeaders.get("accept"), "application/json");
-  assert.equal(normalizedHeaders.has("x-api-key"), false);
+  expect(normalizedHeaders.get("accept")).toBe("application/json");
+  expect(normalizedHeaders.has("x-api-key")).toBe(false);
 });
 
 test("resolveApiBase prefers same-origin in non-local browser environments when env is unset", async () => {
@@ -57,7 +56,7 @@ test("resolveApiBase prefers same-origin in non-local browser environments when 
     origin: "https://compiler.memo.dev",
   });
 
-  assert.equal(apiBase, "https://compiler.memo.dev");
+  expect(apiBase).toBe("https://compiler.memo.dev");
 });
 
 test("resolveApiBase ignores NEXT_PUBLIC_API_URL for browser requests and keeps same-origin", async () => {
@@ -69,7 +68,7 @@ test("resolveApiBase ignores NEXT_PUBLIC_API_URL for browser requests and keeps 
     origin: "https://compiler.memo.dev",
   });
 
-  assert.equal(apiBase, "https://compiler.memo.dev");
+  expect(apiBase).toBe("https://compiler.memo.dev");
 });
 
 test("resolveApiBase keeps localhost same-origin for browser development", async () => {
@@ -81,19 +80,18 @@ test("resolveApiBase keeps localhost same-origin for browser development", async
     origin: "http://localhost:3000",
   });
 
-  assert.equal(apiBase, "http://localhost:3000");
+  expect(apiBase).toBe("http://localhost:3000");
 });
 
 test("describeRequestError rewrites raw browser fetch failures into helpful copy", async () => {
   const { describeRequestError } = await import("./config.ts");
 
-  assert.equal(
-    describeRequestError(new Error("Failed to fetch")),
+  expect(describeRequestError(new Error("Failed to fetch"))).toBe(
     "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
   );
 });
 
-test.after(() => {
+afterAll(() => {
   if (originalApiUrl === undefined) {
     delete process.env.NEXT_PUBLIC_API_URL;
   } else {

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:contracts": "node --test config.test.mts promptc-api.test.mts && vitest run lib/server/backendProxy.test.ts app/proxy-routes.test.ts"
+    "test:contracts": "vitest run --config vitest.contracts.config.ts"
   },
   "dependencies": {
     "@types/diff-match-patch": "^1.0.36",

--- a/web/promptc-api.test.mts
+++ b/web/promptc-api.test.mts
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { expect, test } from "vitest";
 
 import { describeApiError } from "./config.ts";
 import {
@@ -10,8 +9,7 @@ import {
 } from "./lib/api/promptc.ts";
 
 test("describeApiError returns auth-aware copy for 403", () => {
-  assert.equal(
-    describeApiError(403, { detail: "Could not validate credentials" }),
+  expect(describeApiError(403, { detail: "Could not validate credentials" })).toBe(
     "Could not validate credentials",
   );
 });
@@ -21,7 +19,7 @@ test("normalizeRagSearchResults maps legacy source/content fields to canonical s
     { source: "docs/auth.md", content: "Use API keys", score: 0.75 },
   ]);
 
-  assert.deepEqual(results, [
+  expect(results).toEqual([
     {
       path: "docs/auth.md",
       snippet: "Use API keys",
@@ -38,9 +36,9 @@ test("normalizeRagUploadResponse derives compatibility fields from canonical pay
     filename: "auth.py",
   });
 
-  assert.equal(response.success, true);
-  assert.equal(response.num_chunks, 4);
-  assert.match(response.message, /auth\.py/);
+  expect(response.success).toBe(true);
+  expect(response.num_chunks).toBe(4);
+  expect(response.message).toMatch(/auth\.py/);
 });
 
 test("normalizeCompileResponse preserves nested security metadata", () => {
@@ -61,18 +59,15 @@ test("normalizeCompileResponse preserves nested security metadata", () => {
     processing_ms: 25,
   });
 
-  assert.equal(response.processing_ms, 25);
-  assert.equal(response.ir.metadata?.security?.is_safe, false);
-  assert.equal(response.ir.metadata?.security?.redacted_text, "safe text");
-  assert.equal(response.ir.metadata?.security?.findings[0]?.type, "api_key");
+  expect(response.processing_ms).toBe(25);
+  expect(response.ir.metadata?.security?.is_safe).toBe(false);
+  expect(response.ir.metadata?.security?.redacted_text).toBe("safe text");
+  expect(response.ir.metadata?.security?.findings[0]?.type).toBe("api_key");
 });
 
 test("normalizeCompileResponse rejects empty compile payloads", () => {
-  assert.throws(() => normalizeCompileResponse(null), /Invalid compile response/);
-  assert.throws(
-    () => normalizeCompileResponse({}),
-    /Invalid compile response: missing compiler output/,
-  );
+  expect(() => normalizeCompileResponse(null)).toThrow(/Invalid compile response/);
+  expect(() => normalizeCompileResponse({})).toThrow(/Invalid compile response: missing compiler output/);
 });
 
 test("normalizeCompileResponse defaults missing policy fields", () => {
@@ -90,9 +85,9 @@ test("normalizeCompileResponse defaults missing policy fields", () => {
     processing_ms: 25,
   });
 
-  assert.equal(response.ir.policy?.risk_level, "low");
-  assert.deepEqual(response.ir.policy?.allowed_tools, []);
-  assert.equal(response.ir_v2?.policy?.execution_mode, "advice_only");
+  expect(response.ir.policy?.risk_level).toBe("low");
+  expect(response.ir.policy?.allowed_tools).toEqual([]);
+  expect(response.ir_v2?.policy?.execution_mode).toBe("advice_only");
 });
 
 test("normalizeCompileResponse falls back to ir when ir_v2 is missing", () => {
@@ -110,9 +105,9 @@ test("normalizeCompileResponse falls back to ir when ir_v2 is missing", () => {
     processing_ms: 25,
   });
 
-  assert.equal(response.ir_v2?.domain, "security");
-  assert.equal(response.ir_v2?.policy?.risk_level, "high");
-  assert.equal(response.ir_v2?.policy?.data_sensitivity, "public");
+  expect(response.ir_v2?.domain).toBe("security");
+  expect(response.ir_v2?.policy?.risk_level).toBe("high");
+  expect(response.ir_v2?.policy?.data_sensitivity).toBe("public");
 });
 
 test("normalizeCompileResponse preserves optional ir_v2 payload", () => {
@@ -131,9 +126,9 @@ test("normalizeCompileResponse preserves optional ir_v2 payload", () => {
     processing_ms: 25,
   });
 
-  assert.equal(response.ir_v2?.domain, "coding");
-  assert.deepEqual(response.ir_v2?.metadata?.risk_flags, ["security"]);
-  assert.equal(response.ir_v2?.policy?.risk_level, "low");
+  expect(response.ir_v2?.domain).toBe("coding");
+  expect(response.ir_v2?.metadata?.risk_flags).toEqual(["security"]);
+  expect(response.ir_v2?.policy?.risk_level).toBe("low");
 });
 
 test("normalizeCompileResponse preserves backend compile metadata fields", () => {
@@ -152,19 +147,18 @@ test("normalizeCompileResponse preserves backend compile metadata fields", () =>
     trace: ["step 1", "step 2"],
   });
 
-  assert.equal(response.request_id, "abc123");
-  assert.equal(response.heuristic_version, "v1");
-  assert.equal(response.heuristic2_version, "v2");
-  assert.deepEqual(response.trace, ["step 1", "step 2"]);
+  expect(response.request_id).toBe("abc123");
+  expect(response.heuristic_version).toBe("v1");
+  expect(response.heuristic2_version).toBe("v2");
+  expect(response.trace).toEqual(["step 1", "step 2"]);
 });
 
 test("formatSearchResultForPrompt includes path header", () => {
-  assert.equal(
+  expect(
     formatSearchResultForPrompt({
       path: "docs/auth.md",
       snippet: "Use API keys",
       score: 0.4,
     }),
-    "[Source: docs/auth.md]\nUse API keys",
-  );
+  ).toBe("[Source: docs/auth.md]\nUse API keys");
 });

--- a/web/vitest.contracts.config.ts
+++ b/web/vitest.contracts.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import baseConfig from "./vitest.config";
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    exclude: ["node_modules/**"],
+    include: [
+      "config.test.mts",
+      "promptc-api.test.mts",
+      "lib/server/backendProxy.test.ts",
+      "app/proxy-routes.test.ts",
+    ],
+  },
+});


### PR DESCRIPTION
## What changed
- moved the web contract suite onto a single Vitest entrypoint
- converted web/config.test.mts and web/promptc-api.test.mts from node:test assertions to Vitest assertions
- added a dedicated web/vitest.contracts.config.ts so npm run test keeps its current scope while npm run test:contracts runs the shared API and proxy route contract suite together
- updated the web README to match the new test flow

## Why
The contract checks were split across two test runners. That made the workflow harder to maintain and added avoidable setup friction around one small suite. This PR keeps the same coverage but puts the checks behind one command and one runner.

## Product impact
No user-facing behavior changes. This only makes the developer test path simpler and more reliable.

## Validation
- cd web && npm run test:contracts
- cd web && npm run test
- cd web && npm run build
