### PR TITLE
fix(web): make empty-state instructions device-aware

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -512,7 +512,9 @@ export default function Home() {
                 <div className="max-w-sm space-y-2">
                   <h3 className="text-zinc-100 font-semibold tracking-tight text-base">Start with any rough request</h3>
                   <p className="text-sm text-zinc-400 leading-relaxed mb-4">
-                    Paste a task, question, bug report, or workflow on the left, then press <kbd className="rounded border border-white/20 bg-white/5 px-1 py-0.5 font-mono text-[11px]">Ctrl/Cmd Enter</kbd>.
+                    Paste a task, question, bug report, or workflow into the editor{" "}
+                    <span className="hidden md:inline">on the left, then press <kbd className="rounded border border-white/20 bg-white/5 px-1 py-0.5 font-mono text-[11px]">Ctrl/Cmd Enter</kbd></span>
+                    <span className="md:hidden">above, then tap <span className="font-semibold text-zinc-200">Compile Prompt</span> below</span>.
                     You&apos;ll get structured prompts, an execution plan, and policy checks you can inspect before using the result downstream.
                   </p>
                   <div className="flex flex-col items-center gap-3 mt-2 w-full">


### PR DESCRIPTION
## Summary
- The homepage empty state previously told every visitor to "paste on the left and press Ctrl/Cmd Enter." Below the `md` breakpoint the input panel stacks *above* the output and there is no physical keyboard, so the directional clause and the shortcut were both wrong on phones — where first-impression clarity matters most.
- Split the directional clause into paired `hidden md:inline` / `md:hidden` spans so desktop visitors keep the keyboard shortcut, while mobile visitors are explicitly pointed at the actual **Compile Prompt** button right below the message.
- Pattern mirrors the existing responsive `<kbd>` on the Generate button (`web/app/page.tsx:305`), so no new convention is introduced.

## Why it matters (plain language)
The welcome paragraph is the first thing every new user reads. On a phone it was sending people to look left for a panel that isn't there and to press a keyboard that doesn't exist. After this change, phone users see _"paste into the editor above, then tap Compile Prompt below"_ — which matches what they actually see on screen.

## Risk
None expected. Pure copy + Tailwind class change inside the empty state of `web/app/page.tsx`. No compile logic, API hook, error handling, or data path is touched. Existing tests don't assert this exact string.

## Test plan
- [ ] Visual check on desktop (≥768px): empty state still reads "…on the left, then press `Ctrl/Cmd Enter`."
- [ ] Visual check on mobile (<768px): empty state reads "…above, then tap **Compile Prompt** below."
- [ ] Confirm the surrounding sentence flows naturally on both viewports (no orphaned punctuation, no double spaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)