### PR TITLE
fix(web): polish user-facing pages — tab overflow, contrast, copy

### DIFF
--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -251,7 +251,7 @@ export default function AgentPacksPage() {
               </div>
             </button>
 
-            <div className="rounded-2xl border border-amber-400/20 bg-amber-500/5 p-4 text-sm leading-relaxed text-amber-100/90">
+            <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm leading-relaxed text-amber-100/90">
               <div className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-amber-200">Experimental Feature</div>
               Agent Packs is in active development and may produce incomplete or incorrect output for your specific project.
               The generated files — Claude settings, agent definitions, and CI workflows — are a useful starting point,
@@ -307,7 +307,7 @@ export default function AgentPacksPage() {
                       className={`rounded-2xl border px-4 py-3 text-left transition-all ${
                         active
                           ? "border-cyan-400/50 bg-cyan-500/10 text-white shadow-lg shadow-cyan-500/10"
-                          : "border-white/8 bg-white/[0.02] text-zinc-400 hover:border-white/15 hover:bg-white/[0.04]"
+                          : "border-white/10 bg-white/[0.05] text-zinc-300 hover:border-white/20 hover:bg-white/[0.08]"
                       }`}
                     >
                       <div className="mb-1 text-sm font-semibold">{option.label}</div>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -157,6 +157,7 @@ body {
 /* ─── Custom Scrollbar Utility ───────────────────────────── */
 .custom-scrollbar::-webkit-scrollbar {
   width: 4px;
+  height: 4px;
 }
 .custom-scrollbar::-webkit-scrollbar-track {
   background: transparent;

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -385,7 +385,7 @@ export default function OptimizerPage() {
                     </div>
                 </div>
             )}
-            <div className="grid min-h-[50vh] grid-cols-1 gap-5 lg:grid-cols-2">
+            <div className="grid min-h-[50vh] grid-cols-1 gap-5 md:grid-cols-2">
                 <section className="flex min-h-80 flex-col gap-2">
                     <label htmlFor="original-prompt" className="ml-1 text-xs font-bold uppercase tracking-wider text-zinc-500">
                         Original Prompt
@@ -448,7 +448,7 @@ export default function OptimizerPage() {
                         ) : (
                             <div className="flex h-full min-h-72 flex-col items-center justify-center text-center">
                                 <div className="text-sm italic text-zinc-400 mb-4">
-                                    Optimized prompt will appear here.
+                                    Paste a prompt on the left, then run the analyzer to see a shorter version here.
                                 </div>
                                 <button
                                     type="button"

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -65,8 +65,8 @@ function TabButton({
         onFocus={() => setShowTip(true)}
         onBlur={() => setShowTip(false)}
         className={`relative whitespace-nowrap rounded-t-lg px-3 py-2 text-[13px] font-medium transition-all focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 sm:px-4 ${isActive
-          ? "text-white bg-white/5 border-t border-x border-white/5"
-          : "text-zinc-500 hover:text-zinc-300 hover:bg-white/5"
+          ? "text-white bg-white/10 border-t border-x border-white/10"
+          : "text-zinc-400 hover:text-zinc-200 hover:bg-white/5"
           }`}
       >
         <span>{label}</span>
@@ -104,8 +104,8 @@ function CompilerErrorState({
         </div>
         <h3 className="text-base font-semibold text-white">Compile failed</h3>
         <p className="mt-2 text-sm leading-relaxed text-red-100/80">{describeRequestError(error)}</p>
-        <p className="mt-3 text-xs leading-relaxed text-zinc-500">
-          Your prompt is still in the editor. Retry after checking the backend or API URL.
+        <p className="mt-3 text-xs leading-relaxed text-zinc-400">
+          Your prompt is safe in the editor. Try again — if it keeps failing, your connection or the compiler service may be down.
         </p>
         <button
           type="button"
@@ -238,7 +238,7 @@ export default function Home() {
             </div>
 
             <div className="flex items-center gap-2">
-              <div className="min-w-[88px] rounded-lg border border-white/5 bg-black/30 px-3 py-1.5 text-center font-mono text-xs text-zinc-500">
+              <div className="min-w-0 rounded-lg border border-white/5 bg-black/30 px-3 py-1.5 text-center font-mono text-xs text-zinc-300 sm:min-w-[88px]">
                 {status}
               </div>
               {!!lastError && !loading && (
@@ -326,7 +326,8 @@ export default function Home() {
               <>
                 {/* Tabs + policy verdict */}
                 <div className="flex items-center gap-3 border-b border-white/5 px-4 pt-4 pb-1">
-                  <div role="tablist" aria-label="Output views" className="flex min-w-0 flex-1 gap-1 overflow-x-auto scroll-smooth" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
+                  <div className="relative flex min-w-0 flex-1">
+                    <div role="tablist" aria-label="Output views" className="custom-scrollbar flex min-w-0 flex-1 gap-1 overflow-x-auto scroll-smooth pr-6">
                     {(
                       [
                         { key: "user", label: "User Prompt", hint: "The prompt to copy and send to your model. Most users want this tab.", primary: true },
@@ -348,6 +349,11 @@ export default function Home() {
                         onSelect={setActiveTab}
                       />
                     ))}
+                    </div>
+                    <div aria-hidden="true" className="pointer-events-none absolute inset-y-0 right-0 hidden items-center pr-1 sm:flex lg:hidden">
+                      <div className="h-full w-8 bg-gradient-to-l from-black/60 to-transparent" />
+                      <span className="ml-[-14px] rounded-full border border-white/10 bg-black/60 px-1.5 text-[11px] leading-none text-zinc-300 backdrop-blur-sm">›</span>
+                    </div>
                   </div>
                   <PolicyBadge result={result} />
                 </div>
@@ -510,7 +516,7 @@ export default function Home() {
                   </div>
                 </div>
                 <div className="max-w-sm space-y-2">
-                  <h3 className="text-zinc-100 font-semibold tracking-tight text-base">Start with any rough request</h3>
+                  <h3 className="text-zinc-100 font-semibold tracking-tight text-lg">Start with any rough request</h3>
                   <p className="text-sm text-zinc-400 leading-relaxed mb-4">
                     Paste a task, question, bug report, or workflow into the editor{" "}
                     <span className="hidden md:inline">on the left, then press <kbd className="rounded border border-white/20 bg-white/5 px-1 py-0.5 font-mono text-[11px]">Ctrl/Cmd Enter</kbd></span>
@@ -543,10 +549,9 @@ export default function Home() {
                       </button>
                     )}
                   </div>
-                  <p className="text-xs text-zinc-500 leading-relaxed mt-4">
+                  <p className="text-xs italic text-zinc-500 leading-relaxed mt-4">
                     Good first inputs: GitHub issue to implementation brief, PR description to review checklist, or a spec to implementation plan.
                   </p>
-                  <p className="text-[10px] text-zinc-500 mt-4 font-mono">v0.1.1</p>
                 </div>
               </div>
             )}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -327,7 +327,7 @@ export default function Home() {
                 {/* Tabs + policy verdict */}
                 <div className="flex items-center gap-3 border-b border-white/5 px-4 pt-4 pb-1">
                   <div className="relative flex min-w-0 flex-1">
-                    <div role="tablist" aria-label="Output views" className="custom-scrollbar flex min-w-0 flex-1 gap-1 overflow-x-auto scroll-smooth pr-6">
+                    <div role="tablist" aria-label="Output views" className="custom-scrollbar flex min-w-0 flex-1 gap-1 overflow-x-auto scroll-smooth sm:pr-6 lg:pr-0">
                     {(
                       [
                         { key: "user", label: "User Prompt", hint: "The prompt to copy and send to your model. Most users want this tab.", primary: true },


### PR DESCRIPTION
## Summary

Audit-driven polish pass across the three most-visited user-facing pages — the compiler workbench (`/`), Agent Packs (`/agent-packs`), and Optimizer (`/optimizer`). Preserves the existing dark glassmorphic design language; no new components, no theme changes.

The full audit (10 findings across tab overflow, contrast, mobile layout, and product copy) is captured in the worktree's plan file. This PR ships the highest-impact subset — every High-severity finding plus the cheap Medium wins.

## What changed

**Tab overflow & discoverability**
- Compiler output tab strip no longer hides its right edge behind an invisible `maskImage`. Replaced with a thin scrollbar plus a small `›` chevron hint at tablet widths. Visitors can now see and reach *Intent*, *JSON*, and *Quality Scores* on narrow screens.

**Contrast & hierarchy**
- Inactive tab text bumped `zinc-500 → zinc-400`; active tab background `white/5 → white/10`.
- Home-header status pill brightened (`zinc-500 → zinc-300`) and made mobile-friendly (`min-w-[88px]` is now `sm:`-prefixed).
- Empty-state H3 promoted to `text-lg`; duplicate `v0.1.1` label removed; trailing tips line italicised.
- Agent Packs "Pack Type" buttons get a visible inactive state (`bg-white/[0.02] → bg-white/[0.05]`) so they read as clickable.
- "Experimental Feature" amber warning bumped from 5% to 10% opacity so the *review before shipping* message actually registers.

**Mobile / tablet layout**
- Optimizer two-column layout activates at `md:` (768 px) instead of `lg:` — iPads now get the Original / Optimized comparison side-by-side as intended.

**Product copy**
- Compile-error helper text rewritten in plain English (no more "check the backend or API URL").
- Optimizer empty state now tells the user what to do next instead of "will appear here".

## Why

Most of these were small details, but they compounded: tabs that silently disappeared, buttons that looked like decoration, warnings that whispered, and error messages aimed at developers rather than visitors. Each individual fix is a one- or two-token Tailwind value change (or a copy edit), but together they noticeably tighten the first-time-visit feel without touching the established style.

## Risk

Low. All changes are class-string edits, copy edits, or — in one case — a wrapper `<div>` around the tab strip whose JSX balance was verified. No behaviour, routing, state, or API changes. No new dependencies. The duplicate `v0.1.1` label removed from the home empty state is still rendered elsewhere (header / app metadata).

## Test plan

- [ ] `cd web && npm run dev`
- [ ] Visit `/` at ~390 px — header doesn't wrap chaotically; tab strip is scrollable with a visible cue (scrollbar or chevron)
- [ ] Visit `/` at ~820 px — chevron hint visible at right edge of tab strip; inactive tabs readable; active tab clearly emphasised
- [ ] Visit `/agent-packs` — Pack Type buttons look clickable before hover; amber "Experimental Feature" warning is clearly readable
- [ ] Visit `/optimizer` at ~820 px — Original / Optimized columns sit side-by-side
- [ ] Visit `/optimizer` empty — copy explains the next action
- [ ] Stop the backend, click *Generate* on `/` — error copy reads as plain English
- [ ] `cd web && npm run test` — no regressions (no behavioural change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)