### PR TITLE
Fix RAG retrieval dropping useful chunks from the same file

### DIFF
--- a/app/agents/context_strategist.py
+++ b/app/agents/context_strategist.py
@@ -37,7 +37,7 @@ class ContextStrategist:
         base_results = search_hybrid(user_prompt, k=limit)
         for r in base_results:
             r["score"] = r.get("score", 0) * 1.5  # Boost original query
-            all_results[r["path"]] = r
+            all_results[self._result_key(r)] = r
 
         # Search for expanded queries
         for q in expanded_queries:
@@ -45,16 +45,34 @@ class ContextStrategist:
                 continue
             sub_results = search_hybrid(q, k=3)
             for r in sub_results:
-                if r["path"] in all_results:
+                key = self._result_key(r)
+                if key in all_results:
                     # Boost existing (confirmation)
-                    all_results[r["path"]]["score"] += 0.2
+                    all_results[key]["score"] += 0.2
                 else:
-                    all_results[r["path"]] = r
+                    all_results[key] = r
 
         # 3. Sort & Limit
         sorted_results = sorted(all_results.values(), key=lambda x: x.get("score", 0), reverse=True)
 
         return sorted_results[:limit]
+
+    @staticmethod
+    def _result_key(result: Dict[str, Any]) -> str:
+        chunk_id = result.get("chunk_id")
+        if chunk_id is not None:
+            return f"chunk:{chunk_id}"
+
+        path = result.get("path", "unknown")
+        chunk_index = result.get("chunk_index")
+        if chunk_index is not None:
+            return f"path-chunk:{path}:{chunk_index}"
+
+        snippet = " ".join(str(result.get("snippet", "")).split())
+        if snippet:
+            return f"path-snippet:{path}:{snippet}"
+
+        return f"path:{path}"
 
     def _expand_query(self, prompt: str) -> List[str]:
         """

--- a/app/llm_engine/rag.py
+++ b/app/llm_engine/rag.py
@@ -99,11 +99,12 @@ class ContextStrategist:
         for query in queries:
             results = self.vector_db.search(query, limit=5)
             for index, result in enumerate(results):
-                path = result.get("file_path", "unknown")
-                if path in all_results:
-                    all_results[path].score += 1.0 / (index + 1)
+                key = self._snippet_key(result)
+                if key in all_results:
+                    all_results[key].score += 1.0 / (index + 1)
                 else:
-                    all_results[path] = Snippet(
+                    path = result.get("file_path", "unknown")
+                    all_results[key] = Snippet(
                         file_path=path,
                         content=result.get("content", ""),
                         score=1.0 / (index + 1),
@@ -113,6 +114,24 @@ class ContextStrategist:
         snippets = list(all_results.values())
         snippets.sort(key=lambda item: item.score, reverse=True)
         return snippets
+
+    @staticmethod
+    def _snippet_key(result: Dict[str, Any]) -> str:
+        metadata = result.get("metadata") or {}
+        chunk_id = metadata.get("chunk_id")
+        if chunk_id is not None:
+            return f"chunk:{chunk_id}"
+
+        path = result.get("file_path", "unknown")
+        chunk_index = metadata.get("chunk_index")
+        if chunk_index is not None:
+            return f"path-chunk:{path}:{chunk_index}"
+
+        content = " ".join(str(result.get("content", "")).split())
+        if content:
+            return f"path-content:{path}:{content}"
+
+        return f"path:{path}"
 
     def rank_and_prune(self, snippets: List[Snippet], max_tokens: int = 4000) -> List[Snippet]:
         selected: List[Snippet] = []

--- a/tests/test_context_strategist.py
+++ b/tests/test_context_strategist.py
@@ -140,3 +140,42 @@ class TestContextStrategist:
         assert len(results) == 1
         assert results[0]["path"] == "file1.py"
         assert results[0]["score"] == 1.5  # Boost applied
+
+    @patch("app.agents.context_strategist.search_hybrid")
+    def test_retrieve_keeps_distinct_chunks_from_same_path(self, mock_search_hybrid):
+        mock_client = MagicMock()
+        mock_client._call_api.return_value = "[]"
+        strategist = ContextStrategist(client=mock_client)
+
+        mock_search_hybrid.return_value = [
+            {
+                "path": "docs/architecture.md",
+                "chunk_id": 101,
+                "chunk_index": 0,
+                "snippet": "Retry policy applies to API requests.",
+                "score": 0.9,
+            },
+            {
+                "path": "docs/architecture.md",
+                "chunk_id": 102,
+                "chunk_index": 1,
+                "snippet": "Backoff doubles after each failed request.",
+                "score": 0.8,
+            },
+            {
+                "path": "docs/faq.md",
+                "chunk_id": 201,
+                "chunk_index": 0,
+                "snippet": "Unrelated FAQ entry.",
+                "score": 0.1,
+            },
+        ]
+
+        results = strategist.retrieve("retry backoff", limit=3)
+
+        assert len(results) == 3
+        assert [item["chunk_id"] for item in results[:2]] == [101, 102]
+        assert [item["path"] for item in results[:2]] == [
+            "docs/architecture.md",
+            "docs/architecture.md",
+        ]

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -80,6 +80,32 @@ def test_retrieve_rrf(strategist, mock_db):
     assert snippets[1].score == 1.0  # 0.5 + 0.5 = 1.0
 
 
+def test_retrieve_keeps_distinct_chunks_from_same_file():
+    db = MagicMock()
+    db.search.side_effect = [
+        [
+            {
+                "file_path": "docs/ops.md",
+                "content": "Retry policy applies to API requests.",
+                "metadata": {"chunk_id": 11, "chunk_index": 0},
+            },
+            {
+                "file_path": "docs/ops.md",
+                "content": "Backoff doubles after each failed request.",
+                "metadata": {"chunk_id": 12, "chunk_index": 1},
+            },
+        ]
+    ]
+    strategist = ContextStrategist(db, MockLLMClient())
+
+    snippets = strategist.retrieve(["retry backoff"])
+
+    assert len(snippets) == 2
+    assert [snippet.metadata["chunk_id"] for snippet in snippets] == [11, 12]
+    assert snippets[0].file_path == "docs/ops.md"
+    assert snippets[1].file_path == "docs/ops.md"
+
+
 def test_rank_and_prune(strategist):
     snippets = [
         Snippet("a.py", "a" * 400, 10.0, {}),  # 100 tokens


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This change fixes a retrieval ranking issue in the RAG pipeline where compile-time retrieval collapsed results by file path. If two useful chunks came from the same document, only one survived and an unrelated chunk from another file could take its place.

## What changed
- changed both Context Strategist implementations to merge repeated sightings of the same chunk instead of the same file
- preserved score accumulation when the exact same chunk appears across query expansions
- added regression tests for both compile retrieval paths

## Product impact
Compiles now keep multiple relevant chunks from the same uploaded document when they answer different parts of the request. That should reduce cases where helpful context is missed and lower the chance that weaker, unrelated snippets are packed instead.

## Before / after retrieval example
Before (path-level dedupe):
- docs/architecture.md chunk=1 chunk_id=102 score=1.20 :: Backoff doubles after each failed request.
- docs/faq.md chunk=0 chunk_id=201 score=0.15 :: Unrelated FAQ entry.

After (chunk-level dedupe):
- docs/architecture.md chunk=0 chunk_id=101 score=1.35 :: Retry policy applies to API requests.
- docs/architecture.md chunk=1 chunk_id=102 score=1.20 :: Backoff doubles after each failed request.
- docs/faq.md chunk=0 chunk_id=201 score=0.15 :: Unrelated FAQ entry.

## Testing
- `python3 -m pytest tests/test_context_strategist.py tests/test_rag.py tests/test_rag_pipeline.py -q`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9384306-91d5-4b89-9cee-ef6a5491b62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9384306-91d5-4b89-9cee-ef6a5491b62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

