### PR TITLE
fix(web): retryable errors on Agent & Skills generators

### DIFF
--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -11,10 +11,14 @@ vi.hoisted(() => {
 import AgentGeneratorPage from "./page";
 import { apiJson } from "@/config";
 
-vi.mock("@/config", () => ({
-  apiJson: vi.fn(),
-  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
-}));
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    apiJson: vi.fn(),
+    buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+  };
+});
 
 vi.mock("../components/InfoButton", () => ({
   default: ({ title }: { title: string }) => <button type="button">{title}</button>,
@@ -141,5 +145,25 @@ describe("Agent Generator page", () => {
 
     expect(classes).toContain("md:min-h-[220px]");
     expect(classes).not.toContain("md:min-h-0");
+  });
+
+  it("shows a retryable error in the output panel when generation fails", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("The service is temporarily unavailable."));
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Build a code review agent." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+
+    expect(await screen.findByText("Agent generation failed")).toBeTruthy();
+    expect(screen.getByText("The service is temporarily unavailable.")).toBeTruthy();
+
+    apiJsonMock.mockResolvedValueOnce({ system_prompt: "# Reviewer" });
+    fireEvent.click(screen.getByRole("button", { name: "Retry generation" }));
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Reviewer" })).toBeTruthy());
+    expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -11,6 +11,7 @@ import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
 import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
 import ExportPanel from "./components/ExportPanel";
+import GeneratorErrorState from "../components/GeneratorErrorState";
 
 const REPO_ANALYSIS_TIMEOUT_MS = 15000;
 function isSupportedGitHubRepoRootUrl(value: string): boolean {
@@ -26,7 +27,7 @@ export default function AgentGenerator() {
   const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [lastError, setLastError] = useState<unknown>(null);
   const [multiAgent, setMultiAgent] = useState(false);
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
   const [history, setHistory] = useState<{ label: string; prompt: string }[]>([]);
@@ -40,7 +41,7 @@ export default function AgentGenerator() {
 
     setRepoAnalysisLoading(true);
     setRepoAnalysisWarning(null);
-    setError(null);
+    setLastError(null);
 
     try {
       const data = await withTimeout(
@@ -70,7 +71,7 @@ export default function AgentGenerator() {
     isGeneratingRef.current = true;
 
     setLoading(true);
-    setError(null);
+    setLastError(null);
     setResult(null);
 
     try {
@@ -95,7 +96,7 @@ export default function AgentGenerator() {
       ].slice(0, 5));
     } catch (e: unknown) {
       showError(e);
-      setError(e instanceof Error ? e.message : "Failed to generate agent");
+      setLastError(e);
     } finally {
       setLoading(false);
       isGeneratingRef.current = false;
@@ -138,6 +139,15 @@ export default function AgentGenerator() {
               description="Define a role or task, and this tool will architect a comprehensive, constraint-driven system prompt for an autonomous AI agent or multi-agent swarm."
             />
           </div>
+          {!!lastError && !loading && (
+            <button
+              type="button"
+              onClick={() => void handleGenerate()}
+              className="w-full rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/50 sm:w-auto"
+            >
+              Retry
+            </button>
+          )}
         </header>
 
         <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
@@ -304,12 +314,6 @@ export default function AgentGenerator() {
               )}
             </button>
 
-            {error && (
-              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                {error}
-              </div>
-            )}
-
             {/* Context Manager */}
             <ContextManager
               onInsertContext={(text) => setDescription(prev => prev + "\n\n---\nContext:\n" + text)}
@@ -318,7 +322,19 @@ export default function AgentGenerator() {
 
           {/* Right Panel: Output */}
           <div className="relative flex min-h-[360px] w-full flex-col bg-black/20 md:min-h-0 md:w-[65%]">
-            {result ? (
+            {loading ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 p-10 text-center">
+                <span className="animate-pulse text-sm font-medium text-green-300/90">Architecting agent prompt...</span>
+                <p className="max-w-xs text-xs text-zinc-500">This can take a moment when the cloud generator is waking up.</p>
+              </div>
+            ) : lastError ? (
+              <GeneratorErrorState
+                error={lastError}
+                onRetry={() => void handleGenerate()}
+                title="Agent generation failed"
+                retryLabel="Retry generation"
+              />
+            ) : result ? (
               <div className="flex-1 min-h-0 p-0 overflow-hidden relative group bg-black/20 flex flex-col">
                 <div className="flex items-center justify-between border-b border-white/5 px-6 py-3">
                   <h2 className="text-sm font-semibold text-zinc-200 tracking-tight">System Prompt</h2>

--- a/web/app/components/GeneratorErrorState.tsx
+++ b/web/app/components/GeneratorErrorState.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { describeRequestError } from "@/config";
+
+export type GeneratorErrorStateProps = {
+  error: unknown;
+  onRetry: () => void;
+  title: string;
+  retryLabel: string;
+  reassurance?: string;
+};
+
+const DEFAULT_REASSURANCE =
+  "Your description is still in the editor on the left. Try again — if it keeps failing, your connection or the generator service may be down.";
+
+export default function GeneratorErrorState({
+  error,
+  onRetry,
+  title,
+  retryLabel,
+  reassurance = DEFAULT_REASSURANCE,
+}: GeneratorErrorStateProps) {
+  return (
+    <div className="flex flex-1 items-center justify-center p-10 text-center" role="alert">
+      <div className="max-w-md rounded-lg border border-red-500/20 bg-red-500/10 p-6 shadow-xl shadow-red-950/10">
+        <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-lg border border-red-400/30 bg-red-400/10 text-lg font-semibold text-red-200">
+          !
+        </div>
+        <h3 className="text-base font-semibold text-white">{title}</h3>
+        <p className="mt-2 text-sm leading-relaxed text-red-100/80">{describeRequestError(error)}</p>
+        <p className="mt-3 text-xs leading-relaxed text-zinc-400">{reassurance}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-5 rounded-lg border border-red-400/30 bg-red-500/20 px-4 py-2 text-sm font-medium text-red-50 transition-colors hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+        >
+          {retryLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/app/components/__tests__/GeneratorErrorState.test.tsx
+++ b/web/app/components/__tests__/GeneratorErrorState.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import GeneratorErrorState from "../GeneratorErrorState";
+
+vi.mock("@/config", () => ({
+  describeRequestError: (error: unknown) =>
+    error instanceof Error ? error.message : "Something went wrong",
+}));
+
+describe("GeneratorErrorState", () => {
+  it("renders the error message and calls onRetry", () => {
+    const onRetry = vi.fn();
+
+    render(
+      <GeneratorErrorState
+        error={new Error("Cloud generator unavailable")}
+        onRetry={onRetry}
+        title="Agent generation failed"
+        retryLabel="Retry generation"
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Agent generation failed")).toBeTruthy();
+    expect(screen.getByText("Cloud generator unavailable")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry generation" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/skills-generator/page.test.tsx
+++ b/web/app/skills-generator/page.test.tsx
@@ -11,10 +11,14 @@ vi.hoisted(() => {
 import SkillsGeneratorPage from "./page";
 import { apiJson } from "@/config";
 
-vi.mock("@/config", () => ({
-  apiJson: vi.fn(),
-  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
-}));
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    apiJson: vi.fn(),
+    buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+  };
+});
 
 vi.mock("../components/InfoButton", () => ({
   default: ({ title }: { title: string }) => <button type="button">{title}</button>,
@@ -146,5 +150,25 @@ describe("Skills Generator page", () => {
 
     expect(classes).toContain("md:min-h-[220px]");
     expect(classes).not.toContain("md:min-h-0");
+  });
+
+  it("shows a retryable error in the output panel when generation fails", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("The service is temporarily unavailable."));
+
+    render(<SkillsGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Parse JSON and validate schemas." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    expect(await screen.findByText("Skill generation failed")).toBeTruthy();
+    expect(screen.getByText("The service is temporarily unavailable.")).toBeTruthy();
+
+    apiJsonMock.mockResolvedValueOnce({ skill_definition: "## json-validator" });
+    fireEvent.click(screen.getByRole("button", { name: "Retry generation" }));
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "json-validator" })).toBeTruthy());
+    expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -11,6 +11,7 @@ import InfoButton from "../components/InfoButton";
 import ContextManager from "../components/ContextManager";
 import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
 import SkillExportPanel from "./components/ExportPanel";
+import GeneratorErrorState from "../components/GeneratorErrorState";
 
 const REPO_ANALYSIS_TIMEOUT_MS = 15000;
 function isSupportedGitHubRepoRootUrl(value: string): boolean {
@@ -26,7 +27,7 @@ export default function SkillsGenerator() {
   const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [lastError, setLastError] = useState<unknown>(null);
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
   const [history, setHistory] = useState<{ label: string; skill: string }[]>([]);
   const [copied, setCopied] = useState(false);
@@ -39,7 +40,7 @@ export default function SkillsGenerator() {
 
     setRepoAnalysisLoading(true);
     setRepoAnalysisWarning(null);
-    setError(null);
+    setLastError(null);
 
     try {
       const data = await withTimeout(
@@ -69,7 +70,7 @@ export default function SkillsGenerator() {
     isGeneratingRef.current = true;
 
     setLoading(true);
-    setError(null);
+    setLastError(null);
     setResult(null);
 
     try {
@@ -93,7 +94,7 @@ export default function SkillsGenerator() {
       ].slice(0, 5));
     } catch (e: unknown) {
       showError(e);
-      setError(e instanceof Error ? e.message : "Failed to generate skill");
+      setLastError(e);
     } finally {
       setLoading(false);
       isGeneratingRef.current = false;
@@ -136,6 +137,15 @@ export default function SkillsGenerator() {
               description="Describe a capability, and this tool will generate a structured Tool/Skill definition (with input/output schemas) that can be integrated into your AI agents."
             />
           </div>
+          {!!lastError && !loading && (
+            <button
+              type="button"
+              onClick={() => void handleGenerate()}
+              className="w-full rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500/50 sm:w-auto"
+            >
+              Retry
+            </button>
+          )}
         </header>
 
         <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
@@ -284,12 +294,6 @@ export default function SkillsGenerator() {
               )}
             </button>
 
-            {error && (
-              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                {error}
-              </div>
-            )}
-
             {/* Context Manager */}
             <ContextManager
               onInsertContext={(text) => setDescription(prev => prev + "\n\n---\nContext:\n" + text)}
@@ -298,7 +302,19 @@ export default function SkillsGenerator() {
 
           {/* Right Panel: Output */}
           <div className="relative flex min-h-[360px] w-full flex-col bg-black/20 md:min-h-0 md:w-[65%]">
-            {result ? (
+            {loading ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 p-10 text-center">
+                <span className="animate-pulse text-sm font-medium text-yellow-300/90">Forging skill definition...</span>
+                <p className="max-w-xs text-xs text-zinc-500">This can take a moment when the cloud generator is waking up.</p>
+              </div>
+            ) : lastError ? (
+              <GeneratorErrorState
+                error={lastError}
+                onRetry={() => void handleGenerate()}
+                title="Skill generation failed"
+                retryLabel="Retry generation"
+              />
+            ) : result ? (
               <div className="flex-1 min-h-0 p-0 overflow-hidden relative group bg-black/20 flex flex-col">
                 <div className="flex items-center justify-between border-b border-white/5 px-6 py-3">
                   <h2 className="text-sm font-semibold text-zinc-200 tracking-tight">Skill Definition</h2>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When Agent Generator or Skills Generator failed (cold backend, network blip), users only saw a fleeting toast and a small red line in the sidebar. The main Compiler page already had a much better pattern: a clear error panel in the output area, reassurance that their text is still there, and one-click **Retry**.

This change brings that same recovery flow to both generator pages.

## What changed

- Added shared `GeneratorErrorState` component (aligned with the home page compile error panel).
- **Agent Generator** and **Skills Generator** now show:
  - Loading state in the output column while generating
  - Full error panel with **Retry generation** on failure
  - Optional **Retry** in the page header (same as Compiler)
- Removed the small sidebar-only error strip that was easy to miss.

## How to verify

```bash
cd web && npm run test -- app/components/__tests__/GeneratorErrorState.test.tsx app/agent-generator/page.test.tsx app/skills-generator/page.test.tsx
```

Manual check (with backend stopped or unreachable):

1. Open `/agent-generator`, enter a description, click **Generate Agent**.
2. Confirm the right panel shows **Agent generation failed**, your description is mentioned as safe, and **Retry generation** works.
3. Repeat on `/skills-generator`.

## Risk

Low — UI/state only on two pages; no API or auth changes.

## Revert

```bash
git revert c27087e
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6557bd1-5aac-4778-ad2e-289468d9863e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6557bd1-5aac-4778-ad2e-289468d9863e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

