### PR TITLE
🎨 Palette: [UX improvement] Add 'try an example' empty state CTAs

### DIFF
--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -362,15 +362,32 @@ export default function AgentGenerator() {
                   <p className="text-sm text-zinc-500 mb-4">
                     Describe the role on the left, choose single or swarm mode, then generate and copy the system prompt.
                   </p>
-                  <button
-                    type="button"
-                    onClick={handleGenerate}
-                    disabled={loading || !description.trim()}
-                    title={!description.trim() ? "Enter a description first to generate" : "Generate Agent"}
-                    className={`mt-6 mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a] ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20 focus-visible:ring-purple-500' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20 focus-visible:ring-green-500'}`}
-                  >
-                    Generate {multiAgent ? 'Swarm' : 'Agent'}
-                  </button>
+                  <div className="flex flex-col items-center gap-3 mt-6 w-full">
+                    <button
+                      type="button"
+                      onClick={handleGenerate}
+                      disabled={loading || !description.trim()}
+                      title={!description.trim() ? "Enter a description first to generate" : "Generate Agent"}
+                      className={`mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a] ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20 focus-visible:ring-purple-500' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20 focus-visible:ring-green-500'}`}
+                    >
+                      Generate {multiAgent ? 'Swarm' : 'Agent'}
+                    </button>
+                    {!description.trim() && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setDescription("A customer support agent that answers questions about billing, handles refunds, and escalates complex issues to a human.");
+                          setTimeout(() => {
+                            const textarea = document.getElementById('agent-description');
+                            if (textarea) textarea.focus();
+                          }, 0);
+                        }}
+                        className={`text-xs ${multiAgent ? 'text-purple-400/80 hover:text-purple-300 focus-visible:ring-purple-500' : 'text-green-400/80 hover:text-green-300 focus-visible:ring-green-500'} transition-colors focus-visible:outline-none focus-visible:ring-1 rounded px-2 py-1`}
+                      >
+                        or try an example
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
             )}

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -409,15 +409,32 @@ export default function BenchmarkPage() {
                       : "Paste a prompt on the left, pick a real model (the default Mock Engine returns demo numbers), then run a benchmark."}
                   </p>
                   {!errorMessage && (
-                    <button
-                      type="button"
-                      onClick={handleBenchmark}
-                      disabled={loading || !prompt.trim()}
-                      title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
-                      className="mx-auto mt-6 flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 px-6 py-2.5 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      Run Benchmark
-                    </button>
+                    <div className="flex flex-col items-center gap-3 mt-6 w-full">
+                      <button
+                        type="button"
+                        onClick={handleBenchmark}
+                        disabled={loading || !prompt.trim()}
+                        title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
+                        className="mx-auto flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 px-6 py-2.5 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Run Benchmark
+                      </button>
+                      {!prompt.trim() && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setPrompt("Write a Python script to scrape data from a Wikipedia page and extract all the tables.");
+                            setTimeout(() => {
+                              const textarea = document.getElementById('benchmark-prompt');
+                              if (textarea) textarea.focus();
+                            }, 0);
+                          }}
+                          className="text-xs text-amber-400/80 hover:text-amber-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-500 rounded px-2 py-1"
+                        >
+                          or try an example
+                        </button>
+                      )}
+                    </div>
                   )}
                 </div>
               </div>

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -342,15 +342,32 @@ export default function SkillsGenerator() {
                   <p className="text-sm text-zinc-500 mb-4">
                     Describe the capability on the left, choose whether examples belong in it, then generate and copy the skill.
                   </p>
-                  <button
-                    type="button"
-                    onClick={handleGenerate}
-                    disabled={loading || !description.trim()}
-                    title={!description.trim() ? "Enter a description first to generate" : "Generate Skill"}
-                    className="mt-6 mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a]"
-                  >
-                    Generate Skill
-                  </button>
+                  <div className="flex flex-col items-center gap-3 mt-6 w-full">
+                    <button
+                      type="button"
+                      onClick={handleGenerate}
+                      disabled={loading || !description.trim()}
+                      title={!description.trim() ? "Enter a description first to generate" : "Generate Skill"}
+                      className="mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a]"
+                    >
+                      Generate Skill
+                    </button>
+                    {!description.trim() && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setDescription("A skill that takes a URL, fetches the page content, extracts the main article text, and returns a 3-bullet summary.");
+                          setTimeout(() => {
+                            const textarea = document.getElementById('skill-description');
+                            if (textarea) textarea.focus();
+                          }, 0);
+                        }}
+                        className="text-xs text-yellow-400/80 hover:text-yellow-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-yellow-500 rounded px-2 py-1"
+                      >
+                        or try an example
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
💡 What: Added "or try an example" CTA buttons to the empty states of the Benchmark, Agent Generator, and Skills Generator pages.

🎯 Why: Generative inputs suffer from a "blank canvas" problem where users don't always know what kind of prompt or description works well. These buttons provide a one-click way to see a working example, instantly demonstrating the tool's capability and expected input format.

📸 Before/After: Screenshots captured in Playwright verification show the buttons gracefully appearing below the primary CTA when inputs are empty, and hiding once the user begins typing or clicks an example.

♿ Accessibility: Ensured the new buttons use standard focus-visible styles matching the rest of the application so they are clearly identifiable via keyboard navigation.

---
*PR created automatically by Jules for task [6142940477751882531](https://jules.google.com/task/6142940477751882531) started by @madara88645*