### PR TITLE
🎨 Palette: Add aria-busy attribute to Compile Prompt buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-20 - Ensure visual feedback for Copy to Clipboard actions
 **Learning:** Adding a toast notification using a library like `sonner` is a crucial micro-interaction for copy-to-clipboard functionality. Users lack confidence when clicking a copy button without visual confirmation, and this small change significantly improves the perceived reliability of the UI.
 **Action:** Always verify that interactive elements, especially non-destructive actions like copying or sharing, have immediate visual feedback in the form of a toast or inline confirmation.
+## 2024-05-26 - Avoid Redundant `aria-disabled` Attributes
+**Learning:** Adding an `aria-disabled` attribute to a button that already uses the native HTML `disabled` attribute is redundant and considered an ARIA anti-pattern. Native `disabled` inherently communicates the state to assistive technologies and removes the element from the tab order.
+**Action:** When improving loading states for buttons, rely on the native `disabled` attribute and use `aria-busy={loading}` to inform screen readers of the active process without duplicating the disabled state.

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -296,6 +296,7 @@ export default function Home() {
                 type="button"
                 onClick={() => handleGenerate()}
                 disabled={loading || !prompt.trim()}
+                aria-busy={loading}
                 title={!prompt.trim() ? "Enter a prompt first to compile" : "Compile Prompt"}
                 className="w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 shadow-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
               >
@@ -520,6 +521,7 @@ export default function Home() {
                       type="button"
                       onClick={() => handleGenerate()}
                       disabled={loading || !prompt.trim()}
+                      aria-busy={loading}
                       title={!prompt.trim() ? "Enter a prompt first to compile" : "Compile Prompt"}
                       className="mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 shadow-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
                     >


### PR DESCRIPTION
💡 What: Added `aria-busy={loading}` attribute to the main and fallback "Compile Prompt" buttons on the homepage.
🎯 Why: When a user clicks "Compile Prompt", a background process starts. Screen reader users need to be informed that the process is actively running and they should wait. The `aria-busy` attribute effectively communicates this loading state.
📸 Before/After: No visual changes; this is purely an accessibility enhancement.
♿ Accessibility: Improves screen reader experience by explicitly communicating the loading/busy state of the primary compilation action, preventing confusion about whether the button click was registered.

---
*PR created automatically by Jules for task [15192944015314030469](https://jules.google.com/task/15192944015314030469) started by @madara88645*