### PR TITLE
🧪 Add tests for getBenchmarkModelById

### DIFF
--- a/web/app/benchmark/modelCatalog.test.mts
+++ b/web/app/benchmark/modelCatalog.test.mts
@@ -26,3 +26,15 @@ test("benchmark groups keep cheap and balanced models visible", () => {
   assert.equal(labels.includes("Cheap"), true);
   assert.equal(labels.includes("Balanced"), true);
 });
+
+test("getBenchmarkModelById returns the correct model for a valid ID", () => {
+  const model = getBenchmarkModelById("llama-3.1-8b-instant");
+  assert.notEqual(model, undefined);
+  assert.equal(model?.id, "llama-3.1-8b-instant");
+  assert.equal(model?.label, "Llama 3.1 8B Instant");
+});
+
+test("getBenchmarkModelById returns undefined for an invalid ID", () => {
+  const model = getBenchmarkModelById("non-existent-model");
+  assert.equal(model, undefined);
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested pure function `getBenchmarkModelById` in `web/app/benchmark/modelCatalog.ts`.
📊 **Coverage:** The scenarios now tested include the happy path (valid model ID) and the error/edge case (invalid model ID returning `undefined`).
✨ **Result:** Increased test coverage and confidence that benchmark model lookups work correctly.

---
*PR created automatically by Jules for task [16935659684278118430](https://jules.google.com/task/16935659684278118430) started by @madara88645*