### PR TITLE
🧹 [Code Health] Fix silent exception swallowing in RAG history serialization

### DIFF
--- a/app/rag/history_store.py
+++ b/app/rag/history_store.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -77,8 +80,8 @@ class RAGHistoryStore:
             # Bolt Optimization: orjson.dumps is significantly faster than json.dumps
             # for serializing history payloads to disk.
             self.path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error("Failed to save RAG history: %s", e)
 
     def add_query(self, query: str, method: str, k: int) -> None:
         if not query:


### PR DESCRIPTION
🎯 **What:** Fixed an issue in `app/rag/history_store.py` where an exception during history serialization in the `save` method was being silently caught and ignored (`except Exception: pass`).

💡 **Why:** Silently swallowing generic exceptions makes debugging extremely difficult, as there is no visibility into why RAG history failed to persist to disk (e.g., file permissions, bad state). Catching `Exception as e` and logging it via `logging.getLogger` ensures these failures are visible in application logs while still preventing the app from crashing.

✅ **Verification:**
1. Manually verified file modifications with syntax checks (`python3 -m py_compile`).
2. Ran the full backend test suite (`python -m pytest tests/`), ensuring no existing tests break (all 1104 passed).
3. Ran isolated unit test (`python -m pytest tests/test_rag_history_store.py`), both passed successfully.

✨ **Result:** Developers will now see appropriate error logs when history fails to serialize, improving maintainability, operational visibility, and making debugging much easier.

---
*PR created automatically by Jules for task [1656037116077794778](https://jules.google.com/task/1656037116077794778) started by @madara88645*