### PR TITLE
🧹 Narrow except Exception to ImportError for yaml import in CLI utils

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -8,7 +8,7 @@ from rich import print
 # Optional YAML support
 try:
     import yaml  # type: ignore
-except Exception:
+except ImportError:
     yaml = None  # type: ignore
 
 from app.compiler import (


### PR DESCRIPTION
🎯 **What:** Narrowed the overly broad `except Exception:` clause to `except ImportError:` when handling the optional `yaml` import in `cli/utils.py`.

💡 **Why:** Catching a broad `Exception` is an anti-pattern, especially around imports. It can silently swallow unexpected errors (like syntax errors, out-of-memory errors, or keyboard interrupts) that should be surfaced. Narrowing it to `ImportError` explicitly targets the expected failure condition (the package not being installed), improving maintainability and debuggability.

✅ **Verification:** Verified the change by manually reading the file after applying the patch and successfully running the full backend test suite (`python -m pytest tests/`), ensuring no existing CLI or compilation functionality was broken.

✨ **Result:** A safer, more targeted exception handling block that improves code readability and prevents masking of unrelated errors during runtime.

---
*PR created automatically by Jules for task [350695331984048089](https://jules.google.com/task/350695331984048089) started by @madara88645*