### PR TITLE
🧹 Fix silent error on DB open in simple_index.py

### DIFF
--- a/app/rag/simple_index.py
+++ b/app/rag/simple_index.py
@@ -215,7 +215,8 @@ def get_all_indexed_files(db_path: Optional[str] = None) -> List[str]:
         paths = [row[0] for row in cursor.fetchall()]
         conn.close()
         return paths
-    except Exception:
+    except Exception as e:
+        logger.error("Failed to get indexed files: %s", e)
         return []
 
 


### PR DESCRIPTION
🎯 **What:** Modified `get_all_indexed_files` in `app/rag/simple_index.py` to catch `Exception as e` and log it via `logger.error` rather than silently suppressing the exception and returning an empty list.
💡 **Why:** This improves maintainability and debuggability by ensuring that database connection or read errors during file indexing are visible in the logs, while still safely returning an empty list to avoid crashing the application.
✅ **Verification:** Verified the code changes locally via `cat` and successfully executed the full backend test suite (`python -m pytest tests/`), ensuring no existing tests were broken.
✨ **Result:** Enhanced visibility into database errors in the RAG indexing workflow without introducing functional regressions.

---
*PR created automatically by Jules for task [14631639609735355462](https://jules.google.com/task/14631639609735355462) started by @madara88645*