### PR TITLE
🧹 Fix bare Exception in TemplatesManager.import_template

### DIFF
--- a/app/templates_manager.py
+++ b/app/templates_manager.py
@@ -354,7 +354,10 @@ class TemplatesManager:
             self.registry.save_template(template, user_template=True)
 
             return template
-        except Exception:
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).error(f"Failed to import template from {input_path}: {e}")
             return None
 
     def validate_template(self, template_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
🎯 **What:** Replaced the bare `except Exception:` block with `except Exception as e:` and added proper logging of the error in `app/templates_manager.py` during template imports.
💡 **Why:** Silently swallowing errors made it difficult to diagnose failures, such as invalid YAML files when trying to import a template. Logging the explicit failure alongside the input path improves observability and the maintainability of the codebase.
✅ **Verification:** Ran `python -m ruff check app/templates_manager.py` to confirm code health and styling. Ran `python -m pytest tests/` with the full suite to verify that no functional or regression errors were introduced. Checked via explicit cat output that only the necessary lines were correctly refactored.
✨ **Result:** A safer, more debuggable import process that adheres to the established Python exceptions and telemetry patterns.

---
*PR created automatically by Jules for task [3270413304520270419](https://jules.google.com/task/3270413304520270419) started by @madara88645*