### PR TITLE
🧹 [Code Health] Fix bare except in parser fallback

### DIFF
--- a/app/rag/parsers.py
+++ b/app/rag/parsers.py
@@ -486,7 +486,10 @@ def parse_file(path: Path, fallback_to_text: bool = True) -> ParseResult:
         # Try plain text for unknown extensions
         try:
             return parse_plain_text(path)
-        except Exception:
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).error(f"Parsing error: {e}")
             return ParseResult(
                 content="",
                 metadata={"error": f"Unable to parse file with extension: {ext}"},


### PR DESCRIPTION
🎯 **What:** Fixed a bare `except Exception:` block in `app/rag/parsers.py` (line 489) that was silently swallowing errors during plain text parsing fallback.
💡 **Why:** Silently catching all exceptions without logging makes it extremely difficult to diagnose *why* a parsing operation failed (e.g., unexpected file permissions, encoding issues, etc.). Logging the exception improves the maintainability and debuggability of the RAG ingestion pipeline.
✅ **Verification:** Verified the fix by running the full backend test suite (`python -m pytest tests/`), ensuring no regressions were introduced. Evaluated that the core behavior and returned `ParseResult` schema remains unchanged.
✨ **Result:** The codebase is now safer and more diagnosable. When plain text fallback parsing fails, the error is properly tracked in the application logs, allowing developers to investigate failures without guessing.

---
*PR created automatically by Jules for task [2553749359961221106](https://jules.google.com/task/2553749359961221106) started by @madara88645*