### PR TITLE
🧹 Code Health: Replace bare except with debug logging in CLI Analytics

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 import orjson
 import time
 from pathlib import Path
@@ -125,8 +126,8 @@ def _run_compile(
                 tags=tags or [],
             )
             AnalyticsManager().record_prompt(record)
-        except Exception:
-            pass
+        except Exception as e:
+            logging.getLogger(__name__).debug(f"Analytics recording failed: {e}")
 
     if json_only and quiet:
         quiet = False


### PR DESCRIPTION
🎯 **What:** Replaced the bare `except Exception:` block in the CLI analytics recording with an `except Exception as e:` block that logs the exception using `logging.getLogger(__name__).debug`.
💡 **Why:** A bare `except: pass` suppresses all error information, making it impossible to debug why analytics might be failing silently. Logging the error at the `DEBUG` level ensures the program still doesn't crash, but developers can see the failure reason when running with debug logs enabled, improving the maintainability and observability of the codebase.
✅ **Verification:** Verified the syntax using `py_compile` and successfully ran the full backend test suite (`python -m pytest tests/`, 1104 passing tests) to ensure the core application behavior is unaffected.
✨ **Result:** Analytics failures are now safely caught and logged without crashing the CLI, improving debuggability.

---
*PR created automatically by Jules for task [5461940210055446063](https://jules.google.com/task/5461940210055446063) started by @madara88645*