### PR TITLE
🧹 Code Health Improvement: Add logging to catch block in Template Export

### DIFF
--- a/app/templates_manager.py
+++ b/app/templates_manager.py
@@ -7,12 +7,15 @@ interactive prompts, and rich CLI output support.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from app.templates import PromptTemplate, TemplateRegistry, TemplateVariable, get_registry
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -329,7 +332,8 @@ class TemplatesManager:
             with open(output_path, "w", encoding="utf-8") as f:
                 yaml.safe_dump(template.to_dict(), f, sort_keys=False, allow_unicode=True)
             return True
-        except Exception:
+        except Exception as e:
+            logger.error(f"Failed to export template {template_id}: {e}", exc_info=True)
             return False
 
     def import_template(self, input_path: Path) -> Optional[PromptTemplate]:


### PR DESCRIPTION
🎯 **What:** Replaced the bare `except Exception:` block in `export_template` with `except Exception as e:` and added proper logging.
💡 **Why:** A bare `except Exception:` makes it nearly impossible to debug why template export failed (e.g. disk space, permission denied, invalid YAML). Logging the exact exception using a module logger captures the context for easier operational maintenance without impacting execution flow.
✅ **Verification:** Verified safe by ensuring the module initializes the logger safely, runs flawlessly through lint checks (`ruff check`), and passes the specific `tests/test_templates_manager.py` as well as the full backend test suite (`pytest tests/`).
✨ **Result:** Improved code health and maintainability; unhandled errors during template export are now accurately logged, while preserving existing backward-compatible error handling functionality.

---
*PR created automatically by Jules for task [17588258319827569911](https://jules.google.com/task/17588258319827569911) started by @madara88645*