### PR TITLE
🧹 Code Health: Use NotImplementedError for MCP tool stubs

### DIFF
--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -162,7 +162,7 @@ def to_claude_mcp_tool_stub(ir: SkillExportIR) -> list[dict[str, str]]:
         @mcp.tool()
         async def {tool_name}({param_signature}) -> str:
             \"\"\"{ir.purpose or f"Execute {tool_name}."}\"\"\"
-            return "TODO: implement {tool_name}"
+            raise NotImplementedError("TODO: implement {tool_name}")
 
 
         if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** Replaced the hardcoded string return with `raise NotImplementedError(...)` in the generated FastMCP tool stub within `app/adapters/claude_code.py:to_claude_mcp_tool_stub`.
💡 **Why:** Returning a string for an unimplemented tool could be silently swallowed by callers. Raising a proper exception makes the unhandled state explicit and safer for consumers extending the stub.
✅ **Verification:** Verified visually, ran specific `test_export_adapters.py` tests and ran the full test suite (`pytest tests/`) to ensure no regressions were introduced.
✨ **Result:** Cleaned up the code generation output, improving generated code quality without modifying behavioral capabilities or functionality.

---
*PR created automatically by Jules for task [2083357534359930227](https://jules.google.com/task/2083357534359930227) started by @madara88645*