### PR TITLE
🧹 Narrow bare exception in TemplatesManager._load_stats

### DIFF
--- a/app/templates_manager.py
+++ b/app/templates_manager.py
@@ -44,7 +44,7 @@ class TemplatesManager:
             with open(self.stats_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
                 self._stats = {tid: TemplateUsageStats(**stats) for tid, stats in data.items()}
-        except Exception:
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
             self._stats = {}
 
     def _save_stats(self) -> None:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced a bare `except Exception:` block with `except (OSError, json.JSONDecodeError, TypeError, ValueError):` in the `_load_stats` method of `TemplatesManager` (line 47).

💡 **Why:** How this improves maintainability
Using a bare `except Exception` is an anti-pattern as it can silently swallow unexpected errors like `KeyboardInterrupt`, `MemoryError`, or unexpected logic bugs (e.g., `NameError`), making debugging difficult. Narrowing it down to the exact expected failures (file not found, bad JSON, or malformed data structure) ensures the system behaves predictably and only catches failures related to loading the stats file.

✅ **Verification:** How you confirmed the change is safe
Ran `python -m pytest tests/` which passed completely. Also requested a code review and reverted any unintentional scope-creep modifications in other parts of the file to ensure strict adherence to the requested bugfix boundaries.

✨ **Result:** The improvement achieved
The codebase is safer, easier to debug, and adheres better to Python best practices regarding exception handling.

---
*PR created automatically by Jules for task [10926003646122668556](https://jules.google.com/task/10926003646122668556) started by @madara88645*