### PR TITLE
🧹 Fix unimplemented Skill Adapter logic

### DIFF
--- a/app/adapters/skill_adapter.py
+++ b/app/adapters/skill_adapter.py
@@ -183,7 +183,7 @@ def to_langchain_tool(ir: SkillExportIR) -> str:
         parts.append(f"def {func_name}() -> {ir.output_type}:")
     parts.append(_build_docstring(ir))
     parts.append("    # TODO: implement")
-    parts.append("    pass")
+    parts.append("    raise NotImplementedError")
 
     return "\n".join(parts)
 


### PR DESCRIPTION
🎯 **What:** Replaced the `pass` statement with `raise NotImplementedError` in the generated code stub within `to_langchain_tool` in `app/adapters/skill_adapter.py`.
💡 **Why:** Generating `raise NotImplementedError` is the standard and correct way to handle unimplemented code stubs in Python. It improves maintainability and correctness by clearly signaling to the developer when a stub hasn't been properly filled out, rather than silently passing if it's called.
✅ **Verification:** Ran `python -m ruff check app/adapters/skill_adapter.py` to confirm no new lint issues were introduced. Ran `python -m pytest tests/test_skill_adapter.py tests/test_skills_generator.py` and confirmed the specific file tests pass. Earlier in the session, the full test suite (`python -m pytest tests/`) was also run successfully.
✨ **Result:** Generated code stubs are now more robust and adhere to standard Python conventions.

---
*PR created automatically by Jules for task [8574083238242346708](https://jules.google.com/task/8574083238242346708) started by @madara88645*