### PR TITLE
🧪 [testing improvement] Add missing test for InvalidCompileResponseError

### DIFF
--- a/web/lib/api/promptc.test.ts
+++ b/web/lib/api/promptc.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiError, apiJson } from "../../config";
 import {
+  InvalidCompileResponseError,
   compilePrompt,
   normalizeCompileResponse,
   normalizeRagSearchResults,
@@ -18,6 +19,21 @@ vi.mock("../../config", async () => {
 });
 
 const apiJsonMock = vi.mocked(apiJson);
+
+describe("InvalidCompileResponseError", () => {
+  it("sets the default message and name correctly", () => {
+    const error = new InvalidCompileResponseError();
+    expect(error.message).toBe("Invalid compile response.");
+    expect(error.name).toBe("InvalidCompileResponseError");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("allows setting a custom message", () => {
+    const error = new InvalidCompileResponseError("Custom error message.");
+    expect(error.message).toBe("Custom error message.");
+    expect(error.name).toBe("InvalidCompileResponseError");
+  });
+});
 
 describe("compile response normalization", () => {
   it("treats incomplete security metadata without findings as safe", () => {


### PR DESCRIPTION
🎯 **What:** The testing gap for the `InvalidCompileResponseError` class instantiation and properties check was addressed by creating a dedicated test block.
📊 **Coverage:** The scenarios now tested include basic instantiations with the default message and custom error messages, verifying the inheritance, name and correct message fields.
✨ **Result:** Increased code reliability and testing coverage for error handlers, protecting against future regressions.

---
*PR created automatically by Jules for task [8997797121848916497](https://jules.google.com/task/8997797121848916497) started by @madara88645*