### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing CORS restriction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -68,3 +68,8 @@
 **Vulnerability:** Information Exposure (CWE-200) in FastAPI error handling. An endpoint raised an `HTTPException` where the `detail` parameter was populated dynamically with the raw exception string (`str(exc)`).
 **Learning:** Returning `str(exc)` directly to the client can inadvertently expose sensitive internal paths, downstream API details, or error contexts meant only for developers. The exception must be logged securely on the backend while a sanitized generic message is returned to the user.
 **Prevention:** When raising `HTTPException` inside a `try...except` block, never pass the stringified exception `str(exc)` directly to the `detail` parameter. Instead, provide a generic, safe error message to the client, and rely on `logger.exception()` or explicit backend logging (e.g., `_log_repo_analyze_outcome`) to record the raw exception for internal troubleshooting.
+
+## 2024-05-20 - Ensure Environment Configuration for CORS is Testable
+**Vulnerability:** Default local CORS allowed origins (`localhost:3000`) enabled by default without explicit environment checks.
+**Learning:** Default configuration logic evaluated at module import (`os.environ.get`) is harder to test using standard pytest monkeypatch without using `importlib.reload()`, and defaults can expose unverified environments.
+**Prevention:** Always scope permissive security defaults (like localhost origins) behind strict environment checks (e.g., `ENV == "development"`), and ensure proper mock-reloading when testing top-level variables.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	cd web && npm ci
 
 dev-backend:
-	uvicorn api.main:app --reload --host 0.0.0.0 --port 8080
+	ENV=development uvicorn api.main:app --reload --host 0.0.0.0 --port 8080
 
 dev-web:
 	cd web && npm run dev
@@ -14,7 +14,7 @@ dev:
 	@echo "Starting backend (8080) + web (3000) in parallel..."
 	@if command -v npx >/dev/null 2>&1; then \
 		npx -y concurrently -n backend,web -c blue,green \
-			"uvicorn api.main:app --reload --host 0.0.0.0 --port 8080" \
+			"ENV=development uvicorn api.main:app --reload --host 0.0.0.0 --port 8080" \
 			"cd web && npm run dev"; \
 	else \
 		echo "npx not found — run 'make dev-backend' and 'make dev-web' in separate terminals"; \

--- a/api/main.py
+++ b/api/main.py
@@ -71,9 +71,9 @@ async def add_security_headers(request, call_next):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-    response.headers["Content-Security-Policy"] = (
-        "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
-    )
+    response.headers[
+        "Content-Security-Policy"
+    ] = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
     return response
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -39,12 +39,13 @@ app = FastAPI(title="Prompt Compiler API", lifespan=lifespan)
 allowed_origins_env = os.environ.get("ALLOWED_ORIGINS", "")
 allow_origins = [origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()]
 if not allow_origins:
-    allow_origins = [
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-        "http://localhost:3001",
-        "http://127.0.0.1:3001",
-    ]
+    if os.environ.get("ENV", "production").strip().lower() == "development":
+        allow_origins = [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:3001",
+            "http://127.0.0.1:3001",
+        ]
 
 app.add_middleware(
     CORSMiddleware,
@@ -70,9 +71,9 @@ async def add_security_headers(request, call_next):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-    response.headers[
-        "Content-Security-Policy"
-    ] = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
+    )
     return response
 
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -217,8 +217,9 @@ def test_repo_context_endpoint_keeps_per_ip_buckets_isolated(monkeypatch):
 def test_benchmark_requires_api_key():
     client = TestClient(app)
 
-    with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
-        "app.routers.benchmark._judge_with_llm", return_value=None
+    with (
+        patch("app.routers.benchmark._generate_llm_output") as mock_llm,
+        patch("app.routers.benchmark._judge_with_llm", return_value=None),
     ):
         mock_llm.side_effect = ["raw output", "compiled output"]
         response = client.post(
@@ -289,8 +290,13 @@ def test_rag_ingest_rejects_path_outside_allowed_root(test_key, monkeypatch):
         assert "invalid path specified" in response.json()["detail"].lower()
 
 
-def test_cors_preflight_allows_prompt_mode_header():
-    client = TestClient(app)
+def test_cors_preflight_allows_prompt_mode_header(monkeypatch):
+    monkeypatch.setenv("ALLOWED_ORIGINS", "http://localhost:3000")
+    import importlib
+    import api.main
+
+    importlib.reload(api.main)
+    client = TestClient(api.main.app)
 
     response = client.options(
         "/compile",


### PR DESCRIPTION
🎯 **What:** The application's CORS configuration allowed local origins (`localhost:3000`, etc.) by default if `ALLOWED_ORIGINS` was not set, which occurred in all environments, including production.
⚠️ **Risk:** If the API is exposed in a production environment, unconditionally allowing localhost origins can open it up to DNS rebinding attacks or exploitation if a user runs a malicious local server, expanding the attack surface.
🛡️ **Solution:** Modified the default behavior to only allow localhost CORS origins when the explicit `ENV=development` environment variable is provided. Updated the `Makefile` to pass this variable during local development (`make dev` and `make dev-backend`) to ensure standard development workflows are completely unaffected. Validated via `tests/test_api_hardening.py` updates.

---
*PR created automatically by Jules for task [1875742290765181941](https://jules.google.com/task/1875742290765181941) started by @madara88645*