### PR TITLE
[codex] cover retry behavior for agent pack proxy routes

### DIFF
--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -107,6 +107,20 @@ describe("Next backend proxy route wiring", () => {
 
   it.each<RouteCase>([
     {
+      name: "agent packs",
+      handler: agentPacksClaudeRoute,
+      requestUrl: "http://localhost:3000/agent-packs/claude",
+      requestBody: { project_type: "SaaS", stack: "FastAPI", goal: "Generate a project pack", pack_type: "project-pack" },
+      expectedUrl: "http://127.0.0.1:8080/agent-packs/claude",
+    },
+    {
+      name: "agent pack download",
+      handler: agentPacksClaudeDownloadRoute,
+      requestUrl: "http://localhost:3000/agent-packs/claude/download",
+      requestBody: { project_type: "SaaS", stack: "FastAPI", goal: "Generate a project pack", pack_type: "project-pack" },
+      expectedUrl: "http://127.0.0.1:8080/agent-packs/claude/download",
+    },
+    {
       name: "repo context analysis",
       handler: repoContextGithubRoute,
       requestUrl: "http://localhost:3000/repo-context/github",

--- a/web/lib/server/backendProxy.test.ts
+++ b/web/lib/server/backendProxy.test.ts
@@ -109,6 +109,40 @@ describe("backend proxy", () => {
     await expect(response.json()).resolves.toEqual({ ok: true });
   });
 
+  it("retries binary download requests and keeps the response streaming", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
+
+    const upstreamResponse = new Response("zip-bytes", {
+      status: 200,
+      headers: { "content-type": "application/zip" },
+    });
+    const arrayBufferSpy = vi.spyOn(upstreamResponse, "arrayBuffer");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce(upstreamResponse);
+
+    const request = new Request("http://localhost:3000/agent-packs/claude/download", {
+      method: "POST",
+      headers: {
+        Accept: "application/octet-stream",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ goal: "download code" }),
+    });
+
+    const response = await proxyBackendRequest(request, "/agent-packs/claude/download", {
+      retryNetworkErrors: true,
+      networkRetryAttempts: 2,
+      networkRetryDelayMs: 1,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+    expect(response.headers.get("x-promptc-proxy-attempts")).toBe("2");
+    await expect(response.text()).resolves.toBe("zip-bytes");
+  });
+
   it("does not retry non-retryable requests when the backend fetch throws", async () => {
     process.env.NEXT_PUBLIC_API_URL = "https://api.memo.dev";
 


### PR DESCRIPTION
## What changed
- added retry contract coverage for `/agent-packs/claude`
- added retry contract coverage for `/agent-packs/claude/download`
- added a backend proxy test that proves binary downloads still stream after a transient network failure

## Why this changed
These routes were recently opted into retry-on-wakeup behavior, but the regression tests did not cover the agent pack create/download flows. This PR locks that behavior in so a later refactor does not quietly remove it.

## Product impact
Users are less likely to see flaky first-load failures on agent pack create and download flows, and we now have tests that catch regressions before they ship.

## Verification
- `cd web && npx vitest run app/proxy-routes.test.ts lib/server/backendProxy.test.ts`
- `cd web && npm run test:contracts`
