### PR TITLE
feat: make OpenRouter the only cloud provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Core model access
-OPENROUTER_API_KEY=sk-or-v1-your-key-here
+# Get your key from https://openrouter.ai/keys
+OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OPENROUTER_MODEL=openai/gpt-oss-20b
 OPENROUTER_HTTP_REFERER=

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 # Core model access
-OPENAI_API_KEY=sk-your-key-here
-OPENAI_BASE_URL=https://api.openai.com
-GROQ_API_KEY=gsk-your-key-here
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_MODEL=openai/gpt-oss-20b
+OPENROUTER_HTTP_REFERER=
+OPENROUTER_TITLE=Prompt Compiler
 LLM_AGENT_MAX_TOKENS=2048
 LLM_SKILL_MAX_TOKENS=2048
 

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,13 @@
+# GitGuardian configuration
+# Documentation: https://docs.gitguardian.com/internal-repositories-monitoring/integrations/git_hooks/pre_commit#gitguardian-configuration-file
+
+version: 2
+
+paths-ignore:
+  - .env.example  # Template file with placeholder credentials only
+  - "**/*.example"  # All example files
+  - "**/example.env"  # Alternative naming patterns
+
+# Do not scan example/template files
+exclude:
+  - .env.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ Prompt Compiler is a FastAPI + Next.js product that turns vague requests into st
 - Prefer focused tests before broad suites.
 - Keep Claude-native integrations adapter-scoped; preserve provider-agnostic core behavior.
 - Never expose secrets, `.env` contents, or database credentials in outputs.
-- Public product rule: do not add end-user Prompt Compiler API key requirements, browser API-key prompts, or proxy-only secret setup steps for public web flows. If cloud features need credentials, they belong on the server as provider keys (`OPENAI_API_KEY`, `GROQ_API_KEY`), not in the hands of visitors.
+- Public product rule: do not add end-user Prompt Compiler API key requirements, browser API-key prompts, or proxy-only secret setup steps for public web flows. If cloud features need credentials, they belong on the server as provider keys (`OPENROUTER_API_KEY`), not in the hands of visitors.
+- Cloud provider rule: Prompt Compiler uses OpenRouter only. Do not add Groq or OpenAI fallbacks back into defaults, env guidance, or user-facing flows.
 
 ## Runbook
 - Backend dev server: `python -m uvicorn api.main:app --reload --port 8080`

--- a/README.md
+++ b/README.md
@@ -272,9 +272,11 @@ cp .env.example .env
 Core variables:
 
 ```env
-OPENAI_API_KEY=sk-your-actual-key
-OPENAI_BASE_URL=https://api.openai.com
-GROQ_API_KEY=gsk_your_groq_key
+OPENROUTER_API_KEY=sk-or-v1-your-actual-key
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_MODEL=openai/gpt-oss-20b
+OPENROUTER_HTTP_REFERER=
+OPENROUTER_TITLE=Prompt Compiler
 
 # Prompt compiler mode: conservative (default) or default
 PROMPT_COMPILER_MODE=conservative
@@ -291,7 +293,8 @@ PROMPTC_RAG_ALLOWED_ROOTS=
 Notes:
 
 - Public app routes are intended to work without custom Prompt Compiler API keys.
-- `OPENAI_API_KEY` / `GROQ_API_KEY` are server-side provider credentials, not values that visitors should type into the app.
+- `OPENROUTER_API_KEY` is a server-side provider credential, not a value that visitors should type into the app.
+- Prompt Compiler's cloud path is OpenRouter-only. Groq and legacy OpenAI fallback guidance should be treated as obsolete.
 - If you set `PROMPTC_RAG_ALLOWED_ROOTS`, only files inside those roots can be ingested by path.
 
 ---

--- a/agents.md
+++ b/agents.md
@@ -31,9 +31,9 @@ You do **not** need to commit `.env`. It is gitignored and only needed for local
 
 | Variable | Required for | Default / Notes |
 |---|---|---|
-| `OPENAI_API_KEY` | LLM compile, optimize, benchmark | No default — must be set for LLM paths |
-| `OPENAI_BASE_URL` | LLM provider URL | `https://api.openai.com` |
-| `GROQ_API_KEY` | Groq-backed LLM paths | Optional; LLM routes fall back to OpenAI |
+| `OPENROUTER_API_KEY` | LLM compile, optimize, benchmark | No default — must be set for cloud LLM paths |
+| `OPENROUTER_BASE_URL` | LLM provider URL | `https://openrouter.ai/api/v1` |
+| `OPENROUTER_MODEL` | Default cloud model slug | `openai/gpt-oss-20b` |
 | `LLM_AGENT_MAX_TOKENS` | Agent generator response cap | `2048`; lower it to reduce token usage or raise it for longer generated packs |
 | `LLM_SKILL_MAX_TOKENS` | Skill generator response cap | `2048`; mirrors the agent cap for MCP/skill output generation |
 | `PROMPT_COMPILER_MODE` | Compiler aggressiveness | `conservative` (default) or `default` |
@@ -59,13 +59,14 @@ NEXT_PUBLIC_API_URL=http://127.0.0.1:8080
 ### Auth / API key notes
 
 - Public app routes are intended to work **without** asking visitors for a Prompt Compiler API key.
-- Cloud-backed features may still need server-side provider credentials such as `OPENAI_API_KEY` or `GROQ_API_KEY`, but those stay on the server and are never typed by end users.
+- Cloud-backed features may still need a server-side provider credential such as `OPENROUTER_API_KEY`, but that stays on the server and is never typed by end users.
+- OpenRouter is the **only** supported cloud provider for this repo. Do not reintroduce Groq or OpenAI fallbacks into public product flows, defaults, or docs.
 - `x-api-key`, `PROMPTC_SERVER_API_KEY`, and similar custom backend keys are legacy/internal mechanisms and should not be introduced into public web flows.
 - In tests, authentication is **automatically bypassed** by `conftest.py` unless the test is marked `@pytest.mark.auth_required`.
 
 ### Mocking / disabling LLM calls
 
-The codebase is designed so that offline heuristics in `app/heuristics/` run without any LLM key. Set `PROMPT_COMPILER_MODE=conservative` and simply omit `OPENAI_API_KEY` / `GROQ_API_KEY`; the compiler falls back to local heuristics for most operations. Test files under `tests/` do the same — no live LLM calls are made.
+The codebase is designed so that offline heuristics in `app/heuristics/` run without any LLM key. Set `PROMPT_COMPILER_MODE=conservative` and simply omit `OPENROUTER_API_KEY`; the compiler falls back to local heuristics for most operations. Test files under `tests/` do the same — no live LLM calls are made.
 
 If agent-pack or skill exports are getting truncated, adjust `LLM_AGENT_MAX_TOKENS` or `LLM_SKILL_MAX_TOKENS` in `.env` before retrying.
 
@@ -196,7 +197,7 @@ pytest tests/test_compile_policy_api.py tests/test_agent_generator.py tests/test
 **Live optimizer tests (opt-in only; requires upstream credentials):**
 
 ```bash
-GROQ_API_KEY=... pytest tests/optimizer/test_optimize_live.py --run-live -m live -v
+OPENROUTER_API_KEY=... pytest tests/optimizer/test_optimize_live.py --run-live -m live -v
 ```
 
 **Live API smoke test (requires running backend):**
@@ -422,6 +423,13 @@ cd ../..
 ```
 
 Full matrix tests (Python 3.10–3.12, Linux/Windows/macOS) only run on push to `main`, not on PRs.
+
+### Snyk dependency scan
+
+The dedicated GitHub workflow in `.github/workflows/snyk.yml` scans `requirements.txt` and `pyproject.toml`
+explicitly with separate `snyk test --file=...` commands. Keep the runtime dependency snapshot in
+`requirements.txt` aligned with `pyproject.toml`, and avoid adding editable-install-only packages to the Snyk job
+because that can create noisy dependency graphs and stale vulnerability alerts.
 
 ---
 

--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -26,7 +26,12 @@ from app.emitters import (
 )
 from app.llm_engine.schemas import QualityReport
 from app.models_v2 import DiagnosticItem, IRv2
-from app.optimizer.language_costs import DEFAULT_GROQ_MODEL, detect_language, estimate_prompt_cost
+from app.optimizer.language_costs import (
+    DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_PROVIDER,
+    detect_language,
+    estimate_prompt_cost,
+)
 from app.optimizer.postprocess import strip_wrapper_labels
 from app.validator import validate_prompt
 
@@ -99,7 +104,7 @@ class OptimizeRequest(BaseModel):
     max_chars: Optional[int] = Field(default=None, ge=1, le=_MAX_PROMPT_CHARS)
     max_tokens: Optional[int] = Field(default=None, ge=1, le=8_000)
     token_ratio: float = Field(default=4.0, gt=0, le=20.0)
-    provider: str = Field(default="groq", max_length=40)
+    provider: str = Field(default=DEFAULT_PROVIDER, max_length=40)
     model: Optional[str] = Field(default=None, max_length=120)
 
 
@@ -539,9 +544,9 @@ async def optimize_endpoint(
         model = (
             req.model
             or (worker_model if isinstance(worker_model, str) else None)
-            or DEFAULT_GROQ_MODEL
+            or DEFAULT_OPENROUTER_MODEL
         )
-        provider = (req.provider or "groq").strip().lower()
+        provider = (req.provider or DEFAULT_PROVIDER).strip().lower()
         raw_result, optimizer_call_usage = await anyio.to_thread.run_sync(
             functools.partial(
                 compiler.worker.optimize_prompt,

--- a/app/llm/factory.py
+++ b/app/llm/factory.py
@@ -53,9 +53,13 @@ def get_provider(
             )
             model = os.environ.get("PROMPTC_LLM_MODEL", "claude-opus-4-7")
         else:
-            api_key = os.environ.get("OPENAI_API_KEY")
-            base_url = os.environ.get("PROMPTC_LLM_BASE_URL")
-            model = os.environ.get("PROMPTC_LLM_MODEL", "gpt-4o")
+            api_key = os.environ.get("OPENROUTER_API_KEY")
+            base_url = os.environ.get("PROMPTC_LLM_BASE_URL") or os.environ.get(
+                "OPENROUTER_BASE_URL"
+            )
+            model = os.environ.get("PROMPTC_LLM_MODEL") or os.environ.get(
+                "OPENROUTER_MODEL", "openai/gpt-oss-20b"
+            )
 
         config = ProviderConfig(
             api_key=api_key,

--- a/app/llm/providers.py
+++ b/app/llm/providers.py
@@ -92,21 +92,30 @@ class OllamaProvider(LLMProvider):
 
 class OpenAIProvider(LLMProvider):
     """
-    Provider for OpenAI API.
-    Requires OPENAI_API_KEY env var or config.api_key.
+    Provider for OpenAI-compatible APIs.
+    Defaults to OpenRouter via OPENROUTER_* env vars or config overrides.
     """
 
     def generate(self, prompt: str, system_prompt: Optional[str] = None, **kwargs) -> LLMResponse:
-        api_key = self.config.api_key or os.environ.get("OPENAI_API_KEY")
+        api_key = self.config.api_key or os.environ.get("OPENROUTER_API_KEY")
         if not api_key:
-            return LLMResponse(content="Error: Missing OpenAI API Key", latency_ms=0)
+            return LLMResponse(content="Error: Missing OpenRouter API Key", latency_ms=0)
 
         # We use httpx directly to avoid strict dependency on openai package if not installed,
         # but for robustness usually the package is better.
         # For this implementation plan, we will stick to httpx for lightweight dependency.
 
-        url = "https://api.openai.com/v1/chat/completions"
+        base_url = (
+            self.config.base_url
+            or os.environ.get("OPENROUTER_BASE_URL")
+            or "https://openrouter.ai/api/v1"
+        ).rstrip("/")
+        url = f"{base_url}/chat/completions"
         headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        if os.environ.get("OPENROUTER_HTTP_REFERER"):
+            headers["HTTP-Referer"] = os.environ["OPENROUTER_HTTP_REFERER"]
+        if os.environ.get("OPENROUTER_TITLE"):
+            headers["X-OpenRouter-Title"] = os.environ["OPENROUTER_TITLE"]
 
         messages = []
         if system_prompt:

--- a/app/llm/providers.py
+++ b/app/llm/providers.py
@@ -115,7 +115,7 @@ class OpenAIProvider(LLMProvider):
         if os.environ.get("OPENROUTER_HTTP_REFERER"):
             headers["HTTP-Referer"] = os.environ["OPENROUTER_HTTP_REFERER"]
         if os.environ.get("OPENROUTER_TITLE"):
-            headers["X-OpenRouter-Title"] = os.environ["OPENROUTER_TITLE"]
+            headers["X-Title"] = os.environ["OPENROUTER_TITLE"]
 
         messages = []
         if system_prompt:

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -118,7 +118,7 @@ class WorkerClient:
         if referer:
             headers["HTTP-Referer"] = referer
         if title:
-            headers["X-OpenRouter-Title"] = title
+            headers["X-Title"] = title
 
         return headers
 

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -18,9 +18,10 @@ from openai import OpenAI, APIError
 from .schemas import WorkerResponse, QualityReport, LLMFixResponse
 from app.heuristics.security import scan_text
 
-# Default settings - Groq (much faster than LLM Service)
-DEFAULT_MODEL = os.environ.get("LLM_MODEL", "llama-3.1-8b-instant")
-DEFAULT_BASE_URL = os.environ.get("LLM_BASE_URL", "https://api.groq.com/openai/v1")
+OPENROUTER_DEFAULT_MODEL = "openai/gpt-oss-20b"
+OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_MODEL = os.environ.get("OPENROUTER_MODEL", OPENROUTER_DEFAULT_MODEL)
+DEFAULT_BASE_URL = os.environ.get("OPENROUTER_BASE_URL", OPENROUTER_DEFAULT_BASE_URL)
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 WORKER_PROMPT_PATH = PROMPTS_DIR / "worker_v1.md"
 WORKER_CONSERVATIVE_PROMPT_PATH = PROMPTS_DIR / "worker_conservative.md"
@@ -29,7 +30,6 @@ AGENT_GENERATOR_PROMPT_PATH = PROMPTS_DIR / "agent_generator.md"
 SKILLS_GENERATOR_PROMPT_PATH = PROMPTS_DIR / "skills_generator.md"
 MULTI_AGENT_PLANNER_PROMPT_PATH = PROMPTS_DIR / "multi_agent_planner.md"
 
-# Timeouts - Much shorter for Groq (300+ tok/s)
 # Allow overriding timeout via env var
 try:
     HARD_TIMEOUT_SECONDS = int(os.environ.get("LLM_TIMEOUT", 30))
@@ -73,23 +73,22 @@ class WorkerClient:
         self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        model: str = DEFAULT_MODEL,
+        model: Optional[str] = None,
     ):
-        self.api_key = (
-            api_key
-            or os.environ.get("OPENAI_API_KEY")
-            or os.environ.get("GROQ_API_KEY")
-            or "missing_key"
-        )
-        self.base_url = base_url or os.environ.get("OPENAI_BASE_URL") or DEFAULT_BASE_URL
-        self.model = model
+        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY") or "missing_key"
+        self.base_url = base_url or os.environ.get("OPENROUTER_BASE_URL") or DEFAULT_BASE_URL
+        self.model = model or os.environ.get("OPENROUTER_MODEL") or DEFAULT_MODEL
+        default_headers = self._build_default_headers()
 
         # Explicit timeout for the HTTP client
-        self.client = OpenAI(
+        client_kwargs = dict(
             api_key=self.api_key,
             base_url=self.base_url,
             timeout=HARD_TIMEOUT_SECONDS,  # Pass timeout to underlying httpx client
         )
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+        self.client = OpenAI(**client_kwargs)
         self.default_mode = (
             (os.environ.get("PROMPT_COMPILER_MODE") or "conservative").strip().lower()
         )
@@ -110,6 +109,21 @@ class WorkerClient:
     def _resolve_mode(self, mode: Optional[str]) -> str:
         m = (mode or self.default_mode or "conservative").strip().lower()
         return m if m in {"conservative", "default"} else "conservative"
+
+    def _build_default_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        referer = os.environ.get("OPENROUTER_HTTP_REFERER")
+        title = os.environ.get("OPENROUTER_TITLE")
+
+        if referer:
+            headers["HTTP-Referer"] = referer
+        if title:
+            headers["X-OpenRouter-Title"] = title
+
+        return headers
+
+    def _is_openrouter_request(self) -> bool:
+        return "openrouter.ai" in (self.base_url or "").lower()
 
     def _worker_system_prompt_for_mode(self, mode: str) -> str:
         if mode == "default":
@@ -142,6 +156,8 @@ class WorkerClient:
         }
         if json_mode:
             kwargs["response_format"] = {"type": "json_object"}
+            if self._is_openrouter_request():
+                kwargs["extra_body"] = {"provider": {"require_parameters": True}}
 
         try:
             completion = self.client.chat.completions.create(**kwargs)
@@ -296,7 +312,7 @@ class WorkerClient:
     ) -> WorkerResponse:
         """Compile user text into structured prompt components."""
         if self.api_key == "missing_key":
-            raise RuntimeError("API Key is missing. Please set OPENAI_API_KEY.")
+            raise RuntimeError("API Key is missing. Please set OPENROUTER_API_KEY.")
 
         resolved_mode = self._resolve_mode(mode)
         system_prompt = self._worker_system_prompt_for_mode(resolved_mode)
@@ -369,7 +385,7 @@ class WorkerClient:
     def analyze_prompt(self, user_text: str) -> QualityReport:
         """Analyze prompt quality and return score/feedback."""
         if self.api_key == "missing_key":
-            raise RuntimeError("API Key is missing. Please set OPENAI_API_KEY.")
+            raise RuntimeError("API Key is missing. Please set OPENROUTER_API_KEY.")
 
         if not self.coach_prompt:
             raise RuntimeError("Quality Coach prompt not found.")
@@ -400,7 +416,7 @@ class WorkerClient:
         so concurrent callers never see each other's token counts.
         """
         if self.api_key == "missing_key":
-            raise RuntimeError("API Key is missing. Please set OPENAI_API_KEY or GROQ_API_KEY.")
+            raise RuntimeError("API Key is missing. Please set OPENROUTER_API_KEY.")
 
         if not self.optimizer_prompt:
             # Fallback if file missing
@@ -445,7 +461,7 @@ class WorkerClient:
     def fix_prompt(self, user_text: str) -> LLMFixResponse:
         """Auto-fix prompt using LLM Editor."""
         if self.api_key == "missing_key":
-            raise RuntimeError("API Key is missing. Please set OPENAI_API_KEY.")
+            raise RuntimeError("API Key is missing. Please set OPENROUTER_API_KEY.")
 
         if not self.editor_prompt:
             self.editor_prompt = "You are an expert editor. Rewrite this prompt to be better. Return JSON: {fixed_text, explanation, changes}"
@@ -475,7 +491,7 @@ class WorkerClient:
         Returns ``(english_text, usage_dict_or_none)``.
         """
         if self.api_key == "missing_key":
-            raise RuntimeError("API Key is missing. Please set OPENAI_API_KEY or GROQ_API_KEY.")
+            raise RuntimeError("API Key is missing. Please set OPENROUTER_API_KEY.")
 
         sys_prompt = (
             self.optimizer_prompt
@@ -561,7 +577,7 @@ class WorkerClient:
     ) -> str:
         """Generate a comprehensive AI Agent system prompt."""
         if self.api_key == "missing_key":
-            raise RuntimeError("API Key is missing. Please set OPENAI_API_KEY.")
+            raise RuntimeError("API Key is missing. Please set OPENROUTER_API_KEY.")
 
         if multi_agent:
             system_prompt = self._multi_agent_prompt(include_example_code)
@@ -651,7 +667,7 @@ class WorkerClient:
     ) -> str:
         """Generate a comprehensive AI Skill definition."""
         if self.api_key == "missing_key":
-            raise RuntimeError("API Key is missing. Please set OPENAI_API_KEY.")
+            raise RuntimeError("API Key is missing. Please set OPENROUTER_API_KEY.")
         system_prompt = self._skill_prompt(include_example_code)
 
         messages = [

--- a/app/optimizer/language_costs.py
+++ b/app/optimizer/language_costs.py
@@ -12,19 +12,16 @@ except Exception:  # pragma: no cover - tiktoken is a declared dependency.
     tiktoken = None
 
 
-DEFAULT_PROVIDER = "groq"
-DEFAULT_GROQ_MODEL = "llama-3.1-8b-instant"
+DEFAULT_PROVIDER = "openrouter"
+DEFAULT_OPENROUTER_MODEL = "openai/gpt-oss-20b"
 TOKENIZER_METHOD = "tiktoken:o200k_base:estimated"
 
-# USD per 1M tokens. Source: Groq public pricing page, captured in AGENTS-driven plan.
-GROQ_RATES: dict[str, dict[str, float]] = {
-    "llama-3.1-8b-instant": {"input": 0.05, "output": 0.08},
-    "llama-3.3-70b-versatile": {"input": 0.59, "output": 0.79},
+# USD per 1M tokens.
+OPENROUTER_RATES: dict[str, dict[str, float]] = {
     "openai/gpt-oss-20b": {"input": 0.075, "output": 0.30},
     "openai/gpt-oss-120b": {"input": 0.15, "output": 0.60},
-    "openai/gpt-oss-safeguard-20b": {"input": 0.075, "output": 0.30},
-    "meta-llama/llama-4-scout-17b-16e-instruct": {"input": 0.11, "output": 0.34},
-    "qwen/qwen3-32b": {"input": 0.29, "output": 0.59},
+    "mistralai/mistral-small-3.2-24b-instruct": {"input": 0.075, "output": 0.20},
+    "qwen/qwen3-32b": {"input": 0.08, "output": 0.28},
 }
 
 _TURKISH_CHARS_RE = re.compile(r"[çğıöşüÇĞİÖŞÜ]")
@@ -126,45 +123,55 @@ def count_estimated_tokens(text: str) -> int:
         return estimate_tokens(text)
 
 
-def get_groq_rates(model: str) -> tuple[float, float, list[str]]:
-    normalized = (model or DEFAULT_GROQ_MODEL).strip()
-    if normalized in GROQ_RATES:
-        rates = GROQ_RATES[normalized]
+def get_openrouter_rates(model: str) -> tuple[float, float, list[str]]:
+    normalized = (model or DEFAULT_OPENROUTER_MODEL).strip()
+    if normalized in OPENROUTER_RATES:
+        rates = OPENROUTER_RATES[normalized]
         return rates["input"], rates["output"], []
 
-    for key in sorted(GROQ_RATES, key=len, reverse=True):
+    for key in sorted(OPENROUTER_RATES, key=len, reverse=True):
         if normalized.startswith(key):
-            rates = GROQ_RATES[key]
+            rates = OPENROUTER_RATES[key]
             return rates["input"], rates["output"], []
 
-    return 0.0, 0.0, [f"No Groq pricing configured for model '{normalized}'. Cost shown as $0."]
+    return (
+        0.0,
+        0.0,
+        [f"No OpenRouter pricing configured for model '{normalized}'. Cost shown as $0."],
+    )
 
 
 def estimate_prompt_cost(
     text: str,
     *,
     provider: str = DEFAULT_PROVIDER,
-    model: str = DEFAULT_GROQ_MODEL,
+    model: str = DEFAULT_OPENROUTER_MODEL,
     direction: Literal["input", "output"] = "input",
     token_count_override: int | None = None,
 ) -> PromptCostEstimate:
     value = text or ""
+    normalized_provider = (provider or DEFAULT_PROVIDER).strip().lower()
+    resolved_model = (model or DEFAULT_OPENROUTER_MODEL).strip()
     tokens = (
         token_count_override if token_count_override is not None else count_estimated_tokens(value)
     )
-    input_rate, output_rate, warnings = (
-        get_groq_rates(model) if provider == "groq" else (0.0, 0.0, [])
-    )
-    if provider != "groq":
-        warnings = [f"No pricing configured for provider '{provider}'. Cost shown as $0."]
+    if normalized_provider == "local":
+        input_rate, output_rate, warnings = (0.0, 0.0, [])
+    elif normalized_provider == "openrouter":
+        input_rate, output_rate, warnings = get_openrouter_rates(resolved_model)
+    else:
+        input_rate, output_rate, warnings = (0.0, 0.0, [])
+        warnings = [
+            f"No pricing configured for provider '{normalized_provider}'. Cost shown as $0."
+        ]
 
     rate = input_rate if direction == "input" else output_rate
     estimated_cost = round((tokens / 1_000_000) * rate, 10)
     chars_per_token = round((len(value) / tokens), 2) if tokens else 0.0
 
     return PromptCostEstimate(
-        provider=provider,
-        model=model or DEFAULT_GROQ_MODEL,
+        provider=normalized_provider,
+        model=resolved_model,
         source_language=detect_language(value),
         tokenizer_method=TOKENIZER_METHOD,
         tokens=tokens,

--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -36,12 +36,9 @@ router = APIRouter(prefix="/benchmark", tags=["benchmark"])
 
 MAX_BENCHMARK_TEXT_LENGTH = 4000
 SUPPORTED_BENCHMARK_MODELS = {
-    "llama-3.1-8b-instant",
     "openai/gpt-oss-20b",
     "openai/gpt-oss-120b",
-    "llama-3.3-70b-versatile",
-    "mistral-saba-24b",
-    "meta-llama/llama-4-scout-17b-16e-instruct",
+    "mistralai/mistral-small-3.2-24b-instruct",
     "qwen/qwen3-32b",
 }
 
@@ -61,8 +58,8 @@ class BenchmarkRequest(BaseModel):
         description="Raw user input prompt",
     )
     model: str = Field(
-        default="llama-3.1-8b-instant",
-        description="LLM model identifier (e.g. 'llama-3.1-8b-instant')",
+        default="openai/gpt-oss-20b",
+        description="LLM model identifier (e.g. 'openai/gpt-oss-20b')",
     )
 
     @field_validator("text")

--- a/app/routers/jules.py
+++ b/app/routers/jules.py
@@ -88,7 +88,7 @@ def generate_jules_reply(
     if instruction_text:
         fallback = f"{instruction_text}\n\n{fallback}".strip()
 
-    if not (os.getenv("OPENAI_API_KEY") or os.getenv("GROQ_API_KEY")):
+    if not os.getenv("OPENROUTER_API_KEY"):
         return fallback[:2000]
 
     worker = WorkerClient()

--- a/tests/optimizer/test_language_costs.py
+++ b/tests/optimizer/test_language_costs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.optimizer.language_costs import (
-    DEFAULT_GROQ_MODEL,
+    DEFAULT_OPENROUTER_MODEL,
     detect_language,
     estimate_prompt_cost,
 )
@@ -14,8 +14,8 @@ def test_turkish_prompt_can_cost_more_tokens_than_english_equivalent():
     english_estimate = estimate_prompt_cost(english)
     turkish_estimate = estimate_prompt_cost(turkish)
 
-    assert english_estimate.provider == "groq"
-    assert english_estimate.model == DEFAULT_GROQ_MODEL
+    assert english_estimate.provider == "openrouter"
+    assert english_estimate.model == DEFAULT_OPENROUTER_MODEL
     assert english_estimate.source_language == "en"
     assert turkish_estimate.source_language == "tr"
     assert turkish_estimate.tokens > english_estimate.tokens
@@ -23,12 +23,12 @@ def test_turkish_prompt_can_cost_more_tokens_than_english_equivalent():
     assert turkish_estimate.tokenizer_method.endswith(":estimated")
 
 
-def test_default_groq_llama_31_8b_pricing_is_applied():
+def test_default_openrouter_gpt_oss_20b_pricing_is_applied():
     estimate = estimate_prompt_cost("hello world", token_count_override=1_000_000)
 
-    assert estimate.input_rate_per_million == pytest.approx(0.05)
-    assert estimate.output_rate_per_million == pytest.approx(0.08)
-    assert estimate.estimated_cost_usd == pytest.approx(0.05)
+    assert estimate.input_rate_per_million == pytest.approx(0.075)
+    assert estimate.output_rate_per_million == pytest.approx(0.30)
+    assert estimate.estimated_cost_usd == pytest.approx(0.075)
 
 
 def test_unknown_model_returns_zero_cost_with_warning():
@@ -37,6 +37,15 @@ def test_unknown_model_returns_zero_cost_with_warning():
     assert estimate.tokens > 0
     assert estimate.estimated_cost_usd == 0.0
     assert any("unknown-model" in warning for warning in estimate.warnings)
+
+
+def test_local_provider_always_returns_zero_cost():
+    estimate = estimate_prompt_cost("hello world", provider="local", model="offline")
+
+    assert estimate.provider == "local"
+    assert estimate.input_rate_per_million == 0.0
+    assert estimate.output_rate_per_million == 0.0
+    assert estimate.estimated_cost_usd == 0.0
 
 
 def test_detect_language_returns_tr_for_turkish_with_diacritics():

--- a/tests/optimizer/test_optimize_live.py
+++ b/tests/optimizer/test_optimize_live.py
@@ -1,13 +1,13 @@
-"""Live integration tests for the /optimize endpoint against the real Groq API.
+"""Live integration tests for the /optimize endpoint against the real OpenRouter API.
 
 These tests are double-gated:
 - The `live` pytest marker is skipped by default unless `--run-live` or
   `PROMPTC_RUN_LIVE_TESTS=1` is set, so CI does not hit Groq accidentally.
-- The `GROQ_API_KEY` skipif keeps local runs from emitting confusing auth errors.
+- The `OPENROUTER_API_KEY` skipif keeps local runs from emitting confusing auth errors.
 
 Run them explicitly with:
 
-    GROQ_API_KEY=... python -m pytest tests/optimizer/test_optimize_live.py --run-live -m live -v
+    OPENROUTER_API_KEY=... python -m pytest tests/optimizer/test_optimize_live.py --run-live -m live -v
 
 Assertions verify *invariants* (language preserved, no wrapper text, costs > 0)
 rather than exact strings, since real LLM output is non-deterministic.
@@ -26,8 +26,8 @@ from app.optimizer.language_costs import detect_language
 pytestmark = [
     pytest.mark.live,
     pytest.mark.skipif(
-        not os.environ.get("GROQ_API_KEY") and not os.environ.get("OPENAI_API_KEY"),
-        reason="GROQ_API_KEY/OPENAI_API_KEY not set; skipping live Groq tests",
+        not os.environ.get("OPENROUTER_API_KEY"),
+        reason="OPENROUTER_API_KEY not set; skipping live OpenRouter tests",
     ),
 ]
 
@@ -109,12 +109,12 @@ def test_live_optimizer_strips_wrapper_labels_if_emitted(client: TestClient) -> 
 
 
 def test_live_costs_and_metadata_are_populated(client: TestClient) -> None:
-    """Sanity-check the response shape against the real Groq pricing path."""
+    """Sanity-check the response shape against the real OpenRouter pricing path."""
 
     text = "Write a haiku about debugging at 3am."
     data = _post_optimize(client, text)
 
-    assert data["provider"] == "groq"
+    assert data["provider"] == "openrouter"
     assert data["model"], "Model identifier should be present"
     assert data["before_tokens"] > 0
     assert data["after_tokens"] > 0

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -224,7 +224,7 @@ def test_benchmark_requires_api_key():
         mock_llm.side_effect = ["raw output", "compiled output"]
         response = client.post(
             "/benchmark/run",
-            json={"text": "Explain Python", "model": "llama-3.1-8b-instant"},
+            json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
         )
 
     assert response.status_code == 403

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -411,7 +411,7 @@ def test_validate_no_key():
 def test_validate_no_key_falls_back_when_worker_analysis_is_unavailable():
     with patch("api.main.get_compiler") as mock_get_compiler:
         mock_get_compiler.return_value.worker.analyze_prompt.side_effect = RuntimeError(
-            "API Key is missing. Please set OPENAI_API_KEY."
+            "API Key is missing. Please set OPENROUTER_API_KEY."
         )
 
         resp = client.post("/validate", json={"text": "hello"})

--- a/tests/test_benchmark_api.py
+++ b/tests/test_benchmark_api.py
@@ -78,7 +78,7 @@ def test_benchmark_run_endpoint(client):
 
         response = client.post(
             "/benchmark/run",
-            json={"text": "Explain Python", "model": "llama-3.1-8b-instant"},
+            json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
         )
 
     assert response.status_code == 200
@@ -134,7 +134,7 @@ def test_benchmark_run_short_prompt_with_valid_model(client):
 
         response = client.post(
             "/benchmark/run",
-            json={"text": "hello", "model": "llama-3.1-8b-instant"},
+            json={"text": "hello", "model": "openai/gpt-oss-20b"},
         )
 
     assert response.status_code == 200
@@ -163,7 +163,7 @@ def test_benchmark_request_rejects_blank_text(client):
     """Blank prompts should be rejected before any LLM work starts."""
     response = client.post(
         "/benchmark/run",
-        json={"text": "", "model": "llama-3.1-8b-instant"},
+        json={"text": "", "model": "openai/gpt-oss-20b"},
     )
 
     assert response.status_code == 422
@@ -177,7 +177,7 @@ def test_benchmark_provider_failure_returns_safe_error(client):
     ), patch("app.routers.benchmark._judge_with_llm", return_value=None):
         response = client.post(
             "/benchmark/run",
-            json={"text": "Explain Python", "model": "llama-3.1-8b-instant"},
+            json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
         )
 
     assert response.status_code == 502

--- a/tests/test_llm_client_openrouter.py
+++ b/tests/test_llm_client_openrouter.py
@@ -24,7 +24,7 @@ def test_worker_client_prefers_openrouter_env_defaults():
     mock_openai.assert_called_once()
     _, kwargs = mock_openai.call_args
     assert kwargs["default_headers"]["HTTP-Referer"] == "https://prcompiler.com"
-    assert kwargs["default_headers"]["X-OpenRouter-Title"] == "Prompt Compiler"
+    assert kwargs["default_headers"]["X-Title"] == "Prompt Compiler"
 
 
 def test_call_api_requires_parameter_support_for_openrouter_json_mode():

--- a/tests/test_llm_client_openrouter.py
+++ b/tests/test_llm_client_openrouter.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.llm_engine.client import WorkerClient
+
+
+def test_worker_client_prefers_openrouter_env_defaults():
+    with patch.dict(
+        "os.environ",
+        {
+            "OPENROUTER_API_KEY": "or-key",
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_MODEL": "openai/gpt-oss-20b",
+            "OPENROUTER_HTTP_REFERER": "https://prcompiler.com",
+            "OPENROUTER_TITLE": "Prompt Compiler",
+        },
+        clear=False,
+    ), patch("app.llm_engine.client.OpenAI") as mock_openai:
+        client = WorkerClient()
+
+    assert client.api_key == "or-key"
+    assert client.base_url == "https://openrouter.ai/api/v1"
+    assert client.model == "openai/gpt-oss-20b"
+    mock_openai.assert_called_once()
+    _, kwargs = mock_openai.call_args
+    assert kwargs["default_headers"]["HTTP-Referer"] == "https://prcompiler.com"
+    assert kwargs["default_headers"]["X-OpenRouter-Title"] == "Prompt Compiler"
+
+
+def test_call_api_requires_parameter_support_for_openrouter_json_mode():
+    with patch("app.llm_engine.client.OpenAI") as mock_openai:
+        completion = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='{"ok":true}'))],
+            usage=None,
+        )
+        create_mock = MagicMock(return_value=completion)
+        mock_openai.return_value = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+        )
+        client = WorkerClient(
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="openai/gpt-oss-20b",
+        )
+
+        response = client._call_api([{"role": "user", "content": "hello"}], json_mode=True)
+
+    assert response == '{"ok":true}'
+    _, kwargs = create_mock.call_args
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["extra_body"]["provider"]["require_parameters"] is True

--- a/tests/test_optimize_api.py
+++ b/tests/test_optimize_api.py
@@ -24,8 +24,8 @@ def test_api_optimize_basic_reduces_whitespace(mock_optimize):
     # Tokens should ideally be less or equal
     assert data["after_tokens"] <= data["before_tokens"]
     assert data["changed"] is True
-    assert data["provider"] == "groq"
-    assert data["model"] == "llama-3.1-8b-instant"
+    assert data["provider"] == "openrouter"
+    assert data["model"] == "openai/gpt-oss-20b"
     assert data["source_language"] == "en"
     assert data["tokenizer_method"].endswith(":estimated")
     assert data["estimated_input_cost_usd"] > data["estimated_output_cost_usd"]

--- a/web/README.md
+++ b/web/README.md
@@ -34,7 +34,7 @@ npm run test:contracts
 
 - Browser calls stay same-origin and hit the Next proxy layer first. Server-side proxy handlers forward to `NEXT_PUBLIC_API_URL` (or `http://127.0.0.1:8080` locally).
 - Public web flows should never ask visitors for a Prompt Compiler API key or rely on proxy-only secret setup in the browser.
-- If a cloud feature needs credentials, that configuration belongs on the backend via provider keys such as `OPENAI_API_KEY` or `GROQ_API_KEY`.
+- If a cloud feature needs credentials, that configuration belongs on the backend via provider keys such as `OPENROUTER_API_KEY`.
 - `/rag/search` returns canonical items shaped like `{ path, snippet, score }`.
 - `/rag/upload` returns canonical ingest metadata and may also include compatibility fields.
 - Public app routes should not return `403` just because a Prompt Compiler-specific API key is missing.

--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -31,7 +31,7 @@ describe("Optimizer page", () => {
     });
   });
 
-  it("shows Groq cost estimates and a separate English suggestion", async () => {
+  it("shows OpenRouter cost estimates and a separate English suggestion", async () => {
     apiJsonMock.mockResolvedValueOnce({
       text: "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
       before_chars: 96,
@@ -44,8 +44,8 @@ describe("Optimizer page", () => {
       met_max_tokens: true,
       met_budget: true,
       changed: true,
-      provider: "groq",
-      model: "llama-3.1-8b-instant",
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
       source_language: "tr",
       tokenizer_method: "tiktoken:o200k_base:estimated",
       estimated_input_cost_usd: 0.0000017,
@@ -67,7 +67,7 @@ describe("Optimizer page", () => {
 
     expect(await screen.findByText("Original estimate")).toBeTruthy();
     expect(screen.getByText("Optimized estimate")).toBeTruthy();
-    expect(screen.getByText("Groq / llama-3.1-8b-instant")).toBeTruthy();
+    expect(screen.getByText("OpenRouter / openai/gpt-oss-20b")).toBeTruthy();
     expect(screen.getByText("TR")).toBeTruthy();
     expect(screen.getByText("38.2%")).toBeTruthy();
     expect(screen.getByDisplayValue("Summarize PDF. Write implementation plan for junior developer.")).toBeTruthy();
@@ -95,8 +95,8 @@ describe("Optimizer page", () => {
       met_max_tokens: true,
       met_budget: true,
       changed: true,
-      provider: "groq",
-      model: "llama-3.1-8b-instant",
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
       source_language: "en",
       tokenizer_method: "tiktoken:o200k_base:estimated",
       estimated_input_cost_usd: 0.0000004,
@@ -151,8 +151,8 @@ describe("Optimizer page", () => {
       after_tokens: 7,
       saved_percent: 61.1,
       changed: true,
-      provider: "groq",
-      model: "llama-3.1-8b-instant",
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
       source_language: "tr",
       tokenizer_method: "tiktoken:o200k_base:estimated",
       estimated_input_cost_usd: 0.0000018,
@@ -184,8 +184,8 @@ describe("Optimizer page", () => {
       after_tokens: 4,
       saved_percent: 50,
       changed: true,
-      provider: "groq",
-      model: "llama-3.1-8b-instant",
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
       source_language: "en",
       tokenizer_method: "tiktoken:o200k_base:estimated",
       estimated_input_cost_usd: 0.0000004,
@@ -221,8 +221,8 @@ describe("Optimizer page", () => {
       after_tokens: 1,
       saved_percent: 50,
       changed: true,
-      provider: "groq",
-      model: "llama-3.1-8b-instant",
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
       source_language: "en",
       tokenizer_method: "tiktoken:o200k_base:estimated",
       estimated_input_cost_usd: 0.00000017,

--- a/web/app/benchmark/modelCatalog.test.mts
+++ b/web/app/benchmark/modelCatalog.test.mts
@@ -27,15 +27,3 @@ test("benchmark groups keep cheap and balanced models visible", () => {
   assert.equal(labels.includes("Cheap"), true);
   assert.equal(labels.includes("Balanced"), true);
 });
-
-test("getBenchmarkModelById returns the correct model for a valid ID", () => {
-  const model = getBenchmarkModelById("llama-3.1-8b-instant");
-  assert.notEqual(model, undefined);
-  assert.equal(model?.id, "llama-3.1-8b-instant");
-  assert.equal(model?.label, "Llama 3.1 8B Instant");
-});
-
-test("getBenchmarkModelById returns undefined for an invalid ID", () => {
-  const model = getBenchmarkModelById("non-existent-model");
-  assert.equal(model, undefined);
-});

--- a/web/app/benchmark/modelCatalog.test.mts
+++ b/web/app/benchmark/modelCatalog.test.mts
@@ -7,16 +7,17 @@ import {
   getBenchmarkModelById,
 } from "./modelCatalog.ts";
 
-test("benchmark catalog removes deprecated Maverick and includes production + preview targets", () => {
+test("benchmark catalog is OpenRouter-only and keeps GPT-OSS 20B as the default cheap option", () => {
   const ids = BENCHMARK_MODELS.map((model) => model.id);
 
-  assert.equal(ids.includes("meta-llama/llama-4-maverick-17b-128e-instruct"), false);
-  assert.equal(ids.includes("qwen/qwen3-32b"), true);
-  assert.equal(ids.includes("meta-llama/llama-4-scout-17b-16e-instruct"), true);
+  assert.equal(ids.includes("openai/gpt-oss-20b"), true);
+  assert.equal(ids.includes("openai/gpt-oss-120b"), true);
+  assert.equal(ids.includes("mistralai/mistral-small-3.2-24b-instruct"), true);
+  assert.equal(ids.includes("llama-3.1-8b-instant"), false);
+  assert.equal(ids[0], "openai/gpt-oss-20b");
 });
 
-test("benchmark catalog exposes preview badges for scout and qwen", () => {
-  assert.equal(getBenchmarkModelById("meta-llama/llama-4-scout-17b-16e-instruct")?.availability, "preview");
+test("benchmark catalog keeps preview coverage for qwen", () => {
   assert.equal(getBenchmarkModelById("qwen/qwen3-32b")?.availability, "preview");
 });
 

--- a/web/app/benchmark/modelCatalog.ts
+++ b/web/app/benchmark/modelCatalog.ts
@@ -12,14 +12,6 @@ export type BenchmarkModelDefinition = {
 
 export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
   {
-    id: "llama-3.1-8b-instant",
-    label: "Llama 3.1 8B Instant",
-    badge: "cheap",
-    availability: "production",
-    helperText: "Cheapest model. Use this for a quick sanity check — runs in a second or two.",
-    group: "Cheap",
-  },
-  {
     id: "openai/gpt-oss-20b",
     label: "GPT-OSS 20B",
     badge: "cheap",
@@ -28,36 +20,20 @@ export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
     group: "Cheap",
   },
   {
-    id: "mistral-saba-24b",
-    label: "Mistral Saba 24B",
+    id: "mistralai/mistral-small-3.2-24b-instruct",
+    label: "Mistral Small 3.2 24B",
     badge: "cheap",
     availability: "production",
-    helperText: "Affordable and works well in multiple languages — handy if your prompt isn't in English.",
+    helperText: "Affordable and strong at instruction-following plus structured output.",
     group: "Cheap",
-  },
-  {
-    id: "llama-3.3-70b-versatile",
-    label: "Llama 3.3 70B Versatile",
-    badge: "balanced",
-    availability: "production",
-    helperText: "Smarter model. Slower and pricier, but answers are more thoughtful.",
-    group: "Balanced",
   },
   {
     id: "openai/gpt-oss-120b",
     label: "GPT-OSS 120B",
     badge: "balanced",
     availability: "production",
-    helperText: "Bigger and stronger. Use this when you want the most polished comparison.",
+    helperText: "Higher-quality option when you can trade speed for depth.",
     group: "Balanced",
-  },
-  {
-    id: "meta-llama/llama-4-scout-17b-16e-instruct",
-    label: "Llama 4 Scout 17B 16E",
-    badge: "preview",
-    availability: "preview",
-    helperText: "Newer model. Still being evaluated — try it if you want to compare cutting-edge results.",
-    group: "Preview",
   },
   {
     id: "qwen/qwen3-32b",

--- a/web/app/benchmark/page.test.tsx
+++ b/web/app/benchmark/page.test.tsx
@@ -43,10 +43,14 @@ describe("Benchmark page", () => {
     apiJsonMock.mockReset();
   });
 
-  it("shows a mock-only helper message and demo banner for the default engine", async () => {
+  it("lets the user switch into mock mode and shows the demo banner", async () => {
     vi.useFakeTimers();
 
     render(<BenchmarkPage />);
+
+    fireEvent.change(screen.getByLabelText("Model"), {
+      target: { value: "mock" },
+    });
 
     expect(
       screen.getByText(
@@ -68,7 +72,7 @@ describe("Benchmark page", () => {
     expect(screen.getByText("Demo result (Mock Engine — fake scores)")).toBeTruthy();
   });
 
-  it("submits the selected real model and prompt to the benchmark route", async () => {
+  it("submits the default OpenRouter model and prompt to the benchmark route", async () => {
     apiJsonMock.mockResolvedValueOnce({
       raw_output: "Raw answer",
       compiled_output: "Compiled answer",
@@ -86,9 +90,6 @@ describe("Benchmark page", () => {
 
     fireEvent.change(screen.getByLabelText("Benchmark prompt input"), {
       target: { value: "  Write a safer onboarding checklist.  " },
-    });
-    fireEvent.change(screen.getByLabelText("Model"), {
-      target: { value: "openai/gpt-oss-20b" },
     });
     fireEvent.click(screen.getAllByRole("button", { name: /Run Benchmark/i })[0]);
 
@@ -114,7 +115,7 @@ describe("Benchmark page", () => {
       target: { value: "Explain rate limiting." },
     });
     fireEvent.change(screen.getByLabelText("Model"), {
-      target: { value: "llama-3.1-8b-instant" },
+      target: { value: "openai/gpt-oss-120b" },
     });
     fireEvent.click(screen.getAllByRole("button", { name: /Run Benchmark/i })[0]);
 

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -63,7 +63,7 @@ export default function BenchmarkPage() {
   const [loading, setLoading] = useState(false);
   const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkPayload | null>(null);
   const [resultIsMock, setResultIsMock] = useState(false);
-  const [selectedModel, setSelectedModel] = useState("mock");
+  const [selectedModel, setSelectedModel] = useState("openai/gpt-oss-20b");
   const [status, setStatus] = useState("Ready");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -406,7 +406,7 @@ export default function BenchmarkPage() {
                   <p className="mb-4 text-sm text-zinc-400">
                     {errorMessage
                       ? errorMessage
-                      : "Paste a prompt on the left, pick a real model (the default Mock Engine returns demo numbers), then run a benchmark."}
+                      : "Paste a prompt on the left, tweak the OpenRouter model if needed, then run a benchmark."}
                   </p>
                   {!errorMessage && (
                     <div className="flex flex-col items-center gap-3 mt-6 w-full">

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -29,8 +29,8 @@ type OptimizeResponse = {
     warnings: string[];
 };
 
-const DEFAULT_OPTIMIZER_PROVIDER = "groq";
-const DEFAULT_OPTIMIZER_MODEL = "llama-3.1-8b-instant";
+const DEFAULT_OPTIMIZER_PROVIDER = "openrouter";
+const DEFAULT_OPTIMIZER_MODEL = "openai/gpt-oss-20b";
 const DEFAULT_TOKENIZER_METHOD = "tiktoken:o200k_base:estimated";
 
 function toFiniteNumber(value: unknown, fallback = 0): number {
@@ -100,6 +100,17 @@ function charsPerToken(chars: number, tokens: number): string {
         return "0.00";
     }
     return (chars / tokens).toFixed(2);
+}
+
+function formatProviderName(provider: string): string {
+    const normalized = (provider ?? "").toLowerCase();
+    if (normalized === "openrouter") {
+        return "OpenRouter";
+    }
+    if (normalized === "local") {
+        return "Local";
+    }
+    return provider || "Unknown";
 }
 
 function getErrorMessage(error: unknown): string {
@@ -181,8 +192,8 @@ export default function OptimizerPage() {
     const [result, setResult] = useState<OptimizeResponse | null>(null);
     const [loading, setLoading] = useState(false);
     const [maxTokens, setMaxTokens] = useState<number>(1000);
-    const [provider, setProvider] = useState("groq");
-    const [model, setModel] = useState("llama-3.1-8b-instant");
+    const [provider, setProvider] = useState(DEFAULT_OPTIMIZER_PROVIDER);
+    const [model, setModel] = useState(DEFAULT_OPTIMIZER_MODEL);
     const [optimizationError, setOptimizationError] = useState<string | null>(null);
 
     const output = result?.text ?? "";
@@ -294,7 +305,7 @@ export default function OptimizerPage() {
                     </div>
                     <InfoButton
                         title="Prompt Optimizer"
-                        description="Shortens prompts while keeping intent, constraints, variables, and safety details visible. Estimates Groq cost and compares language efficiency."
+                        description="Shortens prompts while keeping intent, constraints, variables, and safety details visible. Estimates OpenRouter cost and compares language efficiency."
                     />
                 </div>
 
@@ -314,7 +325,8 @@ export default function OptimizerPage() {
                             }}
                             className="rounded-lg border border-white/10 bg-zinc-900 px-3 py-1.5 text-xs text-white outline-none focus:border-emerald-500/50 focus:ring-1 focus:ring-emerald-500/50"
                         >
-                            <option value="groq:llama-3.1-8b-instant">Groq Llama 3 (Cloud)</option>
+                            <option value="openrouter:openai/gpt-oss-20b">OpenRouter GPT-OSS 20B (Cloud)</option>
+                            <option value="openrouter:openai/gpt-oss-120b">OpenRouter GPT-OSS 120B (Quality)</option>
                             <option value="local:offline">Local Heuristics (Offline)</option>
                         </select>
                     </div>
@@ -525,7 +537,7 @@ export default function OptimizerPage() {
                                 <div>
                                     <h2 className="text-sm font-semibold text-white">English compact suggestion</h2>
                                     <p className="mt-1 text-xs text-zinc-500">
-                                        Groq / {result.model}
+                                        {formatProviderName(result.provider)} / {result.model}
                                     </p>
                                 </div>
                                 <span className="rounded-lg border border-white/10 px-2 py-1 font-mono text-xs text-zinc-400">


### PR DESCRIPTION
## Summary
- make OpenRouter the only supported cloud provider across runtime defaults, docs, and UI
- remove Groq/OpenAI fallback expectations from optimizer and benchmark flows
- add regression tests so future agents do not silently reintroduce old providers

## Verification
- uv run --extra dev pytest tests/test_optimize_api.py tests/optimizer/test_language_costs.py tests/test_benchmark_api.py tests/test_llm_client_openrouter.py tests/test_api_hardening.py tests/test_auth_fast_path.py -q
- npm run test -- --run app/__tests__/optimizer-page.test.tsx app/benchmark/page.test.tsx
- node --test app/benchmark/modelCatalog.test.mts
- npm run build
