### PR TITLE
🎨 Palette: Add aria-busy to loading buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-30 - Empty States Call-to-Action
 **Learning:** Including an 'or try an example' call-to-action button that populates the input field solves the 'blank canvas' UX problem by explicitly demonstrating the expected input format to users.
 **Action:** When designing empty states for text areas and generative tools, include an 'or try an example' call-to-action button that populates the input field.
+## 2024-05-31 - Add aria-busy to loading buttons
+**Learning:** Found that while buttons were being visually and functionally disabled via `disabled={loading}`, screen readers were not being explicitly informed of the loading state. This is an accessibility issue for async actions across multiple pages.
+**Action:** Use `aria-busy={loading}` along with `disabled` states for asynchronous actions like fetching, processing, or generating. Do not use `aria-disabled` if the native `disabled` attribute is already correctly managing focus and click prevention, as it's a known ARIA anti-pattern.

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -193,6 +193,7 @@ export default function AgentGenerator() {
                     type="button"
                     onClick={handleAnalyzeRepo}
                     disabled={!isValidRepoUrl || repoAnalysisLoading}
+                    aria-busy={repoAnalysisLoading}
                     className="w-full rounded-xl border border-green-500/20 bg-green-500/10 px-4 py-2.5 text-sm font-semibold text-green-100 transition-all hover:bg-green-500/15 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {repoAnalysisLoading ? "Analyzing Repo..." : "Analyze Repo"}
@@ -304,6 +305,7 @@ export default function AgentGenerator() {
               type="button"
               onClick={handleGenerate}
               disabled={loading || !description.trim()}
+              aria-busy={loading}
               title={!description.trim() ? "Enter a description first to generate" : "Generate Agent"}
               className={`w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20 focus-visible:ring-purple-500' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20 focus-visible:ring-green-500'}`}
             >
@@ -383,6 +385,7 @@ export default function AgentGenerator() {
                       type="button"
                       onClick={handleGenerate}
                       disabled={loading || !description.trim()}
+                      aria-busy={loading}
                       title={!description.trim() ? "Enter a description first to generate" : "Generate Agent"}
                       className={`mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a] ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20 focus-visible:ring-purple-500' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20 focus-visible:ring-green-500'}`}
                     >

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -349,6 +349,7 @@ export default function AgentPacksPage() {
               type="button"
               onClick={handleGenerate}
               disabled={loading || !request.goal.trim()}
+              aria-busy={loading}
               className={`mt-1 flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3 text-sm font-bold text-white shadow-lg transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${provider.buttonClass}`}
             >
               {loading ? "Generating..." : provider.ctaLabel}

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -287,6 +287,7 @@ export default function BenchmarkPage() {
               type="button"
               onClick={handleBenchmark}
               disabled={loading || !prompt.trim()}
+              aria-busy={loading}
               title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
               className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
             >
@@ -414,6 +415,7 @@ export default function BenchmarkPage() {
                         type="button"
                         onClick={handleBenchmark}
                         disabled={loading || !prompt.trim()}
+                        aria-busy={loading}
                         title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
                         className="mx-auto flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 px-6 py-2.5 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 disabled:cursor-not-allowed disabled:opacity-50"
                       >

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -151,6 +151,7 @@ export default function OfflinePage() {
                                     type="button"
                                     onClick={() => handleGenerate()}
                                     disabled={loading || !prompt.trim()}
+                                    aria-busy={loading}
                                     title={!prompt.trim() ? "Enter a prompt first to generate" : "Generate Prompt"}
                                     className="px-4 py-3 text-sm font-bold bg-zinc-800 hover:bg-zinc-700 text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group border border-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500/50"
                                 >
@@ -252,6 +253,7 @@ export default function OfflinePage() {
                                         type="button"
                                         onClick={() => handleGenerate()}
                                         disabled={loading || !prompt.trim()}
+                                        aria-busy={loading}
                                         title={!prompt.trim() ? "Enter a prompt first to generate" : "Run Heuristics"}
                                         className="mt-6 mx-auto px-6 py-2.5 text-sm font-bold bg-zinc-800 hover:bg-zinc-700 text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group border border-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500/50"
                                     >

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -340,6 +340,7 @@ export default function OptimizerPage() {
                         type="button"
                         onClick={handleOptimize}
                         disabled={loading || !input.trim()}
+                        aria-busy={loading}
                         title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
                         className="w-full rounded-lg bg-emerald-600 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-emerald-950/30 transition-colors hover:bg-emerald-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 sm:w-auto"
                     >
@@ -455,6 +456,7 @@ export default function OptimizerPage() {
                                     type="button"
                                     onClick={handleOptimize}
                                     disabled={loading || !input.trim()}
+                                    aria-busy={loading}
                                     title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
                                     className="rounded-lg bg-emerald-600/20 border border-emerald-500/30 px-5 py-2 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-600/30 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
                                 >

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -191,6 +191,7 @@ export default function SkillsGenerator() {
                     type="button"
                     onClick={handleAnalyzeRepo}
                     disabled={!isValidRepoUrl || repoAnalysisLoading}
+                    aria-busy={repoAnalysisLoading}
                     className="w-full rounded-xl border border-yellow-500/20 bg-yellow-500/10 px-4 py-2.5 text-sm font-semibold text-yellow-100 transition-all hover:bg-yellow-500/15 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {repoAnalysisLoading ? "Analyzing Repo..." : "Analyze Repo"}
@@ -284,6 +285,7 @@ export default function SkillsGenerator() {
               type="button"
               onClick={handleGenerate}
               disabled={loading || !description.trim()}
+              aria-busy={loading}
               title={!description.trim() ? "Enter a description first to generate" : "Generate Skill"}
               className="w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
@@ -363,6 +365,7 @@ export default function SkillsGenerator() {
                       type="button"
                       onClick={handleGenerate}
                       disabled={loading || !description.trim()}
+                      aria-busy={loading}
                       title={!description.trim() ? "Enter a description first to generate" : "Generate Skill"}
                       className="mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a]"
                     >


### PR DESCRIPTION
💡 What: Added `aria-busy={loading}` (or respective specific loading variables) to action buttons across the `agent-generator`, `agent-packs`, `benchmark`, `offline`, `optimizer`, and `skills-generator` pages.

🎯 Why: While these buttons were visually and functionally disabled during async processes, assistive technologies were not explicitly informed of the active background processing state.

📸 Before/After: Visuals remain unchanged, but assistive devices will now announce "busy" when the button is engaged. (Screenshot verified locally using frontend verification instructions).

♿ Accessibility: Greatly improves screen reader experience by conveying loading states explicitly. Evaluated avoiding `aria-disabled` as native HTML `disabled` already provides correct focus and behavior control, making `aria-busy` the proper pairing.

---
*PR created automatically by Jules for task [10608078282221355774](https://jules.google.com/task/10608078282221355774) started by @madara88645*