### PR TITLE
fix(optimizer): add Gemini 2.5 Flash pricing to OpenRouter cost table

### DIFF
--- a/app/optimizer/language_costs.py
+++ b/app/optimizer/language_costs.py
@@ -20,6 +20,8 @@ TOKENIZER_METHOD = "tiktoken:o200k_base:estimated"
 OPENROUTER_RATES: dict[str, dict[str, float]] = {
     "openai/gpt-oss-20b": {"input": 0.075, "output": 0.30},
     "openai/gpt-oss-120b": {"input": 0.15, "output": 0.60},
+    "google/gemini-2.5-flash-lite": {"input": 0.10, "output": 0.40},
+    "google/gemini-2.5-flash": {"input": 0.30, "output": 2.50},
     "mistralai/mistral-small-3.2-24b-instruct": {"input": 0.075, "output": 0.20},
     "qwen/qwen3-32b": {"input": 0.08, "output": 0.28},
 }

--- a/tests/optimizer/test_language_costs.py
+++ b/tests/optimizer/test_language_costs.py
@@ -31,6 +31,19 @@ def test_default_openrouter_gpt_oss_20b_pricing_is_applied():
     assert estimate.estimated_cost_usd == pytest.approx(0.075)
 
 
+def test_gemini_flash_lite_pricing_is_applied():
+    estimate = estimate_prompt_cost(
+        "hello world",
+        model="google/gemini-2.5-flash-lite",
+        token_count_override=1_000_000,
+    )
+
+    assert estimate.input_rate_per_million == pytest.approx(0.10)
+    assert estimate.output_rate_per_million == pytest.approx(0.40)
+    assert estimate.estimated_cost_usd == pytest.approx(0.10)
+    assert not estimate.warnings
+
+
 def test_unknown_model_returns_zero_cost_with_warning():
     estimate = estimate_prompt_cost("hello world", model="unknown-model")
 


### PR DESCRIPTION
## What
Adds **Gemini 2.5 Flash** family pricing to `OPENROUTER_RATES` in `app/optimizer/language_costs.py`:

| Model | Input $/M | Output $/M |
|-------|-----------|------------|
| google/gemini-2.5-flash-lite | 0.10 | 0.40 |
| google/gemini-2.5-flash | 0.30 | 2.50 |

## Why
`gemini-2.5-flash-lite` is now the **production default model** (set via `OPENROUTER_MODEL` on Fly). Without these entries the optimizer shows a `Cost shown as $0` warning and $0 estimates. This makes cost estimates accurate again.

## Tests
- Added `test_gemini_flash_lite_pricing_is_applied` (0.10/0.40 resolves correctly, no warnings).
- Focused suite green: `tests/optimizer/test_language_costs.py` → 9 passed.

No behavior change to the LLM call path; pricing/display only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)