### PR TITLE
Fix: Make benchmark, agent generator, and skills generator public endpoints

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from api.auth import rate_limit_by_ip, APIKey, verify_api_key
+from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -181,7 +181,6 @@ async def analyze_github_repo_endpoint(
 @router.post("/skills-generator/generate", response_model=SkillGenResponse)
 async def generate_skill_endpoint(
     req: SkillGenRequest,
-    api_key: APIKey = Depends(verify_api_key),
     _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()
@@ -202,7 +201,6 @@ async def generate_skill_endpoint(
 @router.post("/agent-generator/generate", response_model=AgentGenResponse)
 async def generate_agent_endpoint(
     req: AgentGenRequest,
-    api_key: APIKey = Depends(verify_api_key),
     _: None = Depends(rate_limit_by_ip),
 ):
     compiler = _get_compiler()

--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -20,8 +20,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from api.auth import rate_limit_by_ip, verify_api_key
-from api.auth import APIKey
+from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -273,7 +272,6 @@ def _heuristic_judge(raw_output: str, compiled_output: str) -> dict:
 @router.post("/run", response_model=BenchmarkResponse)
 async def benchmark_run(
     req: BenchmarkRequest,
-    api_key: APIKey = Depends(verify_api_key),
     _: None = Depends(rate_limit_by_ip),
 ):
     """

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -214,7 +214,13 @@ def test_repo_context_endpoint_keeps_per_ip_buckets_isolated(monkeypatch):
 
 
 @pytest.mark.auth_required
-def test_benchmark_requires_api_key():
+def test_benchmark_is_public_endpoint():
+    """
+    /benchmark/run should be accessible without API key (public endpoint).
+    
+    This endpoint is rate-limited by IP but does not require authentication,
+    following the CLAUDE.md policy for public web flows.
+    """
     client = TestClient(app)
 
     with (
@@ -227,7 +233,11 @@ def test_benchmark_requires_api_key():
             json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
         )
 
-    assert response.status_code == 403
+    # Should succeed without API key (public endpoint)
+    assert response.status_code == 200
+    data = response.json()
+    assert "raw_output" in data
+    assert "compiled_output" in data
 
 
 @pytest.mark.auth_required
@@ -339,12 +349,26 @@ def test_worker_client_wraps_user_input_and_context_with_tags():
 
 
 @pytest.mark.auth_required
-def test_generator_endpoints_reject_without_api_key():
+def test_generator_endpoints_are_public():
+    """
+    /agent-generator/generate and /skills-generator/generate should be accessible
+    without API key (public endpoints).
+    
+    These endpoints are rate-limited by IP but do not require authentication,
+    following the CLAUDE.md policy for public web flows.
+    """
     client = TestClient(app)
 
-    with patch("api.main.hybrid_compiler") as _mock_compiler:  # noqa: F841
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = "# Mock Agent"
+        mock_compiler.generate_skill.return_value = "# Mock Skill"
+        
         agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"})
         skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"})
 
-    assert agent_resp.status_code == 403
-    assert skill_resp.status_code == 403
+    # Both should succeed without API key (public endpoints)
+    assert agent_resp.status_code == 200
+    assert agent_resp.json() == {"system_prompt": "# Mock Agent"}
+    
+    assert skill_resp.status_code == 200
+    assert skill_resp.json() == {"skill_definition": "# Mock Skill"}

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -217,7 +217,7 @@ def test_repo_context_endpoint_keeps_per_ip_buckets_isolated(monkeypatch):
 def test_benchmark_is_public_endpoint():
     """
     /benchmark/run should be accessible without API key (public endpoint).
-    
+
     This endpoint is rate-limited by IP but does not require authentication,
     following the CLAUDE.md policy for public web flows.
     """
@@ -353,7 +353,7 @@ def test_generator_endpoints_are_public():
     """
     /agent-generator/generate and /skills-generator/generate should be accessible
     without API key (public endpoints).
-    
+
     These endpoints are rate-limited by IP but do not require authentication,
     following the CLAUDE.md policy for public web flows.
     """
@@ -362,13 +362,13 @@ def test_generator_endpoints_are_public():
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = "# Mock Agent"
         mock_compiler.generate_skill.return_value = "# Mock Skill"
-        
+
         agent_resp = client.post("/agent-generator/generate", json={"description": "Test Agent"})
         skill_resp = client.post("/skills-generator/generate", json={"description": "Test Skill"})
 
     # Both should succeed without API key (public endpoints)
     assert agent_resp.status_code == 200
     assert agent_resp.json() == {"system_prompt": "# Mock Agent"}
-    
+
     assert skill_resp.status_code == 200
     assert skill_resp.json() == {"skill_definition": "# Mock Skill"}

--- a/tests/test_benchmark_api.py
+++ b/tests/test_benchmark_api.py
@@ -12,13 +12,9 @@ def client():
     """Create a test client with the benchmark router mounted."""
     from fastapi import FastAPI
     from app.routers.benchmark import router
-    from api.auth import verify_api_key
 
     test_app = FastAPI()
     test_app.include_router(router)
-
-    # Override auth to allow unauthenticated test calls
-    test_app.dependency_overrides[verify_api_key] = lambda: None
 
     return TestClient(test_app)
 

--- a/tests/test_public_endpoints_keyless.py
+++ b/tests/test_public_endpoints_keyless.py
@@ -1,0 +1,127 @@
+"""
+Tests to verify that public endpoints work without API keys but are still rate-limited.
+
+These tests verify the fix for the production issue where /benchmark/run,
+/skills-generator/generate, and /agent-generator/generate were requiring
+API keys, blocking public access.
+"""
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from api.main import app
+
+
+@pytest.fixture
+def client_without_auth_override():
+    """
+    Create a test client that does NOT override auth dependencies.
+    
+    This ensures we're testing the actual endpoint behavior without
+    the test suite's automatic auth bypass.
+    """
+    # Clear any existing overrides
+    app.dependency_overrides.clear()
+    client = TestClient(app)
+    yield client
+    # Clean up
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.auth_required
+def test_benchmark_endpoint_works_without_api_key(client_without_auth_override):
+    """
+    /benchmark/run should work without API key authentication.
+    """
+    with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
+        "app.routers.benchmark._judge_with_llm", return_value=None
+    ):
+        mock_llm.side_effect = ["raw output", "compiled output"]
+        
+        response = client_without_auth_override.post(
+            "/benchmark/run",
+            json={"text": "Test prompt", "model": "openai/gpt-oss-20b"},
+        )
+    
+    # Should succeed without credentials
+    assert response.status_code == 200
+    data = response.json()
+    assert "raw_output" in data
+    assert "compiled_output" in data
+    assert "winner" in data
+
+
+@pytest.mark.auth_required
+def test_skills_generator_works_without_api_key(client_without_auth_override):
+    """
+    /skills-generator/generate should work without API key authentication.
+    """
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = "# Mock Skill Definition"
+        
+        response = client_without_auth_override.post(
+            "/skills-generator/generate",
+            json={"description": "Test skill request"},
+        )
+    
+    # Should succeed without credentials
+    assert response.status_code == 200
+    data = response.json()
+    assert "skill_definition" in data
+    assert data["skill_definition"] == "# Mock Skill Definition"
+
+
+@pytest.mark.auth_required
+def test_agent_generator_works_without_api_key(client_without_auth_override):
+    """
+    /agent-generator/generate should work without API key authentication.
+    """
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = "# Mock Agent System Prompt"
+        
+        response = client_without_auth_override.post(
+            "/agent-generator/generate",
+            json={"description": "Test agent request"},
+        )
+    
+    # Should succeed without credentials
+    assert response.status_code == 200
+    data = response.json()
+    assert "system_prompt" in data
+    assert data["system_prompt"] == "# Mock Agent System Prompt"
+
+
+@pytest.mark.auth_required
+def test_public_endpoints_have_rate_limiting(client_without_auth_override):
+    """
+    Verify that public endpoints are still protected by IP rate limiting.
+    
+    This test ensures we didn't accidentally remove rate limiting when
+    removing API key requirements.
+    """
+    # Check that the endpoints have rate_limit_by_ip dependency
+    from app.routers.benchmark import benchmark_run
+    from api.routes.generators import generate_skill_endpoint, generate_agent_endpoint
+    
+    # These endpoints should have rate_limit_by_ip in their dependencies
+    # We can't easily test the actual rate limiting without making many requests,
+    # but we can verify the dependency is present by checking the function signature
+    import inspect
+    
+    # Check benchmark endpoint
+    benchmark_sig = inspect.signature(benchmark_run)
+    assert any(
+        param.name == "_" for param in benchmark_sig.parameters.values()
+    ), "benchmark_run should have rate limit dependency"
+    
+    # Check skills generator endpoint
+    skills_sig = inspect.signature(generate_skill_endpoint)
+    assert any(
+        param.name == "_" for param in skills_sig.parameters.values()
+    ), "generate_skill_endpoint should have rate limit dependency"
+    
+    # Check agent generator endpoint
+    agent_sig = inspect.signature(generate_agent_endpoint)
+    assert any(
+        param.name == "_" for param in agent_sig.parameters.values()
+    ), "generate_agent_endpoint should have rate limit dependency"

--- a/tests/test_public_endpoints_keyless.py
+++ b/tests/test_public_endpoints_keyless.py
@@ -16,7 +16,7 @@ from api.main import app
 def client_without_auth_override():
     """
     Create a test client that does NOT override auth dependencies.
-    
+
     This ensures we're testing the actual endpoint behavior without
     the test suite's automatic auth bypass.
     """
@@ -37,12 +37,12 @@ def test_benchmark_endpoint_works_without_api_key(client_without_auth_override):
         "app.routers.benchmark._judge_with_llm", return_value=None
     ):
         mock_llm.side_effect = ["raw output", "compiled output"]
-        
+
         response = client_without_auth_override.post(
             "/benchmark/run",
             json={"text": "Test prompt", "model": "openai/gpt-oss-20b"},
         )
-    
+
     # Should succeed without credentials
     assert response.status_code == 200
     data = response.json()
@@ -58,12 +58,12 @@ def test_skills_generator_works_without_api_key(client_without_auth_override):
     """
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_skill.return_value = "# Mock Skill Definition"
-        
+
         response = client_without_auth_override.post(
             "/skills-generator/generate",
             json={"description": "Test skill request"},
         )
-    
+
     # Should succeed without credentials
     assert response.status_code == 200
     data = response.json()
@@ -78,12 +78,12 @@ def test_agent_generator_works_without_api_key(client_without_auth_override):
     """
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = "# Mock Agent System Prompt"
-        
+
         response = client_without_auth_override.post(
             "/agent-generator/generate",
             json={"description": "Test agent request"},
         )
-    
+
     # Should succeed without credentials
     assert response.status_code == 200
     data = response.json()
@@ -95,31 +95,31 @@ def test_agent_generator_works_without_api_key(client_without_auth_override):
 def test_public_endpoints_have_rate_limiting(client_without_auth_override):
     """
     Verify that public endpoints are still protected by IP rate limiting.
-    
+
     This test ensures we didn't accidentally remove rate limiting when
     removing API key requirements.
     """
     # Check that the endpoints have rate_limit_by_ip dependency
     from app.routers.benchmark import benchmark_run
     from api.routes.generators import generate_skill_endpoint, generate_agent_endpoint
-    
+
     # These endpoints should have rate_limit_by_ip in their dependencies
     # We can't easily test the actual rate limiting without making many requests,
     # but we can verify the dependency is present by checking the function signature
     import inspect
-    
+
     # Check benchmark endpoint
     benchmark_sig = inspect.signature(benchmark_run)
     assert any(
         param.name == "_" for param in benchmark_sig.parameters.values()
     ), "benchmark_run should have rate limit dependency"
-    
+
     # Check skills generator endpoint
     skills_sig = inspect.signature(generate_skill_endpoint)
     assert any(
         param.name == "_" for param in skills_sig.parameters.values()
     ), "generate_skill_endpoint should have rate limit dependency"
-    
+
     # Check agent generator endpoint
     agent_sig = inspect.signature(generate_agent_endpoint)
     assert any(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed three broken features in production by removing the API key requirement from public endpoints. The Benchmark, Agent Generator, and Skills Generator features were completely non-functional for all visitors because they required authentication that the public web app doesn't provide.

## What Changed

**Code changes:**
- Removed `verify_api_key` dependency from three endpoints:
  - `/benchmark/run` (app/routers/benchmark.py)
  - `/skills-generator/generate` (api/routes/generators.py)
  - `/agent-generator/generate` (api/routes/generators.py)
- Kept `rate_limit_by_ip` protection on all three endpoints
- Removed unused `APIKey` and `verify_api_key` imports

**Test changes:**
- Added new test suite `test_public_endpoints_keyless.py` to explicitly verify endpoints work without API keys
- Updated `test_api_hardening.py` tests to reflect new public endpoint behavior
- Removed unnecessary auth override from `test_benchmark_api.py`
- All 143 API/auth/generator tests pass

## What This Does for the Product

These three features are now accessible to everyone visiting prcompiler.com, just like the Compile and Optimize features. Visitors can:
- **Benchmark prompts** to see how much the compiler improves quality
- **Generate agent system prompts** from descriptions
- **Generate skill definitions** for custom workflows

Before this fix, all three features returned "Could not validate credentials" errors for 100% of public users.

## Risk Assessment

**Low risk of breaking anything:**
- The changes only remove authentication requirements (making endpoints more permissive)
- Rate limiting by IP is still in place to prevent abuse
- All existing tests pass, plus new tests explicitly verify the public access works
- This aligns with the project policy in CLAUDE.md: "do not add end-user Prompt Compiler API key requirements for public web flows"

## Testing

Ran comprehensive test suite:
- ✅ All 26 endpoint-specific tests pass
- ✅ All 4 new public endpoint verification tests pass  
- ✅ All 143 API/auth/generator tests pass
- ✅ Verified rate limiting is still in place
- ✅ Verified endpoints work without any authentication

## Policy Alignment

This fix implements the CLAUDE.md public-product rule: "do not add end-user Prompt Compiler API key requirements, browser API-key prompts, or proxy-only secret setup steps for public web flows."

These endpoints now follow the same access pattern as `/compile` and `/optimize`, which are already public and rate-limited by IP only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99fcb149-84f0-4055-96e7-2311b6ccbb85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99fcb149-84f0-4055-96e7-2311b6ccbb85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

