### PR TITLE
Fix Agent Pack export formatting: strip indentation and markdown fences

### DIFF
--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -86,7 +86,8 @@ def to_claude_subagent(ir: AgentExportIR) -> dict[str, str]:
     tools = ", ".join(ir.allowed_tools or ["Read", "Edit", "Write"])
     description = ir.role or (ir.goals[0] if ir.goals else f"Specialized assistant for {ir.name}")
     clean_prompt = _strip_markdown_fences(ir.raw_system_prompt)
-    content = textwrap.dedent(f"""\
+    content = textwrap.dedent(
+        f"""\
 ---
 name: {slug}
 description: {description}
@@ -94,7 +95,8 @@ tools: {tools}
 ---
 
 {clean_prompt}
-""")
+"""
+    )
     return {"path": f".claude/agents/{slug}.md", "content": content}
 
 
@@ -124,7 +126,8 @@ def to_claude_project_pack(ir: AgentExportIR) -> list[dict[str, str]]:
 
 def to_claude_subagent_bundle(ir: AgentExportIR) -> list[dict[str, str]]:
     subagent = to_claude_subagent(ir)
-    readme = textwrap.dedent(f"""\
+    readme = textwrap.dedent(
+        f"""\
 # Claude Subagent Bundle
 
 Drop `{subagent["path"]}` into your repo, then ask Claude Code to use the `{_slugify(ir.name)}` subagent.
@@ -132,7 +135,8 @@ Drop `{subagent["path"]}` into your repo, then ask Claude Code to use the `{_slu
 Recommended usage:
 - Keep `CLAUDE.md` in the repo root for shared guidance.
 - Add `.claude/settings.json` if you want permission guardrails alongside this agent.
-""")
+"""
+    )
     return [
         subagent,
         {"path": "README.md", "content": readme},
@@ -159,7 +163,8 @@ def to_claude_mcp_tool_stub(ir: SkillExportIR) -> list[dict[str, str]]:
         + ("" if param.required else " | None = None")
         for param in ir.params
     )
-    content = textwrap.dedent(f"""\
+    content = textwrap.dedent(
+        f"""\
 from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("{tool_name}")
@@ -173,14 +178,17 @@ async def {tool_name}({param_signature}) -> str:
 
 if __name__ == "__main__":
     mcp.run()
-""")
-    readme = textwrap.dedent(f"""\
+"""
+    )
+    readme = textwrap.dedent(
+        f"""\
 # {tool_name} MCP Tool Stub
 
 Generated from Prompt Compiler for Claude Code / MCP workflows.
 
 Purpose: {ir.purpose}
-""")
+"""
+    )
     return [
         {"path": "server.py", "content": content},
         {"path": "README.md", "content": readme},
@@ -197,7 +205,8 @@ def _project_claude_md(ir: AgentExportIR) -> str:
         or "- Do not leak secrets."
     )
     mcp_servers = ", ".join(ir.mcp_servers) if ir.mcp_servers else "none yet"
-    return textwrap.dedent(f"""\
+    return textwrap.dedent(
+        f"""\
 # Prompt Compiler Claude Code Memory
 
 ## Project Summary
@@ -225,7 +234,8 @@ Prompt Compiler is a FastAPI + Next.js product that turns vague requests into st
 - Permission mode: `{ir.permission_mode}`
 - Suggested tools: {", ".join(ir.allowed_tools)}
 - Suggested MCP servers: {mcp_servers}
-""")
+"""
+    )
 
 
 def _project_settings_json(ir: AgentExportIR) -> str:
@@ -280,7 +290,8 @@ def _named_subagent(name: str) -> str:
         "mcp-integrator": "Read, Edit, Write, Grep, Glob, Bash",
         "frontend-polisher": "Read, Edit, Write, Grep, Glob, Bash",
     }
-    return textwrap.dedent(f"""\
+    return textwrap.dedent(
+        f"""\
 ---
 name: {name}
 description: {descriptions[name]}
@@ -288,11 +299,13 @@ tools: {tools[name]}
 ---
 
 {prompts[name]}
-""")
+"""
+    )
 
 
 def _github_action_workflow() -> str:
-    return textwrap.dedent("""\
+    return textwrap.dedent(
+        """\
 name: Claude Code
 
 on:
@@ -314,7 +327,8 @@ jobs:
             Follow CLAUDE.md, inspect the referenced issue or PR context,
             and respond or create changes only when the request is actionable.
           claude_args: "--max-turns 5"
-""")
+"""
+    )
 
 
 def _pr_reviewer_memory(ir: AgentExportIR) -> str:
@@ -322,7 +336,8 @@ def _pr_reviewer_memory(ir: AgentExportIR) -> str:
         "\n".join(f"- {goal}" for goal in ir.goals[:4])
         or "- Review code changes for risk, regressions, and safety gaps."
     )
-    return textwrap.dedent(f"""\
+    return textwrap.dedent(
+        f"""\
 # Claude PR Reviewer Memory
 
 ## Mission
@@ -339,11 +354,13 @@ Review pull requests with a focus on prompt safety, secret handling, permission 
 - Do not expose secrets or credentials.
 - Flag unsafe `.claude/settings.json` permissions.
 - Call out prompt leakage, weak validation, and missing regression coverage.
-""")
+"""
+    )
 
 
 def _pr_reviewer_readme() -> str:
-    return textwrap.dedent("""\
+    return textwrap.dedent(
+        """\
 # Claude PR Reviewer Pack
 
 This pack gives Claude Code a dedicated `pr-reviewer` subagent plus review-focused repo memory.
@@ -351,7 +368,8 @@ This pack gives Claude Code a dedicated `pr-reviewer` subagent plus review-focus
 Suggested prompts:
 - `Use the pr-reviewer subagent to review this pull request for prompt leakage and unsafe settings.`
 - `Review this diff for missing tests, secret exposure, and MCP misconfiguration.`
-""")
+"""
+    )
 
 
 def _ordered_tools(tools: list[str]) -> list[str]:

--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -18,6 +18,16 @@ def _escape_triple_quotes(text: str) -> str:
     return text.replace('"""', '\\"\\"\\"')
 
 
+def _strip_markdown_fences(text: str) -> str:
+    """Remove leading/trailing markdown code fences from text."""
+    text = text.strip()
+    # Strip leading fence (```lang or just ```)
+    text = re.sub(r"^```[a-zA-Z0-9]*\n", "", text)
+    # Strip trailing fence
+    text = re.sub(r"\n```\s*$", "", text)
+    return text.strip()
+
+
 def to_agent_sdk_python(ir: AgentExportIR) -> str:
     prompt = _escape_triple_quotes(ir.raw_system_prompt)
     allowed_tools = ", ".join(f'"{tool}"' for tool in _ordered_tools(ir.allowed_tools))
@@ -75,17 +85,16 @@ def to_claude_subagent(ir: AgentExportIR) -> dict[str, str]:
     slug = _slugify(ir.name)
     tools = ", ".join(ir.allowed_tools or ["Read", "Edit", "Write"])
     description = ir.role or (ir.goals[0] if ir.goals else f"Specialized assistant for {ir.name}")
-    content = textwrap.dedent(
-        f"""\
-        ---
-        name: {slug}
-        description: {description}
-        tools: {tools}
-        ---
+    clean_prompt = _strip_markdown_fences(ir.raw_system_prompt)
+    content = textwrap.dedent(f"""\
+---
+name: {slug}
+description: {description}
+tools: {tools}
+---
 
-        {ir.raw_system_prompt.strip()}
-        """
-    )
+{clean_prompt}
+""")
     return {"path": f".claude/agents/{slug}.md", "content": content}
 
 
@@ -115,17 +124,15 @@ def to_claude_project_pack(ir: AgentExportIR) -> list[dict[str, str]]:
 
 def to_claude_subagent_bundle(ir: AgentExportIR) -> list[dict[str, str]]:
     subagent = to_claude_subagent(ir)
-    readme = textwrap.dedent(
-        f"""\
-        # Claude Subagent Bundle
+    readme = textwrap.dedent(f"""\
+# Claude Subagent Bundle
 
-        Drop `{subagent["path"]}` into your repo, then ask Claude Code to use the `{_slugify(ir.name)}` subagent.
+Drop `{subagent["path"]}` into your repo, then ask Claude Code to use the `{_slugify(ir.name)}` subagent.
 
-        Recommended usage:
-        - Keep `CLAUDE.md` in the repo root for shared guidance.
-        - Add `.claude/settings.json` if you want permission guardrails alongside this agent.
-        """
-    )
+Recommended usage:
+- Keep `CLAUDE.md` in the repo root for shared guidance.
+- Add `.claude/settings.json` if you want permission guardrails alongside this agent.
+""")
     return [
         subagent,
         {"path": "README.md", "content": readme},
@@ -152,32 +159,28 @@ def to_claude_mcp_tool_stub(ir: SkillExportIR) -> list[dict[str, str]]:
         + ("" if param.required else " | None = None")
         for param in ir.params
     )
-    content = textwrap.dedent(
-        f"""\
-        from mcp.server.fastmcp import FastMCP
+    content = textwrap.dedent(f"""\
+from mcp.server.fastmcp import FastMCP
 
-        mcp = FastMCP("{tool_name}")
-
-
-        @mcp.tool()
-        async def {tool_name}({param_signature}) -> str:
-            \"\"\"{ir.purpose or f"Execute {tool_name}."}\"\"\"
-            raise NotImplementedError("TODO: implement {tool_name}")
+mcp = FastMCP("{tool_name}")
 
 
-        if __name__ == "__main__":
-            mcp.run()
-        """
-    )
-    readme = textwrap.dedent(
-        f"""\
-        # {tool_name} MCP Tool Stub
+@mcp.tool()
+async def {tool_name}({param_signature}) -> str:
+    \"\"\"{ir.purpose or f"Execute {tool_name}."}\"\"\"
+    raise NotImplementedError("TODO: implement {tool_name}")
 
-        Generated from Prompt Compiler for Claude Code / MCP workflows.
 
-        Purpose: {ir.purpose}
-        """
-    )
+if __name__ == "__main__":
+    mcp.run()
+""")
+    readme = textwrap.dedent(f"""\
+# {tool_name} MCP Tool Stub
+
+Generated from Prompt Compiler for Claude Code / MCP workflows.
+
+Purpose: {ir.purpose}
+""")
     return [
         {"path": "server.py", "content": content},
         {"path": "README.md", "content": readme},
@@ -194,37 +197,35 @@ def _project_claude_md(ir: AgentExportIR) -> str:
         or "- Do not leak secrets."
     )
     mcp_servers = ", ".join(ir.mcp_servers) if ir.mcp_servers else "none yet"
-    return textwrap.dedent(
-        f"""\
-        # Prompt Compiler Claude Code Memory
+    return textwrap.dedent(f"""\
+# Prompt Compiler Claude Code Memory
 
-        ## Project Summary
-        Prompt Compiler is a FastAPI + Next.js product that turns vague requests into structured prompts, execution plans, policy layers, agent packs, and workflow artifacts.
+## Project Summary
+Prompt Compiler is a FastAPI + Next.js product that turns vague requests into structured prompts, execution plans, policy layers, agent packs, and workflow artifacts.
 
-        ## Working Rules
-        - Start from repo-root commands.
-        - Prefer targeted tests before broad suites.
-        - Respect API/auth boundaries and never expose secrets.
-        - Keep provider integrations framework-agnostic unless the export surface is explicitly Claude-native.
+## Working Rules
+- Start from repo-root commands.
+- Prefer targeted tests before broad suites.
+- Respect API/auth boundaries and never expose secrets.
+- Keep provider integrations framework-agnostic unless the export surface is explicitly Claude-native.
 
-        ## Domain Concepts
-        {goals}
+## Domain Concepts
+{goals}
 
-        ## Constraints
-        {constraints}
+## Constraints
+{constraints}
 
-        ## Runbook
-        - Backend: `python -m uvicorn api.main:app --reload --port 8080`
-        - Frontend: `cd web && npm run dev`
-        - Python tests: `python -m pytest tests/ -q`
-        - Frontend tests: `cd web && npm run test`
+## Runbook
+- Backend: `python -m uvicorn api.main:app --reload --port 8080`
+- Frontend: `cd web && npm run dev`
+- Python tests: `python -m pytest tests/ -q`
+- Frontend tests: `cd web && npm run test`
 
-        ## Claude-Native Notes
-        - Permission mode: `{ir.permission_mode}`
-        - Suggested tools: {", ".join(ir.allowed_tools)}
-        - Suggested MCP servers: {mcp_servers}
-        """
-    )
+## Claude-Native Notes
+- Permission mode: `{ir.permission_mode}`
+- Suggested tools: {", ".join(ir.allowed_tools)}
+- Suggested MCP servers: {mcp_servers}
+""")
 
 
 def _project_settings_json(ir: AgentExportIR) -> str:
@@ -279,45 +280,41 @@ def _named_subagent(name: str) -> str:
         "mcp-integrator": "Read, Edit, Write, Grep, Glob, Bash",
         "frontend-polisher": "Read, Edit, Write, Grep, Glob, Bash",
     }
-    return textwrap.dedent(
-        f"""\
-        ---
-        name: {name}
-        description: {descriptions[name]}
-        tools: {tools[name]}
-        ---
+    return textwrap.dedent(f"""\
+---
+name: {name}
+description: {descriptions[name]}
+tools: {tools[name]}
+---
 
-        {prompts[name]}
-        """
-    )
+{prompts[name]}
+""")
 
 
 def _github_action_workflow() -> str:
-    return textwrap.dedent(
-        """\
-        name: Claude Code
+    return textwrap.dedent("""\
+name: Claude Code
 
-        on:
-          issue_comment:
-            types: [created]
-          pull_request_review_comment:
-            types: [created]
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
 
-        jobs:
-          claude:
-            if: contains(github.event.comment.body, '@claude')
-            runs-on: ubuntu-latest
-            steps:
-              - uses: actions/checkout@v4
-              - uses: anthropics/claude-code-action@v1
-                with:
-                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-                  prompt: >
-                    Follow CLAUDE.md, inspect the referenced issue or PR context,
-                    and respond or create changes only when the request is actionable.
-                  claude_args: "--max-turns 5"
-        """
-    )
+jobs:
+  claude:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: >
+            Follow CLAUDE.md, inspect the referenced issue or PR context,
+            and respond or create changes only when the request is actionable.
+          claude_args: "--max-turns 5"
+""")
 
 
 def _pr_reviewer_memory(ir: AgentExportIR) -> str:
@@ -325,40 +322,36 @@ def _pr_reviewer_memory(ir: AgentExportIR) -> str:
         "\n".join(f"- {goal}" for goal in ir.goals[:4])
         or "- Review code changes for risk, regressions, and safety gaps."
     )
-    return textwrap.dedent(
-        f"""\
-        # Claude PR Reviewer Memory
+    return textwrap.dedent(f"""\
+# Claude PR Reviewer Memory
 
-        ## Mission
-        Review pull requests with a focus on prompt safety, secret handling, permission boundaries, and missing tests.
+## Mission
+Review pull requests with a focus on prompt safety, secret handling, permission boundaries, and missing tests.
 
-        ## Repo Context
-        - Project type: repo-specific software product
-        - Default review posture: skeptical, concrete, and test-aware
+## Repo Context
+- Project type: repo-specific software product
+- Default review posture: skeptical, concrete, and test-aware
 
-        ## Review Checklist
-        {goals}
+## Review Checklist
+{goals}
 
-        ## Guardrails
-        - Do not expose secrets or credentials.
-        - Flag unsafe `.claude/settings.json` permissions.
-        - Call out prompt leakage, weak validation, and missing regression coverage.
-        """
-    )
+## Guardrails
+- Do not expose secrets or credentials.
+- Flag unsafe `.claude/settings.json` permissions.
+- Call out prompt leakage, weak validation, and missing regression coverage.
+""")
 
 
 def _pr_reviewer_readme() -> str:
-    return textwrap.dedent(
-        """\
-        # Claude PR Reviewer Pack
+    return textwrap.dedent("""\
+# Claude PR Reviewer Pack
 
-        This pack gives Claude Code a dedicated `pr-reviewer` subagent plus review-focused repo memory.
+This pack gives Claude Code a dedicated `pr-reviewer` subagent plus review-focused repo memory.
 
-        Suggested prompts:
-        - `Use the pr-reviewer subagent to review this pull request for prompt leakage and unsafe settings.`
-        - `Review this diff for missing tests, secret exposure, and MCP misconfiguration.`
-        """
-    )
+Suggested prompts:
+- `Use the pr-reviewer subagent to review this pull request for prompt leakage and unsafe settings.`
+- `Review this diff for missing tests, secret exposure, and MCP misconfiguration.`
+""")
 
 
 def _ordered_tools(tools: list[str]) -> list[str]:

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -247,22 +247,22 @@ def test_claude_subagent_frontmatter_starts_at_column_zero():
     """Verify agent file starts with --- at column 0 (no leading spaces)."""
     ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
     file_spec = to_claude_subagent(ir)
-    
+
     content = file_spec["content"]
     lines = content.split("\n")
-    
+
     # First line must be exactly "---" with no leading spaces
     assert lines[0] == "---", f"Expected '---' at column 0, got: {repr(lines[0])}"
-    
+
     # Find the closing frontmatter line
     closing_idx = None
     for idx, line in enumerate(lines[1:], start=1):
         if line == "---":
             closing_idx = idx
             break
-    
+
     assert closing_idx is not None, "Missing closing --- in frontmatter"
-    
+
     # Verify frontmatter fields have no leading spaces
     for line in lines[1:closing_idx]:
         if line.strip():  # Skip empty lines
@@ -273,10 +273,10 @@ def test_claude_subagent_no_stray_code_fences():
     """Verify agent file contains no stray markdown code fences."""
     ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
     file_spec = to_claude_subagent(ir)
-    
+
     content = file_spec["content"]
     lines = content.split("\n")
-    
+
     # Count all ``` occurrences (should be 0 for regular agent markdown)
     fence_count = sum(1 for line in lines if line.strip().startswith("```"))
     assert fence_count == 0, f"Found {fence_count} stray code fence(s) in agent file"
@@ -287,14 +287,14 @@ def test_claude_subagent_strips_markdown_fences_from_prompt():
     # Create a markdown with code fences around it (simulating model output)
     fenced_markdown = "```markdown\n" + SINGLE_AGENT_MARKDOWN + "\n```"
     ir = parse_agent_markdown(fenced_markdown)
-    
+
     file_spec = to_claude_subagent(ir)
     content = file_spec["content"]
-    
+
     # Should not contain the wrapper fences
     assert not content.strip().startswith("```"), "Content starts with code fence"
     assert not content.strip().endswith("```"), "Content ends with code fence"
-    
+
     # Should still contain the actual agent content
     assert "Data Analyst" in content or "expert data analyst" in content
 
@@ -314,15 +314,15 @@ def test_claude_project_pack_claude_md_starts_at_column_zero():
     """Verify CLAUDE.md starts with # at column 0 (no leading spaces)."""
     ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
     pack = to_claude_project_pack(ir)
-    
+
     claude_md = next(item for item in pack if item["path"] == "CLAUDE.md")
     content = claude_md["content"]
     lines = content.split("\n")
-    
+
     # First line must start with # at column 0
     assert lines[0].startswith("#"), f"Expected heading at column 0, got: {repr(lines[0])}"
     assert not lines[0].startswith(" "), f"CLAUDE.md has leading spaces: {repr(lines[0])}"
-    
+
     # Check that all markdown headings start at column 0
     for line in lines:
         if line.strip().startswith("#"):
@@ -332,27 +332,34 @@ def test_claude_project_pack_claude_md_starts_at_column_zero():
 def test_named_subagent_frontmatter_at_column_zero():
     """Verify named subagents have frontmatter at column 0."""
     from app.adapters.claude_code import _named_subagent
-    
-    for name in ["compiler-architect", "prompt-safety-reviewer", "mcp-integrator", "frontend-polisher"]:
+
+    for name in [
+        "compiler-architect",
+        "prompt-safety-reviewer",
+        "mcp-integrator",
+        "frontend-polisher",
+    ]:
         content = _named_subagent(name)
         lines = content.split("\n")
-        
+
         # First line must be exactly "---"
         assert lines[0] == "---", f"Agent {name}: Expected '---' at column 0, got: {repr(lines[0])}"
-        
+
         # Find closing frontmatter
         closing_idx = None
         for idx, line in enumerate(lines[1:], start=1):
             if line == "---":
                 closing_idx = idx
                 break
-        
+
         assert closing_idx is not None, f"Agent {name}: Missing closing --- in frontmatter"
-        
+
         # Verify frontmatter fields have no leading spaces
         for line in lines[1:closing_idx]:
             if line.strip():
-                assert not line.startswith(" "), f"Agent {name}: Frontmatter line has leading spaces: {repr(line)}"
+                assert not line.startswith(
+                    " "
+                ), f"Agent {name}: Frontmatter line has leading spaces: {repr(line)}"
 
 
 def test_claude_mcp_tool_stub_output():

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -243,6 +243,62 @@ def test_claude_subagent_output():
     assert "tools:" in file_spec["content"]
 
 
+def test_claude_subagent_frontmatter_starts_at_column_zero():
+    """Verify agent file starts with --- at column 0 (no leading spaces)."""
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    file_spec = to_claude_subagent(ir)
+    
+    content = file_spec["content"]
+    lines = content.split("\n")
+    
+    # First line must be exactly "---" with no leading spaces
+    assert lines[0] == "---", f"Expected '---' at column 0, got: {repr(lines[0])}"
+    
+    # Find the closing frontmatter line
+    closing_idx = None
+    for idx, line in enumerate(lines[1:], start=1):
+        if line == "---":
+            closing_idx = idx
+            break
+    
+    assert closing_idx is not None, "Missing closing --- in frontmatter"
+    
+    # Verify frontmatter fields have no leading spaces
+    for line in lines[1:closing_idx]:
+        if line.strip():  # Skip empty lines
+            assert not line.startswith(" "), f"Frontmatter line has leading spaces: {repr(line)}"
+
+
+def test_claude_subagent_no_stray_code_fences():
+    """Verify agent file contains no stray markdown code fences."""
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    file_spec = to_claude_subagent(ir)
+    
+    content = file_spec["content"]
+    lines = content.split("\n")
+    
+    # Count all ``` occurrences (should be 0 for regular agent markdown)
+    fence_count = sum(1 for line in lines if line.strip().startswith("```"))
+    assert fence_count == 0, f"Found {fence_count} stray code fence(s) in agent file"
+
+
+def test_claude_subagent_strips_markdown_fences_from_prompt():
+    """Verify markdown fences are stripped from raw_system_prompt."""
+    # Create a markdown with code fences around it (simulating model output)
+    fenced_markdown = "```markdown\n" + SINGLE_AGENT_MARKDOWN + "\n```"
+    ir = parse_agent_markdown(fenced_markdown)
+    
+    file_spec = to_claude_subagent(ir)
+    content = file_spec["content"]
+    
+    # Should not contain the wrapper fences
+    assert not content.strip().startswith("```"), "Content starts with code fence"
+    assert not content.strip().endswith("```"), "Content ends with code fence"
+    
+    # Should still contain the actual agent content
+    assert "Data Analyst" in content or "expert data analyst" in content
+
+
 def test_claude_project_pack_output():
     ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
     pack = to_claude_project_pack(ir)
@@ -252,6 +308,51 @@ def test_claude_project_pack_output():
     assert ".claude/settings.json" in paths
     assert ".github/workflows/claude.yml" in paths
     assert any(path.startswith(".claude/agents/") for path in paths)
+
+
+def test_claude_project_pack_claude_md_starts_at_column_zero():
+    """Verify CLAUDE.md starts with # at column 0 (no leading spaces)."""
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    pack = to_claude_project_pack(ir)
+    
+    claude_md = next(item for item in pack if item["path"] == "CLAUDE.md")
+    content = claude_md["content"]
+    lines = content.split("\n")
+    
+    # First line must start with # at column 0
+    assert lines[0].startswith("#"), f"Expected heading at column 0, got: {repr(lines[0])}"
+    assert not lines[0].startswith(" "), f"CLAUDE.md has leading spaces: {repr(lines[0])}"
+    
+    # Check that all markdown headings start at column 0
+    for line in lines:
+        if line.strip().startswith("#"):
+            assert not line.startswith(" "), f"Heading has leading spaces: {repr(line)}"
+
+
+def test_named_subagent_frontmatter_at_column_zero():
+    """Verify named subagents have frontmatter at column 0."""
+    from app.adapters.claude_code import _named_subagent
+    
+    for name in ["compiler-architect", "prompt-safety-reviewer", "mcp-integrator", "frontend-polisher"]:
+        content = _named_subagent(name)
+        lines = content.split("\n")
+        
+        # First line must be exactly "---"
+        assert lines[0] == "---", f"Agent {name}: Expected '---' at column 0, got: {repr(lines[0])}"
+        
+        # Find closing frontmatter
+        closing_idx = None
+        for idx, line in enumerate(lines[1:], start=1):
+            if line == "---":
+                closing_idx = idx
+                break
+        
+        assert closing_idx is not None, f"Agent {name}: Missing closing --- in frontmatter"
+        
+        # Verify frontmatter fields have no leading spaces
+        for line in lines[1:closing_idx]:
+            if line.strip():
+                assert not line.startswith(" "), f"Agent {name}: Frontmatter line has leading spaces: {repr(line)}"
 
 
 def test_claude_mcp_tool_stub_output():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the Agent Pack export formatting issues where generated `.md` files had leaked indentation and trailing markdown code fences, making them unusable in Claude Code.

## Changes Made

### Core Fix
- Added `_strip_markdown_fences()` helper function that removes leading/trailing markdown code fences (` ```lang` and ` ``` `) from `raw_system_prompt` before embedding in generated files
- Converted all f-string templates to use column-0 formatting so `textwrap.dedent()` works correctly

### Updated Functions
Fixed indentation in these export template functions:
- `to_claude_subagent()` - agent subagent files
- `_project_claude_md()` - CLAUDE.md project memory
- `to_claude_subagent_bundle()` - subagent bundle README
- `to_claude_mcp_tool_stub()` - MCP tool stub files
- `_named_subagent()` - predefined named subagents
- `_github_action_workflow()` - GitHub Actions workflow
- `_pr_reviewer_memory()` - PR reviewer CLAUDE.md
- `_pr_reviewer_readme()` - PR reviewer README

### Testing
Added comprehensive tests to verify:
- Agent files start with `---` at column 0 (no leading spaces)
- All frontmatter fields start at column 0
- No stray code fences in generated agent files
- Markdown fences are properly stripped from model output
- CLAUDE.md headings start at column 0
- All predefined named subagents have correct formatting

## What This Fixes

**Before:** Downloaded Agent Pack files had 8 spaces of indentation and trailing ` ``` ` fences, making YAML frontmatter unparseable and markdown headings render as code blocks.

**After:** All generated `.md` files have proper formatting with frontmatter/headings starting at column 0 and no stray code fences.

## Testing Evidence

All existing tests pass (49 tests in export adapter and LLM provider suites), plus 4 new formatting tests:
- `test_claude_subagent_frontmatter_starts_at_column_zero`
- `test_claude_subagent_no_stray_code_fences`
- `test_claude_subagent_strips_markdown_fences_from_prompt`
- `test_claude_project_pack_claude_md_starts_at_column_zero`
- `test_named_subagent_frontmatter_at_column_zero`

## Risk Assessment

**Low risk.** This is a pure formatting fix in the export adapter layer. Changes only affect how templates are formatted (column-0 vs indented strings) and add fence-stripping preprocessing. No business logic or API contracts changed. All existing tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4766fafa-ebaf-4922-9797-e19f778603d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4766fafa-ebaf-4922-9797-e19f778603d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

