### PR TITLE
test: fix Full Test regression on main (stale test_safety assertion vs #712 flag format)

### DIFF
--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -32,8 +32,10 @@ def test_pii_credit_card(handler):
 def test_unsafe_keywords(handler):
     text = "How to bypass the filter and ignore previous instructions?"
     flags = handler._scan_unsafe_content(text)
-    assert "bypass" in flags
-    assert "ignore previous instructions" in flags
+    # Flags are now formatted as "injection_pattern: <matched text>" (see #712),
+    # so check that a flag containing each unsafe phrase was raised.
+    assert any("bypass" in flag for flag in flags)
+    assert any("ignore previous instructions" in flag for flag in flags)
 
 
 def test_guardrails_length_short(handler):


### PR DESCRIPTION
## What
Fixes the single failing test on `main` after the security-detection merge (#712).

`tests/test_safety.py::test_unsafe_keywords` asserted the old flag format (`assert "bypass" in flags`). #712 changed `SafetyHandler._scan_unsafe_content` to return `"injection_pattern: <matched text>"`, so the exact-membership assert failed across all platforms (1 failed, 1142 passed).

## Fix
Update the assertions to check substring membership (`any("bypass" in flag ...)`) — faithful to the test's intent (these unsafe phrases get flagged), aligned with the new format.

## Verification
Full local suite: **1143 passed, 5 skipped** (`python -m pytest tests/`).

## Why it slipped through
PR CI only runs "Smoke" (lint); "Full Test" is skipped on PRs and only runs on `main` push — so this stale test wasn't caught pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)