### PR TITLE
ci: run full tests/ suite on pull requests (close the PR test-coverage gap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,33 @@ jobs:
         working-directory: integrations/vscode-extension
         run: npm run package
 
+  pr-tests:
+    name: PR Tests (full suite)
+    # Run the complete tests/ suite on pull requests (single platform, no
+    # coverage gate) so test regressions are caught before merge. The full
+    # cross-platform matrix below still runs on push/schedule.
+    if: github.event_name == 'pull_request'
+    needs: [smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,docs]
+
+      - name: Run full test suite
+        run: pytest tests/ -q
+
   full-test:
     name: Full Test
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Problem
PRs only ran the `smoke` job (lint + 4 specific test files). The full `tests/` suite ran **only on push to `main`** (`full-test` job is gated by `if: github.event_name != 'pull_request'`). So a PR that breaks a test outside the smoke subset passes PR CI but **breaks main** — exactly what happened with `test_safety.py` after #712 (caught only post-merge, fixed in #714).

## Fix
Add a lightweight **`PR Tests (full suite)`** job that runs the complete `tests/` suite on every PR (single platform: ubuntu + py3.12, no coverage gate). The full 3×3 cross-platform matrix + coverage stays on push/schedule.

- Fast & cheap (1 job vs the 9-job matrix).
- Catches test regressions **before** merge.

## Note
Because `pull_request` workflows run from the base branch's definition, this new job takes effect on PRs opened **after** this merges (it won't run on this PR itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)