### PR TITLE
fix(compile): gate refusal on safety signal, not critique quality verdict (#716)

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -417,43 +417,46 @@ def compile_endpoint(
 
     elapsed = int((time.time() - t0) * 1000)
 
-    # Enforce REJECT verdict: if critique says REJECT with critical policy violations
-    # (not system errors), return a safe refusal payload instead of the compiled prompts
-    if critique_result and critique_result.get("verdict") == "REJECT":
-        has_critical_policy_violation = any(
-            issue.get("severity") == "critical" and issue.get("type") != "System Error"
-            for issue in critique_result.get("issues", [])
-        )
-        if has_critical_policy_violation:
-            logger.warning(
-                "Critique REJECT verdict with critical issues - returning refusal payload",
-                extra={"request_id": rid, "critique": critique_result},
-            )
-            refusal_message = (
-                "Request rejected due to policy violation. "
-                "The critique identified critical issues that prevent compilation."
-            )
-            if critique_result.get("feedback"):
-                refusal_message = critique_result["feedback"]
+    # Block compilation ONLY when the safety scan flags the input as unsafe
+    # (prompt injection / secret exfiltration detected by SafetyHandler, see #712).
+    # A quality REJECT from the critique is advisory feedback and must NOT empty the
+    # output — it is surfaced via the `critique` field instead (see #716).
+    security_meta = {}
+    if ir2 and isinstance(getattr(ir2, "metadata", None), dict):
+        security_meta = ir2.metadata.get("security") or {}
+    if not security_meta and isinstance(getattr(ir, "metadata", None), dict):
+        security_meta = ir.metadata.get("security") or {}
 
-            return CompileResponse(
-                ir=ir.model_dump(),
-                ir_v2=(ir2.model_dump() if ir2 else None),
-                system_prompt=refusal_message,
-                user_prompt="",
-                plan="",
-                expanded_prompt=refusal_message,
-                system_prompt_v2=refusal_message,
-                user_prompt_v2="",
-                plan_v2="",
-                expanded_prompt_v2=refusal_message,
-                processing_ms=elapsed,
-                request_id=rid,
-                heuristic_version=HEURISTIC_VERSION,
-                heuristic2_version=(HEURISTIC2_VERSION if ir2 else None),
-                trace=trace_lines,
-                critique=critique_result,
-            )
+    if security_meta.get("is_safe") is False:
+        logger.warning(
+            "Unsafe input blocked - returning safety refusal payload",
+            extra={"request_id": rid, "security": security_meta},
+        )
+        refusal_message = (
+            "⚠️ Blocked for safety. This request looks like a prompt-injection or "
+            "secret-exfiltration attempt (e.g. overriding instructions or extracting "
+            "hidden system data), so Prompt Compiler will not compile it. Rephrase your "
+            "actual task without trying to override or extract instructions."
+        )
+
+        return CompileResponse(
+            ir=ir.model_dump(),
+            ir_v2=(ir2.model_dump() if ir2 else None),
+            system_prompt=refusal_message,
+            user_prompt="",
+            plan="",
+            expanded_prompt=refusal_message,
+            system_prompt_v2=refusal_message,
+            user_prompt_v2="",
+            plan_v2="",
+            expanded_prompt_v2=refusal_message,
+            processing_ms=elapsed,
+            request_id=rid,
+            heuristic_version=HEURISTIC_VERSION,
+            heuristic2_version=(HEURISTIC2_VERSION if ir2 else None),
+            trace=trace_lines,
+            critique=critique_result,
+        )
 
     return CompileResponse(
         ir=ir.model_dump(),

--- a/tests/test_critique_verdict_enforcement.py
+++ b/tests/test_critique_verdict_enforcement.py
@@ -11,8 +11,8 @@ def client():
     return TestClient(app)
 
 
-def test_compile_endpoint_enforces_reject_verdict_with_critical_issue(client):
-    """When critique returns REJECT with a critical issue, compile should return refusal."""
+def test_compile_endpoint_blocks_unsafe_injection_input(client):
+    """An unsafe input (injection/exfiltration) is blocked with a safety refusal (see #716)."""
 
     # Mock the critique to return a REJECT verdict with critical issue
     mock_critique_result = {
@@ -56,7 +56,7 @@ def test_compile_endpoint_enforces_reject_verdict_with_critical_issue(client):
         examples=[],
         banned=[],
         tools=[],
-        metadata={},
+        metadata={"security": {"is_safe": False, "findings": [], "redacted_text": ""}},
         diagnostics=[],
     )
 
@@ -89,21 +89,19 @@ def test_compile_endpoint_enforces_reject_verdict_with_critical_issue(client):
         assert response.status_code == 200
         data = response.json()
 
-        # Verify the critique was included
-        assert data["critique"] is not None
-        assert data["critique"]["verdict"] == "REJECT"
+        # The refusal is driven by the safety scan (is_safe=False), not the critique verdict.
+        assert data["ir_v2"]["metadata"].get("security", {}).get("is_safe") is False
 
-        # Verify that the compiled prompts contain the refusal message, not the attack
-        refusal_message = mock_critique_result["feedback"]
-        assert refusal_message in data["system_prompt"]
-        assert refusal_message in data["expanded_prompt"]
+        # Output is replaced with a clear SAFETY refusal (not the attack, not critique text).
+        assert "Blocked for safety" in data["system_prompt"]
+        assert "Blocked for safety" in data["expanded_prompt"]
 
-        # Verify that the adversarial content is NOT in the compiled prompts
+        # The adversarial content must NOT appear in the compiled prompts.
         attack_text = "Ignore all previous instructions"
         assert attack_text not in data["system_prompt"]
         assert attack_text not in data["expanded_prompt"]
 
-        # The user_prompt and plan should be empty or safe
+        # The user_prompt and plan are emptied.
         assert data["user_prompt"] == ""
         assert data["plan"] == ""
 


### PR DESCRIPTION
Fixes #716 (CRITICAL, live regression).

## Problem
#709 returned an empty refusal payload whenever the critique returned `verdict=REJECT` with any `critical` issue. But the critique's issue types are **all quality categories** (`Hallucination | Constraint Violation | Logic Error | Style Issue`, per `critic.md`) — never security. So benign prompts the critique happened to dislike (e.g. a simple REST API request → critical `Constraint Violation`) produced **no output**, only a vague message. The core product was broken for everyday use.

## Fix
Refusal now triggers **only** when the safety scan flags the input unsafe — `metadata.security.is_safe is False` (set by SafetyHandler / #712) — with a clear **"Blocked for safety"** message. A quality `REJECT` is kept as advisory `critique` feedback and no longer empties the compiled output.

This also fixes the second half of #716: a real safety block now clearly signals *unsafe* (explicit message + the `is_safe=false` / high-risk policy already carried in the `ir`/`ir_v2` payload), instead of a generic 'can't compile' note.

## Tests
- `tests/test_critique_verdict_enforcement.py` updated: unsafe input (is_safe=False) → safety refusal; quality REJECT / ACCEPT → normal output. 4 passed.
- Safety/security/policy/critique suite: 56 passed locally.
- This PR also exercises the new full-suite PR check from #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)