### PR TITLE
UX: Remove decorative Reasoning badges from Compiler and Offline pages

### DIFF
--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -216,23 +216,6 @@ export default function OfflinePage() {
                                     aria-labelledby={`tab-${activeTab}`}
                                     className="flex-1 p-0 overflow-hidden relative group bg-black/20"
                                 >
-                                    {/* Badge */}
-                                    <div
-                                        className="absolute top-4 right-6 z-10 opacity-50 hover:opacity-100 transition-opacity cursor-help group/reasoning-v2"
-                                        tabIndex={0}
-                                        title="Reasoning V2 enabled"
-                                    >
-                                        <div className="relative flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-800/50 border border-zinc-700/50">
-                                            <div className="w-1.5 h-1.5 rounded-full bg-blue-400" />
-                                            <span className="text-[10px] text-zinc-400 font-medium">Reasoning V2</span>
-                                            <div className="absolute top-8 right-0 w-64 bg-zinc-900 border border-white/10 rounded-xl p-3 shadow-2xl opacity-0 invisible group-hover/reasoning-v2:opacity-100 group-hover/reasoning-v2:visible group-focus/reasoning-v2:opacity-100 group-focus/reasoning-v2:visible transition-all z-50 pointer-events-none">
-                                                <div className="text-xs text-zinc-300 leading-relaxed">
-                                                    Offline mode uses the V2 heuristic engine for faster, deterministic prompt compilation without requiring an API connection.
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-
                                     {activeTab !== "json" && (
                                         <>
                                             <textarea

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -443,28 +443,6 @@ export default function Home() {
                               </div>
                             </div>
                           )}
-
-                          {/* Reasoning Badge */}
-                          {result.system_prompt_v2 ? (
-                            <div
-                              className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-blue-500/10 border border-blue-500/20 backdrop-blur-md cursor-help group/reasoning relative"
-                              tabIndex={0}
-                              title="Reasoning Model enabled"
-                            >
-                              <div className="w-1.5 h-1.5 rounded-full bg-blue-400 shadow-[0_0_5px_rgba(96,165,250,0.8)]" />
-                              <span className="text-[10px] text-blue-200 font-medium">Reasoning Model</span>
-                              <div className="absolute top-8 right-0 w-64 bg-zinc-900 border border-white/10 rounded-xl p-3 shadow-2xl opacity-0 invisible group-hover/reasoning:opacity-100 group-hover/reasoning:visible group-focus/reasoning:opacity-100 group-focus/reasoning:visible transition-all z-50 pointer-events-none">
-                                <div className="text-xs text-zinc-300 leading-relaxed">
-                                  This output was generated using extended reasoning capabilities for deeper analysis and more structured responses.
-                                </div>
-                              </div>
-                            </div>
-                          ) : (
-                            <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-zinc-800/50 border border-zinc-700/50 backdrop-blur-md">
-                              <div className="w-1.5 h-1.5 rounded-full bg-zinc-400" />
-                              <span className="text-[10px] text-zinc-400 font-medium">Standard</span>
-                            </div>
-                          )}
                         </div>
 
                         <textarea


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed
Removed the decorative "Reasoning V2" and "Reasoning Model" badges from the output panels. These badges looked clickable but had no interactive value for users.

**Files modified:**
- `web/app/offline/page.tsx`: Removed "Reasoning V2" badge
- `web/app/page.tsx`: Removed "Reasoning Model" / "Standard" badge

## Product Impact
This cleanup removes visual clutter from the output area. Users can now focus on the generated content without being distracted by non-functional UI elements. The output textarea and copy buttons remain fully functional.

## Risk Assessment
**Low risk** - Pure visual cleanup with no behavior changes. Pre-commit checks passed, and both pages were manually tested to confirm:
- ✅ Output generation works correctly
- ✅ Copy buttons still functional  
- ✅ All tabs display properly
- ✅ No console errors

## Evidence

**Offline Page** - Badge removed, output working:

[Offline page without Reasoning V2 badge](https://cursor.com/agents/bc-dbd78761-b86d-45e9-a3a7-cf1676c8efc2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foffline_page_no_badge.webp)

**Compiler Page** - Badge removed, output working:

[Compiler page without Reasoning Model badge](https://cursor.com/agents/bc-dbd78761-b86d-45e9-a3a7-cf1676c8efc2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompiler_page_no_badge.webp)

Resolves #717

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbd78761-b86d-45e9-a3a7-cf1676c8efc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbd78761-b86d-45e9-a3a7-cf1676c8efc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

