### PR TITLE
fix(benchmark): share benchmark model manifest across web and API

### DIFF
--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import json
 import re
 import time
+from functools import lru_cache
+from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -34,12 +36,31 @@ _HEADER_RE = re.compile(r"^#{1,3} ", re.MULTILINE)
 router = APIRouter(prefix="/benchmark", tags=["benchmark"])
 
 MAX_BENCHMARK_TEXT_LENGTH = 4000
-SUPPORTED_BENCHMARK_MODELS = {
-    "openai/gpt-oss-20b",
-    "openai/gpt-oss-120b",
-    "mistralai/mistral-small-3.2-24b-instruct",
-    "qwen/qwen3-32b",
-}
+_BENCHMARK_MODEL_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[2] / "web" / "app" / "benchmark" / "models.json"
+)
+
+
+@lru_cache(maxsize=1)
+def _load_benchmark_model_manifest() -> tuple[dict[str, str], ...]:
+    raw = json.loads(_BENCHMARK_MODEL_MANIFEST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("Benchmark model manifest must contain at least one model")
+
+    manifest: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("Benchmark model manifest entries must be objects")
+        model_id = item.get("id")
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("Benchmark model manifest entries must include a non-empty id")
+        manifest.append(item)
+
+    return tuple(manifest)
+
+
+SUPPORTED_BENCHMARK_MODELS = tuple(item["id"] for item in _load_benchmark_model_manifest())
+DEFAULT_BENCHMARK_MODEL = SUPPORTED_BENCHMARK_MODELS[0]
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +78,7 @@ class BenchmarkRequest(BaseModel):
         description="Raw user input prompt",
     )
     model: str = Field(
-        default="openai/gpt-oss-20b",
+        default=DEFAULT_BENCHMARK_MODEL,
         description="LLM model identifier (e.g. 'openai/gpt-oss-20b')",
     )
 

--- a/tests/test_benchmark_api.py
+++ b/tests/test_benchmark_api.py
@@ -178,3 +178,18 @@ def test_benchmark_provider_failure_returns_safe_error(client):
 
     assert response.status_code == 502
     assert response.json()["detail"] == "Benchmark model request failed"
+
+
+def test_benchmark_models_are_loaded_from_shared_manifest():
+    """Backend benchmark model validation should follow the shared frontend manifest."""
+    from app.routers.benchmark import (
+        DEFAULT_BENCHMARK_MODEL,
+        SUPPORTED_BENCHMARK_MODELS,
+        _load_benchmark_model_manifest,
+    )
+
+    manifest = _load_benchmark_model_manifest()
+    manifest_ids = [item["id"] for item in manifest]
+
+    assert tuple(manifest_ids) == SUPPORTED_BENCHMARK_MODELS
+    assert DEFAULT_BENCHMARK_MODEL == manifest_ids[0]

--- a/web/app/benchmark/modelCatalog.ts
+++ b/web/app/benchmark/modelCatalog.ts
@@ -1,3 +1,5 @@
+import benchmarkModelsData from "./models.json" with { type: "json" };
+
 export type BenchmarkModelBadge = "cheap" | "balanced" | "preview";
 export type BenchmarkModelAvailability = "production" | "preview";
 
@@ -10,40 +12,7 @@ export type BenchmarkModelDefinition = {
   group: "Cheap" | "Balanced" | "Preview";
 };
 
-export const BENCHMARK_MODELS: BenchmarkModelDefinition[] = [
-  {
-    id: "openai/gpt-oss-20b",
-    label: "GPT-OSS 20B",
-    badge: "cheap",
-    availability: "production",
-    helperText: "Cheap and surprisingly capable. Good default for everyday tests.",
-    group: "Cheap",
-  },
-  {
-    id: "mistralai/mistral-small-3.2-24b-instruct",
-    label: "Mistral Small 3.2 24B",
-    badge: "cheap",
-    availability: "production",
-    helperText: "Affordable and strong at instruction-following plus structured output.",
-    group: "Cheap",
-  },
-  {
-    id: "openai/gpt-oss-120b",
-    label: "GPT-OSS 120B",
-    badge: "balanced",
-    availability: "production",
-    helperText: "Higher-quality option when you can trade speed for depth.",
-    group: "Balanced",
-  },
-  {
-    id: "qwen/qwen3-32b",
-    label: "Qwen 3 32B",
-    badge: "preview",
-    availability: "preview",
-    helperText: "Newer model with a different reasoning style. Useful for a second opinion on your prompt.",
-    group: "Preview",
-  },
-];
+export const BENCHMARK_MODELS = benchmarkModelsData as BenchmarkModelDefinition[];
 
 export const BENCHMARK_MODEL_GROUPS = [
   { label: "Cheap", options: BENCHMARK_MODELS.filter((model) => model.group === "Cheap") },

--- a/web/app/benchmark/models.json
+++ b/web/app/benchmark/models.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "openai/gpt-oss-20b",
+    "label": "GPT-OSS 20B",
+    "badge": "cheap",
+    "availability": "production",
+    "helperText": "Cheap and surprisingly capable. Good default for everyday tests.",
+    "group": "Cheap"
+  },
+  {
+    "id": "mistralai/mistral-small-3.2-24b-instruct",
+    "label": "Mistral Small 3.2 24B",
+    "badge": "cheap",
+    "availability": "production",
+    "helperText": "Affordable and strong at instruction-following plus structured output.",
+    "group": "Cheap"
+  },
+  {
+    "id": "openai/gpt-oss-120b",
+    "label": "GPT-OSS 120B",
+    "badge": "balanced",
+    "availability": "production",
+    "helperText": "Higher-quality option when you can trade speed for depth.",
+    "group": "Balanced"
+  },
+  {
+    "id": "qwen/qwen3-32b",
+    "label": "Qwen 3 32B",
+    "badge": "preview",
+    "availability": "preview",
+    "helperText": "Newer model with a different reasoning style. Useful for a second opinion on your prompt.",
+    "group": "Preview"
+  }
+]


### PR DESCRIPTION
## What changed
- moved benchmark model definitions into a shared `web/app/benchmark/models.json` file
- made the API load supported benchmark models and the default model from that shared manifest
- kept the frontend catalog wired to the same manifest so both sides stay aligned
- added a backend regression test that locks the API model list to the shared manifest

## What this does for the product
This keeps the benchmark model dropdown and the backend validator reading the same source of truth, so we avoid the situation where users can pick a model in the UI that the server later rejects.

## Risk
Low. Scope is limited to benchmark model configuration and related tests.

## Verification
- `py -3.12 -m pytest tests/test_benchmark_api.py -q`
- `npm run test -- app/benchmark/page.test.tsx`
- `node --test web/app/benchmark/modelCatalog.test.mts`