### PR TITLE
🎨 Palette: Add aria-busy to loading buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-30 - Empty States Call-to-Action
 **Learning:** Including an 'or try an example' call-to-action button that populates the input field solves the 'blank canvas' UX problem by explicitly demonstrating the expected input format to users.
 **Action:** When designing empty states for text areas and generative tools, include an 'or try an example' call-to-action button that populates the input field.
+## 2024-06-01 - Avoid duplicate ARIA attributes in React
+**Learning:** Adding duplicate props like `aria-busy={downloading}` and `aria-busy={loading}` causes React build failures due to `react/jsx-no-duplicate-props`. Even though one of the values might be correct logically, both cannot exist on the same element.
+**Action:** When adding accessibility attributes like `aria-busy` to existing elements, ensure there isn't already one present, or replace the existing one with the correct value if necessary.

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -304,6 +304,7 @@ export default function AgentGenerator() {
               type="button"
               onClick={handleGenerate}
               disabled={loading || !description.trim()}
+              aria-busy={loading}
               title={!description.trim() ? "Enter a description first to generate" : "Generate Agent"}
               className={`w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20 focus-visible:ring-purple-500' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20 focus-visible:ring-green-500'}`}
             >
@@ -383,6 +384,7 @@ export default function AgentGenerator() {
                       type="button"
                       onClick={handleGenerate}
                       disabled={loading || !description.trim()}
+                      aria-busy={loading}
                       title={!description.trim() ? "Enter a description first to generate" : "Generate Agent"}
                       className={`mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a] ${multiAgent ? 'bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-purple-500/20 focus-visible:ring-purple-500' : 'bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-500 hover:to-emerald-500 shadow-green-500/20 focus-visible:ring-green-500'}`}
                     >

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -349,6 +349,7 @@ export default function AgentPacksPage() {
               type="button"
               onClick={handleGenerate}
               disabled={loading || !request.goal.trim()}
+              aria-busy={loading}
               className={`mt-1 flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3 text-sm font-bold text-white shadow-lg transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${provider.buttonClass}`}
             >
               {loading ? "Generating..." : provider.ctaLabel}
@@ -393,6 +394,7 @@ export default function AgentPacksPage() {
                       type="button"
                       onClick={handleDownload}
                       disabled={downloading}
+                      aria-busy={downloading}
                       className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
                     >
                       <Download size={14} aria-hidden="true" />

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -304,6 +304,7 @@ export default function BenchmarkPage() {
               type="button"
               onClick={handleBenchmark}
               disabled={loading || !prompt.trim()}
+              aria-busy={loading}
               title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
               className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 py-4 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50"
             >
@@ -431,6 +432,7 @@ export default function BenchmarkPage() {
                         type="button"
                         onClick={handleBenchmark}
                         disabled={loading || !prompt.trim()}
+                        aria-busy={loading}
                         title={!prompt.trim() ? "Enter a prompt first to run a benchmark" : "Run Benchmark"}
                         className="mx-auto flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-600 to-orange-600 px-6 py-2.5 text-sm font-bold text-white shadow-lg shadow-amber-500/20 transition-all active:scale-95 hover:from-amber-500 hover:to-orange-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 disabled:cursor-not-allowed disabled:opacity-50"
                       >

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -163,6 +163,7 @@ export default function OfflinePage() {
                                     type="button"
                                     onClick={() => handleGenerate()}
                                     disabled={loading || !prompt.trim()}
+                                    aria-busy={loading}
                                     title={!prompt.trim() ? "Enter a prompt first to generate" : "Generate Prompt"}
                                     className="px-4 py-3 text-sm font-bold bg-zinc-800 hover:bg-zinc-700 text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group border border-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500/50"
                                 >
@@ -259,6 +260,7 @@ export default function OfflinePage() {
                                         type="button"
                                         onClick={() => handleGenerate()}
                                         disabled={loading || !prompt.trim()}
+                                        aria-busy={loading}
                                         title={!prompt.trim() ? "Enter a prompt first to generate" : "Run Heuristics"}
                                         className="mt-6 mx-auto px-6 py-2.5 text-sm font-bold bg-zinc-800 hover:bg-zinc-700 text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group border border-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500/50"
                                     >

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -352,6 +352,7 @@ export default function OptimizerPage() {
                         type="button"
                         onClick={handleOptimize}
                         disabled={loading || !input.trim()}
+                        aria-busy={loading}
                         title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
                         className="w-full rounded-lg bg-emerald-600 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-emerald-950/30 transition-colors hover:bg-emerald-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 sm:w-auto"
                     >
@@ -484,6 +485,7 @@ export default function OptimizerPage() {
                                     type="button"
                                     onClick={handleOptimize}
                                     disabled={loading || !input.trim()}
+                                    aria-busy={loading}
                                     title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
                                     className="rounded-lg bg-emerald-600/20 border border-emerald-500/30 px-5 py-2 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-600/30 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
                                 >

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -11,7 +11,7 @@ import PolicyBadge from "./components/PolicyBadge";
 import CopyButton from "./components/CopyButton";
 import { useCompiler } from "./hooks/useCompiler";
 import { useContextManager } from "./hooks/useContextManager";
-import { toast } from "sonner";
+
 import { describeRequestError } from "../config";
 import type { CompileMode, CompileResponse } from "../lib/api/types";
 

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -284,6 +284,7 @@ export default function SkillsGenerator() {
               type="button"
               onClick={handleGenerate}
               disabled={loading || !description.trim()}
+              aria-busy={loading}
               title={!description.trim() ? "Enter a description first to generate" : "Generate Skill"}
               className="w-full px-4 py-3 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
@@ -363,6 +364,7 @@ export default function SkillsGenerator() {
                       type="button"
                       onClick={handleGenerate}
                       disabled={loading || !description.trim()}
+                      aria-busy={loading}
                       title={!description.trim() ? "Enter a description first to generate" : "Generate Skill"}
                       className="mx-auto px-6 py-2.5 text-sm font-bold text-white rounded-xl shadow-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 group bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500 shadow-yellow-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a]"
                     >


### PR DESCRIPTION
💡 What:
Added `aria-busy={loading}` (or `aria-busy={downloading}`) to buttons across the application that perform asynchronous actions and disable themselves while loading.
Also removed an unused `toast` import in `web/app/page.tsx` to keep the codebase clean.

🎯 Why:
To improve the user experience for screen reader users by properly announcing the loading state of these buttons instead of just silently disabling them.

📸 Before/After:
Before: Buttons just became disabled while loading.
After: Buttons become disabled and also have the `aria-busy` attribute set to true while loading.

♿ Accessibility:
Improved accessibility for screen reader users by explicitly communicating the busy state of interactive elements during asynchronous operations.

---
*PR created automatically by Jules for task [134060404273457376](https://jules.google.com/task/134060404273457376) started by @madara88645*