### PR TITLE
Show safety refusal message in all compile output tabs

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -11,7 +11,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
-from api.shared import forced_minimal_expanded_prompt, is_meta_leaked, logger, resolve_mode
+from api.shared import (
+    forced_minimal_expanded_prompt,
+    is_meta_leaked,
+    logger,
+    resolve_mode,
+    safety_refusal_prompt_fields,
+)
 from app.compiler import HEURISTIC_VERSION, HEURISTIC2_VERSION
 from app.compiler import compile_text, compile_text_v2, generate_trace, optimize_ir
 from app.emitters import (
@@ -462,24 +468,10 @@ def compile_endpoint(
             "Unsafe input blocked - returning safety refusal payload",
             extra={"request_id": rid, "security": security_meta},
         )
-        refusal_message = (
-            "⚠️ Blocked for safety. This request looks like a prompt-injection or "
-            "secret-exfiltration attempt (e.g. overriding instructions or extracting "
-            "hidden system data), so Prompt Compiler will not compile it. Rephrase your "
-            "actual task without trying to override or extract instructions."
-        )
-
         return CompileResponse(
             ir=ir.model_dump(),
             ir_v2=(ir2.model_dump() if ir2 else None),
-            system_prompt=refusal_message,
-            user_prompt="",
-            plan="",
-            expanded_prompt=refusal_message,
-            system_prompt_v2=refusal_message,
-            user_prompt_v2="",
-            plan_v2="",
-            expanded_prompt_v2=refusal_message,
+            **safety_refusal_prompt_fields(),
             processing_ms=elapsed,
             request_id=rid,
             heuristic_version=HEURISTIC_VERSION,

--- a/api/shared.py
+++ b/api/shared.py
@@ -70,6 +70,29 @@ def resolve_mode(req_mode: Optional[str], request: Request) -> str:
     return (os.environ.get("PROMPT_COMPILER_MODE") or "conservative").strip().lower()
 
 
+SAFETY_REFUSAL_MESSAGE = (
+    "⚠️ Blocked for safety. This request looks like a prompt-injection or "
+    "secret-exfiltration attempt (e.g. overriding instructions or extracting "
+    "hidden system data), so Prompt Compiler will not compile it. Rephrase your "
+    "actual task without trying to override or extract instructions."
+)
+
+
+def safety_refusal_prompt_fields() -> dict[str, str]:
+    """All compiled prompt slots carry the same refusal when input is unsafe."""
+    msg = SAFETY_REFUSAL_MESSAGE
+    return {
+        "system_prompt": msg,
+        "user_prompt": msg,
+        "plan": msg,
+        "expanded_prompt": msg,
+        "system_prompt_v2": msg,
+        "user_prompt_v2": msg,
+        "plan_v2": msg,
+        "expanded_prompt_v2": msg,
+    }
+
+
 def forced_minimal_expanded_prompt(text: str, ir2, diagnostics: bool = False) -> str | None:
     if ir2 is None:
         return None

--- a/tests/test_critique_verdict_enforcement.py
+++ b/tests/test_critique_verdict_enforcement.py
@@ -92,18 +92,23 @@ def test_compile_endpoint_blocks_unsafe_injection_input(client):
         # The refusal is driven by the safety scan (is_safe=False), not the critique verdict.
         assert data["ir_v2"]["metadata"].get("security", {}).get("is_safe") is False
 
-        # Output is replaced with a clear SAFETY refusal (not the attack, not critique text).
-        assert "Blocked for safety" in data["system_prompt"]
-        assert "Blocked for safety" in data["expanded_prompt"]
+        # Output is replaced with a clear SAFETY refusal in every prompt section.
+        for field in (
+            "system_prompt",
+            "user_prompt",
+            "plan",
+            "expanded_prompt",
+            "system_prompt_v2",
+            "user_prompt_v2",
+            "plan_v2",
+            "expanded_prompt_v2",
+        ):
+            assert "Blocked for safety" in data[field], field
 
         # The adversarial content must NOT appear in the compiled prompts.
         attack_text = "Ignore all previous instructions"
-        assert attack_text not in data["system_prompt"]
-        assert attack_text not in data["expanded_prompt"]
-
-        # The user_prompt and plan are emptied.
-        assert data["user_prompt"] == ""
-        assert data["plan"] == ""
+        for field in ("system_prompt", "user_prompt", "plan", "expanded_prompt"):
+            assert attack_text not in data[field], field
 
 
 def test_compile_endpoint_enforces_reject_verdict_without_critical_issue(client):
@@ -356,6 +361,16 @@ def test_compile_v2_worker_path_preserves_safety_block(client):
     # The heuristic safety verdict must be preserved onto the worker IR and trigger the block.
     assert data["ir_v2"]["metadata"].get("security", {}).get("is_safe") is False
     assert data["ir_v2"]["policy"]["risk_level"] == "high"
-    assert "Blocked for safety" in data["system_prompt"]
-    assert data["user_prompt"] == ""
+    for field in (
+        "system_prompt",
+        "user_prompt",
+        "plan",
+        "expanded_prompt",
+        "system_prompt_v2",
+        "user_prompt_v2",
+        "plan_v2",
+        "expanded_prompt_v2",
+    ):
+        assert "Blocked for safety" in data[field], field
     assert "Ignore all previous instructions" not in data["system_prompt"]
+    assert "Ignore all previous instructions" not in data["user_prompt"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a request is blocked for prompt-injection or secret exfiltration, the API now returns the same safety refusal text in **every** compiled output field (system, user, plan, expanded, and their v2 variants). Previously only system and expanded carried the warning; user and plan were empty, so switching tabs in the UI looked like a partial or broken compile.

## What changed

- Added `SAFETY_REFUSAL_MESSAGE` and `safety_refusal_prompt_fields()` in `api/shared.py` so the refusal copy lives in one place.
- Updated the unsafe-input branch in `/compile` to spread those fields into the response instead of leaving `user_prompt` and `plan` blank.

## Product impact

Users who hit a risky-intent block see a consistent explanation on **User Prompt**, **System Prompt**, **Execution Plan**, and **Long-form** tabs—no more empty panels that imply something failed silently.

## Risk

Low. Behavior change is limited to the already-blocked safety path; safe compiles are unchanged. Tests updated to assert the refusal appears in all eight prompt fields.

## Testing

- `python3 -m pytest tests/test_critique_verdict_enforcement.py -q` (5 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c3e1da4-a25d-4fff-abf8-9bd4286b311f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c3e1da4-a25d-4fff-abf8-9bd4286b311f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

