### PR TITLE
🎨 Palette: Add 'try an example' CTA to offline mode empty state

### DIFF
--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -266,6 +266,21 @@ export default function OfflinePage() {
                                     >
                                         Run Heuristics
                                     </button>
+                                    {!prompt.trim() && (
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                setPrompt("Summarize the key points of this meeting transcript.");
+                                                setTimeout(() => {
+                                                    const textarea = document.getElementById('offline-prompt');
+                                                    if (textarea) textarea.focus();
+                                                }, 0);
+                                            }}
+                                            className="mt-3 text-xs text-zinc-400/80 hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded px-2 py-1 mx-auto block"
+                                        >
+                                            or try an example
+                                        </button>
+                                    )}
                                 </div>
                             </div>
                         )}


### PR DESCRIPTION
💡 What: Added an "or try an example" button to the Offline Mode empty state.
🎯 Why: It solves the "blank canvas" problem by giving users a one-click way to see how the tool works with a well-formatted example prompt ("Summarize the key points of this meeting transcript.").
📸 Before/After: Before, the offline mode just had a blank text box. Now it features the helper CTA below the Run Heuristics button, mirroring the UX found on the main compiler page.
♿ Accessibility: The button is fully keyboard accessible, uses proper focus states (`focus-visible:ring-1 focus-visible:ring-zinc-500`), and automatically shifts focus to the textarea when clicked, aiding screen reader and keyboard-only navigation.

---
*PR created automatically by Jules for task [9229836655085803091](https://jules.google.com/task/9229836655085803091) started by @madara88645*