### PR TITLE
[codex] fix windows pytest temp runtime

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -244,7 +244,7 @@ Relevant files: `app/rag/simple_index.py`, `api/routes/rag.py`
 pytest tests/test_rag.py tests/test_rag_upload.py tests/test_rag_pipeline.py tests/test_rag_chunking.py tests/test_rag_hybrid_api.py tests/test_rag_parsers.py -v
 ```
 
-**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. `tests/runtime_bootstrap.py` creates the pytest session directory directly under the candidate root and probes it before use, which avoids Windows environments where `mkdtemp()` succeeds but the returned directory still rejects child file or folder creation. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
+**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. `tests/runtime_bootstrap.py` creates the pytest session directory directly under the candidate root and now probes both a simple child folder and a pytest-style nested temp tree before use, which avoids Windows environments where a session dir looks writable at first but later rejects nested `pytest-of-*` paths or directory scans. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
 
 **RAG upload smoke (requires running backend):**
 

--- a/tests/runtime_bootstrap.py
+++ b/tests/runtime_bootstrap.py
@@ -32,12 +32,22 @@ def _create_session_dir(root: Path) -> Path:
     session_dir = (root / f"pytest-{uuid4().hex[:8]}").resolve()
     session_dir.mkdir(parents=False, exist_ok=False)
     probe_dir = session_dir / ".write-probe"
+    pytest_probe_root = session_dir / "pytest-of-probe"
+    pytest_probe_leaf = pytest_probe_root / "pytest-0"
 
     try:
         probe_dir.mkdir(parents=True, exist_ok=False)
+        pytest_probe_root.mkdir(parents=True, exist_ok=False)
+        pytest_probe_leaf.mkdir(parents=False, exist_ok=False)
+        os.scandir(pytest_probe_root).close()
+        os.scandir(pytest_probe_leaf).close()
     finally:
         if probe_dir.exists():
             probe_dir.rmdir()
+        if pytest_probe_leaf.exists():
+            pytest_probe_leaf.rmdir()
+        if pytest_probe_root.exists():
+            pytest_probe_root.rmdir()
 
     return session_dir
 

--- a/tests/test_test_runtime_bootstrap.py
+++ b/tests/test_test_runtime_bootstrap.py
@@ -100,3 +100,32 @@ def test_prepare_test_runtime_avoids_mkdtemp_dirs_that_cannot_create_children(
     assert runtime.session_dir.resolve() not in blocked_session_dirs
     assert runtime.db_dir == (runtime.session_dir / "db").resolve()
     assert runtime.db_dir.is_dir()
+
+
+def test_prepare_test_runtime_falls_back_when_pytest_style_nested_temp_dirs_fail(
+    tmp_path, monkeypatch
+):
+    from tests.runtime_bootstrap import prepare_test_runtime
+
+    preferred_root = tmp_path / "preferred"
+    fallback_root = tmp_path / "fallback"
+    fallback_root.mkdir()
+
+    original_mkdir = Path.mkdir
+
+    def patched_mkdir(self: Path, parents: bool = False, exist_ok: bool = False):
+        parent = self.parent.resolve()
+        preferred = preferred_root.resolve()
+
+        if self.name.startswith("pytest-of-") and parent.parent == preferred:
+            raise PermissionError("simulated pytest basetemp failure")
+
+        return original_mkdir(self, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", patched_mkdir)
+
+    runtime = prepare_test_runtime(preferred_root=preferred_root, fallback_roots=[fallback_root])
+
+    assert runtime.session_dir.parent == fallback_root.resolve()
+    assert runtime.db_dir == (runtime.session_dir / "db").resolve()
+    assert runtime.db_dir.is_dir()


### PR DESCRIPTION
## Summary
- harden `tests/runtime_bootstrap.py` by probing a pytest-style nested temp tree before accepting a runtime directory
- add a regression test that forces fallback when nested `pytest-of-*` temp paths fail under the preferred root
- update `agents.md` with the new Windows temp-dir behavior

## Why
Some Windows environments look writable at the top level but later fail when pytest creates or scans deeper temp directories. This makes RAG/auth coverage flaky even when the app code is fine.

## Root cause
The runtime bootstrap only verified a shallow child directory. It did not validate the deeper nested temp layout that pytest later creates on Windows.

## Validation
- `C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m pytest tests/test_test_runtime_bootstrap.py tests/test_rag_upload.py tests/test_auth_fast_path.py -q`
