### PR TITLE
🎨 Palette: Add actionable buttons to Agent Packs empty state

### DIFF
--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -76,7 +76,7 @@ describe("Agent Packs page", () => {
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
       target: { value: "Review pull requests for secret leaks and missing tests." },
     });
-    fireEvent.click(screen.getByRole("button", { name: /generate claude pack/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
 
     await waitFor(() => expect(apiJson).toHaveBeenCalledTimes(1));
     const [path, options] = apiJson.mock.calls[0];
@@ -107,7 +107,7 @@ describe("Agent Packs page", () => {
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
       target: { value: "Create a full project pack." },
     });
-    fireEvent.click(screen.getByRole("button", { name: /generate claude pack/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
 
     await screen.findByText("Pack Preview");
     fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
@@ -127,7 +127,7 @@ describe("Agent Packs page", () => {
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
       target: { value: "Create a full project pack." },
     });
-    fireEvent.click(screen.getByRole("button", { name: /generate claude pack/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
 
     expect(
       await screen.findByText("The service is temporarily unavailable or still waking up. Please retry in a few seconds."),

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -468,6 +468,33 @@ export default function AgentPacksPage() {
                   <p className="text-sm leading-relaxed text-zinc-500">
                     Pick a pack type, describe what Claude should do, then generate a ready-to-review asset bundle on the right.
                   </p>
+                  <div className="flex flex-col items-center gap-3 mt-6 w-full">
+                    <button
+                      type="button"
+                      onClick={handleGenerate}
+                      disabled={loading || !request.goal.trim()}
+                      aria-busy={loading}
+                      title={!request.goal.trim() ? "Enter a goal first to generate" : provider.ctaLabel}
+                      className={`mx-auto flex items-center justify-center gap-2 rounded-2xl px-6 py-2.5 text-sm font-bold text-white shadow-lg transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1a1a1a] ${provider.buttonClass}`}
+                    >
+                      {provider.ctaLabel}
+                    </button>
+                    {!request.goal.trim() && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          handleFieldChange("goal", "Review PRs for prompt leakage, unsafe settings, and missing regression tests.");
+                          setTimeout(() => {
+                            const textarea = document.getElementById('agent-pack-goal');
+                            if (textarea) textarea.focus();
+                          }, 0);
+                        }}
+                        className="text-xs text-cyan-400/80 hover:text-cyan-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded px-2 py-1"
+                      >
+                        or try an example
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
💡 What: Added a "Generate Pack" button and an "or try an example" button to the empty state of the Agent Packs page (`web/app/agent-packs/page.tsx`).

🎯 Why: To solve the "blank canvas" UX problem. New users landing on the Agent Packs page previously had to infer that they needed to type a goal into the textarea first. Providing clear call-to-actions directly in the empty state, including one that auto-fills an example, significantly reduces friction and demonstrates the expected input format immediately.

📸 Before/After: See the attached video for a demonstration of the new empty state and the "or try an example" auto-fill behavior.

♿ Accessibility: The new button uses standard focus-visible styles, is keyboard navigable, uses the `disabled` attribute correctly, and utilizes `aria-busy={loading}` for its loading state.

---
*PR created automatically by Jules for task [1290152265202161736](https://jules.google.com/task/1290152265202161736) started by @madara88645*