### PR TITLE
fix(web): remove remote font dependency from app layout

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -12,8 +12,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Cascadia Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 
 body {

--- a/web/app/layout.fonts.test.mts
+++ b/web/app/layout.fonts.test.mts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const layoutSource = readFileSync(path.join(thisDir, "layout.tsx"), "utf8");
+const globalsSource = readFileSync(path.join(thisDir, "globals.css"), "utf8");
+
+test("app layout does not depend on remote Google fonts", () => {
+  assert.equal(layoutSource.includes('from "next/font/google"'), false);
+  assert.equal(layoutSource.includes("Geist("), false);
+  assert.equal(layoutSource.includes("Geist_Mono("), false);
+});
+
+test("global theme keeps local fallback font stacks", () => {
+  assert.match(globalsSource, /--font-sans:\s*"Segoe UI"/);
+  assert.match(globalsSource, /--font-mono:\s*"Cascadia Code"/);
+});

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,18 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Sidebar from "./components/Sidebar";
 import ToastProvider from "./components/ToastProvider";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Prompt Compiler",
@@ -26,10 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-        suppressHydrationWarning
-      >
+      <body className="antialiased" suppressHydrationWarning>
         <ToastProvider />
         <div className="flex h-screen bg-[#050505] text-zinc-300 overflow-hidden">
           {/* Sidebar Navigation */}


### PR DESCRIPTION
## Summary
- remove the Google font import from the app layout
- switch the global theme to local system font stacks
- add a regression test so the layout stays offline-safe

## Verification
- node --test web/app/layout.fonts.test.mts
- cd web && npm run build
- cd web && npm run lint *(shows one pre-existing warning in web/app/hooks/useContextManager.ts)*