### PR TITLE
fix(tests): isolate Windows temp runtime scratch dir

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -244,7 +244,7 @@ Relevant files: `app/rag/simple_index.py`, `api/routes/rag.py`
 pytest tests/test_rag.py tests/test_rag_upload.py tests/test_rag_pipeline.py tests/test_rag_chunking.py tests/test_rag_hybrid_api.py tests/test_rag_parsers.py -v
 ```
 
-**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. `tests/runtime_bootstrap.py` creates the pytest session directory directly under the candidate root and now probes both a simple child folder and a pytest-style nested temp tree before use, which avoids Windows environments where a session dir looks writable at first but later rejects nested `pytest-of-*` paths or directory scans. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
+**Windows temp-dir note:** `tests/conftest.py` now prefers a repo-local `.\.tmp-test-run` session dir and falls back to a user temp folder automatically if that repo-local runtime root is not writable. `tests/runtime_bootstrap.py` creates the pytest session directory directly under the candidate root, probes both a simple child folder and a pytest-style nested temp tree before use, and points `TMP`/`TEMP`/`TMPDIR` at a dedicated `tmp` child inside that session so ad-hoc `tempfile` directories do not collide with pytest's own `pytest-of-*` folders on Windows. If you still hit a `PermissionError`, inspect stale directories under `.\.tmp-test-run` first, then override `TMP`, `TEMP`, and `DB_DIR` manually only as a last resort.
 
 **RAG upload smoke (requires running backend):**
 

--- a/tests/runtime_bootstrap.py
+++ b/tests/runtime_bootstrap.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 @dataclass(frozen=True)
 class TestRuntime:
     session_dir: Path
+    temp_root: Path
     db_dir: Path
     env_updates: dict[str, str]
 
@@ -63,16 +64,23 @@ def prepare_test_runtime(
         try:
             root.mkdir(parents=True, exist_ok=True)
             session_dir = _create_session_dir(root)
+            temp_root = (session_dir / "tmp").resolve()
+            temp_root.mkdir(parents=True, exist_ok=True)
             db_dir = (session_dir / "db").resolve()
             db_dir.mkdir(parents=True, exist_ok=True)
 
             env_updates = {
-                "TMP": str(session_dir),
-                "TEMP": str(session_dir),
-                "TMPDIR": str(session_dir),
+                "TMP": str(temp_root),
+                "TEMP": str(temp_root),
+                "TMPDIR": str(temp_root),
                 "DB_DIR": str(db_dir),
             }
-            return TestRuntime(session_dir=session_dir, db_dir=db_dir, env_updates=env_updates)
+            return TestRuntime(
+                session_dir=session_dir,
+                temp_root=temp_root,
+                db_dir=db_dir,
+                env_updates=env_updates,
+            )
         except PermissionError as exc:
             if "session_dir" in locals():
                 shutil.rmtree(session_dir, ignore_errors=True)
@@ -87,4 +95,4 @@ def prepare_test_runtime(
 def apply_test_runtime(runtime: TestRuntime) -> None:
     for env_name, value in runtime.env_updates.items():
         os.environ[env_name] = value
-    tempfile.tempdir = str(runtime.session_dir)
+    tempfile.tempdir = str(runtime.temp_root)

--- a/tests/test_test_runtime_bootstrap.py
+++ b/tests/test_test_runtime_bootstrap.py
@@ -33,9 +33,13 @@ def test_prepare_test_runtime_sets_process_temp_environment(tmp_path):
 
     assert runtime.session_dir.is_dir()
     assert runtime.db_dir.is_dir()
-    assert runtime.env_updates["TMP"] == str(runtime.session_dir)
-    assert runtime.env_updates["TEMP"] == str(runtime.session_dir)
-    assert runtime.env_updates["TMPDIR"] == str(runtime.session_dir)
+    assert runtime.env_updates["TMP"] != str(runtime.session_dir)
+    assert runtime.env_updates["TEMP"] != str(runtime.session_dir)
+    assert runtime.env_updates["TMPDIR"] != str(runtime.session_dir)
+    assert Path(runtime.env_updates["TMP"]) == runtime.session_dir / "tmp"
+    assert Path(runtime.env_updates["TEMP"]) == runtime.session_dir / "tmp"
+    assert Path(runtime.env_updates["TMPDIR"]) == runtime.session_dir / "tmp"
+    assert Path(runtime.env_updates["TMP"]).is_dir()
     assert runtime.env_updates["DB_DIR"] == str(runtime.db_dir)
 
 


### PR DESCRIPTION
## Summary
- isolate ad-hoc tempfile usage under a dedicated `tmp` child inside each pytest runtime session
- keep Windows test runtime behavior documented in `agents.md`
- extend bootstrap coverage so the temp env no longer points at the session root itself

## Verification
- `C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m pytest tests/test_test_runtime_bootstrap.py tests/test_rag_upload.py tests/test_auth_fast_path.py tests/test_api_hardening.py tests/test_benchmark_api.py -q`
- `C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m ruff check tests/runtime_bootstrap.py tests/test_test_runtime_bootstrap.py`
- `C:\Users\User\Desktop\myCompiler\.venv\Scripts\python.exe -m ruff format tests/runtime_bootstrap.py tests/test_test_runtime_bootstrap.py --check`
