### PR TITLE
🎨 Palette: Add aria-pressed to ExportPanel toggle buttons

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -238,6 +238,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 type="button"
                 key={item.id}
                 onClick={() => handleTargetClick(item.id)}
+                aria-pressed={target === item.id}
                 className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
                   target === item.id ? item.activeColor : item.color
                 }`}
@@ -253,6 +254,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 type="button"
                 key={tab.id}
                 onClick={() => handleOutputModeClick(tab.id)}
+                aria-pressed={outputMode === tab.id}
                 className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
                   outputMode === tab.id
                     ? "bg-white/10 text-zinc-100"

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -210,6 +210,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 type="button"
                 key={item.id}
                 onClick={() => handleTargetClick(item.id)}
+                aria-pressed={target === item.id}
                 className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
                   target === item.id ? item.activeColor : item.color
                 }`}
@@ -225,6 +226,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 type="button"
                 key={tab.id}
                 onClick={() => handleOutputModeClick(tab.id)}
+                aria-pressed={outputMode === tab.id}
                 className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
                   outputMode === tab.id
                     ? "bg-white/10 text-zinc-100"


### PR DESCRIPTION
💡 What: Added `aria-pressed` attributes to the target and output mode toggle buttons in both `agent-generator` and `skills-generator` `ExportPanel` components.
🎯 Why: To explicitly convey the active/selected state of these mutually exclusive toggle buttons to screen readers, improving accessibility for visually impaired users.
📸 Before/After: Visual presentation remains identical, but DOM now includes `aria-pressed="true"` for active tabs.
♿ Accessibility: Ensures WCAG compliance for toggle button states.

---
*PR created automatically by Jules for task [1839656788384490074](https://jules.google.com/task/1839656788384490074) started by @madara88645*