### PR TITLE
[codex] fix repeated linter ambiguity counting

### DIFF
--- a/app/heuristics/linter.py
+++ b/app/heuristics/linter.py
@@ -190,7 +190,7 @@ class PromptLinter:
 
         # Count every repeated multi-word weasel phrase instead of only the first match.
         for pattern in _MULTI_WORD_WEASEL_PATTERNS:
-            weasel_count += len(pattern.findall(lower_text))
+            weasel_count += sum(1 for _ in pattern.finditer(lower_text))
 
         ambiguity_score = weasel_count / total_words if total_words > 0 else 0.0
 

--- a/app/heuristics/linter.py
+++ b/app/heuristics/linter.py
@@ -88,6 +88,11 @@ _COMBINED_PII_FAST_PATH: re.Pattern = re.compile(
 
 # Pre-compiled regex for fast word tokenization
 _WORD_PATTERN = re.compile(r"\w+")
+_MULTI_WORD_WEASEL_PATTERNS: Tuple[re.Pattern[str], ...] = (
+    re.compile(r"\btry to\b"),
+    re.compile(r"\bkind of\b"),
+    re.compile(r"\bsort of\b"),
+)
 
 # 4. Conflict Pairs (Mutually exclusive concepts)
 CONFLICT_PAIRS: List[Tuple[Set[str], Set[str]]] = [
@@ -183,13 +188,9 @@ class PromptLinter:
         # Bolt Optimization: C-level sum(map) with __contains__ is highly optimized and memory efficient
         weasel_count = sum(map(WEASEL_WORDS.__contains__, words))
 
-        # Check for multi-word weasels (e.g. "try to") - simple heuristic check
-        if "try to" in lower_text:
-            weasel_count += 1
-        if "kind of" in lower_text:
-            weasel_count += 1
-        if "sort of" in lower_text:
-            weasel_count += 1
+        # Count every repeated multi-word weasel phrase instead of only the first match.
+        for pattern in _MULTI_WORD_WEASEL_PATTERNS:
+            weasel_count += len(pattern.findall(lower_text))
 
         ambiguity_score = weasel_count / total_words if total_words > 0 else 0.0
 

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -14,6 +14,15 @@ def test_linter_ambiguity():
     assert any(w.code == "AMBIGUITY" for w in report.warnings)
 
 
+def test_linter_counts_repeated_multi_word_weasel_phrases():
+    linter = PromptLinter()
+
+    single = linter.lint("Try to improve this.")
+    repeated = linter.lint("Try to try to improve this.")
+
+    assert repeated.ambiguity_score > single.ambiguity_score
+
+
 def test_linter_density():
     linter = PromptLinter()
     # High density


### PR DESCRIPTION
## Summary
- count every repeated multi-word ambiguity phrase in the linter instead of only the first match
- add a regression test that proves repeated `try to` phrases increase ambiguity instead of lowering it
- keep nearby offline heuristic coverage green after the linter change

## Why
The recent linter optimization kept multi-word phrases like `try to`, `kind of`, and `sort of` on a simple first-match check. That meant a prompt with the same vague phrase repeated could look less ambiguous than a shorter prompt with the phrase once, which is backwards for users reading the linter score.

## Product impact
Users get a more honest ambiguity score when they repeat vague instructions. In plain terms: if a prompt is more fuzzy, the warning now gets stronger instead of weaker.

## Risk
Low. The change is narrowly scoped to counting repeated multi-word ambiguity phrases and is covered by a focused regression test plus nearby offline tests.

## Validation
- `python -m pytest tests/test_linter.py tests/test_offline_mode.py tests/test_offline_advanced.py -q`
- `python -m ruff check app/heuristics/linter.py tests/test_linter.py`
