### PR TITLE
[codex] test: cover offline example CTA focus flow

### DIFF
--- a/web/app/__tests__/offline-page-error-state.test.tsx
+++ b/web/app/__tests__/offline-page-error-state.test.tsx
@@ -61,4 +61,18 @@ describe("Offline compiler page", () => {
     expect(screen.queryByText("→")).toBeNull();
     expect(screen.queryByText("Ctrl/⌘ Enter")).toBeNull();
   });
+  it("prefills the prompt and restores focus when the example shortcut is used", () => {
+    render(<OfflinePage />);
+
+    const promptInput = screen.getByLabelText("Offline prompt input");
+    const exampleButton = screen.getByRole("button", { name: "or try an example" });
+
+    fireEvent.click(exampleButton);
+
+    expect((promptInput as HTMLTextAreaElement).value).toBe(
+      "Summarize the key points of this meeting transcript.",
+    );
+    expect(document.activeElement).toBe(promptInput);
+    expect(screen.queryByRole("button", { name: "or try an example" })).toBeNull();
+  });
 });

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { WifiOff } from "lucide-react";
 import ContextManager from "../components/ContextManager";
 import CopyButton from "../components/CopyButton";
@@ -13,6 +13,7 @@ import InfoButton from "../components/InfoButton";
 type OfflineOutputTab = "system" | "user" | "plan" | "expanded" | "json";
 
 const OFFLINE_MODE: CompileMode = "conservative";
+const OFFLINE_EXAMPLE_PROMPT = "Summarize the key points of this meeting transcript.";
 
 function getOfflineTabContent(result: CompileResponse, activeTab: OfflineOutputTab): string {
     if (activeTab === "system") {
@@ -37,6 +38,7 @@ export default function OfflinePage() {
     const [activeTab, setActiveTab] = useState<OfflineOutputTab>("system");
     const [lastError, setLastError] = useState<unknown>(null);
     const [lastRequest, setLastRequest] = useState("");
+    const promptInputRef = useRef<HTMLTextAreaElement | null>(null);
 
     // Diagnostics ON by default
     const diagnostics = true;
@@ -130,6 +132,7 @@ export default function OfflinePage() {
                             <textarea
                                 id="offline-prompt"
                                 aria-label="Offline prompt input"
+                                ref={promptInputRef}
                                 className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-500/50 sm:min-h-44 md:min-h-0"
                                 placeholder="Enter prompt (offline heuristics active)..."
                                 value={prompt}
@@ -270,11 +273,8 @@ export default function OfflinePage() {
                                         <button
                                             type="button"
                                             onClick={() => {
-                                                setPrompt("Summarize the key points of this meeting transcript.");
-                                                setTimeout(() => {
-                                                    const textarea = document.getElementById('offline-prompt');
-                                                    if (textarea) textarea.focus();
-                                                }, 0);
+                                                setPrompt(OFFLINE_EXAMPLE_PROMPT);
+                                                promptInputRef.current?.focus();
                                             }}
                                             className="mt-3 text-xs text-zinc-400/80 hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded px-2 py-1 mx-auto block"
                                         >


### PR DESCRIPTION
## Summary
- add regression coverage for the Offline page example shortcut
- make the shortcut focus the prompt immediately using a stable ref instead of a delayed DOM lookup
- keep the scope limited to the new helper flow introduced on the offline page

## Why
The new "or try an example" helper improved the empty state, but it had no test coverage and used a brittle delayed focus handoff. This PR locks down the visible behavior and makes the interaction feel immediate for users.

## Test Plan
- [x] `cd web && npm run test -- app/__tests__/offline-page-error-state.test.tsx`
- [x] `cd web && npm run lint -- app/offline/page.tsx app/__tests__/offline-page-error-state.test.tsx`
