### PR TITLE
fix: avoid reflecting unsupported export formats

### DIFF
--- a/api/routes/export.py
+++ b/api/routes/export.py
@@ -35,7 +35,7 @@ async def export_agent(
         "langchain-yaml",
         "langgraph",
     ]:
-        raise HTTPException(status_code=400, detail=f"Unsupported format: {req.format}")
+        raise HTTPException(status_code=400, detail="Unsupported format.")
 
     from app.adapters.agent_ir import parse_agent_markdown
     from app.adapters.claude_code import (
@@ -108,7 +108,7 @@ async def export_skill(
     _: None = Depends(rate_limit_by_ip),
 ):
     if req.format not in _SKILL_EXPORT_FORMATS:
-        raise HTTPException(status_code=400, detail=f"Unsupported format: {req.format}")
+        raise HTTPException(status_code=400, detail="Unsupported format.")
 
     from app.adapters.claude_code import to_claude_mcp_tool_stub
     from app.adapters.skill_adapter import (

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -633,6 +633,38 @@ def test_export_api_invalid_format(client):
     assert response.status_code == 400
 
 
+def test_export_api_invalid_agent_format_does_not_reflect_input(client):
+    malicious_format = '<script>alert("pwnd")</script>'
+    response = client.post(
+        "/agent-generator/export",
+        json={
+            "system_prompt": SINGLE_AGENT_MARKDOWN,
+            "format": malicious_format,
+            "output_type": "python",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Unsupported format."}
+    assert malicious_format not in response.text
+
+
+def test_export_api_invalid_skill_format_does_not_reflect_input(client):
+    malicious_format = '<img src=x onerror="alert(1)">'
+    response = client.post(
+        "/skills-generator/export",
+        json={
+            "skill_definition": SKILL_MARKDOWN,
+            "format": malicious_format,
+            "output_type": "python",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Unsupported format."}
+    assert malicious_format not in response.text
+
+
 def test_export_api_python_only(client):
     response = client.post(
         "/agent-generator/export",


### PR DESCRIPTION
## Summary
- replace dynamic unsupported format errors with a static safe message
- add regression tests for both export endpoints to prove malicious format values are not reflected
- keep valid export formats unchanged

## Testing
- python -m pytest tests/test_export_adapters.py -q
- python -m pytest tests/test_api_hardening.py tests/test_auth_fast_path.py -q

## Notes
- Replacement for #737
- Old #737 can be closed after this PR is reviewed