### PR TITLE
fix(agent-packs): make pack downloads trigger browser file save

### DIFF
--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -108,6 +108,29 @@ def test_agent_packs_download_returns_single_file_when_manifest_has_one_file():
         assert set(archive.namelist()) == {"server.py", "README.md"}
 
 
+def test_agent_packs_download_multi_file_pack_returns_nonempty_zip():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = (
+            "# Review Agent\n\n## Role\nYou review code.\n\n## Goals\n- Catch prompt leaks"
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/agent-packs/claude/download", json=_request_payload("project-pack")
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/zip")
+        assert "filename=" in response.headers["content-disposition"]
+        assert 'filename="saas-project-pack-claude.zip"' in response.headers["content-disposition"]
+        assert len(response.content) > 0
+
+        archive = zipfile.ZipFile(io.BytesIO(response.content))
+        assert len(archive.namelist()) > 1
+        # Every archived file should carry real content.
+        assert all(archive.read(name) for name in archive.namelist())
+
+
 def test_agent_packs_download_returns_plain_file_for_single_file_manifest():
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = "# Review Agent\n\n## Role\nYou review code."

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -117,6 +117,46 @@ describe("Agent Packs page", () => {
     expect(path).toBe("/agent-packs/claude/download");
     expect(JSON.parse(options.body).goal).toBe("Create a full project pack.");
     expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    // The blob URL is created for the download and cleaned up afterwards.
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview"));
+
+    // Button leaves the "Preparing..." state after a successful download.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /download pack/i }).textContent).toContain(
+        "Download Pack",
+      ),
+    );
+  });
+
+  test("shows a visible error and resets the button when download fails", async () => {
+    render(<AgentPacksPage />);
+
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "Create a full project pack." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+
+    await screen.findByText("Pack Preview");
+
+    apiFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: "Pack generation failed." }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
+
+    expect(await screen.findByText("Pack generation failed.")).toBeTruthy();
+
+    // No silent infinite loading state: the button returns to its idle label.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /download pack/i }).textContent).toContain(
+        "Download Pack",
+      ),
+    );
   });
 
   test("shows a normalized network error when generation fails to fetch", async () => {

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -168,13 +168,24 @@ export default function AgentPacksPage() {
       }
 
       const blob = await response.blob();
+      if (blob.size === 0) {
+        throw new Error("The agent pack download was empty. Please try generating it again.");
+      }
+
       const href = URL.createObjectURL(blob);
       const filename = getDownloadFilename(response, `${manifest?.download_name || "agent-pack"}.zip`);
       const anchor = document.createElement("a");
       anchor.href = href;
       anchor.download = filename;
+      anchor.rel = "noopener";
+      anchor.style.display = "none";
+      // The anchor must be in the document for the synthetic click to trigger a
+      // download in Firefox, and the object URL must outlive the click — revoking
+      // it synchronously cancels the download in Chromium-based browsers.
+      document.body.appendChild(anchor);
       anchor.click();
-      URL.revokeObjectURL(href);
+      anchor.remove();
+      setTimeout(() => URL.revokeObjectURL(href), 0);
     } catch (err: unknown) {
       showError(err);
       setError(describeRequestError(err, { fallback: "Failed to download agent pack." }));


### PR DESCRIPTION
Fixes #760

## Summary
On `/agent-packs`, generating a pack worked but clicking **Download Pack** flashed "Preparing..." and reset with no file saved and no error shown. This fixes the client-side download flow so the browser actually saves a non-empty file, and surfaces a clear error when something goes wrong.

## Root cause
In `web/app/agent-packs/page.tsx`, `handleDownload` built a blob anchor but:
- called `URL.revokeObjectURL(href)` **synchronously** immediately after `anchor.click()` — Chromium-based browsers cancel the in-flight download when the object URL is revoked in the same tick, so no file reached `chrome://downloads`.
- never appended the anchor to the DOM — Firefox ignores synthetic clicks on detached anchors.

Because the `fetch` itself succeeded, no error was thrown, so the button silently returned to its idle state.

The backend route (`/agent-packs/claude/download`), `create_download_response`, and the proxy (which already streams `application/zip` and preserves `Content-Disposition`) were all correct and unchanged.

## Fix
- Append a hidden `<a>` to `document.body`, click it, remove it, and defer `URL.revokeObjectURL` to a later tick so the download can start.
- Guard against an empty blob and throw a user-friendly error, so failures show the existing red error banner instead of silently resetting.
- Pack generation semantics are untouched.

## Changed files
- `web/app/agent-packs/page.tsx` — fixed the download flow (deferred revoke, DOM-attached anchor, empty-blob guard).
- `web/app/agent-packs/page.test.tsx` — assert blob URL create/revoke + button reset on success; new test for visible error + button reset on failure.
- `tests/test_agent_packs_api.py` — new test asserting the multi-file pack download returns `200`, `application/zip`, a `Content-Disposition` filename, a non-empty body, and non-empty archive entries.

## Tests run
- `python -m pytest tests/test_agent_packs_api.py -q` → **23 passed**
- `cd web && npm run test` → **104 passed (22 files)**
- `cd web && npm run build` → **success**

Full backend suite was not run (env has no preinstalled deps); the focused Agent Packs suite directly covers the changed endpoint.

## Manual verification steps
1. Open `/agent-packs`, enter a goal, generate a pack.
2. Click **Download Pack** → a `.zip` (multi-file) or single file downloads and is non-empty.
3. Simulate a backend error (e.g. 500) → the red error banner appears and the button returns to "Download Pack" instead of hanging on "Preparing...".

https://claude.ai/code/session_01Qy4VG9vJb8qx6nC99hW8qX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy4VG9vJb8qx6nC99hW8qX)_