### PR TITLE
fix(benchmark): show errors instead of getting stuck running

### DIFF
--- a/tests/test_benchmark_api.py
+++ b/tests/test_benchmark_api.py
@@ -180,6 +180,49 @@ def test_benchmark_provider_failure_returns_safe_error(client):
     assert response.json()["detail"] == "Benchmark model request failed"
 
 
+def test_judge_with_llm_handles_malformed_provider_response():
+    """A malformed (non-JSON) judge response must degrade to None, not raise."""
+    from unittest.mock import MagicMock
+
+    import app.routers.benchmark as benchmark_mod
+
+    fake_worker = MagicMock()
+    fake_worker._call_api.return_value = "not valid json <<< {oops"
+    fake_hybrid = MagicMock()
+    fake_hybrid.worker = fake_worker
+
+    with patch("api.main.hybrid_compiler", fake_hybrid):
+        result = benchmark_mod._judge_with_llm("task", "raw output", "compiled output")
+
+    assert result is None
+
+
+def test_benchmark_run_succeeds_when_judge_response_is_malformed(client):
+    """A malformed judge response must still yield a 200 via the heuristic fallback."""
+    from unittest.mock import MagicMock
+
+    fake_worker = MagicMock()
+    # Judge returns non-JSON garbage -> _judge_with_llm returns None -> heuristic judge.
+    fake_worker._call_api.return_value = "}}} not json"
+    fake_hybrid = MagicMock()
+    fake_hybrid.worker = fake_worker
+
+    with patch(
+        "app.routers.benchmark._generate_llm_output",
+        side_effect=["raw output", "compiled output"],
+    ), patch("api.main.hybrid_compiler", fake_hybrid):
+        response = client.post(
+            "/benchmark/run",
+            json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["raw_output"] == "raw output"
+    assert data["compiled_output"] == "compiled output"
+    assert data["winner"] in ("compiled", "raw")
+
+
 def test_benchmark_models_are_loaded_from_shared_manifest():
     """Backend benchmark model validation should follow the shared frontend manifest."""
     from app.routers.benchmark import (

--- a/web/app/benchmark/page.test.tsx
+++ b/web/app/benchmark/page.test.tsx
@@ -4,9 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import BenchmarkPage from "./page";
 import { apiJson } from "@/config";
 
-vi.mock("@/config", () => ({
-  apiJson: vi.fn(),
-}));
+vi.mock("@/config", async () => {
+  const actual = await vi.importActual<typeof import("@/config")>("@/config");
+  return {
+    ...actual,
+    apiJson: vi.fn(),
+  };
+});
 
 vi.mock("../lib/showError", () => ({
   showError: vi.fn(),
@@ -126,5 +130,100 @@ describe("Benchmark page", () => {
     expect(screen.getByText("Ready")).toBeTruthy();
     expect(screen.queryByText("Cloud Benchmark Unavailable")).toBeNull();
     expect((screen.getByLabelText("Model") as HTMLSelectElement).value).toBe("mock");
+  });
+
+  it("ends loading and shows a visible error when the benchmark request fails", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("Benchmark model request failed"));
+
+    render(<BenchmarkPage />);
+
+    fireEvent.change(screen.getByLabelText("Benchmark prompt input"), {
+      target: { value: "Explain rate limiting." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Run Benchmark/i })[0]);
+
+    expect(await screen.findByText("Benchmark failed")).toBeTruthy();
+    expect(screen.getByText("Benchmark Issue")).toBeTruthy();
+
+    // Loading state cleared: button is no longer "Running..." and is re-enabled.
+    expect(screen.queryByText("Running...")).toBeNull();
+    const runButton = screen.getByRole("button", { name: /Run Benchmark/i }) as HTMLButtonElement;
+    expect(runButton.disabled).toBe(false);
+  });
+
+  it("does not stay stuck on Running when the request never resolves", async () => {
+    vi.useFakeTimers();
+    // Simulate a request that hangs forever (never resolves or rejects).
+    apiJsonMock.mockReturnValueOnce(new Promise<never>(() => {}));
+
+    render(<BenchmarkPage />);
+
+    fireEvent.change(screen.getByLabelText("Benchmark prompt input"), {
+      target: { value: "Explain rate limiting." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Run Benchmark/i })[0]);
+
+    // While in flight the button shows the running state.
+    expect(screen.getByText("Running...")).toBeTruthy();
+
+    // Advance past the client-side benchmark timeout (default 60s).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(screen.getByText("Benchmark failed")).toBeTruthy();
+    expect(screen.getByText("Benchmark Issue")).toBeTruthy();
+    expect(screen.getAllByText(/Benchmark timed out/i).length).toBeGreaterThan(0);
+
+    // Loading state cleared: button reset and re-enabled, not stuck on "Running...".
+    expect(screen.queryByText("Running...")).toBeNull();
+    const runButton = screen.getByRole("button", { name: /Run Benchmark/i }) as HTMLButtonElement;
+    expect(runButton.disabled).toBe(false);
+  });
+
+  it("shows an error instead of crashing when the response is malformed", async () => {
+    apiJsonMock.mockResolvedValueOnce({ unexpected: "shape" } as never);
+
+    render(<BenchmarkPage />);
+
+    fireEvent.change(screen.getByLabelText("Benchmark prompt input"), {
+      target: { value: "Explain rate limiting." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Run Benchmark/i })[0]);
+
+    expect(await screen.findByText("Benchmark failed")).toBeTruthy();
+    expect(screen.getByText("Benchmark Issue")).toBeTruthy();
+    expect(screen.queryByText("Running...")).toBeNull();
+  });
+
+  it("recovers on retry after a failed run", async () => {
+    apiJsonMock
+      .mockRejectedValueOnce(new Error("Benchmark model request failed"))
+      .mockResolvedValueOnce({
+        raw_output: "Raw answer",
+        compiled_output: "Compiled answer",
+        metrics: {
+          safety: { raw: 6, compiled: 9 },
+          clarity: { raw: 5, compiled: 9 },
+          conciseness: { raw: 5, compiled: 8 },
+        },
+        processing_ms: 4321,
+        winner: "compiled",
+        improvement_score: 35,
+      });
+
+    render(<BenchmarkPage />);
+
+    fireEvent.change(screen.getByLabelText("Benchmark prompt input"), {
+      target: { value: "Explain rate limiting." },
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Run Benchmark/i })[0]);
+    expect(await screen.findByText("Benchmark failed")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Run Benchmark/i }));
+    expect(await screen.findByText("Benchmark complete (4321ms)")).toBeTruthy();
+    expect(screen.getByText("COMPILED PROMPT")).toBeTruthy();
+    expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -11,7 +11,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-import { apiJson } from "@/config";
+import { apiJson, TimeoutError, withTimeout } from "@/config";
 import DiffViewer from "../components/DiffViewer";
 import InfoButton from "../components/InfoButton";
 import { showError } from "../lib/showError";
@@ -30,7 +30,76 @@ type BenchmarkPayload = {
   improvement_score: number;
 };
 
+// Client-side safety net so the UI can never wait forever on a request that
+// the network/proxy fails to settle. The backend + proxy already enforce their
+// own (shorter) timeouts; this is the last-resort backstop on the browser side.
+const DEFAULT_BENCHMARK_TIMEOUT_MS = 60_000;
+const MIN_BENCHMARK_TIMEOUT_MS = 1_000;
+
+function resolveBenchmarkTimeoutMs(): number {
+  const raw = process.env.NEXT_PUBLIC_BENCHMARK_TIMEOUT_MS;
+  if (!raw || !raw.trim()) {
+    return DEFAULT_BENCHMARK_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed < MIN_BENCHMARK_TIMEOUT_MS) {
+    return DEFAULT_BENCHMARK_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+const BENCHMARK_TIMEOUT_MS = resolveBenchmarkTimeoutMs();
+
+const BENCHMARK_TIMEOUT_MESSAGE =
+  "Benchmark timed out — the model took too long to respond. Try again or switch to the Mock Engine.";
+const BENCHMARK_MALFORMED_MESSAGE =
+  "Benchmark returned an unexpected response. Try again or switch to the Mock Engine.";
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isMetricPair(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const pair = value as { raw?: unknown; compiled?: unknown };
+  return isFiniteNumber(pair.raw) && isFiniteNumber(pair.compiled);
+}
+
+// Validate the response against the existing BenchmarkPayload/UI contract so a
+// malformed body becomes a clean error instead of crashing the radar/diff render.
+function isValidBenchmarkPayload(data: unknown): data is BenchmarkPayload {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+  const payload = data as Record<string, unknown>;
+  if (typeof payload.raw_output !== "string" || typeof payload.compiled_output !== "string") {
+    return false;
+  }
+  if (payload.winner !== "compiled" && payload.winner !== "raw") {
+    return false;
+  }
+  if (!isFiniteNumber(payload.improvement_score) || !isFiniteNumber(payload.processing_ms)) {
+    return false;
+  }
+  const metrics = payload.metrics;
+  if (!metrics || typeof metrics !== "object") {
+    return false;
+  }
+  const metricGroups = metrics as Record<string, unknown>;
+  return (
+    isMetricPair(metricGroups.safety) &&
+    isMetricPair(metricGroups.clarity) &&
+    isMetricPair(metricGroups.conciseness)
+  );
+}
+
 function buildBenchmarkErrorMessage(error: unknown): string {
+  if (error instanceof TimeoutError || (error instanceof Error && error.name === "AbortError")) {
+    return BENCHMARK_TIMEOUT_MESSAGE;
+  }
+
   if (error instanceof Error && error.message.trim()) {
     return error.message;
   }
@@ -122,11 +191,22 @@ export default function BenchmarkPage() {
         return;
       }
 
-      const data = await apiJson<BenchmarkPayload>("/benchmark/run", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: prompt.trim(), model: selectedModel }),
-      });
+      const controller = new AbortController();
+      const data = await withTimeout(
+        apiJson<BenchmarkPayload>("/benchmark/run", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: prompt.trim(), model: selectedModel }),
+          signal: controller.signal,
+        }),
+        BENCHMARK_TIMEOUT_MS,
+        () => controller.abort(),
+      );
+
+      if (!isValidBenchmarkPayload(data)) {
+        throw new Error(BENCHMARK_MALFORMED_MESSAGE);
+      }
+
       setBenchmarkResult(data);
       setResultIsMock(false);
       setStatus(`Benchmark complete (${data.processing_ms}ms)`);

--- a/web/config.ts
+++ b/web/config.ts
@@ -30,6 +30,53 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Raised by {@link withTimeout} when a wrapped promise does not settle within
+ * the allotted time. Surfaced like an AbortError by {@link describeRequestError}.
+ */
+export class TimeoutError extends Error {
+  constructor(message = "The request timed out.") {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * Opt-in client-side timeout wrapper. Races `promise` against a timer; if the
+ * timer wins it invokes `onTimeout` (e.g. to abort an in-flight request) and
+ * rejects with a {@link TimeoutError}. Handlers are always attached to
+ * `promise`, so a losing rejection can never surface as an unhandled rejection.
+ *
+ * This does not alter `apiFetch`/`apiJson` default behavior — callers opt in by
+ * wrapping a request promise and passing their own timeout.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onTimeout?: () => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } finally {
+        reject(new TimeoutError());
+      }
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 export function resolveApiBase(locationLike?: LocationLike | null): string {
   const runtimeLocation =
     locationLike ?? (typeof window !== "undefined" ? window.location : undefined);
@@ -93,7 +140,7 @@ export function describeRequestError(
     return error.detail;
   }
 
-  if (error instanceof Error && error.name === "AbortError") {
+  if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
     return copy.timeout || "The backend took too long to respond.";
   }
 


### PR DESCRIPTION
Fixes #759

## Summary
On `/benchmark`, clicking **Run Benchmark** could leave the UI stuck on "Running…" forever with no result and no error. This adds a client-side safety net so the loading state always ends in either results or a clear, user-facing error, the button resets, and retry works — without any browser API-key prompt and without leaking stack traces or secrets.

## Root cause
The benchmark page's exit from the loading state hinges entirely on `await apiJson("/benchmark/run", …)` settling inside a `try/catch/finally`. But `apiFetch` (`web/config.ts`) calls `fetch()` with **no `AbortController` and no client-side timeout**. The Next.js proxy bounds each upstream call to 25s and retries up to ~78s, but if the browser→server request never settles (the platform kills the serverless function before the proxy returns, or the connection hangs without the fetch promise rejecting), then:

- `await apiJson(...)` never resolves or rejects,
- `finally { setLoading(false) }` never runs → the button stays "Running…" forever,
- nothing throws → no `errorMessage` is set → the right pane stays "No benchmark yet".

Secondary gap: a `200` with a malformed body was returned as-is and later crashed the radar/diff render instead of surfacing a clean error.

The backend (`app/routers/benchmark.py`) already maps failures to clean `502/500/422` with safe `detail` text (stack traces only go to `logger.exception`), so **no backend behavior change was needed**.

## Changed files
- `web/config.ts` — new opt-in `TimeoutError` class and `withTimeout()` helper (races a promise against a timer, aborts on timeout, can't leak unhandled rejections); `describeRequestError` now treats `TimeoutError` like `AbortError`. **Default behavior of `apiFetch`/`apiJson` is unchanged.**
- `web/app/benchmark/page.tsx` — wraps the benchmark request in `withTimeout` + an `AbortController` (60s default, overridable via `NEXT_PUBLIC_BENCHMARK_TIMEOUT_MS` with a safe fallback for missing/invalid/NaN/too-small values); validates the response against the existing `BenchmarkPayload` contract; friendlier timeout/malformed error copy.
- `web/app/benchmark/page.test.tsx` — tests for loading→error, never-resolving→timeout+button reset, malformed response→error, and retry-after-failure→success (existing success/mock paths kept).
- `tests/test_benchmark_api.py` — resilience tests that a malformed provider/judge response degrades gracefully (no production code change).

## Tests run
- `python -m pytest tests/test_benchmark_api.py tests/test_api_hardening.py -q` → **26 passed**
- `cd web && npm run test` → **108 passed (22 files)**
- `cd web && npm run build` → **success, TypeScript clean**

## Manual verification steps
1. On `/benchmark`, pick a real model with the backend down / provider failing → an error box appears within ≤60s ("Benchmark Issue" / "Cloud Benchmark Unavailable"), the button returns to "Run Benchmark", and the right pane shows "Benchmark unavailable".
2. Click **Run Benchmark** again (retry) → a healthy backend renders the radar chart + diff normally.
3. Mock Engine still works and shows the demo banner.
4. Confirm: no browser API-key prompt appears, and the error text carries no stack trace or secret.

## Scope
Focused launch-blocker fix only. No changes to benchmark semantics, RAG, the Example Code toggle, P3 UX items, dependencies, or unrelated PRs.
