### PR TITLE
fix(rag): show friendly error for empty file uploads

### DIFF
--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -64,7 +64,7 @@ class RagIngestResponse(BaseModel):
 class RagUploadRequest(BaseModel):
     filename: str = Field(default="upload.txt", max_length=255)
     relative_path: Optional[str] = Field(default=None, max_length=1024)
-    content: str = Field(..., min_length=1, max_length=1_000_000)
+    content: str = Field(..., max_length=1_000_000)
     embed: bool = Field(default=False)
     embed_dim: int = Field(default=64, ge=8, le=1024)
 
@@ -210,6 +210,14 @@ async def rag_upload(
     req: RagUploadRequest,
     _: None = Depends(rate_limit_by_ip),
 ):
+    # Normalize the empty-file case to a clear 4xx with a string detail so the UI
+    # never surfaces a raw 422. (Raised before the try so it is not re-wrapped.)
+    if not req.content:
+        raise HTTPException(
+            status_code=400,
+            detail="This file is empty. Please upload a file with content.",
+        )
+
     try:
         display_name = normalize_display_name(req.filename)
         _, chunks, secs = await anyio.to_thread.run_sync(

--- a/tests/test_rag_upload.py
+++ b/tests/test_rag_upload.py
@@ -63,6 +63,25 @@ def test_rag_upload_indexes_file(client):
     assert "auth.py" in data["message"]
 
 
+def test_rag_upload_rejects_empty_content_with_friendly_detail(client):
+    """Empty content should return a clean 400 with a string detail, not a raw 422 list."""
+    response = client.post(
+        "/rag/upload",
+        json={"filename": "empty.txt", "content": ""},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert isinstance(detail, str)
+    assert "empty" in detail.lower()
+    assert "API Error" not in detail
+
+    # A failed empty upload must not change the index stats.
+    stats = client.get("/rag/stats")
+    assert stats.status_code == 200
+    assert stats.json()["docs"] == 0
+
+
 def test_rag_stats_get(client):
     """GET /rag/stats should return index statistics."""
     response = client.get("/rag/stats")

--- a/web/app/hooks/useContextManager.test.tsx
+++ b/web/app/hooks/useContextManager.test.tsx
@@ -175,6 +175,69 @@ describe("useContextManager", () => {
     expect(fetchRagStatsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("shows a friendly error and skips the request for an empty file", async () => {
+    const emptyFile = new File([], "empty.txt", { type: "text/plain" });
+
+    const { result } = renderHook(() => useContextManager());
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    fetchRagStatsMock.mockClear();
+
+    await act(async () => {
+      await result.current.uploadFiles([emptyFile]);
+    });
+
+    // No request is sent for an empty file.
+    expect(uploadContextFileMock).not.toHaveBeenCalled();
+    // Friendly, actionable copy — not a raw "API Error: 422".
+    expect(result.current.status).toContain("This file is empty. Please upload a file with content.");
+    expect(result.current.status).not.toContain("422");
+    // Progress is not stuck and stats are not refreshed after a failed empty upload.
+    expect(result.current.ingesting).toBe(false);
+    expect(result.current.uploadProgress).toBeNull();
+    expect(fetchRagStatsMock).not.toHaveBeenCalled();
+  });
+
+  it("uploads valid files and skips empty ones in a mixed selection", async () => {
+    const emptyFile = new File([], "empty.txt", { type: "text/plain" });
+    const validFile = new File(["hello world"], "notes.md", { type: "text/markdown" });
+
+    uploadContextFileMock.mockResolvedValueOnce({
+      ingested_docs: 1,
+      total_chunks: 2,
+      elapsed_ms: 5,
+      filename: "notes.md",
+      success: true,
+      num_chunks: 2,
+      message: "Indexed notes.md into the RAG index.",
+    });
+
+    const { result } = renderHook(() => useContextManager());
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    fetchRagStatsMock.mockClear();
+
+    await act(async () => {
+      await result.current.uploadFiles([emptyFile, validFile]);
+    });
+
+    // Only the valid file is uploaded; the empty one is skipped.
+    expect(uploadContextFileMock).toHaveBeenCalledTimes(1);
+    expect(uploadContextFileMock).toHaveBeenCalledWith({
+      filename: "notes.md",
+      relative_path: "notes.md",
+      content: "hello world",
+    });
+    expect(result.current.status).toBe("Indexed 1/1 files (2 chunks) — skipped 1 empty file(s)");
+    expect(fetchRagStatsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("resets the indexed path after a successful manual ingest", async () => {
     ingestContextPathMock.mockResolvedValueOnce({
       ingested_docs: 2,

--- a/web/app/hooks/useContextManager.ts
+++ b/web/app/hooks/useContextManager.ts
@@ -21,6 +21,8 @@ type FileWithRelativePath = File & {
   webkitRelativePath?: string;
 };
 
+const EMPTY_FILE_MESSAGE = "This file is empty. Please upload a file with content.";
+
 function toUserMessage(error: unknown): string {
   return describeRequestError(error, {
     network: "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
@@ -102,25 +104,36 @@ export function useContextManager() {
         return;
       }
 
+      // Pre-validate: never send an empty file to the server. This avoids a raw
+      // "API Error: 422" and keeps stats untouched after a failed empty upload.
+      const validFiles = files.filter((file) => file.size > 0);
+      const emptyCount = files.length - validFiles.length;
+
+      if (validFiles.length === 0) {
+        setStatus(`Error: ${EMPTY_FILE_MESSAGE}`);
+        setUploadProgress(null);
+        return;
+      }
+
       setIngesting(true);
-      setStatus(`Uploading ${files.length} file(s)...`);
+      setStatus(`Uploading ${validFiles.length} file(s)...`);
       setUploadProgress({
         completed: 0,
-        currentFile: files[0]?.name ?? null,
-        total: files.length,
+        currentFile: validFiles[0]?.name ?? null,
+        total: validFiles.length,
       });
 
       let totalChunks = 0;
       let successCount = 0;
 
       try {
-        for (const [index, file] of files.entries()) {
+        for (const [index, file] of validFiles.entries()) {
           setUploadProgress({
             completed: successCount,
             currentFile: file.name,
-            total: files.length,
+            total: validFiles.length,
           });
-          setStatus(`Uploading ${index + 1}/${files.length}: ${file.name}`);
+          setStatus(`Uploading ${index + 1}/${validFiles.length}: ${file.name}`);
 
           const content = await file.text();
           const response = await uploadContextFile({
@@ -135,13 +148,14 @@ export function useContextManager() {
             setUploadProgress({
               completed: successCount,
               currentFile: file.name,
-              total: files.length,
+              total: validFiles.length,
             });
           }
         }
 
         setIsConnected(true);
-        setStatus(`Indexed ${successCount}/${files.length} files (${totalChunks} chunks)`);
+        const skippedNote = emptyCount > 0 ? ` — skipped ${emptyCount} empty file(s)` : "";
+        setStatus(`Indexed ${successCount}/${validFiles.length} files (${totalChunks} chunks)${skippedNote}`);
         await refreshStats();
       } catch (error: unknown) {
         setStatus(`Error: ${toUserMessage(error)}`);


### PR DESCRIPTION
Fixes #761

## Summary
Uploading an empty file in the RAG/Context panel showed a raw "Ingestion Alert — Error: API Error: 422" and could leave confusing stats. Now an empty file is caught before any request and shows a friendly, actionable message — "This file is empty. Please upload a file with content." — while index stats stay untouched. The backend also normalizes the empty case to a clean 400 in case a request reaches it directly. Ingestion of non-empty files is unchanged.

## Root cause
`RagUploadRequest.content` was declared with `min_length=1` ([api/routes/rag.py](api/routes/rag.py)). An empty file means `content=""`, which fails Pydantic validation **before** the route handler runs, so FastAPI returns a **422** whose `detail` is a *list* of validation errors. The frontend error helper (`describeApiError` → `extractDetail`) only reads a *string* `detail`, so it fell back to the literal `"API Error: 422"`, rendered by the hook as the alert text. The empty file was also sent at all — there was no client-side pre-check.

## Changed files
- `web/app/hooks/useContextManager.ts` — pre-validate uploads: filter out `file.size === 0`; if all selected files are empty, show the friendly message and send nothing (stats untouched, progress not stuck); mixed selections upload the valid files and append a "skipped N empty file(s)" note.
- `api/routes/rag.py` — drop `min_length=1` on `content` and return a clean `400` with a string `detail` ("This file is empty. Please upload a file with content.") for empty content, raised before the `try` so it isn't re-wrapped as a 500.
- `web/app/hooks/useContextManager.test.tsx` — empty-file → friendly error + no request + no stats refresh + not stuck; mixed selection → valid file uploaded, empty skipped.
- `tests/test_rag_upload.py` — empty content returns 400 with a string detail (no "API Error", no raw 422) and leaves stats at 0 docs.

## Tests run
- `python -m pytest tests/test_rag_upload.py tests/test_api_hardening.py -q` → **23 passed**
- `cd web && npm run test` → **110 passed (22 files)**
- `cd web && npm run build` → **success, TypeScript clean**

## Manual verification steps
1. In the Context Manager, click **Upload Files** and pick a 0-byte file → a friendly amber/red "Ingestion Alert" shows "This file is empty. Please upload a file with content." No "API Error: 422", upload spinner does not get stuck, and Documents/Chunks stats are unchanged.
2. Upload a normal text file → it still indexes (status "Indexed 1/1 files (N chunks)") and stats update.
3. Run a RAG search after the valid upload → results still return.
4. Select an empty file *and* a valid file together → the valid one is indexed and the status notes the skipped empty file.
