### PR TITLE
fix(context): require explicit insert for search results

### DIFF
--- a/web/app/components/__tests__/RagSearchPanel.test.tsx
+++ b/web/app/components/__tests__/RagSearchPanel.test.tsx
@@ -20,6 +20,92 @@ describe("RagSearchPanel", () => {
     expect(button.hasAttribute("disabled")).toBe(true);
   });
 
+  it("focuses the search input on a single mouse click", () => {
+    render(
+      <RagSearchPanel
+        query=""
+        setQuery={vi.fn()}
+        searching={false}
+        results={[]}
+        onRunSearch={vi.fn()}
+        onInsertContext={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText("Search context...");
+    expect(document.activeElement).not.toBe(input);
+
+    fireEvent.click(input);
+
+    // Clicking must focus the input so the user can type immediately,
+    // without first pressing Tab (issue #762).
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("does not insert any result into the prompt just from rendering search results", () => {
+    const onInsertContext = vi.fn();
+
+    render(
+      <RagSearchPanel
+        query="auth flow"
+        setQuery={vi.fn()}
+        searching={false}
+        results={[
+          { path: "src/auth.ts", snippet: "Handle session creation", score: 0.8123 },
+          { path: "src/session.ts", snippet: "Refresh tokens", score: 0.71 },
+        ]}
+        onRunSearch={vi.fn()}
+        onInsertContext={onInsertContext}
+      />,
+    );
+
+    // Results render but nothing is auto-inserted into the prompt.
+    expect(screen.getByText("Handle session creation")).toBeTruthy();
+    expect(onInsertContext).not.toHaveBeenCalled();
+  });
+
+  it("only updates the prompt when an explicit Insert button is clicked", () => {
+    const onInsertContext = vi.fn();
+
+    render(
+      <RagSearchPanel
+        query="auth flow"
+        setQuery={vi.fn()}
+        searching={false}
+        results={[
+          { path: "src/auth.ts", snippet: "Handle session creation", score: 0.8123 },
+        ]}
+        onRunSearch={vi.fn()}
+        onInsertContext={onInsertContext}
+      />,
+    );
+
+    expect(onInsertContext).not.toHaveBeenCalled();
+
+    const insertButton = screen.getByRole("button", {
+      name: /insert snippet from src\/auth\.ts into prompt/i,
+    });
+    fireEvent.click(insertButton);
+
+    expect(onInsertContext).toHaveBeenCalledTimes(1);
+    expect(onInsertContext).toHaveBeenCalledWith("[Source: src/auth.ts]\nHandle session creation");
+  });
+
+  it("shows a clear no-results state when a query returns nothing", () => {
+    render(
+      <RagSearchPanel
+        query="nonexistent"
+        setQuery={vi.fn()}
+        searching={false}
+        results={[]}
+        onRunSearch={vi.fn()}
+        onInsertContext={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/No results found for/i)).toBeTruthy();
+  });
+
   it("runs search on Enter and inserts formatted context safely", () => {
     const onRunSearch = vi.fn();
     const onInsertContext = vi.fn();

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { toast } from "sonner";
 import { formatSearchResultForPrompt, formatSearchScore } from "../../../lib/api/promptc";
 import type { RagSearchResult } from "../../../lib/api/types";
@@ -19,16 +20,25 @@ export default function RagSearchPanel({
     onRunSearch,
     onInsertContext,
 }: RagSearchPanelProps) {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // Guarantee a single mouse click focuses the input. Some ancestor layout
+    // layers can otherwise swallow the initial focus, forcing users to press
+    // Tab first (see issue #762).
+    const focusInput = () => inputRef.current?.focus();
+
     return (
         <div className="flex flex-col gap-2">
             <div className="flex gap-2">
-                <div className="relative flex-1">
+                <div className="relative flex-1" onClick={focusInput}>
                     <input
+                        ref={inputRef}
                         type="text"
                         aria-label="Search context..."
                         className="w-full rounded-lg border border-white/5 bg-black/30 p-2 pr-8 font-mono text-xs transition-colors placeholder-zinc-600 focus:border-blue-500/30 focus:outline-none"
                         placeholder="Search context..."
                         value={query}
+                        onClick={focusInput}
                         onChange={(e) => setQuery(e.target.value)}
                         onKeyDown={(e) => e.key === "Enter" && onRunSearch()}
                     />
@@ -88,7 +98,7 @@ export default function RagSearchPanel({
                                 toast.success("Snippet inserted into prompt");
                             }}
                             aria-label={`Insert snippet from ${result.path} into prompt`}
-                            className="mt-1 text-[10px] text-blue-300 hover:text-blue-200 text-left opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded transition-all flex items-center gap-1 font-medium"
+                            className="mt-1 self-start text-[10px] text-blue-300 hover:text-blue-200 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded transition-all flex items-center gap-1 font-medium"
                         >
                             <span>+</span> Insert into Prompt
                         </button>


### PR DESCRIPTION
Fixes #762

## Summary
In the main compiler context panel, clicking the "Search context" input now focuses it on a single mouse click so the user can type immediately (no longer requires pressing `Tab` first). Search results are display-only and never modify the prompt on their own — inserting a snippet requires an explicit, always-visible **Insert into Prompt** button.

## Root cause
- **Focus:** The search `<input>` relied solely on the browser's native click-to-focus, which the QA environment showed could be swallowed before focus landed, forcing a `Tab` press. There was no explicit focus fallback.
- **Insert:** The "auto-insert on search" behavior described in the issue no longer existed in code (`runSearch` in `useContextManager` only sets results; insertion was already gated behind a button), but the Insert button was hidden until hover (`opacity-0 group-hover:opacity-100`), making it easy to miss and unclear that insertion was a deliberate action.

## Exact fix
- `RagSearchPanel.tsx`: added a `useRef` + explicit `focusInput()` handler on the input (and its wrapper) so a single click always focuses the field; keyboard navigation (Enter to search) is unchanged.
- `RagSearchPanel.tsx`: made the per-result **Insert into Prompt** button always visible (removed hover-only opacity gating) so insertion is a clear, explicit user action with a success toast.

## Changed files
- `web/app/components/context/RagSearchPanel.tsx`
- `web/app/components/__tests__/RagSearchPanel.test.tsx`

## Tests run
- `npx vitest run app/components/__tests__/RagSearchPanel.test.tsx` → 6 passed, including new tests:
  - clicking the input focuses it
  - rendering search results does not update the prompt
  - clicking explicit Insert updates the prompt once
  - no-results state still renders
- `npm run test` → 22 files, 114 tests passed
- `npm run build` → compiled successfully
- `npm run lint` → 0 errors (1 pre-existing unrelated warning)

## Manual / verification steps
1. Upload a doc in the context panel on `/`.
2. Click directly on the "Search context" input → cursor focuses, typing works immediately.
3. Run a search → matching snippets render, the prompt is unchanged, no toast.
4. Click "Insert into Prompt" on a result → prompt updates once with the formatted snippet and a "Snippet inserted into prompt" toast.
5. Search a nonsense query → clear "No results found" state.

Note: backend RAG search semantics are untouched.

Do not merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_016p6f5kqEpEFZFwbhLydqcs)_