### PR TITLE
fix(context): strip search-highlight brackets from inserted snippets

### DIFF
--- a/web/app/components/__tests__/RagSearchPanel.test.tsx
+++ b/web/app/components/__tests__/RagSearchPanel.test.tsx
@@ -91,6 +91,35 @@ describe("RagSearchPanel", () => {
     expect(onInsertContext).toHaveBeenCalledWith("[Source: src/auth.ts]\nHandle session creation");
   });
 
+  it("strips search-highlight brackets when inserting a snippet into the prompt", () => {
+    const onInsertContext = vi.fn();
+
+    render(
+      <RagSearchPanel
+        query="launch date"
+        setQuery={vi.fn()}
+        searching={false}
+        results={[
+          { path: "docs/launch.md", snippet: "The [launch] [date] is confirmed", score: 0.5 },
+        ]}
+        onRunSearch={vi.fn()}
+        onInsertContext={onInsertContext}
+      />,
+    );
+
+    // The on-screen result keeps the highlighted snippet…
+    expect(screen.getByText("The [launch] [date] is confirmed")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /insert snippet from docs\/launch\.md into prompt/i }),
+    );
+
+    // …but the inserted prompt text is clean (issue #773).
+    expect(onInsertContext).toHaveBeenCalledWith(
+      "[Source: docs/launch.md]\nThe launch date is confirmed",
+    );
+  });
+
   it("shows a clear no-results state when a query returns nothing", () => {
     render(
       <RagSearchPanel

--- a/web/lib/api/promptc.ts
+++ b/web/lib/api/promptc.ts
@@ -318,9 +318,15 @@ export function normalizeRagStats(value: unknown): RagStats {
   };
 }
 
+// The RAG backend highlights FTS matches by wrapping them in literal brackets
+// (e.g. "[launch] [date]"); keep them for on-screen display but strip them
+// from text inserted into the prompt.
+const FTS_HIGHLIGHT_PATTERN = /\[([^[\]]*)\]/g;
+
 export function formatSearchResultForPrompt(result: RagSearchResult): string {
   const location = result.path ? `[Source: ${result.path}]` : "[Source: unknown]";
-  return `${location}\n${result.snippet}`.trim();
+  const cleanSnippet = result.snippet.replace(FTS_HIGHLIGHT_PATTERN, "$1");
+  return `${location}\n${cleanSnippet}`.trim();
 }
 
 export function formatSearchScore(result: RagSearchResult): string {

--- a/web/promptc-api.test.mts
+++ b/web/promptc-api.test.mts
@@ -162,3 +162,23 @@ test("formatSearchResultForPrompt includes path header", () => {
     }),
   ).toBe("[Source: docs/auth.md]\nUse API keys");
 });
+
+test("formatSearchResultForPrompt strips search-highlight brackets from the snippet", () => {
+  expect(
+    formatSearchResultForPrompt({
+      path: "docs/launch.md",
+      snippet: "The [launch] [date] is confirmed …",
+      score: 0.7,
+    }),
+  ).toBe("[Source: docs/launch.md]\nThe launch date is confirmed …");
+});
+
+test("formatSearchResultForPrompt keeps the source header when stripping highlights", () => {
+  expect(
+    formatSearchResultForPrompt({
+      path: "",
+      snippet: "[empty] highlights only",
+      score: 0.1,
+    }),
+  ).toBe("[Source: unknown]\nempty highlights only");
+});


### PR DESCRIPTION
Fixes #773

## Summary
Inserting a RAG search result into the prompt leaked the FTS highlight markers into the prompt text (e.g. `[launch] [date]`). The backend wraps matched terms in literal brackets via `snippet(fts, 0, '[', ']', '…', 10)` in `app/rag/simple_index.py`, and `formatSearchResultForPrompt` inserted the snippet verbatim.

This strips the highlight markers at insert time only:
- the intentional `[Source: <path>]` header line is preserved
- the on-screen search-result list keeps its highlighted display
- frontend-only; no backend, RAG index, dependency, or auth changes

## Changed files
- `web/lib/api/promptc.ts` — unwrap `[term]` highlight markers in `formatSearchResultForPrompt`
- `web/promptc-api.test.mts` — regression tests for stripped snippet + preserved source header
- `web/app/components/__tests__/RagSearchPanel.test.tsx` — end-to-end insert test: display keeps brackets, inserted text is clean

## Known tradeoff
Legitimate square brackets present in the original document text are also unwrapped on insert (display unaffected). Accepted for this P3; the bracket pair is the FTS highlight convention.

## Tests run
- `npx vitest run` (full web suite) → **23 files, 117 tests passed**
- `npm run build` → compiled successfully

## Manual verification
1. Upload a doc in the context panel on `/`.
2. Search a term that matches (e.g. "launch date").
3. Result card still shows the bracket-highlighted snippet.
4. Click **Insert into Prompt** → prompt receives `[Source: …]` header + clean text, no `[launch] [date]`.

https://claude.ai/code/session_01JGmzfnt7btxYwf6hvr1zSB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGmzfnt7btxYwf6hvr1zSB)_