### PR TITLE
test(generators): cover example-code toggle payload

### DIFF
--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -137,6 +137,38 @@ describe("Agent Generator page", () => {
     });
   });
 
+  it("sends include_example_code true and keeps the toggle on after generation", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      system_prompt: "# Agent With Example Code\n\n## Example Code (Pseudo-code Skeleton)",
+    });
+
+    render(<AgentGeneratorPage />);
+
+    const exampleCodeToggle = screen.getByRole("switch", { name: "Include Example Code toggle" });
+    expect(exampleCodeToggle.getAttribute("aria-checked")).toBe("false");
+
+    fireEvent.click(exampleCodeToggle);
+    expect(exampleCodeToggle.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Build a code review agent with examples." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(1));
+    expect(apiJsonMock.mock.calls[0]?.[0]).toBe("/agent-generator/generate");
+    expect(JSON.parse(String(apiJsonMock.mock.calls[0]?.[1]?.body))).toEqual({
+      description: "Build a code review agent with examples.",
+      multi_agent: false,
+      include_example_code: true,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Agent With Example Code" })).toBeTruthy(),
+    );
+    expect(exampleCodeToggle.getAttribute("aria-checked")).toBe("true");
+  });
+
   it("keeps the description textarea at a usable desktop height", () => {
     render(<AgentGeneratorPage />);
 

--- a/web/app/skills-generator/page.test.tsx
+++ b/web/app/skills-generator/page.test.tsx
@@ -142,6 +142,38 @@ describe("Skills Generator page", () => {
     });
   });
 
+  it("sends include_example_code true and keeps the toggle on after generation", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      skill_definition: "# Skill With Example Code\n\n## Implementation Example",
+    });
+
+    render(<SkillsGeneratorPage />);
+
+    const exampleCodeToggle = screen.getByRole("switch", { name: "Include Example Code toggle" });
+    expect(exampleCodeToggle.getAttribute("aria-checked")).toBe("false");
+
+    fireEvent.click(exampleCodeToggle);
+    expect(exampleCodeToggle.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Parse JSON and validate schemas with example code." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(1));
+    expect(apiJsonMock.mock.calls[0]?.[0]).toBe("/skills-generator/generate");
+    expect(JSON.parse(String(apiJsonMock.mock.calls[0]?.[1]?.body))).toEqual({
+      description: "Parse JSON and validate schemas with example code.",
+      include_example_code: true,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Skill With Example Code" })).toBeTruthy(),
+    );
+    expect(exampleCodeToggle.getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByText("With Example Code")).toBeTruthy();
+  });
+
   it("keeps the description textarea at a usable desktop height", () => {
     render(<SkillsGeneratorPage />);
 


### PR DESCRIPTION
## Summary

Refs #763

Adds frontend regression tests on both generator pages for the Example Code toggle **on** path. Existing default-off tests are unchanged.

New coverage:
- Toggle `Include Example Code` → `aria-checked=true`
- Generate → request body includes `include_example_code: true`
- After mocked generation completes → toggle remains on

**No production/runtime code changes.** Unit tests pass locally, indicating the frontend already wires `includeExampleCode` state into the API payload and does not reset the toggle after generation.

## Root cause hypothesis

Issue #763 likely stems from one of:
1. **`include_example_code: false` reaching the backend** (backend intentionally strips code sections when false), or
2. **LLM prompt non-compliance** when the flag is true (secondary; not addressed in this PR).

Static review found no `setIncludeExampleCode(false)` in generator pages. These tests guard the frontend contract; production network capture under #775 is still required before any backend prompt-strengthening work.

## Changed files

- `web/app/agent-generator/page.test.tsx`
- `web/app/skills-generator/page.test.tsx`

## Tests run

```bash
cd web && npm run test -- agent-generator skills-generator  # 13 passed
cd web && npm run test                                       # 120 passed
cd web && npm run build                                      # success
```

## Manual verification pending

Memo must verify in DevTools Network that `include_example_code=true` is sent on production/preview before any backend prompt-strengthening PR.