### PR TITLE
fix(skills): suppress examples when example code is disabled

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -10,6 +10,7 @@ from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
+from app.llm_engine.client import _sanitize_skill_definition_plain
 from app.github_repo_context import (
     GitHubRepoAnalysisError,
     InvalidGitHubRepoUrl,
@@ -192,6 +193,8 @@ async def generate_skill_endpoint(
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
             repo_context_mode=req.repo_context_mode,
         )
+        if not req.include_example_code:
+            result = _sanitize_skill_definition_plain(result)
         return SkillGenResponse(skill_definition=result)
     except Exception as exc:
         logger.exception("skill generation failed")

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -59,18 +59,39 @@ _MULTI_AGENT_PATTERNS = [
     re.compile(r"^- Only include a final `## Swarm Example Code .*?$\n?", flags=re.MULTILINE),
 ]
 
+_SKILL_PLAIN_SECTION_BOUNDARY = r"(?=^#{1,3} |\n\*\*[^*]+?\*\*|\Z)"
+
 _SKILL_PLAIN_OUTPUT_SECTION_PATTERNS = [
-    re.compile(r"^## Examples\b.*?(?=^## |\Z)", flags=re.MULTILINE | re.DOTALL),
-    re.compile(r"^## Implementation Example\b.*?(?=^## |\Z)", flags=re.MULTILINE | re.DOTALL),
     re.compile(
-        r"^\*\*Examples:\*\*\s*\n.*?(?=^## |\n\*\*[^*]+:\*\*|\Z)",
+        rf"^## Examples\b.*?{_SKILL_PLAIN_SECTION_BOUNDARY}", flags=re.MULTILINE | re.DOTALL
+    ),
+    re.compile(
+        rf"^### Examples\b.*?{_SKILL_PLAIN_SECTION_BOUNDARY}", flags=re.MULTILINE | re.DOTALL
+    ),
+    re.compile(
+        rf"^Examples:\s*\n.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+    re.compile(
+        rf"^\*\*Examples:?\*\*\s*\n.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+    re.compile(
+        rf"^## Implementation Example\b.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+    re.compile(
+        rf"^\*\*Implementation Example:?\*\*\s*\n.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
         flags=re.MULTILINE | re.DOTALL,
     ),
 ]
 
+_SKILL_PLAIN_FENCED_CODE_PATTERN = re.compile(r"```[\w-]*\s*\r?\n[\s\S]*?```", flags=re.DOTALL)
+
 _SKILL_PLAIN_OUTPUT_LINE_PATTERNS = [
     re.compile(r"^- Input:.*?(?:→|->).*$", flags=re.MULTILINE),
-    re.compile(r"^- (?:Input|Output):\s*`?\{.*$", flags=re.MULTILINE),
+    re.compile(r"^- (?:Input|Output|Example):\s*`?\{.*$", flags=re.MULTILINE),
+    re.compile(r"^- (?:Input|Output|Example):\s*`?\[.*$", flags=re.MULTILINE),
 ]
 
 _SKILL_PATTERNS = [
@@ -99,9 +120,10 @@ def _sanitize_skill_definition_plain(text: str) -> str:
     if not text:
         return text
 
-    cleaned = re.sub(r"```[^\n]*\n.*?```", "", text, flags=re.DOTALL)
+    cleaned = text
     for pattern in _SKILL_PLAIN_OUTPUT_SECTION_PATTERNS:
         cleaned = pattern.sub("", cleaned)
+    cleaned = _SKILL_PLAIN_FENCED_CODE_PATTERN.sub("", cleaned)
     for pattern in _SKILL_PLAIN_OUTPUT_LINE_PATTERNS:
         cleaned = pattern.sub("", cleaned)
 

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -65,6 +65,18 @@ _SKILL_PATTERNS = [
         flags=re.DOTALL,
     ),
     re.compile(r"^- Only include an implementation example section.*\n", flags=re.MULTILINE),
+    re.compile(
+        r"\n## Examples\n\[At least one and at most three concrete invocations.*?\n- Input:.*?\n- Input:.*?\n",
+        flags=re.DOTALL,
+    ),
+    re.compile(
+        r"^- The skill must be idempotent and the Examples section must use inputs/outputs.*\n",
+        flags=re.MULTILINE,
+    ),
+    re.compile(
+        r"^- For uncertain details, prefer pseudo-code and explicit `TODO` comments over confident-looking guesses\.\n",
+        flags=re.MULTILINE,
+    ),
 ]
 
 
@@ -298,9 +310,12 @@ class WorkerClient:
         prompt += (
             "\n\n## EXAMPLE CODE SETTING\n"
             "- Example code is disabled for this request.\n"
-            "- Omit any `## Implementation Example` section from the final markdown.\n"
-            "- Keep `## Implementation` as a concise, code-free execution plan.\n"
-            "- Do not include fenced code blocks or pseudo-code unless the user explicitly asks for raw code."
+            "- Omit `## Implementation Example` entirely from the final markdown.\n"
+            "- Omit `## Examples` entirely — no input/output JSON samples, arrow-form invocations, "
+            "or illustrative payloads.\n"
+            "- Keep `## Implementation` as a concise, code-free execution plan in plain language only.\n"
+            "- Do not include fenced code blocks (```), pseudo-code, or code snippets anywhere in the output.\n"
+            "- `## Input Schema` and `## Output Schema` must describe fields/types only — no sample JSON values."
         )
         return prompt
 
@@ -681,14 +696,25 @@ class WorkerClient:
             "- If implementation details are unknown, provide explicit TODO-oriented steps instead of fake certainty.\n"
             "- Keep the skill definition practical, modular, and implementation-ready."
         )
-        example_code_note = (
-            "Include a final `## Implementation Example` section with concise code only when explicitly requested."
-            if include_example_code
-            else (
-                "Do not include any example code snippets, pseudo-code, or fenced code blocks. "
-                "Omit the entire `## Implementation Example` section from the generated output."
+        if include_example_code:
+            example_code_note = (
+                "Example code is enabled for this request. You MUST include:\n"
+                "1. A `## Examples` section with at least one `Input: ... → Output: ...` invocation "
+                "that matches the declared schemas.\n"
+                "2. A `## Implementation Example` section after `## Implementation` with a short fenced "
+                "code skeleton using TODO comments for unknown APIs.\n"
+                "Keep examples illustrative only — do not invent secrets, endpoints, or dependencies "
+                "not supported by context."
             )
-        )
+        else:
+            example_code_note = (
+                "Example code is disabled for this request. You MUST NOT include:\n"
+                "- fenced code blocks (```) or pseudo-code snippets\n"
+                "- a `## Examples` section or any input/output JSON samples\n"
+                "- arrow-form invocations such as `Input: {...} → Output: ...`\n"
+                "- a `## Implementation Example` section\n"
+                "Keep `## Implementation` code-free and limit schemas to field/type descriptions only."
+            )
         messages.insert(1, {"role": "system", "content": safety_note})
         messages.insert(2, {"role": "system", "content": example_code_note})
 

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -59,6 +59,20 @@ _MULTI_AGENT_PATTERNS = [
     re.compile(r"^- Only include a final `## Swarm Example Code .*?$\n?", flags=re.MULTILINE),
 ]
 
+_SKILL_PLAIN_OUTPUT_SECTION_PATTERNS = [
+    re.compile(r"^## Examples\b.*?(?=^## |\Z)", flags=re.MULTILINE | re.DOTALL),
+    re.compile(r"^## Implementation Example\b.*?(?=^## |\Z)", flags=re.MULTILINE | re.DOTALL),
+    re.compile(
+        r"^\*\*Examples:\*\*\s*\n.*?(?=^## |\n\*\*[^*]+:\*\*|\Z)",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+]
+
+_SKILL_PLAIN_OUTPUT_LINE_PATTERNS = [
+    re.compile(r"^- Input:.*?(?:→|->).*$", flags=re.MULTILINE),
+    re.compile(r"^- (?:Input|Output):\s*`?\{.*$", flags=re.MULTILINE),
+]
+
 _SKILL_PATTERNS = [
     re.compile(
         r"\n## OPTIONAL IMPLEMENTATION EXAMPLE SECTION.*?(?=\n## INPUT HANDLING)",
@@ -78,6 +92,21 @@ _SKILL_PATTERNS = [
         flags=re.MULTILINE,
     ),
 ]
+
+
+def _sanitize_skill_definition_plain(text: str) -> str:
+    """Strip example/code artifacts from plain skill output when example code is disabled."""
+    if not text:
+        return text
+
+    cleaned = re.sub(r"```[^\n]*\n.*?```", "", text, flags=re.DOTALL)
+    for pattern in _SKILL_PLAIN_OUTPUT_SECTION_PATTERNS:
+        cleaned = pattern.sub("", cleaned)
+    for pattern in _SKILL_PLAIN_OUTPUT_LINE_PATTERNS:
+        cleaned = pattern.sub("", cleaned)
+
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
 
 
 class WorkerClient:
@@ -732,6 +761,8 @@ class WorkerClient:
             future = executor.submit(self._call_api, messages, 3000, json_mode=False)
             try:
                 content = future.result(timeout=HARD_TIMEOUT_SECONDS)
+                if not include_example_code:
+                    content = _sanitize_skill_definition_plain(content)
                 return content
             except FuturesTimeoutError:
                 future.cancel()

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -111,6 +111,19 @@ def test_api_generate_skill_endpoint_with_example_code_enabled():
         )
 
 
+def test_skill_prompt_omits_examples_section_when_disabled():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    rendered = client._skill_prompt(include_example_code=False)
+
+    assert "## Examples\n[At least one" not in rendered
+    assert "Input: `{param_name:" not in rendered
+    assert "## OPTIONAL IMPLEMENTATION EXAMPLE SECTION" not in rendered
+    assert "Omit `## Examples` entirely" in rendered
+    assert "Do not include fenced code blocks" in rendered
+
+
 def test_worker_client_omits_skill_implementation_example_when_disabled():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")
@@ -129,7 +142,14 @@ def test_worker_client_omits_skill_implementation_example_when_disabled():
             msg["content"] for msg in captured["messages"] if msg["role"] == "system"
         ]
         assert any(
-            "Omit the entire `## Implementation Example` section" in message
+            "Example code is disabled for this request" in message for message in system_messages
+        )
+        assert any(
+            "You MUST NOT include" in message and "`## Examples` section" in message
+            for message in system_messages
+        )
+        assert any(
+            "fenced code blocks" in message and "`## Implementation Example` section" in message
             for message in system_messages
         )
 
@@ -152,6 +172,10 @@ def test_worker_client_requests_skill_implementation_example_when_enabled():
             msg["content"] for msg in captured["messages"] if msg["role"] == "system"
         ]
         assert any(
-            "Include a final `## Implementation Example` section" in message
+            "Example code is enabled for this request" in message for message in system_messages
+        )
+        assert any(
+            "You MUST include" in message and "`## Examples` section" in message
             for message in system_messages
         )
+        assert any("`## Implementation Example` section" in message for message in system_messages)

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -1,9 +1,24 @@
+import re
+
 import pytest
 from unittest.mock import MagicMock, patch
 from app.llm_engine.client import WorkerClient, _sanitize_skill_definition_plain
 from app.llm_engine.hybrid import HybridCompiler
 from api.main import app
 from fastapi.testclient import TestClient
+
+
+def _assert_plain_skill_output_is_clean(text: str) -> None:
+    assert "```" not in text
+    assert "**Examples**" not in text
+    assert "**Examples:**" not in text
+    assert "## Examples" not in text
+    assert "### Examples" not in text
+    assert re.search(r"^Examples:\s*$", text, flags=re.MULTILINE) is None
+    assert 'Input: `{"' not in text
+    assert "→ Output:" not in text
+    assert "-> Output:" not in text
+
 
 _SKILL_OUTPUT_WITH_EXAMPLES = """\
 # json-validator - Skill Definition
@@ -34,6 +49,49 @@ def run_skill(payload):
 
 ## Error Handling
 - Return a structured error when JSON is invalid.
+"""
+
+_PREVIEW_STYLE_SKILL_OUTPUT = """\
+# url-summarizer - Skill Definition
+
+## Name
+url_summarizer
+
+## Purpose
+**What:** Summarizes web page content from a URL.
+**When to use:** Use when a user provides a URL and wants a short summary.
+
+## Input Schema
+- `url` (str): Public HTTP or HTTPS URL.
+
+**Output Schema**
+A JSON object with page metadata and summary text.
+
+```json
+{
+  "title": "string",
+  "summary": "string"
+}
+```
+
+## Implementation
+1. Validate the URL scheme.
+2. Fetch and extract readable text.
+3. Return a concise summary.
+
+**Examples**
+
+```json
+{
+  "input": {"url": "https://example.com"},
+  "output": {"title": "Example Domain", "summary": "Illustrative example page."}
+}
+```
+
+- Input: `{"url": "https://example.com"}` → Output: `{"title": "Example Domain", "summary": "..."}`
+
+## Error Handling
+- Reject unsupported URL schemes.
 """
 
 
@@ -188,27 +246,73 @@ def test_worker_client_omits_skill_implementation_example_when_disabled():
 def test_sanitize_skill_definition_plain_removes_examples_and_code():
     cleaned = _sanitize_skill_definition_plain(_SKILL_OUTPUT_WITH_EXAMPLES)
 
-    assert "## Examples" not in cleaned
-    assert "**Examples:**" not in cleaned
+    _assert_plain_skill_output_is_clean(cleaned)
     assert "## Implementation Example" not in cleaned
-    assert "```" not in cleaned
-    assert "Input: `{" not in cleaned
     assert "## Error Handling" in cleaned
     assert "## Implementation" in cleaned
+
+
+def test_sanitize_skill_definition_plain_removes_preview_style_markdown():
+    cleaned = _sanitize_skill_definition_plain(_PREVIEW_STYLE_SKILL_OUTPUT)
+
+    _assert_plain_skill_output_is_clean(cleaned)
+    assert "**Output Schema**" in cleaned
+    assert "A JSON object with page metadata and summary text." in cleaned
+    assert "## Error Handling" in cleaned
 
 
 def test_generate_skill_sanitizes_plain_output_when_example_code_disabled():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")
 
-        with patch.object(client, "_call_api", return_value=_SKILL_OUTPUT_WITH_EXAMPLES):
+        with patch.object(client, "_call_api", return_value=_PREVIEW_STYLE_SKILL_OUTPUT):
             result = client.generate_skill("Test Skill", include_example_code=False)
 
-    assert "## Examples" not in result
-    assert "**Examples:**" not in result
-    assert "## Implementation Example" not in result
-    assert "```" not in result
+    _assert_plain_skill_output_is_clean(result)
+    assert "**Output Schema**" in result
     assert "## Error Handling" in result
+
+
+def test_api_generate_skill_plain_response_is_sanitized_at_route_boundary():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = _PREVIEW_STYLE_SKILL_OUTPUT
+
+        client = TestClient(app)
+        response = client.post(
+            "/skills-generator/generate",
+            json={"description": "Summarize a web page from a URL"},
+        )
+
+        assert response.status_code == 200
+        skill_definition = response.json()["skill_definition"]
+        _assert_plain_skill_output_is_clean(skill_definition)
+        assert "**Output Schema**" in skill_definition
+        mock_compiler.generate_skill.assert_called_with(
+            "Summarize a web page from a URL",
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
+        )
+
+
+def test_api_generate_skill_preserves_examples_when_example_code_enabled():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = _PREVIEW_STYLE_SKILL_OUTPUT
+
+        client = TestClient(app)
+        response = client.post(
+            "/skills-generator/generate",
+            json={
+                "description": "Summarize a web page from a URL",
+                "include_example_code": True,
+            },
+        )
+
+        assert response.status_code == 200
+        skill_definition = response.json()["skill_definition"]
+        assert "```json" in skill_definition
+        assert "**Examples**" in skill_definition
+        assert 'Input: `{"url"' in skill_definition
 
 
 def test_generate_skill_preserves_examples_when_example_code_enabled():

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -1,9 +1,40 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from app.llm_engine.client import WorkerClient
+from app.llm_engine.client import WorkerClient, _sanitize_skill_definition_plain
 from app.llm_engine.hybrid import HybridCompiler
 from api.main import app
 from fastapi.testclient import TestClient
+
+_SKILL_OUTPUT_WITH_EXAMPLES = """\
+# json-validator - Skill Definition
+
+## Name
+json_validator
+
+## Purpose
+Validates JSON payloads.
+
+## Implementation
+1. Parse the payload.
+2. Validate against schema rules.
+
+## Examples
+- Input: `{"data": "x"}` → Output: `{"valid": true}`
+
+**Examples:**
+```json
+{"input": {"data": "x"}, "output": {"valid": true}}
+```
+
+## Implementation Example
+```python
+def run_skill(payload):
+    return {"valid": True}
+```
+
+## Error Handling
+- Return a structured error when JSON is invalid.
+"""
 
 
 # Mock WorkerClient to avoid API calls
@@ -152,6 +183,46 @@ def test_worker_client_omits_skill_implementation_example_when_disabled():
             "fenced code blocks" in message and "`## Implementation Example` section" in message
             for message in system_messages
         )
+
+
+def test_sanitize_skill_definition_plain_removes_examples_and_code():
+    cleaned = _sanitize_skill_definition_plain(_SKILL_OUTPUT_WITH_EXAMPLES)
+
+    assert "## Examples" not in cleaned
+    assert "**Examples:**" not in cleaned
+    assert "## Implementation Example" not in cleaned
+    assert "```" not in cleaned
+    assert "Input: `{" not in cleaned
+    assert "## Error Handling" in cleaned
+    assert "## Implementation" in cleaned
+
+
+def test_generate_skill_sanitizes_plain_output_when_example_code_disabled():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+        with patch.object(client, "_call_api", return_value=_SKILL_OUTPUT_WITH_EXAMPLES):
+            result = client.generate_skill("Test Skill", include_example_code=False)
+
+    assert "## Examples" not in result
+    assert "**Examples:**" not in result
+    assert "## Implementation Example" not in result
+    assert "```" not in result
+    assert "## Error Handling" in result
+
+
+def test_generate_skill_preserves_examples_when_example_code_enabled():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+        with patch.object(client, "_call_api", return_value=_SKILL_OUTPUT_WITH_EXAMPLES):
+            result = client.generate_skill("Test Skill", include_example_code=True)
+
+    assert "## Examples" in result
+    assert "**Examples:**" in result
+    assert "## Implementation Example" in result
+    assert "```json" in result
+    assert "```python" in result
 
 
 def test_worker_client_requests_skill_implementation_example_when_enabled():


### PR DESCRIPTION
## Summary

Refs #763
Refs #775

Fixes Skills Generator plain-mode output when `include_example_code=false`.

PR #786 confirmed frontend wiring. Preview QA on the first #787 revision showed prompt-only compliance was **insufficient**: with Example Code OFF (PLAIN header), the LLM still returned `**Examples:**`, fenced ` ```json ` blocks, and JSON input/output samples.

This revision keeps the prompt cleanup **and** adds a deterministic post-LLM sanitization guard in `WorkerClient.generate_skill()`.

## Root cause

1. **Prompt layer:** `skills_generator.md` template mandates a `## Examples` section with arrow-form JSON samples.
2. **Runtime layer:** LLM can still ignore/disable-path instructions → examples/code leak into `skill_definition`.

Agent Generator unchanged (no evidence of same bug).

## Changed files

- `app/llm_engine/client.py`
  - `_sanitize_skill_definition_plain()` — output guard (disabled path only)
  - existing `_skill_prompt()` / `example_code_note` prompt tightening retained
- `tests/test_skills_generator.py`
  - output-level sanitization tests (false cleans, true preserves)
  - existing prompt assembly tests retained

## Sanitization behavior (`include_example_code=false` only)

Applied to returned `skill_definition` after LLM response:

| Removed | Details |
|---------|---------|
| Fenced code blocks | Any ` ```lang ... ``` ` block |
| `## Examples` | Section through next `##` heading |
| `**Examples:**` | Bold variant through next section |
| `## Implementation Example` | Section through next `##` heading |
| Arrow-form lines | `Input: ... → Output: ...` bullets |
| JSON example bullets | `Input: `{...}` / `Output: `{...}` lines |

When `include_example_code=true`, output is returned unchanged.

## Tests run

```bash
python -m pytest tests/test_skills_generator.py tests/test_agent_generator.py -q  # 20 passed
python -m pytest tests/test_api_hardening.py -q                                   # 13 passed
```

## Manual verification pending

Memo should verify on **PR preview** (Skills Generator):
1. Example Code **OFF** → header shows **PLAIN**
2. Generate → output has **no** `Examples` / `**Examples:**` / fenced code / JSON sample blocks
3. Example Code **ON** → examples and fenced code **still present**

Preview deploy: https://vercel.com/madara88645s-projects/compiler/GrEmD7zrMq1khoaYMuMLBScz927R (Vercel dashboard for this PR build)