### PR TITLE
[codex] fix skills generator plain fence cleanup

### DIFF
--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -95,6 +95,45 @@ _SKILL_PLAIN_OUTPUT_LINE_PATTERNS = [
     re.compile(r"^- (?:Input|Output|Example):\s*`?\[.*$", flags=re.MULTILINE),
 ]
 
+_SKILL_PLAIN_NAME_FENCE_PATTERN = re.compile(
+    r"(?im)^(?P<heading>\s*(?:#{1,3}\s+Name|Name:|\*\*Name:?\*\*)\s*)\r?\n"
+    r"[ \t]*```[^\r\n]*\r?\n"
+    r"(?P<name>[A-Za-z_][\w.-]*)\s*\r?\n"
+    r"[ \t]*```[ \t]*\r?\n?"
+)
+
+_SKILL_PLAIN_ATX_HEADING_PATTERN = re.compile(r"^\s{0,3}#{1,3}\s+(?P<heading>.+?)\s*#*\s*$")
+_SKILL_PLAIN_BOLD_HEADING_PATTERN = re.compile(r"^\s*\*\*(?P<heading>[^*]+?)\*\*:?\s*$")
+_SKILL_PLAIN_BRACKET_HEADING_PATTERN = re.compile(r"^\s*\[(?P<heading>[^\]]+?)\]\s*$")
+_SKILL_PLAIN_COLON_HEADING_PATTERN = re.compile(
+    r"^\s*(?P<heading>[A-Za-z][A-Za-z0-9 /_-]{0,60}):\s*$"
+)
+
+_SKILL_PLAIN_ALLOWED_SECTION_NAMES = {
+    "name",
+    "purpose",
+    "input schema",
+    "output schema",
+    "implementation",
+    "error handling",
+    "testing strategy",
+    "test strategy",
+    "notes",
+    "constraints",
+    "notes constraints",
+}
+
+_SKILL_PLAIN_JSON_SAMPLE_LINE_PATTERN = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:Input|Output|Example)\s*:\s*(?:`?\s*)?(?:[\[{]|$)",
+    flags=re.IGNORECASE,
+)
+_SKILL_PLAIN_JSONISH_LINE_PATTERN = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:`?\s*)?[\[{\]}]", flags=re.IGNORECASE
+)
+_SKILL_PLAIN_JSON_FIELD_LINE_PATTERN = re.compile(
+    r'^\s*(?:[-*]\s*)?"[^"]+"\s*:', flags=re.IGNORECASE
+)
+
 _SKILL_PATTERNS = [
     re.compile(
         r"\n## OPTIONAL IMPLEMENTATION EXAMPLE SECTION.*?(?=\n## INPUT HANDLING)",
@@ -116,19 +155,120 @@ _SKILL_PATTERNS = [
 ]
 
 
+def _normalize_skill_plain_heading(heading: str) -> str:
+    normalized = heading.strip().strip(":").strip("#").strip("[]").strip()
+    normalized = normalized.replace("&", " and ")
+    normalized = re.sub(r"[^A-Za-z0-9]+", " ", normalized)
+    return re.sub(r"\s+", " ", normalized).strip().lower()
+
+
+def _skill_plain_heading_name(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    for pattern in (
+        _SKILL_PLAIN_ATX_HEADING_PATTERN,
+        _SKILL_PLAIN_BOLD_HEADING_PATTERN,
+        _SKILL_PLAIN_BRACKET_HEADING_PATTERN,
+        _SKILL_PLAIN_COLON_HEADING_PATTERN,
+    ):
+        match = pattern.match(stripped)
+        if match:
+            return _normalize_skill_plain_heading(match.group("heading"))
+    return None
+
+
+def _strip_skill_plain_fenced_blocks(text: str) -> str:
+    lines = text.splitlines()
+    cleaned_lines: list[str] = []
+    in_fence = False
+
+    for line in lines:
+        if _SKILL_PLAIN_FENCE_LINE_PATTERN.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            if _skill_plain_heading_name(line):
+                in_fence = False
+                cleaned_lines.append(line)
+            continue
+        cleaned_lines.append(line)
+
+    return "\n".join(cleaned_lines)
+
+
+def _is_skill_plain_sample_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if _SKILL_PLAIN_JSON_SAMPLE_LINE_PATTERN.match(stripped):
+        return True
+    if _SKILL_PLAIN_JSONISH_LINE_PATTERN.match(stripped):
+        return True
+    if _SKILL_PLAIN_JSON_FIELD_LINE_PATTERN.match(stripped):
+        return True
+    if re.search(r"(?:→|->)\s*Output\s*:", stripped, flags=re.IGNORECASE):
+        return True
+    return False
+
+
+def _filter_skill_plain_allowed_sections(text: str) -> str:
+    cleaned_lines: list[str] = []
+    current_section_allowed = False
+
+    for line in text.splitlines():
+        heading_name = _skill_plain_heading_name(line)
+        if heading_name:
+            if "example" in heading_name:
+                current_section_allowed = False
+                continue
+            current_section_allowed = heading_name in _SKILL_PLAIN_ALLOWED_SECTION_NAMES
+            if current_section_allowed:
+                cleaned_lines.append(line)
+            continue
+
+        if current_section_allowed and not _is_skill_plain_sample_line(line):
+            cleaned_lines.append(line)
+
+    return "\n".join(cleaned_lines)
+
+
+def _skill_plain_heading_summary(text: str) -> tuple[bool, bool]:
+    has_allowed = False
+    has_forbidden = False
+    for line in text.splitlines():
+        heading_name = _skill_plain_heading_name(line)
+        if not heading_name:
+            continue
+        has_allowed = has_allowed or heading_name in _SKILL_PLAIN_ALLOWED_SECTION_NAMES
+        has_forbidden = has_forbidden or "example" in heading_name
+    return has_allowed, has_forbidden
+
+
+def _remove_skill_plain_remaining_fence_lines(text: str) -> str:
+    return "\n".join(line for line in text.splitlines() if "```" not in line)
+
+
 def _sanitize_skill_definition_plain(text: str) -> str:
     """Strip example/code artifacts from plain skill output when example code is disabled."""
     if not text:
         return text
 
-    cleaned = text
-    for pattern in _SKILL_PLAIN_OUTPUT_SECTION_PATTERNS:
-        cleaned = pattern.sub("", cleaned)
-    cleaned = _SKILL_PLAIN_FENCED_CODE_PATTERN.sub("", cleaned)
-    cleaned = _SKILL_PLAIN_FENCE_LINE_PATTERN.sub("", cleaned)
+    cleaned = _SKILL_PLAIN_NAME_FENCE_PATTERN.sub(
+        lambda match: f"{match.group('heading')}\n{match.group('name')}\n",
+        text.replace("\r\n", "\n").replace("\r", "\n"),
+    )
+    cleaned = _strip_skill_plain_fenced_blocks(cleaned)
+    has_allowed_heading, has_forbidden_heading = _skill_plain_heading_summary(cleaned)
+    filtered = _filter_skill_plain_allowed_sections(cleaned)
+    if filtered.strip() or has_allowed_heading or has_forbidden_heading:
+        cleaned = filtered
     for pattern in _SKILL_PLAIN_OUTPUT_LINE_PATTERNS:
         cleaned = pattern.sub("", cleaned)
 
+    cleaned = _SKILL_PLAIN_FENCE_LINE_PATTERN.sub("", cleaned)
+    cleaned = _remove_skill_plain_remaining_fence_lines(cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
     return cleaned.strip()
 

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -87,6 +87,7 @@ _SKILL_PLAIN_OUTPUT_SECTION_PATTERNS = [
 ]
 
 _SKILL_PLAIN_FENCED_CODE_PATTERN = re.compile(r"```[\w-]*\s*\r?\n[\s\S]*?```", flags=re.DOTALL)
+_SKILL_PLAIN_FENCE_LINE_PATTERN = re.compile(r"(?m)^[ \t]*```[\w-]*[ \t]*\r?\n?")
 
 _SKILL_PLAIN_OUTPUT_LINE_PATTERNS = [
     re.compile(r"^- Input:.*?(?:→|->).*$", flags=re.MULTILINE),
@@ -124,6 +125,7 @@ def _sanitize_skill_definition_plain(text: str) -> str:
     for pattern in _SKILL_PLAIN_OUTPUT_SECTION_PATTERNS:
         cleaned = pattern.sub("", cleaned)
     cleaned = _SKILL_PLAIN_FENCED_CODE_PATTERN.sub("", cleaned)
+    cleaned = _SKILL_PLAIN_FENCE_LINE_PATTERN.sub("", cleaned)
     for pattern in _SKILL_PLAIN_OUTPUT_LINE_PATTERNS:
         cleaned = pattern.sub("", cleaned)
 

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -10,12 +10,17 @@ from fastapi.testclient import TestClient
 
 def _assert_plain_skill_output_is_clean(text: str) -> None:
     assert "```" not in text
+    assert "Example JSON" not in text
+    assert "[Example JSON]" not in text
+    assert "Implementation Example" not in text
     assert "**Examples**" not in text
     assert "**Examples:**" not in text
     assert "## Examples" not in text
     assert "### Examples" not in text
     assert re.search(r"^Examples:\s*$", text, flags=re.MULTILINE) is None
     assert 'Input: `{"' not in text
+    assert re.search(r"^\s*-?\s*Input:\s*[`{\[]", text, flags=re.MULTILINE) is None
+    assert re.search(r"^\s*-?\s*Output:\s*[`{\[]", text, flags=re.MULTILINE) is None
     assert "→ Output:" not in text
     assert "-> Output:" not in text
 
@@ -115,6 +120,66 @@ Validates a project plan and returns blockers, risks, and next steps.
 ## Error Handling
 - Return empty lists when the plan is empty.
 ```
+"""
+
+_BROWSER_FAILED_PLAIN_SKILL_OUTPUT = """\
+# Skill Definition
+
+**Name**
+```text
+project_plan_validator
+```
+
+**Purpose**
+Validates project plans and returns blockers, risks, and next steps.
+
+**Input Schema**
+```json
+{
+  "project_plan": "string",
+  "team": "string"
+}
+```
+
+- Input: {"project_plan": "Ship v1", "team": "Platform"}
+- Output: {"blockers": [], "risks": ["unclear owner"], "next_steps": ["assign owner"]}
+
+**Output Schema**
+```json
+{
+  "blockers": ["string"],
+  "risks": ["string"],
+  "next_steps": ["string"]
+}
+```
+
+**Implementation**
+1. Read the project plan.
+2. Identify blockers, risks, and next steps.
+
+**Example JSON**
+```json
+{
+  "input": {"project_plan": "Ship v1"},
+  "output": {"blockers": [], "risks": [], "next_steps": ["Start"]}
+}
+```
+
+[Example JSON]
+```json
+{
+  "project_plan": "Ship v1"
+}
+```
+
+## Implementation Example
+```python
+def run_skill(payload):
+    return {"blockers": [], "risks": [], "next_steps": []}
+```
+
+**Error Handling**
+- Return a clear validation error when the plan is empty.
 """
 
 
@@ -293,6 +358,19 @@ def test_sanitize_skill_definition_plain_removes_orphan_fence_after_example_clea
     assert cleaned.endswith("empty.")
 
 
+def test_sanitize_skill_definition_plain_normalizes_browser_failed_output():
+    cleaned = _sanitize_skill_definition_plain(_BROWSER_FAILED_PLAIN_SKILL_OUTPUT)
+
+    _assert_plain_skill_output_is_clean(cleaned)
+    assert "project_plan_validator" in cleaned
+    assert "**Name**" in cleaned
+    assert "**Input Schema**" in cleaned
+    assert "**Output Schema**" in cleaned
+    assert "**Implementation**" in cleaned
+    assert "**Error Handling**" in cleaned
+    assert "Return a clear validation error" in cleaned
+
+
 def test_generate_skill_sanitizes_plain_output_when_example_code_disabled():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")
@@ -307,7 +385,7 @@ def test_generate_skill_sanitizes_plain_output_when_example_code_disabled():
 
 def test_api_generate_skill_plain_response_is_sanitized_at_route_boundary():
     with patch("api.main.hybrid_compiler") as mock_compiler:
-        mock_compiler.generate_skill.return_value = _ORPHAN_FENCE_SKILL_OUTPUT
+        mock_compiler.generate_skill.return_value = _BROWSER_FAILED_PLAIN_SKILL_OUTPUT
 
         client = TestClient(app)
         response = client.post(
@@ -319,7 +397,7 @@ def test_api_generate_skill_plain_response_is_sanitized_at_route_boundary():
         skill_definition = response.json()["skill_definition"]
         _assert_plain_skill_output_is_clean(skill_definition)
         assert "Implementation Example" not in skill_definition
-        assert "## Error Handling" in skill_definition
+        assert "Error Handling" in skill_definition
         mock_compiler.generate_skill.assert_called_with(
             "Validate a project plan",
             include_example_code=False,

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -94,6 +94,29 @@ A JSON object with page metadata and summary text.
 - Reject unsupported URL schemes.
 """
 
+_ORPHAN_FENCE_SKILL_OUTPUT = """\
+# project-plan-validator - Skill Definition
+
+## Name
+project_plan_validator
+
+## Purpose
+Validates a project plan and returns blockers, risks, and next steps.
+
+## Implementation
+1. Parse the plan.
+2. Identify blockers and risks.
+3. Return next steps.
+
+**Implementation Example**
+```json
+{"input": {"plan": "Ship v1"}, "output": {"blockers": [], "risks": [], "next_steps": ["Start delivery"]}}
+
+## Error Handling
+- Return empty lists when the plan is empty.
+```
+"""
+
 
 # Mock WorkerClient to avoid API calls
 @pytest.fixture
@@ -261,6 +284,15 @@ def test_sanitize_skill_definition_plain_removes_preview_style_markdown():
     assert "## Error Handling" in cleaned
 
 
+def test_sanitize_skill_definition_plain_removes_orphan_fence_after_example_cleanup():
+    cleaned = _sanitize_skill_definition_plain(_ORPHAN_FENCE_SKILL_OUTPUT)
+
+    _assert_plain_skill_output_is_clean(cleaned)
+    assert "Implementation Example" not in cleaned
+    assert "## Error Handling" in cleaned
+    assert cleaned.endswith("empty.")
+
+
 def test_generate_skill_sanitizes_plain_output_when_example_code_disabled():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")
@@ -275,20 +307,21 @@ def test_generate_skill_sanitizes_plain_output_when_example_code_disabled():
 
 def test_api_generate_skill_plain_response_is_sanitized_at_route_boundary():
     with patch("api.main.hybrid_compiler") as mock_compiler:
-        mock_compiler.generate_skill.return_value = _PREVIEW_STYLE_SKILL_OUTPUT
+        mock_compiler.generate_skill.return_value = _ORPHAN_FENCE_SKILL_OUTPUT
 
         client = TestClient(app)
         response = client.post(
             "/skills-generator/generate",
-            json={"description": "Summarize a web page from a URL"},
+            json={"description": "Validate a project plan"},
         )
 
         assert response.status_code == 200
         skill_definition = response.json()["skill_definition"]
         _assert_plain_skill_output_is_clean(skill_definition)
-        assert "**Output Schema**" in skill_definition
+        assert "Implementation Example" not in skill_definition
+        assert "## Error Handling" in skill_definition
         mock_compiler.generate_skill.assert_called_with(
-            "Summarize a web page from a URL",
+            "Validate a project plan",
             include_example_code=False,
             repo_context=None,
             repo_context_mode="full",


### PR DESCRIPTION
## Summary
This PR hardens Skills Generator plain-mode output when `include_example_code=false` by replacing narrow cleanup with a deterministic plain-output sanitizer/normalizer.

## What changed
- Removes fenced code blocks globally, including complete blocks, orphan fence lines, and unmatched fence regions.
- Preserves a simple code-fenced skill name as plain text, then removes the fence wrapper.
- Keeps only plain-mode sections that belong in the final response: Name, Purpose, Input Schema, Output Schema, Implementation, Error Handling, Testing Strategy, Notes, and Constraints.
- Drops example-like sections such as Examples, Example JSON, bracketed Example JSON, and Implementation Example.
- Removes JSON input/output sample bullets and JSON-ish sample lines from the final plain response.
- Keeps `include_example_code=true` behavior unchanged.

## Root cause
The previous sanitizer was blacklist-based. It handled some exact headings and fences, but preview QA showed many nearby shapes still leaking: schema JSON fences, Example JSON sections, bracketed example headings, JSON sample bullets, and code-fenced names.

## Product impact
With Example Code OFF / Plain, the API response should no longer render code blocks, empty pre/code artifacts, example sections, or JSON samples. With Example Code ON, examples and code are still preserved.

## Validation
- `python -m pytest tests/test_skills_generator.py tests/test_agent_generator.py -q`
- `python -m pytest tests/test_api_hardening.py -q`
