### PR TITLE
🎨 Palette: Improve accessibility for mutually exclusive buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-06-01 - Avoid duplicate ARIA attributes in React
 **Learning:** Adding duplicate props like `aria-busy={downloading}` and `aria-busy={loading}` causes React build failures due to `react/jsx-no-duplicate-props`. Even though one of the values might be correct logically, both cannot exist on the same element.
 **Action:** When adding accessibility attributes like `aria-busy` to existing elements, ensure there isn't already one present, or replace the existing one with the correct value if necessary.
+## 2024-06-03 - Mutually Exclusive Button ARIA Grouping
+**Learning:** When using standard `<button>` tags to create mutually exclusive selection groups (like toggle groups or choice cards), relying solely on visual styling is insufficient for accessibility. Screen readers will treat them as independent, unrelated buttons without state.
+**Action:** Always wrap the buttons in a container with `role="radiogroup"` and a descriptive `aria-label`, and add `role="radio"` and `aria-checked={active}` to each button. This ensures the component is properly announced as a radio group and communicates selection state correctly.

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -72,7 +72,7 @@ describe("Agent Packs page", () => {
   test("submits the selected pack type and renders grouped preview output", async () => {
     render(<AgentPacksPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: /PR Reviewer/i }));
+    fireEvent.click(screen.getByRole("radio", { name: /PR Reviewer/i }));
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
       target: { value: "Review pull requests for secret leaks and missing tests." },
     });

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -307,13 +307,15 @@ export default function AgentPacksPage() {
 
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium text-zinc-300">Pack Type</span>
-              <div className="grid gap-2">
+              <div className="grid gap-2" role="radiogroup" aria-label="Pack Type">
                 {PACK_OPTIONS.map((option) => {
                   const active = request.pack_type === option.id;
                   return (
                     <button
                       key={option.id}
                       type="button"
+                      role="radio"
+                      aria-checked={active}
                       onClick={() => handleFieldChange("pack_type", option.id)}
                       className={`rounded-2xl border px-4 py-3 text-left transition-all ${
                         active
@@ -331,13 +333,15 @@ export default function AgentPacksPage() {
 
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium text-zinc-300">Risk Mode</span>
-              <div className="grid gap-2 sm:grid-cols-2">
+              <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Risk Mode">
                 {RISK_OPTIONS.map((option) => {
                   const active = request.risk_mode === option.id;
                   return (
                     <button
                       key={option.id}
                       type="button"
+                      role="radio"
+                      aria-checked={active}
                       onClick={() => handleFieldChange("risk_mode", option.id)}
                       className={`rounded-xl border px-4 py-3 text-left transition-all ${
                         active


### PR DESCRIPTION
💡 What:
Added missing ARIA attributes (`role="radio"`, `aria-checked`) to the mutually exclusive "Pack Type" and "Risk Mode" options on the Agent Packs page, and wrapped them in `role="radiogroup"` containers. Updated the unit tests to match the new roles.

🎯 Why:
Although these buttons functioned like radio buttons visually, they lacked semantic meaning for screen readers. This change ensures that assistive technologies properly announce them as a group of mutually exclusive options and correctly communicate their selection state.

📸 Before/After:
Before: Screen readers announced them as individual, unrelated buttons with no selection state.
After: Screen readers announce them as a radio group and indicate which option is currently checked.

♿ Accessibility:
Significantly improves keyboard and screen reader navigation for critical configuration options on the Agent Packs page.

---
*PR created automatically by Jules for task [13122438225508433874](https://jules.google.com/task/13122438225508433874) started by @madara88645*