### PR TITLE
⚡ Bolt: Replace lambdas with operator.attrgetter in stats paths

### DIFF
--- a/app/reporting/generator.py
+++ b/app/reporting/generator.py
@@ -256,7 +256,7 @@ class ReportGenerator:
             # Fallback scan
             best_candidate = max(
                 (c for gen in run.generations for c in gen),
-                key=lambda x: x.score,
+                key=operator.attrgetter("score"),
                 default=baseline_candidate,
             )
 

--- a/app/templates_manager.py
+++ b/app/templates_manager.py
@@ -7,6 +7,7 @@ interactive prompts, and rich CLI output support.
 from __future__ import annotations
 
 import json
+import operator
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -288,12 +289,14 @@ class TemplatesManager:
             }
 
         # Return overall stats
-        total_uses = sum(s.use_count for s in self._stats.values())
+        total_uses = sum(map(operator.attrgetter("use_count"), self._stats.values()))
         templates_used = len(self._stats)
 
         most_used = []
         if self._stats:
-            sorted_stats = sorted(self._stats.values(), key=lambda s: s.use_count, reverse=True)
+            sorted_stats = sorted(
+                self._stats.values(), key=operator.attrgetter("use_count"), reverse=True
+            )
             most_used = [
                 {
                     "template_id": s.template_id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Extracted from #799 after #801 merged the overlapping `linter.py` optimization separately.

## What
- `app/reporting/generator.py`: use `operator.attrgetter("score")` for best-candidate lookup
- `app/templates_manager.py`: use `operator.attrgetter("use_count")` for stats sum/sort

## Why
Same Bolt micro-optimization as the original Jules task, scoped to non-linter files only.

## Verification
- `python3 -m pytest tests/test_templates_manager.py tests/test_report_generator.py -q` — 42 passed
- Behavior unchanged (attribute lookup only)

## Supersedes
Closes the remaining hunks from #799. The linter portion is already on `main` via #801.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb9b4ec6-1ee6-43cc-8522-ae30188642ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb9b4ec6-1ee6-43cc-8522-ae30188642ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

