### PR TITLE
[codex] fix generator toggle hit area

### DIFF
--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -82,7 +82,7 @@ describe("Agent Generator page", () => {
     await screen.findByText("openai/openai-python");
     expect(screen.getByText("Python SDK repo with a compact README and clear manifest signals.")).toBeTruthy();
 
-    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+    fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
 
     await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
 
@@ -127,7 +127,7 @@ describe("Agent Generator page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Analyze Repo" }));
     expect(await screen.findByText("Repository analysis failed")).toBeTruthy();
 
-    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+    fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
 
     await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(2));
     expect(JSON.parse(String(apiJsonMock.mock.calls[1]?.[1]?.body))).toEqual({
@@ -155,7 +155,7 @@ describe("Agent Generator page", () => {
     fireEvent.change(screen.getByLabelText("Agent Description"), {
       target: { value: "Build a code review agent." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Generate Agent/i })[0]!);
+    fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
 
     expect(await screen.findByText("Agent generation failed")).toBeTruthy();
     expect(screen.getByText("The service is temporarily unavailable.")).toBeTruthy();
@@ -165,5 +165,41 @@ describe("Agent Generator page", () => {
 
     await waitFor(() => expect(screen.getByRole("heading", { name: "Reviewer" })).toBeTruthy());
     expect(apiJsonMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("toggles both switches from label clicks and preserves payload values", async () => {
+    apiJsonMock.mockResolvedValueOnce({ system_prompt: "# Swarm Agent" });
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Build a collaborative agent." },
+    });
+
+    fireEvent.click(screen.getByText("Multi-Agent Swarm"));
+    fireEvent.click(screen.getByText("Example Code?"));
+    fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[0]?.[1]?.body))).toEqual({
+      description: "Build a collaborative agent.",
+      multi_agent: true,
+      include_example_code: true,
+    });
+  });
+
+  it("supports keyboard activation for the switch row", () => {
+    render(<AgentGeneratorPage />);
+
+    const multiAgentSwitch = screen.getByRole("switch", { name: "Multi-Agent Swarm toggle" });
+    expect(multiAgentSwitch.tagName).toBe("BUTTON");
+    expect(multiAgentSwitch.getAttribute("type")).toBe("button");
+    expect(multiAgentSwitch.getAttribute("aria-checked")).toBe("false");
+
+    multiAgentSwitch.focus();
+    expect(document.activeElement).toBe(multiAgentSwitch);
+
+    fireEvent.click(multiAgentSwitch);
+    expect(multiAgentSwitch.getAttribute("aria-checked")).toBe("true");
   });
 });

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -238,41 +238,47 @@ export default function AgentGenerator() {
               />
             </div>
 
-            <div className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3">
-              <button
-                type="button"
-                role="switch"
-                aria-checked={multiAgent}
-                aria-label="Multi-Agent Swarm toggle"
-                onClick={() => setMultiAgent(!multiAgent)}
-                className={`w-10 h-6 rounded-full flex items-center p-1 cursor-pointer transition-colors ${multiAgent ? 'bg-green-500' : 'bg-zinc-700'} focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none`}
+            <button
+              type="button"
+              role="switch"
+              aria-checked={multiAgent}
+              aria-label="Multi-Agent Swarm toggle"
+              onClick={() => setMultiAgent(!multiAgent)}
+              className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3 text-left transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+            >
+              <span
+                aria-hidden="true"
+                className={`flex h-6 w-10 items-center rounded-full p-1 transition-colors ${multiAgent ? "bg-green-500" : "bg-zinc-700"}`}
               >
-                <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform ${multiAgent ? 'translate-x-4' : 'translate-x-0'}`} />
-              </button>
-              <div className="flex min-w-0 flex-col">
+                <span className={`h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${multiAgent ? "translate-x-4" : "translate-x-0"}`} />
+              </span>
+              <span className="flex min-w-0 flex-col">
                 <span className="text-xs font-medium text-zinc-200">Multi-Agent Swarm</span>
                 <span className="text-xs text-zinc-500">Decompose into 2-4 specialized agents</span>
-              </div>
-            </div>
+              </span>
+            </button>
 
-            <div className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3">
-              <button
-                type="button"
-                role="switch"
-                aria-checked={includeExampleCode}
-                aria-label="Include Example Code toggle"
-                onClick={() => setIncludeExampleCode(v => !v)}
-                className={`w-10 h-6 rounded-full flex items-center p-1 cursor-pointer transition-colors ${includeExampleCode ? 'bg-blue-500' : 'bg-zinc-700'} focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
+            <button
+              type="button"
+              role="switch"
+              aria-checked={includeExampleCode}
+              aria-label="Include Example Code toggle"
+              onClick={() => setIncludeExampleCode(v => !v)}
+              className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3 text-left transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              <span
+                aria-hidden="true"
+                className={`flex h-6 w-10 items-center rounded-full p-1 transition-colors ${includeExampleCode ? "bg-blue-500" : "bg-zinc-700"}`}
               >
-                <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform ${includeExampleCode ? 'translate-x-4' : 'translate-x-0'}`} />
-              </button>
-              <div className="flex min-w-0 flex-col">
+                <span className={`h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${includeExampleCode ? "translate-x-4" : "translate-x-0"}`} />
+              </span>
+              <span className="flex min-w-0 flex-col">
                 <span className="text-xs font-medium text-zinc-200">Example Code?</span>
                 <span className="text-xs text-zinc-500">
                   Yes = include example code, No = keep it code-free to avoid confusion
                 </span>
-              </div>
-            </div>
+              </span>
+            </button>
 
             {history.length > 0 && (
               <div className="flex flex-col gap-2">

--- a/web/app/skills-generator/page.test.tsx
+++ b/web/app/skills-generator/page.test.tsx
@@ -171,4 +171,38 @@ describe("Skills Generator page", () => {
     await waitFor(() => expect(screen.getByRole("heading", { name: "json-validator" })).toBeTruthy());
     expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
+
+  it("toggles the example-code switch from its label and preserves payload values", async () => {
+    apiJsonMock.mockResolvedValueOnce({ skill_definition: "## example-skill" });
+
+    render(<SkillsGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Generate a code-heavy skill." },
+    });
+
+    fireEvent.click(screen.getByText("Example Code?"));
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(String(apiJsonMock.mock.calls[0]?.[1]?.body))).toEqual({
+      description: "Generate a code-heavy skill.",
+      include_example_code: true,
+    });
+  });
+
+  it("supports keyboard activation for the switch row", () => {
+    render(<SkillsGeneratorPage />);
+
+    const exampleCodeSwitch = screen.getByRole("switch", { name: "Include Example Code toggle" });
+    expect(exampleCodeSwitch.tagName).toBe("BUTTON");
+    expect(exampleCodeSwitch.getAttribute("type")).toBe("button");
+    expect(exampleCodeSwitch.getAttribute("aria-checked")).toBe("false");
+
+    exampleCodeSwitch.focus();
+    expect(document.activeElement).toBe(exampleCodeSwitch);
+
+    fireEvent.click(exampleCodeSwitch);
+    expect(exampleCodeSwitch.getAttribute("aria-checked")).toBe("true");
+  });
 });

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -235,24 +235,27 @@ export default function SkillsGenerator() {
               />
             </div>
 
-            <div className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3">
-              <button
-                type="button"
-                role="switch"
-                aria-checked={includeExampleCode}
-                aria-label="Include Example Code toggle"
-                onClick={() => setIncludeExampleCode((v) => !v)}
-                className={`w-10 h-6 rounded-full flex items-center p-1 cursor-pointer transition-colors ${includeExampleCode ? "bg-blue-500" : "bg-zinc-700"} focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
+            <button
+              type="button"
+              role="switch"
+              aria-checked={includeExampleCode}
+              aria-label="Include Example Code toggle"
+              onClick={() => setIncludeExampleCode((v) => !v)}
+              className="flex shrink-0 items-center gap-3 rounded-xl border border-white/5 bg-white/5 p-3 text-left transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              <span
+                aria-hidden="true"
+                className={`flex h-6 w-10 items-center rounded-full p-1 transition-colors ${includeExampleCode ? "bg-blue-500" : "bg-zinc-700"}`}
               >
-                <div className={`w-4 h-4 bg-white rounded-full shadow-sm transform transition-transform ${includeExampleCode ? "translate-x-4" : "translate-x-0"}`} />
-              </button>
-              <div className="flex min-w-0 flex-col">
+                <span className={`h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${includeExampleCode ? "translate-x-4" : "translate-x-0"}`} />
+              </span>
+              <span className="flex min-w-0 flex-col">
                 <span className="text-xs font-medium text-zinc-200">Example Code?</span>
                 <span className="text-xs text-zinc-500">
                   Yes = include implementation code, No = keep it code-free
                 </span>
-              </div>
-            </div>
+              </span>
+            </button>
 
             {history.length > 0 && (
               <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
Fix the generator toggle controls so the entire toggle row is clickable on both `/agent-generator` and `/skills-generator`.

## What Changed
- Replaced the small standalone switch buttons with full-row `button[role="switch"]` controls.
- Kept the existing toggle state, payload booleans, and visual knob styling intact.
- Added focused frontend tests covering label-click toggling, payload preservation, and focusable switch-row behavior.

## Root Cause
The previous markup made only the small knob button interactive while the adjacent label text and padded row were inert, which made the clickable area much smaller than intended.

## Validation
- `cd web && npm run test -- app/agent-generator/page.test.tsx app/skills-generator/page.test.tsx`
- `cd web && npx eslint app/agent-generator/page.tsx app/skills-generator/page.tsx app/agent-generator/page.test.tsx app/skills-generator/page.test.tsx`

## Notes
- Browser verification was attempted but blocked by local browser-plugin connectivity issues on this machine.
- `next build` was not used as a final gate because Turbopack hit an environment-level sandbox/port-binding error unrelated to this UI change.