### PR TITLE
fix(agent-packs): first-time field guidance + close-preview control (#765)

### DIFF
--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -173,4 +173,35 @@ describe("Agent Packs page", () => {
       await screen.findByText("The service is temporarily unavailable or still waking up. Please retry in a few seconds."),
     ).toBeTruthy();
   });
+
+  test("explains the Project Type and Stack fields for first-time users", () => {
+    render(<AgentPacksPage />);
+
+    // Both fields are properly labelled (and therefore focusable by label click).
+    expect(screen.getByLabelText("Project Type")).toBeTruthy();
+    expect(screen.getByLabelText("Stack")).toBeTruthy();
+
+    // Inline guidance text is present for first-time users.
+    expect(screen.getByText(/shapes the tone and sensible defaults/i)).toBeTruthy();
+    expect(screen.getByText(/so the generated files match your setup/i)).toBeTruthy();
+  });
+
+  test("closing the preview clears the generated pack and its labels", async () => {
+    render(<AgentPacksPage />);
+
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "Create a full project pack." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+
+    expect(await screen.findByText("Pack Preview")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /close pack preview/i }));
+
+    // The preview and its stale file-group labels are gone; the empty state returns.
+    await waitFor(() => expect(screen.queryByText("Pack Preview")).toBeNull());
+    expect(screen.queryByRole("button", { name: "CLAUDE.md" })).toBeNull();
+    expect(screen.getByText("Single-click pack generation")).toBeTruthy();
+  });
 });

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Bot, Copy, Download, FileCode2, FolderArchive, ShieldCheck, Sparkles } from "lucide-react";
+import { Bot, Copy, Download, FileCode2, FolderArchive, ShieldCheck, Sparkles, X } from "lucide-react";
 
 import { apiFetch, apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
 import InfoButton from "../components/InfoButton";
@@ -150,6 +150,13 @@ export default function AgentPacksPage() {
     setTimeout(() => setCopiedState(null), 1800);
   };
 
+  const handleClosePreview = () => {
+    setManifest(null);
+    setActiveKind(null);
+    setSelectedPath(null);
+    setCopiedState(null);
+  };
+
   const handleDownload = async () => {
     if (!request.goal.trim()) return;
 
@@ -270,25 +277,39 @@ export default function AgentPacksPage() {
             </div>
 
             <div className="grid gap-3 sm:grid-cols-2">
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-zinc-300">Project Type</span>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="agent-pack-project-type" className="text-sm font-medium text-zinc-300">
+                  Project Type
+                </label>
+                <p id="agent-pack-project-type-hint" className="text-xs leading-relaxed text-zinc-500">
+                  The kind of app you&apos;re building — this shapes the tone and sensible defaults of the generated files.
+                </p>
                 <input
+                  id="agent-pack-project-type"
+                  aria-describedby="agent-pack-project-type-hint"
                   value={request.project_type}
                   onChange={(event) => handleFieldChange("project_type", event.target.value)}
                   className="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-zinc-200 outline-none transition focus:ring-1 focus:ring-cyan-500/50"
                   placeholder="SaaS, CLI, internal tool..."
                 />
-              </label>
+              </div>
 
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-zinc-300">Stack</span>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="agent-pack-stack" className="text-sm font-medium text-zinc-300">
+                  Stack
+                </label>
+                <p id="agent-pack-stack-hint" className="text-xs leading-relaxed text-zinc-500">
+                  Your main languages or frameworks, so the generated files match your setup.
+                </p>
                 <input
+                  id="agent-pack-stack"
+                  aria-describedby="agent-pack-stack-hint"
                   value={request.stack}
                   onChange={(event) => handleFieldChange("stack", event.target.value)}
                   className="rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-zinc-200 outline-none transition focus:ring-1 focus:ring-cyan-500/50"
                   placeholder="React, FastAPI, Node..."
                 />
-              </label>
+              </div>
             </div>
 
             <div className="flex flex-col gap-2">
@@ -414,6 +435,15 @@ export default function AgentPacksPage() {
                     >
                       <Download size={14} aria-hidden="true" />
                       {downloading ? "Preparing..." : "Download Pack"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleClosePreview}
+                      aria-label="Close pack preview"
+                      className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-medium text-zinc-300 transition hover:bg-white/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
+                    >
+                      <X size={14} aria-hidden="true" />
+                      Close
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
Improves the `/agent-packs` page for first-time users (issue #765):
1. **Field guidance** — inline helper text under **Project Type** and **Stack** so newcomers know what each field controls. Both inputs are now properly labelled (`htmlFor` + `aria-describedby`) for clean accessible names.
2. **Close preview** — a **Close** button in the Pack Preview header that fully resets preview state (manifest, active tab, selected file), so dismissing a preview no longer leaves stale labels/tabs on the page.

## Why
First-time users met ambiguous fields with no context, and once a pack was generated there was no clean way to dismiss the preview. Both are the UX papercuts called out in #765.

## Changed files (scope)
- `web/app/agent-packs/page.tsx`
- `web/app/agent-packs/page.test.tsx`

No backend, no API contract, no prompts, no dependencies. Deliberately does **not** touch `/agent-generator` or `/skills-generator` — kept clear of the in-flight #763 work to avoid parallel conflicts.

## Validation
- `npx vitest run app/agent-packs/page.test.tsx` → **7/7 pass** (2 new).
- `npx eslint app/agent-packs/page.tsx app/agent-packs/page.test.tsx` → **clean**.
- `npx tsc --noEmit` → no new errors from these files (some pre-existing, unrelated type errors in other test files remain).
- ⚠️ **Browser / visual QA pending** — a real browser wasn't available in this environment. Kept as **draft** until the helper text + Close button are eyeballed on the live UI.

## Notes for reviewer
- Issue #765 part 2 mentions a specific stale label string ("Project Type: Code Review") that isn't present in the current code, so this implements a clean dismiss path rather than chasing an unreproducible label. Worth confirming in browser.
- Hard boundaries respected: no `.env`, provider, model, temperature, max_tokens, or deploy-config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)