### PR TITLE
[codex] Fix #763 example code determinism and generator timeouts

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -15,6 +15,7 @@ from app.github_repo_context import (
     InvalidGitHubRepoUrl,
     analyze_public_github_repo,
 )
+from app.llm_engine.example_code import inspect_agent_example_code, inspect_skill_example_code
 
 
 def _safe_repo_full_name(repo_url: str) -> str | None:
@@ -110,6 +111,9 @@ class SkillGenRequest(BaseModel):
 
 class SkillGenResponse(BaseModel):
     skill_definition: str
+    example_code_requested: bool
+    example_code_present: bool
+    example_code_warning: str | None
 
 
 class AgentGenRequest(BaseModel):
@@ -125,6 +129,9 @@ class AgentGenRequest(BaseModel):
 
 class AgentGenResponse(BaseModel):
     system_prompt: str
+    example_code_requested: bool
+    example_code_present: bool
+    example_code_warning: str | None
 
 
 @router.post("/repo-context/github", response_model=GitHubRepoContextPayload)
@@ -192,7 +199,8 @@ async def generate_skill_endpoint(
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
             repo_context_mode=req.repo_context_mode,
         )
-        return SkillGenResponse(skill_definition=result)
+        inspection = inspect_skill_example_code(result, requested=req.include_example_code)
+        return SkillGenResponse(skill_definition=result, **inspection.__dict__)
     except Exception as exc:
         logger.exception("skill generation failed")
         raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
@@ -213,7 +221,12 @@ async def generate_agent_endpoint(
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
             repo_context_mode=req.repo_context_mode,
         )
-        return AgentGenResponse(system_prompt=result)
+        inspection = inspect_agent_example_code(
+            result,
+            multi_agent=req.multi_agent,
+            requested=req.include_example_code,
+        )
+        return AgentGenResponse(system_prompt=result, **inspection.__dict__)
     except Exception as exc:
         logger.exception("agent generation failed")
         raise HTTPException(status_code=500, detail="An internal error occurred.") from exc

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -122,6 +122,37 @@ class WorkerClient:
 
         return headers
 
+    def _call_api_with_timeout(
+        self,
+        messages: list,
+        *,
+        max_tokens: int,
+        timeout_seconds: int,
+        json_mode: bool = True,
+        model_override: Optional[str] = None,
+        max_workers: int = 3,
+        usage_sink: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Run an LLM call with a timeout that does not block on executor shutdown."""
+        executor = ThreadPoolExecutor(max_workers=max_workers)
+        future = executor.submit(
+            self._call_api,
+            messages,
+            max_tokens,
+            json_mode,
+            model_override,
+            usage_sink=usage_sink,
+        )
+        timed_out = False
+        try:
+            return future.result(timeout=timeout_seconds)
+        except FuturesTimeoutError:
+            timed_out = True
+            future.cancel()
+            raise
+        finally:
+            executor.shutdown(wait=not timed_out, cancel_futures=timed_out)
+
     def _is_openrouter_request(self) -> bool:
         return "openrouter.ai" in (self.base_url or "").lower()
 
@@ -326,20 +357,21 @@ class WorkerClient:
             {"role": "user", "content": self._tagged_block("user_input", user_text)},
         ]
 
-        with ThreadPoolExecutor(max_workers=3) as executor:
+        try:
             # Increased max tokens to prevent JSON truncation (reliability > speed cap)
-            future = executor.submit(self._call_api, messages, max_tokens=3000)
-            try:
-                content = future.result(timeout=HARD_TIMEOUT_SECONDS)
-            except FuturesTimeoutError:
-                future.cancel()
-                raise RuntimeError(
-                    f"LLM API did not respond within {HARD_TIMEOUT_SECONDS} seconds."
-                )
-            except APIError as e:
-                raise RuntimeError(f"LLM API failed: {e}") from e
-            except Exception as e:
-                raise RuntimeError(f"LLM error: {e}") from e
+            content = self._call_api_with_timeout(
+                messages,
+                max_tokens=3000,
+                timeout_seconds=HARD_TIMEOUT_SECONDS,
+            )
+        except FuturesTimeoutError:
+            raise RuntimeError(
+                f"LLM API did not respond within {HARD_TIMEOUT_SECONDS} seconds."
+            )
+        except APIError as e:
+            raise RuntimeError(f"LLM API failed: {e}") from e
+        except Exception as e:
+            raise RuntimeError(f"LLM error: {e}") from e
 
         response = WorkerResponse.model_validate_json(content)
 
@@ -395,15 +427,16 @@ class WorkerClient:
             {"role": "user", "content": self._tagged_block("prompt_under_review", user_text)},
         ]
 
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            future = executor.submit(self._call_api, messages, 1024)
-            try:
-                content = future.result(timeout=COACH_TIMEOUT_SECONDS)
-            except FuturesTimeoutError:
-                future.cancel()
-                raise RuntimeError(f"Quality analysis timed out after {COACH_TIMEOUT_SECONDS}s.")
-            except Exception as e:
-                raise RuntimeError(f"Quality analysis error: {e}") from e
+        try:
+            content = self._call_api_with_timeout(
+                messages,
+                max_tokens=1024,
+                timeout_seconds=COACH_TIMEOUT_SECONDS,
+            )
+        except FuturesTimeoutError:
+            raise RuntimeError(f"Quality analysis timed out after {COACH_TIMEOUT_SECONDS}s.")
+        except Exception as e:
+            raise RuntimeError(f"Quality analysis error: {e}") from e
 
         return QualityReport.model_validate_json(content)
 
@@ -439,24 +472,20 @@ class WorkerClient:
         ]
 
         usage_sink: Dict[str, Any] = {}
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            api_max_tokens = max_tokens if max_tokens else 2048
-            future = executor.submit(
-                self._call_api,
+        api_max_tokens = max_tokens if max_tokens else 2048
+        try:
+            content = self._call_api_with_timeout(
                 messages,
-                api_max_tokens,
-                False,  # json_mode: optimizer output is text
-                None,  # model_override
+                max_tokens=api_max_tokens,
+                timeout_seconds=COACH_TIMEOUT_SECONDS,
+                json_mode=False,
                 usage_sink=usage_sink,
             )
-            try:
-                content = future.result(timeout=COACH_TIMEOUT_SECONDS)
-                return content.strip(), (usage_sink or None)
-            except FuturesTimeoutError:
-                future.cancel()
-                raise RuntimeError(f"Optimization timed out after {COACH_TIMEOUT_SECONDS}s.")
-            except Exception as e:
-                raise RuntimeError(f"Optimization error: {e}") from e
+            return content.strip(), (usage_sink or None)
+        except FuturesTimeoutError:
+            raise RuntimeError(f"Optimization timed out after {COACH_TIMEOUT_SECONDS}s.")
+        except Exception as e:
+            raise RuntimeError(f"Optimization error: {e}") from e
 
     def fix_prompt(self, user_text: str) -> LLMFixResponse:
         """Auto-fix prompt using LLM Editor."""
@@ -471,15 +500,16 @@ class WorkerClient:
             {"role": "user", "content": self._tagged_block("prompt_to_fix", user_text)},
         ]
 
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            future = executor.submit(self._call_api, messages, 1500)
-            try:
-                content = future.result(timeout=COACH_TIMEOUT_SECONDS)
-            except FuturesTimeoutError:
-                future.cancel()
-                raise RuntimeError(f"Auto-fix timed out after {COACH_TIMEOUT_SECONDS}s.")
-            except Exception as e:
-                raise RuntimeError(f"Auto-fix error: {e}") from e
+        try:
+            content = self._call_api_with_timeout(
+                messages,
+                max_tokens=1500,
+                timeout_seconds=COACH_TIMEOUT_SECONDS,
+            )
+        except FuturesTimeoutError:
+            raise RuntimeError(f"Auto-fix timed out after {COACH_TIMEOUT_SECONDS}s.")
+        except Exception as e:
+            raise RuntimeError(f"Auto-fix error: {e}") from e
 
         return LLMFixResponse.model_validate_json(content)
 
@@ -520,26 +550,22 @@ class WorkerClient:
         ]
 
         usage_sink: Dict[str, Any] = {}
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            api_max_tokens = max_tokens if max_tokens else 2048
-            future = executor.submit(
-                self._call_api,
+        api_max_tokens = max_tokens if max_tokens else 2048
+        try:
+            content = self._call_api_with_timeout(
                 messages,
-                api_max_tokens,
-                False,
-                None,
+                max_tokens=api_max_tokens,
+                timeout_seconds=COACH_TIMEOUT_SECONDS,
+                json_mode=False,
                 usage_sink=usage_sink,
             )
-            try:
-                content = future.result(timeout=COACH_TIMEOUT_SECONDS)
-                return content.strip(), (usage_sink or None)
-            except FuturesTimeoutError:
-                future.cancel()
-                raise RuntimeError(
-                    f"English variant optimization timed out after {COACH_TIMEOUT_SECONDS}s."
-                )
-            except Exception as e:
-                raise RuntimeError(f"English variant optimization error: {e}") from e
+            return content.strip(), (usage_sink or None)
+        except FuturesTimeoutError:
+            raise RuntimeError(
+                f"English variant optimization timed out after {COACH_TIMEOUT_SECONDS}s."
+            )
+        except Exception as e:
+            raise RuntimeError(f"English variant optimization error: {e}") from e
 
     def expand_query_intent(self, user_text: str) -> Dict[str, Any]:
         """Expand user query into semantic search terms."""
@@ -558,12 +584,15 @@ class WorkerClient:
         ]
 
         try:
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(self._call_api, messages, 500, json_mode=True)
-                content = future.result(timeout=10)  # Fast timeout for query expansion
-                import json
+            content = self._call_api_with_timeout(
+                messages,
+                max_tokens=500,
+                timeout_seconds=10,
+                max_workers=1,
+            )
+            import json
 
-                return json.loads(content)
+            return json.loads(content)
         except Exception as e:
             logger.debug("Query expansion failed: %s", e)
             return {"queries": [user_text]}
@@ -599,7 +628,8 @@ class WorkerClient:
         )
         if multi_agent:
             example_code_note = (
-                "Include a final `## Swarm Example Code (Pseudo-code Skeleton)` section with concise pseudo-code only when it reduces ambiguity."
+                "You MUST include a final `## Swarm Example Code (Pseudo-code Skeleton)` section in the generated output. "
+                "That section MUST contain at least one fenced pseudo-code block, even when some integration details are TODOs."
                 if include_example_code
                 else (
                     "Do not include any example code snippets, pseudo-code, or fenced code blocks. "
@@ -608,7 +638,8 @@ class WorkerClient:
             )
         else:
             example_code_note = (
-                "Include a final `## Example Code (Pseudo-code Skeleton)` section with concise pseudo-code only when it reduces ambiguity."
+                "You MUST include a final `## Example Code (Pseudo-code Skeleton)` section in the generated output. "
+                "That section MUST contain at least one fenced pseudo-code block, even when some integration details are TODOs."
                 if include_example_code
                 else (
                     "Do not include any example code snippets, pseudo-code, or fenced code blocks. "
@@ -627,37 +658,39 @@ class WorkerClient:
                 },
             )
 
-        with ThreadPoolExecutor(max_workers=3) as executor:
+        try:
             # json_mode=False because we want Markdown text back
-            future = executor.submit(self._call_api, messages, 4000, json_mode=False)
-            try:
-                content = future.result(timeout=HARD_TIMEOUT_SECONDS)
-                if multi_agent:
-                    import logging
-                    import re
+            content = self._call_api_with_timeout(
+                messages,
+                max_tokens=4000,
+                timeout_seconds=HARD_TIMEOUT_SECONDS,
+                json_mode=False,
+            )
+            if multi_agent:
+                import logging
+                import re
 
-                    # Count top-level agent headers: lines matching "# Agent N:" or "# Agent N "
-                    agent_headers = re.findall(
-                        r"^#\s+Agent\s+\d+", content, re.MULTILINE | re.IGNORECASE
+                # Count top-level agent headers: lines matching "# Agent N:" or "# Agent N "
+                agent_headers = re.findall(
+                    r"^#\s+Agent\s+\d+", content, re.MULTILINE | re.IGNORECASE
+                )
+                agent_count = len(agent_headers)
+                if agent_count > 4:
+                    logging.warning(
+                        f"[AgentGenerator] Multi-agent output exceeded limit: "
+                        f"{agent_count} agents detected (max 4). "
+                        f"Consider strengthening the multi_agent_planner prompt."
                     )
-                    agent_count = len(agent_headers)
-                    if agent_count > 4:
-                        logging.warning(
-                            f"[AgentGenerator] Multi-agent output exceeded limit: "
-                            f"{agent_count} agents detected (max 4). "
-                            f"Consider strengthening the multi_agent_planner prompt."
-                        )
-                    elif agent_count == 0:
-                        logging.warning(
-                            "[AgentGenerator] Multi-agent output contains no '# Agent N:' headers. "
-                            "Output may be malformed."
-                        )
-                return content
-            except FuturesTimeoutError:
-                future.cancel()
-                raise RuntimeError(f"Agent generation timed out after {HARD_TIMEOUT_SECONDS}s.")
-            except Exception as e:
-                raise RuntimeError(f"Agent generation error: {e}") from e
+                elif agent_count == 0:
+                    logging.warning(
+                        "[AgentGenerator] Multi-agent output contains no '# Agent N:' headers. "
+                        "Output may be malformed."
+                    )
+            return content
+        except FuturesTimeoutError:
+            raise RuntimeError(f"Agent generation timed out after {HARD_TIMEOUT_SECONDS}s.")
+        except Exception as e:
+            raise RuntimeError(f"Agent generation error: {e}") from e
 
     def generate_skill(
         self,
@@ -682,7 +715,8 @@ class WorkerClient:
             "- Keep the skill definition practical, modular, and implementation-ready."
         )
         example_code_note = (
-            "Include a final `## Implementation Example` section with concise code only when explicitly requested."
+            "You MUST include a final `## Implementation Example` section in the generated output. "
+            "That section MUST contain at least one fenced code block, even when some integration details are TODOs."
             if include_example_code
             else (
                 "Do not include any example code snippets, pseudo-code, or fenced code blocks. "
@@ -701,14 +735,16 @@ class WorkerClient:
                 },
             )
 
-        with ThreadPoolExecutor(max_workers=3) as executor:
+        try:
             # json_mode=False because we want Markdown text back
-            future = executor.submit(self._call_api, messages, 3000, json_mode=False)
-            try:
-                content = future.result(timeout=HARD_TIMEOUT_SECONDS)
-                return content
-            except FuturesTimeoutError:
-                future.cancel()
-                raise RuntimeError(f"Skill generation timed out after {HARD_TIMEOUT_SECONDS}s.")
-            except Exception as e:
-                raise RuntimeError(f"Skill generation error: {e}") from e
+            content = self._call_api_with_timeout(
+                messages,
+                max_tokens=3000,
+                timeout_seconds=HARD_TIMEOUT_SECONDS,
+                json_mode=False,
+            )
+            return content
+        except FuturesTimeoutError:
+            raise RuntimeError(f"Skill generation timed out after {HARD_TIMEOUT_SECONDS}s.")
+        except Exception as e:
+            raise RuntimeError(f"Skill generation error: {e}") from e

--- a/app/llm_engine/example_code.py
+++ b/app/llm_engine/example_code.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+AGENT_EXAMPLE_CODE_WARNING = (
+    "Example Code was requested, but the generator returned a text-only prompt. "
+    "You can still use this result or try generating again."
+)
+
+SKILL_EXAMPLE_CODE_WARNING = (
+    "Example Code was requested, but the generator returned a text-only skill definition. "
+    "You can still use this result or try generating again."
+)
+
+_FENCED_CODE_BLOCK_RE = re.compile(r"```[a-zA-Z0-9_-]*\n[\s\S]*?\n```")
+_NEXT_SECTION_RE = re.compile(r"^##\s+", re.MULTILINE)
+
+_SINGLE_AGENT_SECTION_RE = re.compile(
+    r"^## Example Code \(Pseudo-code Skeleton\)\s*$", re.MULTILINE
+)
+_MULTI_AGENT_SECTION_RE = re.compile(
+    r"^## Swarm Example Code \(Pseudo-code Skeleton\)\s*$", re.MULTILINE
+)
+_SKILL_SECTION_RE = re.compile(r"^## Implementation Example\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class ExampleCodeInspection:
+    example_code_requested: bool
+    example_code_present: bool
+    example_code_warning: str | None
+
+
+def _section_contains_fenced_code(markdown: str, section_pattern: re.Pattern[str]) -> bool:
+    match = section_pattern.search(markdown)
+    if match is None:
+        return False
+
+    section_body = markdown[match.end() :]
+    next_section = _NEXT_SECTION_RE.search(section_body)
+    if next_section is not None:
+        section_body = section_body[: next_section.start()]
+
+    return _FENCED_CODE_BLOCK_RE.search(section_body) is not None
+
+
+def inspect_agent_example_code(markdown: str, *, multi_agent: bool, requested: bool) -> ExampleCodeInspection:
+    if not requested:
+        return ExampleCodeInspection(
+            example_code_requested=False,
+            example_code_present=False,
+            example_code_warning=None,
+        )
+
+    section_pattern = _MULTI_AGENT_SECTION_RE if multi_agent else _SINGLE_AGENT_SECTION_RE
+    present = _section_contains_fenced_code(markdown, section_pattern)
+    return ExampleCodeInspection(
+        example_code_requested=True,
+        example_code_present=present,
+        example_code_warning=None if present else AGENT_EXAMPLE_CODE_WARNING,
+    )
+
+
+def inspect_skill_example_code(markdown: str, *, requested: bool) -> ExampleCodeInspection:
+    if not requested:
+        return ExampleCodeInspection(
+            example_code_requested=False,
+            example_code_present=False,
+            example_code_warning=None,
+        )
+
+    present = _section_contains_fenced_code(markdown, _SKILL_SECTION_RE)
+    return ExampleCodeInspection(
+        example_code_requested=True,
+        example_code_present=present,
+        example_code_warning=None if present else SKILL_EXAMPLE_CODE_WARNING,
+    )

--- a/app/llm_engine/hybrid.py
+++ b/app/llm_engine/hybrid.py
@@ -219,7 +219,7 @@ class HybridCompiler:
         try:
             # Retrieve relevant code context using Agent 6
             rag_context = self._merge_generator_context(
-                self.context_strategist.process(text),
+                self.context_strategist.process(text, expand_with_llm=False),
                 repo_context,
                 repo_context_mode,
             )
@@ -246,7 +246,7 @@ class HybridCompiler:
         try:
             # Retrieve relevant code context using Agent 6
             rag_context = self._merge_generator_context(
-                self.context_strategist.process(text),
+                self.context_strategist.process(text, expand_with_llm=False),
                 repo_context,
                 repo_context_mode,
             )

--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -103,10 +103,10 @@ The output must strictly follow this Markdown structure:
 - Use technical terminology appropriate for the domain.
 - The generated prompt should be ready to copy-paste into an LLM configuration.
 - Keep code examples explicitly non-final when key details are unknown.
-- Only include an example-code section if a later instruction explicitly asks for example code. Otherwise omit that section entirely.
+- Only include an example-code section when a later instruction explicitly enables example code. When enabled, the section is mandatory and must include a fenced pseudo-code block.
 
 ## OPTIONAL EXAMPLE CODE SECTION
-When explicitly requested, append this section after `## Example Interaction`:
+When explicitly enabled by a later instruction, you MUST append this section after `## Example Interaction` and include at least one fenced pseudo-code block:
 
 ```markdown
 ## Example Code (Pseudo-code Skeleton)

--- a/app/llm_engine/prompts/multi_agent_planner.md
+++ b/app/llm_engine/prompts/multi_agent_planner.md
@@ -59,10 +59,10 @@ After the last agent, add a swarm-level stop-conditions block:
   → Passes `{parsed issue list (JSON array)}` to Agent 2 via `{shared state object}`.
   Acceptable mechanisms: shared state object, message queue, direct function call, HTTP endpoint, file system. Do NOT use vague phrases like "notify" or "pass" alone.
 - **I/O Contracts**: Handoff arrows must reference the producing agent's declared `## Outputs` shape — do not invent new fields that aren't in that schema.
-- Only include a final swarm example-code section if a later instruction explicitly asks for example code. Otherwise omit that section entirely.
+- Only include a final swarm example-code section when a later instruction explicitly enables example code. When enabled, the section is mandatory and must include a fenced pseudo-code block.
 
 ## OPTIONAL SWARM EXAMPLE CODE SECTION
-When explicitly requested, append this section after the Swarm Stop Conditions block:
+When explicitly enabled by a later instruction, you MUST append this section after the Swarm Stop Conditions block and include at least one fenced pseudo-code block:
 
 ## Swarm Example Code (Pseudo-code Skeleton)
 ```python

--- a/app/llm_engine/prompts/skills_generator.md
+++ b/app/llm_engine/prompts/skills_generator.md
@@ -84,10 +84,10 @@ The output must strictly follow this Markdown structure:
 - Technical, precise, and modular.
 - The generated skill should be ready to be implemented as a function or tool for an LLM.
 - Focus on robustness and clarity.
-- Only include an implementation example section if a later instruction explicitly asks for example code.
+- Only include an implementation example section when a later instruction explicitly enables example code. When enabled, the section is mandatory and must include a fenced code block.
 
 ## OPTIONAL IMPLEMENTATION EXAMPLE SECTION
-When explicitly requested, append this section after `## Implementation`:
+When explicitly enabled by a later instruction, you MUST append this section after `## Implementation` and include at least one fenced code block:
 
 ```markdown
 ## Implementation Example

--- a/app/llm_engine/rag.py
+++ b/app/llm_engine/rag.py
@@ -146,8 +146,12 @@ class ContextStrategist:
 
         return selected
 
-    def process(self, user_text: str) -> Dict[str, Any]:
-        queries = self.expand_query(user_text)
+    def process(self, user_text: str, *, expand_with_llm: bool = True) -> Dict[str, Any]:
+        queries = (
+            self.expand_query(user_text)
+            if expand_with_llm
+            else self._normalize_queries([], user_text)
+        )
         raw_snippets = self.retrieve(queries)
         final_snippets = self.rank_and_prune(raw_snippets)
 

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -1,6 +1,8 @@
 import pytest
+import time
 from unittest.mock import MagicMock, patch
 from app.llm_engine.client import WorkerClient
+from app.llm_engine.example_code import AGENT_EXAMPLE_CODE_WARNING, inspect_agent_example_code
 from app.llm_engine.hybrid import HybridCompiler
 from api.main import app
 from fastapi.testclient import TestClient
@@ -51,7 +53,7 @@ def test_worker_client_omits_example_code_section_when_disabled():
 
         captured = {}
 
-        def fake_call_api(messages, max_tokens, json_mode):
+        def fake_call_api(messages, max_tokens, json_mode, model_override=None, usage_sink=None):
             captured["messages"] = messages
             return "# Agent System Prompt"
 
@@ -75,7 +77,7 @@ def test_worker_client_requests_example_code_section_when_enabled():
 
         captured = {}
 
-        def fake_call_api(messages, max_tokens, json_mode):
+        def fake_call_api(messages, max_tokens, json_mode, model_override=None, usage_sink=None):
             captured["messages"] = messages
             return "# Agent System Prompt"
 
@@ -88,9 +90,29 @@ def test_worker_client_requests_example_code_section_when_enabled():
         ]
         assert "## Example Code (Pseudo-code Skeleton)" in system_messages[0]
         assert any(
-            "Include a final `## Example Code (Pseudo-code Skeleton)` section" in message
+            "You MUST include a final `## Example Code (Pseudo-code Skeleton)` section"
+            in message
             for message in system_messages
         )
+
+
+def test_worker_client_generate_agent_timeout_returns_quickly():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    def slow_call_api(*args, **kwargs):
+        time.sleep(0.2)
+        return "# Agent System Prompt"
+
+    with patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01), patch.object(
+        client, "_call_api", side_effect=slow_call_api
+    ):
+        started_at = time.perf_counter()
+        with pytest.raises(RuntimeError, match="Agent generation timed out after 0.01s."):
+            client.generate_agent("Test Agent")
+        elapsed = time.perf_counter() - started_at
+
+    assert elapsed < 0.15
 
 
 def test_worker_client_preserves_repo_context_when_example_code_is_disabled():
@@ -110,7 +132,7 @@ def test_worker_client_preserves_repo_context_when_example_code_is_disabled():
             "detected_stack": ["Python"],
         }
 
-        def fake_call_api(messages, max_tokens, json_mode):
+        def fake_call_api(messages, max_tokens, json_mode, model_override=None, usage_sink=None):
             captured["messages"] = messages
             return "# Agent System Prompt"
 
@@ -145,7 +167,12 @@ def test_api_generate_agent_endpoint():
         )
 
         assert response.status_code == 200
-        assert response.json() == {"system_prompt": "# Mock API Agent"}
+        assert response.json() == {
+            "system_prompt": "# Mock API Agent",
+            "example_code_requested": False,
+            "example_code_present": False,
+            "example_code_warning": None,
+        }
         mock_compiler.generate_agent.assert_called_with(
             "Test Agent Request",
             multi_agent=False,
@@ -157,6 +184,34 @@ def test_api_generate_agent_endpoint():
 
 def test_api_generate_agent_endpoint_with_example_code_enabled():
     with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = (
+            "# Mock API Agent\n\n## Example Code (Pseudo-code Skeleton)\n```python\npass\n```"
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/agent-generator/generate",
+            json={"description": "Test Agent Request", "include_example_code": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "system_prompt": "# Mock API Agent\n\n## Example Code (Pseudo-code Skeleton)\n```python\npass\n```",
+            "example_code_requested": True,
+            "example_code_present": True,
+            "example_code_warning": None,
+        }
+        mock_compiler.generate_agent.assert_called_with(
+            "Test Agent Request",
+            multi_agent=False,
+            include_example_code=True,
+            repo_context=None,
+            repo_context_mode="full",
+        )
+
+
+def test_api_generate_agent_endpoint_warns_when_example_code_is_missing():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = "# Mock API Agent"
 
         client = TestClient(app)
@@ -166,14 +221,12 @@ def test_api_generate_agent_endpoint_with_example_code_enabled():
         )
 
         assert response.status_code == 200
-        assert response.json() == {"system_prompt": "# Mock API Agent"}
-        mock_compiler.generate_agent.assert_called_with(
-            "Test Agent Request",
-            multi_agent=False,
-            include_example_code=True,
-            repo_context=None,
-            repo_context_mode="full",
-        )
+        assert response.json() == {
+            "system_prompt": "# Mock API Agent",
+            "example_code_requested": True,
+            "example_code_present": False,
+            "example_code_warning": AGENT_EXAMPLE_CODE_WARNING,
+        }
 
 
 # ── New section-coverage regression tests ─────────────────────────────────────
@@ -235,3 +288,39 @@ def test_example_code_strip_still_works():
     assert "## Swarm Example Code (Pseudo-code Skeleton)" not in multi_no_code
     assert "## Inputs" in multi_no_code
     assert "## Swarm Stop Conditions" in multi_no_code
+
+
+def test_inspect_agent_example_code_detects_valid_single_agent_section():
+    inspection = inspect_agent_example_code(
+        "# Agent\n\n## Example Code (Pseudo-code Skeleton)\n```python\npass\n```",
+        multi_agent=False,
+        requested=True,
+    )
+
+    assert inspection.example_code_requested is True
+    assert inspection.example_code_present is True
+    assert inspection.example_code_warning is None
+
+
+def test_inspect_agent_example_code_rejects_missing_section_even_with_fenced_code():
+    inspection = inspect_agent_example_code(
+        "# Agent\n\n```python\npass\n```",
+        multi_agent=False,
+        requested=True,
+    )
+
+    assert inspection.example_code_requested is True
+    assert inspection.example_code_present is False
+    assert inspection.example_code_warning == AGENT_EXAMPLE_CODE_WARNING
+
+
+def test_inspect_agent_example_code_rejects_section_without_fenced_code():
+    inspection = inspect_agent_example_code(
+        "# Agent\n\n## Swarm Example Code (Pseudo-code Skeleton)\nTODO",
+        multi_agent=True,
+        requested=True,
+    )
+
+    assert inspection.example_code_requested is True
+    assert inspection.example_code_present is False
+    assert inspection.example_code_warning == AGENT_EXAMPLE_CODE_WARNING

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -116,7 +116,7 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
 
     # Test generate_agent with context
     compiler.generate_agent("Test Agent", repo_context=repo_context)
-    compiler.context_strategist.process.assert_called_with("Test Agent")
+    compiler.context_strategist.process.assert_called_with("Test Agent", expand_with_llm=False)
     mock_worker_client.generate_agent.assert_called_with(
         "Test Agent",
         context={
@@ -133,7 +133,7 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
 
     # Test generate_skill with context
     compiler.generate_skill("Test Skill", repo_context=repo_context)
-    compiler.context_strategist.process.assert_called_with("Test Skill")
+    compiler.context_strategist.process.assert_called_with("Test Skill", expand_with_llm=False)
     mock_worker_client.generate_skill.assert_called_with(
         "Test Skill",
         context={
@@ -186,7 +186,12 @@ def test_api_endpoints_integration():
             json={"description": "Test Agent", "repo_context": repo_context},
         )
         assert resp_agent.status_code == 200
-        assert resp_agent.json() == {"system_prompt": "# Mock API Agent"}
+        assert resp_agent.json() == {
+            "system_prompt": "# Mock API Agent",
+            "example_code_requested": False,
+            "example_code_present": False,
+            "example_code_warning": None,
+        }
         mock_compiler.generate_agent.assert_called_with(
             "Test Agent",
             multi_agent=False,
@@ -205,7 +210,12 @@ def test_api_endpoints_integration():
             },
         )
         assert resp_skill.status_code == 200
-        assert resp_skill.json() == {"skill_definition": "# Mock API Skill"}
+        assert resp_skill.json() == {
+            "skill_definition": "# Mock API Skill",
+            "example_code_requested": False,
+            "example_code_present": False,
+            "example_code_warning": None,
+        }
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill",
             include_example_code=False,

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -236,7 +236,7 @@ def test_generate_agent_success(compiler):
     res = compiler.generate_agent(text, multi_agent=True, include_example_code=True)
 
     assert res == "Agent System Prompt"
-    compiler.context_strategist.process.assert_called_once_with(text)
+    compiler.context_strategist.process.assert_called_once_with(text, expand_with_llm=False)
     compiler.worker.generate_agent.assert_called_once_with(
         text, context="Mock agent context", multi_agent=True, include_example_code=True
     )
@@ -259,7 +259,7 @@ def test_generate_skill_success(compiler):
     res = compiler.generate_skill(text, include_example_code=True)
 
     assert res == "Skill Definition"
-    compiler.context_strategist.process.assert_called_once_with(text)
+    compiler.context_strategist.process.assert_called_once_with(text, expand_with_llm=False)
     compiler.worker.generate_skill.assert_called_once_with(
         text, context="Mock skill context", include_example_code=True
     )

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -65,7 +65,7 @@ def test_worker_client_omits_swarm_example_code_when_disabled():
         client = WorkerClient(api_key="test")
         captured = {}
 
-        def fake_call_api(messages, max_tokens, json_mode):
+        def fake_call_api(messages, max_tokens, json_mode, model_override=None, usage_sink=None):
             captured["messages"] = messages
             return "# Agent 1: Planner"
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -133,6 +133,17 @@ def test_process_end_to_end(strategist):
     assert len(result["snippets"]) == 2
 
 
+def test_process_can_skip_llm_query_expansion(mock_db):
+    mock_llm = MagicMock()
+    strategist = ContextStrategist(mock_db, mock_llm)
+
+    result = strategist.process("fix login", expand_with_llm=False)
+
+    mock_llm.expand_query_intent.assert_not_called()
+    mock_db.search.assert_called_once_with("fix login", limit=5)
+    assert result["retrieved_files"] == ["app/main.py", "app/utils.py"]
+
+
 def test_mock_vector_db():
     db = MockVectorDB()
     assert db.search("anything") == []

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 from app.llm_engine.client import WorkerClient
+from app.llm_engine.example_code import SKILL_EXAMPLE_CODE_WARNING, inspect_skill_example_code
 from app.llm_engine.hybrid import HybridCompiler
 from api.main import app
 from fastapi.testclient import TestClient
@@ -77,7 +78,12 @@ def test_api_generate_skill_endpoint():
         )
 
         assert response.status_code == 200
-        assert response.json() == {"skill_definition": "# Mock API Skill"}
+        assert response.json() == {
+            "skill_definition": "# Mock API Skill",
+            "example_code_requested": False,
+            "example_code_present": False,
+            "example_code_warning": None,
+        }
         mock_compiler.generate_skill.assert_called_with(
             "Test Skill Request",
             include_example_code=False,
@@ -93,6 +99,33 @@ def test_api_generate_skill_endpoint():
 
 def test_api_generate_skill_endpoint_with_example_code_enabled():
     with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = (
+            "# Mock API Skill\n\n## Implementation Example\n```python\npass\n```"
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/skills-generator/generate",
+            json={"description": "Test Skill Request", "include_example_code": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "skill_definition": "# Mock API Skill\n\n## Implementation Example\n```python\npass\n```",
+            "example_code_requested": True,
+            "example_code_present": True,
+            "example_code_warning": None,
+        }
+        mock_compiler.generate_skill.assert_called_with(
+            "Test Skill Request",
+            include_example_code=True,
+            repo_context=None,
+            repo_context_mode="full",
+        )
+
+
+def test_api_generate_skill_endpoint_warns_when_example_code_is_missing():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_skill.return_value = "# Mock API Skill"
 
         client = TestClient(app)
@@ -102,13 +135,12 @@ def test_api_generate_skill_endpoint_with_example_code_enabled():
         )
 
         assert response.status_code == 200
-        assert response.json() == {"skill_definition": "# Mock API Skill"}
-        mock_compiler.generate_skill.assert_called_with(
-            "Test Skill Request",
-            include_example_code=True,
-            repo_context=None,
-            repo_context_mode="full",
-        )
+        assert response.json() == {
+            "skill_definition": "# Mock API Skill",
+            "example_code_requested": True,
+            "example_code_present": False,
+            "example_code_warning": SKILL_EXAMPLE_CODE_WARNING,
+        }
 
 
 def test_worker_client_omits_skill_implementation_example_when_disabled():
@@ -117,7 +149,7 @@ def test_worker_client_omits_skill_implementation_example_when_disabled():
 
         captured = {}
 
-        def fake_call_api(messages, max_tokens, json_mode):
+        def fake_call_api(messages, max_tokens, json_mode, model_override=None, usage_sink=None):
             captured["messages"] = messages
             return "# Skill Definition"
 
@@ -140,7 +172,7 @@ def test_worker_client_requests_skill_implementation_example_when_enabled():
 
         captured = {}
 
-        def fake_call_api(messages, max_tokens, json_mode):
+        def fake_call_api(messages, max_tokens, json_mode, model_override=None, usage_sink=None):
             captured["messages"] = messages
             return "# Skill Definition"
 
@@ -152,6 +184,36 @@ def test_worker_client_requests_skill_implementation_example_when_enabled():
             msg["content"] for msg in captured["messages"] if msg["role"] == "system"
         ]
         assert any(
-            "Include a final `## Implementation Example` section" in message
+            "You MUST include a final `## Implementation Example` section" in message
             for message in system_messages
         )
+
+
+def test_inspect_skill_example_code_detects_valid_section():
+    inspection = inspect_skill_example_code(
+        "# Skill\n\n## Implementation Example\n```python\npass\n```",
+        requested=True,
+    )
+
+    assert inspection.example_code_requested is True
+    assert inspection.example_code_present is True
+    assert inspection.example_code_warning is None
+
+
+def test_inspect_skill_example_code_rejects_missing_section_even_with_fenced_code():
+    inspection = inspect_skill_example_code("# Skill\n\n```python\npass\n```", requested=True)
+
+    assert inspection.example_code_requested is True
+    assert inspection.example_code_present is False
+    assert inspection.example_code_warning == SKILL_EXAMPLE_CODE_WARNING
+
+
+def test_inspect_skill_example_code_rejects_section_without_fenced_code():
+    inspection = inspect_skill_example_code(
+        "# Skill\n\n## Implementation Example\nTODO",
+        requested=True,
+    )
+
+    assert inspection.example_code_requested is True
+    assert inspection.example_code_present is False
+    assert inspection.example_code_warning == SKILL_EXAMPLE_CODE_WARNING

--- a/web/app/agent-generator/generate/route.ts
+++ b/web/app/agent-generator/generate/route.ts
@@ -1,7 +1,9 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
+const GENERATOR_UPSTREAM_TIMEOUT_MS = 40_000;
+
 export async function POST(request: Request): Promise<Response> {
   return proxyBackendRequest(request, "/agent-generator/generate", {
-    retryNetworkErrors: true,
+    upstreamTimeoutMs: GENERATOR_UPSTREAM_TIMEOUT_MS,
   });
 }

--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -37,6 +37,12 @@ vi.mock("../lib/showError", () => ({
 }));
 
 const apiJsonMock = vi.mocked(apiJson);
+const plainAgentResponse = {
+  system_prompt: "# Plain Agent",
+  example_code_requested: false,
+  example_code_present: false,
+  example_code_warning: null,
+};
 
 describe("Agent Generator page", () => {
   beforeEach(() => {
@@ -66,6 +72,9 @@ describe("Agent Generator page", () => {
       })
       .mockResolvedValueOnce({
         system_prompt: "# Repo-aware Agent",
+        example_code_requested: false,
+        example_code_present: false,
+        example_code_warning: null,
       });
 
     render(<AgentGeneratorPage />);
@@ -111,9 +120,7 @@ describe("Agent Generator page", () => {
   it("shows a warning when repo analysis fails but still generates without repo context", async () => {
     apiJsonMock
       .mockRejectedValueOnce(new Error("Repository analysis failed"))
-      .mockResolvedValueOnce({
-        system_prompt: "# Plain Agent",
-      });
+      .mockResolvedValueOnce(plainAgentResponse);
 
     render(<AgentGeneratorPage />);
 
@@ -160,15 +167,25 @@ describe("Agent Generator page", () => {
     expect(await screen.findByText("Agent generation failed")).toBeTruthy();
     expect(screen.getByText("The service is temporarily unavailable.")).toBeTruthy();
 
-    apiJsonMock.mockResolvedValueOnce({ system_prompt: "# Reviewer" });
+    apiJsonMock.mockResolvedValueOnce({
+      system_prompt: "# Reviewer",
+      example_code_requested: false,
+      example_code_present: false,
+      example_code_warning: null,
+    });
     fireEvent.click(screen.getByRole("button", { name: "Retry generation" }));
 
     await waitFor(() => expect(screen.getByRole("heading", { name: "Reviewer" })).toBeTruthy());
     expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
 
-  it("toggles both switches from label clicks and preserves payload values", async () => {
-    apiJsonMock.mockResolvedValueOnce({ system_prompt: "# Swarm Agent" });
+  it("keeps example-code enabled after generation and preserves payload values", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      system_prompt: "# Swarm Agent",
+      example_code_requested: true,
+      example_code_present: true,
+      example_code_warning: null,
+    });
 
     render(<AgentGeneratorPage />);
 
@@ -186,6 +203,70 @@ describe("Agent Generator page", () => {
       multi_agent: true,
       include_example_code: true,
     });
+    expect(screen.getByRole("switch", { name: "Include Example Code toggle" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(screen.getByText("With Example Code")).toBeTruthy();
+  });
+
+  it("shows a warning when example code is requested but missing", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      system_prompt: "# Text Only Agent",
+      example_code_requested: true,
+      example_code_present: false,
+      example_code_warning:
+        "Example Code was requested, but the generator returned a text-only prompt. You can still use this result or try generating again.",
+    });
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Build a collaborative agent." },
+    });
+
+    fireEvent.click(screen.getByText("Example Code?"));
+    fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
+
+    expect(
+      await screen.findByText(
+        "Example Code was requested, but the generator returned a text-only prompt. You can still use this result or try generating again.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Example Code Missing")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Text Only Agent" })).toBeTruthy();
+  });
+
+  it("restores warning metadata when loading a previous result from history", async () => {
+    apiJsonMock
+      .mockResolvedValueOnce({
+        system_prompt: "# Warning Agent",
+        example_code_requested: true,
+        example_code_present: false,
+        example_code_warning:
+          "Example Code was requested, but the generator returned a text-only prompt. You can still use this result or try generating again.",
+      })
+      .mockResolvedValueOnce(plainAgentResponse);
+
+    render(<AgentGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Agent Description"), {
+      target: { value: "Build a collaborative agent." },
+    });
+    fireEvent.click(screen.getByText("Example Code?"));
+    fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
+    await screen.findByRole("heading", { name: "Warning Agent" });
+
+    fireEvent.click(screen.getByText("Example Code?"));
+    fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
+    await screen.findByRole("heading", { name: "Plain Agent" });
+    expect(screen.queryByText("Example Code Missing")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Previous results"), {
+      target: { value: "1" },
+    });
+
+    expect(await screen.findByText("Example Code Missing")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Warning Agent" })).toBeTruthy();
   });
 
   it("supports keyboard activation for the switch row", () => {

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Bot } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
-import type { GitHubRepoContextPayload } from "@/lib/api/types";
+import type { AgentGeneratorResponse, GitHubRepoContextPayload } from "@/lib/api/types";
 import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
 import ContextManager from "../components/ContextManager";
@@ -18,6 +18,34 @@ function isSupportedGitHubRepoRootUrl(value: string): boolean {
   return /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/.test(value.trim());
 }
 
+type AgentGenerationView = {
+  content: string;
+  multiAgent: boolean;
+  exampleCodeRequested: boolean;
+  exampleCodePresent: boolean;
+  exampleCodeWarning: string | null;
+};
+
+function toAgentGenerationView(
+  response: AgentGeneratorResponse,
+  multiAgent: boolean,
+): AgentGenerationView {
+  return {
+    content: response.system_prompt,
+    multiAgent,
+    exampleCodeRequested: response.example_code_requested,
+    exampleCodePresent: response.example_code_present,
+    exampleCodeWarning: response.example_code_warning,
+  };
+}
+
+function getExampleCodeStatusLabel(result: AgentGenerationView): string {
+  if (!result.exampleCodeRequested) {
+    return "Plain";
+  }
+  return result.exampleCodePresent ? "With Example Code" : "Example Code Missing";
+}
+
 export default function AgentGenerator() {
   const [description, setDescription] = useState("");
   const [repoUrl, setRepoUrl] = useState("");
@@ -26,11 +54,11 @@ export default function AgentGenerator() {
   const [repoAnalysisWarning, setRepoAnalysisWarning] = useState<string | null>(null);
   const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<string | null>(null);
+  const [result, setResult] = useState<AgentGenerationView | null>(null);
   const [lastError, setLastError] = useState<unknown>(null);
   const [multiAgent, setMultiAgent] = useState(false);
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
-  const [history, setHistory] = useState<{ label: string; prompt: string }[]>([]);
+  const [history, setHistory] = useState<{ label: string; result: AgentGenerationView }[]>([]);
   const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
@@ -75,7 +103,7 @@ export default function AgentGenerator() {
     setResult(null);
 
     try {
-      const data = await apiJson<{ system_prompt: string }>("/agent-generator/generate", {
+      const data = await apiJson<AgentGeneratorResponse>("/agent-generator/generate", {
         method: "POST",
         headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({
@@ -86,11 +114,12 @@ export default function AgentGenerator() {
         }),
       });
 
-      setResult(data.system_prompt);
+      const nextResult = toAgentGenerationView(data, multiAgent);
+      setResult(nextResult);
       setHistory((prev) => [
         {
           label: description.slice(0, 40) + (multiAgent ? " [swarm]" : " [single]"),
-          prompt: data.system_prompt,
+          result: nextResult,
         },
         ...prev,
       ].slice(0, 5));
@@ -105,7 +134,7 @@ export default function AgentGenerator() {
 
   const copyToClipboard = () => {
     if (result) {
-      navigator.clipboard.writeText(result);
+      navigator.clipboard.writeText(result.content);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }
@@ -290,7 +319,7 @@ export default function AgentGenerator() {
                   onChange={(e) => {
                     const selected = history[Number(e.target.value)];
                     if (selected) {
-                      setResult(selected.prompt);
+                      setResult(selected.result);
                     }
                   }}
                 >
@@ -345,15 +374,21 @@ export default function AgentGenerator() {
               <div className="flex-1 min-h-0 p-0 overflow-hidden relative group bg-black/20 flex flex-col">
                 <div className="flex items-center justify-between border-b border-white/5 px-6 py-3">
                   <h2 className="text-sm font-semibold text-zinc-200 tracking-tight">System Prompt</h2>
-                  <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-500">
-                    {multiAgent ? "Multi-Agent Swarm" : "Single Agent"}
-                  </span>
+                  <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-wider text-zinc-500">
+                    <span>{result.multiAgent ? "Multi-Agent Swarm" : "Single Agent"}</span>
+                    <span>{getExampleCodeStatusLabel(result)}</span>
+                  </div>
                 </div>
 
                 <div className="relative flex-1 min-h-0 overflow-hidden">
                   <div className="absolute inset-0 overflow-y-auto p-6 pb-24 prose prose-invert prose-sm max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-code:text-green-400 prose-pre:bg-zinc-900">
-                    <ReactMarkdown>{result}</ReactMarkdown>
-                    <ExportPanel systemPrompt={result} isMultiAgent={multiAgent} />
+                    {result.exampleCodeWarning ? (
+                      <div className="mb-4 rounded-xl border border-yellow-500/20 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-100 not-prose">
+                        {result.exampleCodeWarning}
+                      </div>
+                    ) : null}
+                    <ReactMarkdown>{result.content}</ReactMarkdown>
+                    <ExportPanel systemPrompt={result.content} isMultiAgent={result.multiAgent} />
                   </div>
 
                   <button

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -128,20 +128,6 @@ describe("Next backend proxy route wiring", () => {
       expectedUrl: "http://127.0.0.1:8080/repo-context/github",
     },
     {
-      name: "agent generation",
-      handler: agentGenerateRoute,
-      requestUrl: "http://localhost:3000/agent-generator/generate",
-      requestBody: { description: "review this PR" },
-      expectedUrl: "http://127.0.0.1:8080/agent-generator/generate",
-    },
-    {
-      name: "skills generation",
-      handler: skillsGenerateRoute,
-      requestUrl: "http://localhost:3000/skills-generator/generate",
-      requestBody: { description: "search docs" },
-      expectedUrl: "http://127.0.0.1:8080/skills-generator/generate",
-    },
-    {
       name: "benchmark run",
       handler: benchmarkRunRoute,
       requestUrl: "http://localhost:3000/benchmark/run",
@@ -200,6 +186,45 @@ describe("Next backend proxy route wiring", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(expectedUrl);
     await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it.each<RouteCase>([
+    {
+      name: "agent generation",
+      handler: agentGenerateRoute,
+      requestUrl: "http://localhost:3000/agent-generator/generate",
+      requestBody: { description: "review this PR" },
+      expectedUrl: "http://127.0.0.1:8080/agent-generator/generate",
+    },
+    {
+      name: "skills generation",
+      handler: skillsGenerateRoute,
+      requestUrl: "http://localhost:3000/skills-generator/generate",
+      requestBody: { description: "search docs" },
+      expectedUrl: "http://127.0.0.1:8080/skills-generator/generate",
+    },
+  ])("does not retry $name requests after a transient backend connection failure", async ({
+    handler,
+    requestUrl,
+    requestBody,
+    expectedUrl,
+  }) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch failed"));
+
+    const response = await handler(
+      new Request(requestUrl, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(expectedUrl);
+    expect(response.status).toBe(502);
   });
 
   it.each<RouteCase>([

--- a/web/app/skills-generator/generate/route.ts
+++ b/web/app/skills-generator/generate/route.ts
@@ -1,7 +1,9 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
+const GENERATOR_UPSTREAM_TIMEOUT_MS = 40_000;
+
 export async function POST(request: Request): Promise<Response> {
   return proxyBackendRequest(request, "/skills-generator/generate", {
-    retryNetworkErrors: true,
+    upstreamTimeoutMs: GENERATOR_UPSTREAM_TIMEOUT_MS,
   });
 }

--- a/web/app/skills-generator/page.test.tsx
+++ b/web/app/skills-generator/page.test.tsx
@@ -37,6 +37,12 @@ vi.mock("../lib/showError", () => ({
 }));
 
 const apiJsonMock = vi.mocked(apiJson);
+const plainSkillResponse = {
+  skill_definition: "## Plain Skill",
+  example_code_requested: false,
+  example_code_present: false,
+  example_code_warning: null,
+};
 
 describe("Skills Generator page", () => {
   beforeEach(() => {
@@ -66,6 +72,9 @@ describe("Skills Generator page", () => {
       })
       .mockResolvedValueOnce({
         skill_definition: "# Repo-aware Skill",
+        example_code_requested: false,
+        example_code_present: false,
+        example_code_warning: null,
       });
 
     render(<SkillsGeneratorPage />);
@@ -111,9 +120,7 @@ describe("Skills Generator page", () => {
         files_used: ["README.md"],
         detected_stack: ["Python"],
       })
-      .mockResolvedValueOnce({
-        skill_definition: "# Plain Skill",
-      });
+      .mockResolvedValueOnce(plainSkillResponse);
 
     render(<SkillsGeneratorPage />);
 
@@ -165,15 +172,25 @@ describe("Skills Generator page", () => {
     expect(await screen.findByText("Skill generation failed")).toBeTruthy();
     expect(screen.getByText("The service is temporarily unavailable.")).toBeTruthy();
 
-    apiJsonMock.mockResolvedValueOnce({ skill_definition: "## json-validator" });
+    apiJsonMock.mockResolvedValueOnce({
+      skill_definition: "## json-validator",
+      example_code_requested: false,
+      example_code_present: false,
+      example_code_warning: null,
+    });
     fireEvent.click(screen.getByRole("button", { name: "Retry generation" }));
 
     await waitFor(() => expect(screen.getByRole("heading", { name: "json-validator" })).toBeTruthy());
     expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
 
-  it("toggles the example-code switch from its label and preserves payload values", async () => {
-    apiJsonMock.mockResolvedValueOnce({ skill_definition: "## example-skill" });
+  it("keeps example-code enabled after generation and preserves payload values", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      skill_definition: "## example-skill",
+      example_code_requested: true,
+      example_code_present: true,
+      example_code_warning: null,
+    });
 
     render(<SkillsGeneratorPage />);
 
@@ -189,6 +206,37 @@ describe("Skills Generator page", () => {
       description: "Generate a code-heavy skill.",
       include_example_code: true,
     });
+    expect(screen.getByRole("switch", { name: "Include Example Code toggle" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(screen.getByText("With Example Code")).toBeTruthy();
+  });
+
+  it("shows a warning when example code is requested but missing", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      skill_definition: "## text-only-skill",
+      example_code_requested: true,
+      example_code_present: false,
+      example_code_warning:
+        "Example Code was requested, but the generator returned a text-only skill definition. You can still use this result or try generating again.",
+    });
+
+    render(<SkillsGeneratorPage />);
+
+    fireEvent.change(screen.getByLabelText("Skill Description"), {
+      target: { value: "Generate a code-heavy skill." },
+    });
+
+    fireEvent.click(screen.getByText("Example Code?"));
+    fireEvent.click(screen.getAllByRole("button", { name: /Generate Skill/i })[0]!);
+
+    expect(
+      await screen.findByText(
+        "Example Code was requested, but the generator returned a text-only skill definition. You can still use this result or try generating again.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Example Code Missing")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "text-only-skill" })).toBeTruthy();
   });
 
   it("supports keyboard activation for the switch row", () => {

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Zap } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
-import type { GitHubRepoContextPayload } from "@/lib/api/types";
+import type { GitHubRepoContextPayload, SkillGeneratorResponse } from "@/lib/api/types";
 import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
 import InfoButton from "../components/InfoButton";
@@ -18,6 +18,29 @@ function isSupportedGitHubRepoRootUrl(value: string): boolean {
   return /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/?$/.test(value.trim());
 }
 
+type SkillGenerationView = {
+  content: string;
+  exampleCodeRequested: boolean;
+  exampleCodePresent: boolean;
+  exampleCodeWarning: string | null;
+};
+
+function toSkillGenerationView(response: SkillGeneratorResponse): SkillGenerationView {
+  return {
+    content: response.skill_definition,
+    exampleCodeRequested: response.example_code_requested,
+    exampleCodePresent: response.example_code_present,
+    exampleCodeWarning: response.example_code_warning,
+  };
+}
+
+function getExampleCodeStatusLabel(result: SkillGenerationView): string {
+  if (!result.exampleCodeRequested) {
+    return "Plain";
+  }
+  return result.exampleCodePresent ? "With Example Code" : "Example Code Missing";
+}
+
 export default function SkillsGenerator() {
   const [description, setDescription] = useState("");
   const [repoUrl, setRepoUrl] = useState("");
@@ -26,10 +49,10 @@ export default function SkillsGenerator() {
   const [repoAnalysisWarning, setRepoAnalysisWarning] = useState<string | null>(null);
   const [repoContextDirty, setRepoContextDirty] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<string | null>(null);
+  const [result, setResult] = useState<SkillGenerationView | null>(null);
   const [lastError, setLastError] = useState<unknown>(null);
   const [includeExampleCode, setIncludeExampleCode] = useState(false);
-  const [history, setHistory] = useState<{ label: string; skill: string }[]>([]);
+  const [history, setHistory] = useState<{ label: string; result: SkillGenerationView }[]>([]);
   const [copied, setCopied] = useState(false);
 
   const isGeneratingRef = useRef(false);
@@ -74,7 +97,7 @@ export default function SkillsGenerator() {
     setResult(null);
 
     try {
-      const data = await apiJson<{ skill_definition: string }>("/skills-generator/generate", {
+      const data = await apiJson<SkillGeneratorResponse>("/skills-generator/generate", {
         method: "POST",
         headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({
@@ -84,11 +107,12 @@ export default function SkillsGenerator() {
         }),
       });
 
-      setResult(data.skill_definition);
+      const nextResult = toSkillGenerationView(data);
+      setResult(nextResult);
       setHistory((prev) => [
         {
           label: description.slice(0, 40) + (includeExampleCode ? " [code]" : " [plain]"),
-          skill: data.skill_definition,
+          result: nextResult,
         },
         ...prev,
       ].slice(0, 5));
@@ -103,7 +127,7 @@ export default function SkillsGenerator() {
 
   const copyToClipboard = () => {
     if (result) {
-      navigator.clipboard.writeText(result);
+      navigator.clipboard.writeText(result.content);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }
@@ -267,7 +291,7 @@ export default function SkillsGenerator() {
                   onChange={(e) => {
                     const selected = history[Number(e.target.value)];
                     if (selected) {
-                      setResult(selected.skill);
+                      setResult(selected.result);
                     }
                   }}
                 >
@@ -323,14 +347,19 @@ export default function SkillsGenerator() {
                 <div className="flex items-center justify-between border-b border-white/5 px-6 py-3">
                   <h2 className="text-sm font-semibold text-zinc-200 tracking-tight">Skill Definition</h2>
                   <span className="text-[10px] font-mono uppercase tracking-wider text-zinc-500">
-                    {includeExampleCode ? "With Example Code" : "Plain"}
+                    {getExampleCodeStatusLabel(result)}
                   </span>
                 </div>
 
                 <div className="relative flex-1 min-h-0 overflow-hidden">
                   <div className="absolute inset-0 overflow-y-auto p-6 pb-24 prose prose-invert prose-sm max-w-none prose-headings:text-zinc-100 prose-p:text-zinc-300 prose-li:text-zinc-300 prose-code:text-yellow-300 prose-pre:bg-zinc-900">
-                    <ReactMarkdown>{result}</ReactMarkdown>
-                    <SkillExportPanel skillDefinition={result} />
+                    {result.exampleCodeWarning ? (
+                      <div className="mb-4 rounded-xl border border-yellow-500/20 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-100 not-prose">
+                        {result.exampleCodeWarning}
+                      </div>
+                    ) : null}
+                    <ReactMarkdown>{result.content}</ReactMarkdown>
+                    <SkillExportPanel skillDefinition={result.content} />
                   </div>
 
                   <button

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -157,3 +157,17 @@ export type GitHubRepoContextPayload = {
   files_used: string[];
   detected_stack: string[];
 };
+
+export type GeneratorExampleCodeMetadata = {
+  example_code_requested: boolean;
+  example_code_present: boolean;
+  example_code_warning: string | null;
+};
+
+export type AgentGeneratorResponse = GeneratorExampleCodeMetadata & {
+  system_prompt: string;
+};
+
+export type SkillGeneratorResponse = GeneratorExampleCodeMetadata & {
+  skill_definition: string;
+};


### PR DESCRIPTION
## Summary
- make agent and skill generator example-code behavior deterministic across backend metadata, frontend state, and history restore
- validate generated markdown for required example-code sections without dropping the main result
- fix generator timeout behavior by removing retry amplification, skipping LLM query expansion in generator RAG, and making worker timeouts fail promptly

## Root Cause
- example-code requests were treated as best-effort, so the UI could not reliably tell whether code was actually returned
- generate POST requests were retried by the Next proxy even though they are expensive, non-idempotent operations
- worker timeout handling used a ThreadPoolExecutor context manager that still waited for the hung thread during shutdown, so a 30s timeout could still take much longer end-to-end

## Validation
- `cd web && npm run test -- lib/server/backendProxy.test.ts app/proxy-routes.test.ts app/agent-generator/page.test.tsx app/skills-generator/page.test.tsx`
- `./.venv/bin/python -m pytest tests/test_rag.py tests/test_hybrid.py tests/test_context_generation.py tests/test_agent_generator.py tests/test_skills_generator.py tests/test_multi_agent.py -q`
- `./.venv/bin/python -m ruff check app/llm_engine/client.py app/llm_engine/rag.py app/llm_engine/hybrid.py tests/test_agent_generator.py tests/test_context_generation.py tests/test_hybrid.py tests/test_rag.py`
- `cd web && npm run lint -- app/proxy-routes.test.ts app/agent-generator/generate/route.ts app/skills-generator/generate/route.ts`
- `cd web && npm run build`
- manual in-app browser smoke on `/agent-generator` and `/skills-generator`

## Notes
- this draft touches prompt/generator behavior and manual browser verification was required, so it is intentionally opened as draft
- `.codex/` was left out of the PR scope
