### PR TITLE
fix(skills): restore plain-output sanitizer silently reverted by #780

### DIFF
--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -10,6 +10,7 @@ from api.auth import rate_limit_by_ip
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
+from app.llm_engine.client import _sanitize_skill_definition_plain
 from app.github_repo_context import (
     GitHubRepoAnalysisError,
     InvalidGitHubRepoUrl,
@@ -192,6 +193,8 @@ async def generate_skill_endpoint(
             repo_context=req.repo_context.model_dump() if req.repo_context else None,
             repo_context_mode=req.repo_context_mode,
         )
+        if not req.include_example_code:
+            result = _sanitize_skill_definition_plain(result)
         return SkillGenResponse(skill_definition=result)
     except Exception as exc:
         logger.exception("skill generation failed")

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -59,13 +59,218 @@ _MULTI_AGENT_PATTERNS = [
     re.compile(r"^- Only include a final `## Swarm Example Code .*?$\n?", flags=re.MULTILINE),
 ]
 
+_SKILL_PLAIN_SECTION_BOUNDARY = r"(?=^#{1,3} |\n\*\*[^*]+?\*\*|\Z)"
+
+_SKILL_PLAIN_OUTPUT_SECTION_PATTERNS = [
+    re.compile(
+        rf"^## Examples\b.*?{_SKILL_PLAIN_SECTION_BOUNDARY}", flags=re.MULTILINE | re.DOTALL
+    ),
+    re.compile(
+        rf"^### Examples\b.*?{_SKILL_PLAIN_SECTION_BOUNDARY}", flags=re.MULTILINE | re.DOTALL
+    ),
+    re.compile(
+        rf"^Examples:\s*\n.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+    re.compile(
+        rf"^\*\*Examples:?\*\*\s*\n.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+    re.compile(
+        rf"^## Implementation Example\b.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+    re.compile(
+        rf"^\*\*Implementation Example:?\*\*\s*\n.*?{_SKILL_PLAIN_SECTION_BOUNDARY}",
+        flags=re.MULTILINE | re.DOTALL,
+    ),
+]
+
+_SKILL_PLAIN_FENCED_CODE_PATTERN = re.compile(r"```[\w-]*\s*\r?\n[\s\S]*?```", flags=re.DOTALL)
+_SKILL_PLAIN_FENCE_LINE_PATTERN = re.compile(r"(?m)^[ \t]*```[\w-]*[ \t]*\r?\n?")
+
+_SKILL_PLAIN_OUTPUT_LINE_PATTERNS = [
+    re.compile(r"^- Input:.*?(?:→|->).*$", flags=re.MULTILINE),
+    re.compile(r"^- (?:Input|Output|Example):\s*`?\{.*$", flags=re.MULTILINE),
+    re.compile(r"^- (?:Input|Output|Example):\s*`?\[.*$", flags=re.MULTILINE),
+]
+
+_SKILL_PLAIN_NAME_FENCE_PATTERN = re.compile(
+    r"(?im)^(?P<heading>\s*(?:#{1,3}\s+Name|Name:|\*\*Name:?\*\*)\s*)\r?\n"
+    r"[ \t]*```[^\r\n]*\r?\n"
+    r"(?P<name>[A-Za-z_][\w.-]*)\s*\r?\n"
+    r"[ \t]*```[ \t]*\r?\n?"
+)
+
+_SKILL_PLAIN_ATX_HEADING_PATTERN = re.compile(r"^\s{0,3}#{1,3}\s+(?P<heading>.+?)\s*#*\s*$")
+_SKILL_PLAIN_BOLD_HEADING_PATTERN = re.compile(r"^\s*\*\*(?P<heading>[^*]+?)\*\*:?\s*$")
+_SKILL_PLAIN_BRACKET_HEADING_PATTERN = re.compile(r"^\s*\[(?P<heading>[^\]]+?)\]\s*$")
+_SKILL_PLAIN_COLON_HEADING_PATTERN = re.compile(
+    r"^\s*(?P<heading>[A-Za-z][A-Za-z0-9 /_-]{0,60}):\s*$"
+)
+
+_SKILL_PLAIN_ALLOWED_SECTION_NAMES = {
+    "name",
+    "purpose",
+    "input schema",
+    "output schema",
+    "implementation",
+    "error handling",
+    "testing strategy",
+    "test strategy",
+    "notes",
+    "constraints",
+    "notes constraints",
+}
+
+_SKILL_PLAIN_JSON_SAMPLE_LINE_PATTERN = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:Input|Output|Example)\s*:\s*(?:`?\s*)?(?:[\[{]|$)",
+    flags=re.IGNORECASE,
+)
+_SKILL_PLAIN_JSONISH_LINE_PATTERN = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:`?\s*)?[\[{\]}]", flags=re.IGNORECASE
+)
+_SKILL_PLAIN_JSON_FIELD_LINE_PATTERN = re.compile(
+    r'^\s*(?:[-*]\s*)?"[^"]+"\s*:', flags=re.IGNORECASE
+)
+
 _SKILL_PATTERNS = [
     re.compile(
         r"\n## OPTIONAL IMPLEMENTATION EXAMPLE SECTION.*?(?=\n## INPUT HANDLING)",
         flags=re.DOTALL,
     ),
     re.compile(r"^- Only include an implementation example section.*\n", flags=re.MULTILINE),
+    re.compile(
+        r"\n## Examples\n\[At least one and at most three concrete invocations.*?\n- Input:.*?\n- Input:.*?\n",
+        flags=re.DOTALL,
+    ),
+    re.compile(
+        r"^- The skill must be idempotent and the Examples section must use inputs/outputs.*\n",
+        flags=re.MULTILINE,
+    ),
+    re.compile(
+        r"^- For uncertain details, prefer pseudo-code and explicit `TODO` comments over confident-looking guesses\.\n",
+        flags=re.MULTILINE,
+    ),
 ]
+
+
+def _normalize_skill_plain_heading(heading: str) -> str:
+    normalized = heading.strip().strip(":").strip("#").strip("[]").strip()
+    normalized = normalized.replace("&", " and ")
+    normalized = re.sub(r"[^A-Za-z0-9]+", " ", normalized)
+    return re.sub(r"\s+", " ", normalized).strip().lower()
+
+
+def _skill_plain_heading_name(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    for pattern in (
+        _SKILL_PLAIN_ATX_HEADING_PATTERN,
+        _SKILL_PLAIN_BOLD_HEADING_PATTERN,
+        _SKILL_PLAIN_BRACKET_HEADING_PATTERN,
+        _SKILL_PLAIN_COLON_HEADING_PATTERN,
+    ):
+        match = pattern.match(stripped)
+        if match:
+            return _normalize_skill_plain_heading(match.group("heading"))
+    return None
+
+
+def _strip_skill_plain_fenced_blocks(text: str) -> str:
+    lines = text.splitlines()
+    cleaned_lines: list[str] = []
+    in_fence = False
+
+    for line in lines:
+        if _SKILL_PLAIN_FENCE_LINE_PATTERN.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            if _skill_plain_heading_name(line):
+                in_fence = False
+                cleaned_lines.append(line)
+            continue
+        cleaned_lines.append(line)
+
+    return "\n".join(cleaned_lines)
+
+
+def _is_skill_plain_sample_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if _SKILL_PLAIN_JSON_SAMPLE_LINE_PATTERN.match(stripped):
+        return True
+    if _SKILL_PLAIN_JSONISH_LINE_PATTERN.match(stripped):
+        return True
+    if _SKILL_PLAIN_JSON_FIELD_LINE_PATTERN.match(stripped):
+        return True
+    if re.search(r"(?:→|->)\s*Output\s*:", stripped, flags=re.IGNORECASE):
+        return True
+    return False
+
+
+def _filter_skill_plain_allowed_sections(text: str) -> str:
+    cleaned_lines: list[str] = []
+    current_section_allowed = False
+
+    for line in text.splitlines():
+        heading_name = _skill_plain_heading_name(line)
+        if heading_name:
+            if "example" in heading_name:
+                current_section_allowed = False
+                continue
+            current_section_allowed = heading_name in _SKILL_PLAIN_ALLOWED_SECTION_NAMES
+            if current_section_allowed:
+                cleaned_lines.append(line)
+            continue
+
+        if current_section_allowed and not _is_skill_plain_sample_line(line):
+            cleaned_lines.append(line)
+
+    return "\n".join(cleaned_lines)
+
+
+def _skill_plain_heading_summary(text: str) -> tuple[bool, bool]:
+    has_allowed = False
+    has_forbidden = False
+    for line in text.splitlines():
+        heading_name = _skill_plain_heading_name(line)
+        if not heading_name:
+            continue
+        has_allowed = has_allowed or heading_name in _SKILL_PLAIN_ALLOWED_SECTION_NAMES
+        has_forbidden = has_forbidden or "example" in heading_name
+    return has_allowed, has_forbidden
+
+
+def _remove_skill_plain_remaining_fence_lines(text: str) -> str:
+    return "\n".join(line for line in text.splitlines() if "```" not in line)
+
+
+def _sanitize_skill_definition_plain(text: str) -> str:
+    """Strip example/code artifacts from plain skill output when example code is disabled."""
+    if not text:
+        return text
+
+    cleaned = _SKILL_PLAIN_NAME_FENCE_PATTERN.sub(
+        lambda match: f"{match.group('heading')}\n{match.group('name')}\n",
+        text.replace("\r\n", "\n").replace("\r", "\n"),
+    )
+    cleaned = _strip_skill_plain_fenced_blocks(cleaned)
+    has_allowed_heading, has_forbidden_heading = _skill_plain_heading_summary(cleaned)
+    filtered = _filter_skill_plain_allowed_sections(cleaned)
+    if filtered.strip() or has_allowed_heading or has_forbidden_heading:
+        cleaned = filtered
+    for pattern in _SKILL_PLAIN_OUTPUT_LINE_PATTERNS:
+        cleaned = pattern.sub("", cleaned)
+
+    cleaned = _SKILL_PLAIN_FENCE_LINE_PATTERN.sub("", cleaned)
+    cleaned = _remove_skill_plain_remaining_fence_lines(cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
 
 
 class WorkerClient:
@@ -298,9 +503,12 @@ class WorkerClient:
         prompt += (
             "\n\n## EXAMPLE CODE SETTING\n"
             "- Example code is disabled for this request.\n"
-            "- Omit any `## Implementation Example` section from the final markdown.\n"
-            "- Keep `## Implementation` as a concise, code-free execution plan.\n"
-            "- Do not include fenced code blocks or pseudo-code unless the user explicitly asks for raw code."
+            "- Omit `## Implementation Example` entirely from the final markdown.\n"
+            "- Omit `## Examples` entirely — no input/output JSON samples, arrow-form invocations, "
+            "or illustrative payloads.\n"
+            "- Keep `## Implementation` as a concise, code-free execution plan in plain language only.\n"
+            "- Do not include fenced code blocks (```), pseudo-code, or code snippets anywhere in the output.\n"
+            "- `## Input Schema` and `## Output Schema` must describe fields/types only — no sample JSON values."
         )
         return prompt
 
@@ -681,14 +889,25 @@ class WorkerClient:
             "- If implementation details are unknown, provide explicit TODO-oriented steps instead of fake certainty.\n"
             "- Keep the skill definition practical, modular, and implementation-ready."
         )
-        example_code_note = (
-            "Include a final `## Implementation Example` section with concise code only when explicitly requested."
-            if include_example_code
-            else (
-                "Do not include any example code snippets, pseudo-code, or fenced code blocks. "
-                "Omit the entire `## Implementation Example` section from the generated output."
+        if include_example_code:
+            example_code_note = (
+                "Example code is enabled for this request. You MUST include:\n"
+                "1. A `## Examples` section with at least one `Input: ... → Output: ...` invocation "
+                "that matches the declared schemas.\n"
+                "2. A `## Implementation Example` section after `## Implementation` with a short fenced "
+                "code skeleton using TODO comments for unknown APIs.\n"
+                "Keep examples illustrative only — do not invent secrets, endpoints, or dependencies "
+                "not supported by context."
             )
-        )
+        else:
+            example_code_note = (
+                "Example code is disabled for this request. You MUST NOT include:\n"
+                "- fenced code blocks (```) or pseudo-code snippets\n"
+                "- a `## Examples` section or any input/output JSON samples\n"
+                "- arrow-form invocations such as `Input: {...} → Output: ...`\n"
+                "- a `## Implementation Example` section\n"
+                "Keep `## Implementation` code-free and limit schemas to field/type descriptions only."
+            )
         messages.insert(1, {"role": "system", "content": safety_note})
         messages.insert(2, {"role": "system", "content": example_code_note})
 
@@ -706,6 +925,8 @@ class WorkerClient:
             future = executor.submit(self._call_api, messages, 3000, json_mode=False)
             try:
                 content = future.result(timeout=HARD_TIMEOUT_SECONDS)
+                if not include_example_code:
+                    content = _sanitize_skill_definition_plain(content)
                 return content
             except FuturesTimeoutError:
                 future.cancel()

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -1,9 +1,186 @@
+import re
+
 import pytest
 from unittest.mock import MagicMock, patch
-from app.llm_engine.client import WorkerClient
+from app.llm_engine.client import WorkerClient, _sanitize_skill_definition_plain
 from app.llm_engine.hybrid import HybridCompiler
 from api.main import app
 from fastapi.testclient import TestClient
+
+
+def _assert_plain_skill_output_is_clean(text: str) -> None:
+    assert "```" not in text
+    assert "Example JSON" not in text
+    assert "[Example JSON]" not in text
+    assert "Implementation Example" not in text
+    assert "**Examples**" not in text
+    assert "**Examples:**" not in text
+    assert "## Examples" not in text
+    assert "### Examples" not in text
+    assert re.search(r"^Examples:\s*$", text, flags=re.MULTILINE) is None
+    assert 'Input: `{"' not in text
+    assert re.search(r"^\s*-?\s*Input:\s*[`{\[]", text, flags=re.MULTILINE) is None
+    assert re.search(r"^\s*-?\s*Output:\s*[`{\[]", text, flags=re.MULTILINE) is None
+    assert "→ Output:" not in text
+    assert "-> Output:" not in text
+
+
+_SKILL_OUTPUT_WITH_EXAMPLES = """\
+# json-validator - Skill Definition
+
+## Name
+json_validator
+
+## Purpose
+Validates JSON payloads.
+
+## Implementation
+1. Parse the payload.
+2. Validate against schema rules.
+
+## Examples
+- Input: `{"data": "x"}` → Output: `{"valid": true}`
+
+**Examples:**
+```json
+{"input": {"data": "x"}, "output": {"valid": true}}
+```
+
+## Implementation Example
+```python
+def run_skill(payload):
+    return {"valid": True}
+```
+
+## Error Handling
+- Return a structured error when JSON is invalid.
+"""
+
+_PREVIEW_STYLE_SKILL_OUTPUT = """\
+# url-summarizer - Skill Definition
+
+## Name
+url_summarizer
+
+## Purpose
+**What:** Summarizes web page content from a URL.
+**When to use:** Use when a user provides a URL and wants a short summary.
+
+## Input Schema
+- `url` (str): Public HTTP or HTTPS URL.
+
+**Output Schema**
+A JSON object with page metadata and summary text.
+
+```json
+{
+  "title": "string",
+  "summary": "string"
+}
+```
+
+## Implementation
+1. Validate the URL scheme.
+2. Fetch and extract readable text.
+3. Return a concise summary.
+
+**Examples**
+
+```json
+{
+  "input": {"url": "https://example.com"},
+  "output": {"title": "Example Domain", "summary": "Illustrative example page."}
+}
+```
+
+- Input: `{"url": "https://example.com"}` → Output: `{"title": "Example Domain", "summary": "..."}`
+
+## Error Handling
+- Reject unsupported URL schemes.
+"""
+
+_ORPHAN_FENCE_SKILL_OUTPUT = """\
+# project-plan-validator - Skill Definition
+
+## Name
+project_plan_validator
+
+## Purpose
+Validates a project plan and returns blockers, risks, and next steps.
+
+## Implementation
+1. Parse the plan.
+2. Identify blockers and risks.
+3. Return next steps.
+
+**Implementation Example**
+```json
+{"input": {"plan": "Ship v1"}, "output": {"blockers": [], "risks": [], "next_steps": ["Start delivery"]}}
+
+## Error Handling
+- Return empty lists when the plan is empty.
+```
+"""
+
+_BROWSER_FAILED_PLAIN_SKILL_OUTPUT = """\
+# Skill Definition
+
+**Name**
+```text
+project_plan_validator
+```
+
+**Purpose**
+Validates project plans and returns blockers, risks, and next steps.
+
+**Input Schema**
+```json
+{
+  "project_plan": "string",
+  "team": "string"
+}
+```
+
+- Input: {"project_plan": "Ship v1", "team": "Platform"}
+- Output: {"blockers": [], "risks": ["unclear owner"], "next_steps": ["assign owner"]}
+
+**Output Schema**
+```json
+{
+  "blockers": ["string"],
+  "risks": ["string"],
+  "next_steps": ["string"]
+}
+```
+
+**Implementation**
+1. Read the project plan.
+2. Identify blockers, risks, and next steps.
+
+**Example JSON**
+```json
+{
+  "input": {"project_plan": "Ship v1"},
+  "output": {"blockers": [], "risks": [], "next_steps": ["Start"]}
+}
+```
+
+[Example JSON]
+```json
+{
+  "project_plan": "Ship v1"
+}
+```
+
+## Implementation Example
+```python
+def run_skill(payload):
+    return {"blockers": [], "risks": [], "next_steps": []}
+```
+
+**Error Handling**
+- Return a clear validation error when the plan is empty.
+"""
 
 
 # Mock WorkerClient to avoid API calls
@@ -111,6 +288,19 @@ def test_api_generate_skill_endpoint_with_example_code_enabled():
         )
 
 
+def test_skill_prompt_omits_examples_section_when_disabled():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    rendered = client._skill_prompt(include_example_code=False)
+
+    assert "## Examples\n[At least one" not in rendered
+    assert "Input: `{param_name:" not in rendered
+    assert "## OPTIONAL IMPLEMENTATION EXAMPLE SECTION" not in rendered
+    assert "Omit `## Examples` entirely" in rendered
+    assert "Do not include fenced code blocks" in rendered
+
+
 def test_worker_client_omits_skill_implementation_example_when_disabled():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")
@@ -129,9 +319,125 @@ def test_worker_client_omits_skill_implementation_example_when_disabled():
             msg["content"] for msg in captured["messages"] if msg["role"] == "system"
         ]
         assert any(
-            "Omit the entire `## Implementation Example` section" in message
+            "Example code is disabled for this request" in message for message in system_messages
+        )
+        assert any(
+            "You MUST NOT include" in message and "`## Examples` section" in message
             for message in system_messages
         )
+        assert any(
+            "fenced code blocks" in message and "`## Implementation Example` section" in message
+            for message in system_messages
+        )
+
+
+def test_sanitize_skill_definition_plain_removes_examples_and_code():
+    cleaned = _sanitize_skill_definition_plain(_SKILL_OUTPUT_WITH_EXAMPLES)
+
+    _assert_plain_skill_output_is_clean(cleaned)
+    assert "## Implementation Example" not in cleaned
+    assert "## Error Handling" in cleaned
+    assert "## Implementation" in cleaned
+
+
+def test_sanitize_skill_definition_plain_removes_preview_style_markdown():
+    cleaned = _sanitize_skill_definition_plain(_PREVIEW_STYLE_SKILL_OUTPUT)
+
+    _assert_plain_skill_output_is_clean(cleaned)
+    assert "**Output Schema**" in cleaned
+    assert "A JSON object with page metadata and summary text." in cleaned
+    assert "## Error Handling" in cleaned
+
+
+def test_sanitize_skill_definition_plain_removes_orphan_fence_after_example_cleanup():
+    cleaned = _sanitize_skill_definition_plain(_ORPHAN_FENCE_SKILL_OUTPUT)
+
+    _assert_plain_skill_output_is_clean(cleaned)
+    assert "Implementation Example" not in cleaned
+    assert "## Error Handling" in cleaned
+    assert cleaned.endswith("empty.")
+
+
+def test_sanitize_skill_definition_plain_normalizes_browser_failed_output():
+    cleaned = _sanitize_skill_definition_plain(_BROWSER_FAILED_PLAIN_SKILL_OUTPUT)
+
+    _assert_plain_skill_output_is_clean(cleaned)
+    assert "project_plan_validator" in cleaned
+    assert "**Name**" in cleaned
+    assert "**Input Schema**" in cleaned
+    assert "**Output Schema**" in cleaned
+    assert "**Implementation**" in cleaned
+    assert "**Error Handling**" in cleaned
+    assert "Return a clear validation error" in cleaned
+
+
+def test_generate_skill_sanitizes_plain_output_when_example_code_disabled():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+        with patch.object(client, "_call_api", return_value=_PREVIEW_STYLE_SKILL_OUTPUT):
+            result = client.generate_skill("Test Skill", include_example_code=False)
+
+    _assert_plain_skill_output_is_clean(result)
+    assert "**Output Schema**" in result
+    assert "## Error Handling" in result
+
+
+def test_api_generate_skill_plain_response_is_sanitized_at_route_boundary():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = _BROWSER_FAILED_PLAIN_SKILL_OUTPUT
+
+        client = TestClient(app)
+        response = client.post(
+            "/skills-generator/generate",
+            json={"description": "Validate a project plan"},
+        )
+
+        assert response.status_code == 200
+        skill_definition = response.json()["skill_definition"]
+        _assert_plain_skill_output_is_clean(skill_definition)
+        assert "Implementation Example" not in skill_definition
+        assert "Error Handling" in skill_definition
+        mock_compiler.generate_skill.assert_called_with(
+            "Validate a project plan",
+            include_example_code=False,
+            repo_context=None,
+            repo_context_mode="full",
+        )
+
+
+def test_api_generate_skill_preserves_examples_when_example_code_enabled():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = _PREVIEW_STYLE_SKILL_OUTPUT
+
+        client = TestClient(app)
+        response = client.post(
+            "/skills-generator/generate",
+            json={
+                "description": "Summarize a web page from a URL",
+                "include_example_code": True,
+            },
+        )
+
+        assert response.status_code == 200
+        skill_definition = response.json()["skill_definition"]
+        assert "```json" in skill_definition
+        assert "**Examples**" in skill_definition
+        assert 'Input: `{"url"' in skill_definition
+
+
+def test_generate_skill_preserves_examples_when_example_code_enabled():
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+        with patch.object(client, "_call_api", return_value=_SKILL_OUTPUT_WITH_EXAMPLES):
+            result = client.generate_skill("Test Skill", include_example_code=True)
+
+    assert "## Examples" in result
+    assert "**Examples:**" in result
+    assert "## Implementation Example" in result
+    assert "```json" in result
+    assert "```python" in result
 
 
 def test_worker_client_requests_skill_implementation_example_when_enabled():
@@ -152,6 +458,10 @@ def test_worker_client_requests_skill_implementation_example_when_enabled():
             msg["content"] for msg in captured["messages"] if msg["role"] == "system"
         ]
         assert any(
-            "Include a final `## Implementation Example` section" in message
+            "Example code is enabled for this request" in message for message in system_messages
+        )
+        assert any(
+            "You MUST include" in message and "`## Examples` section" in message
             for message in system_messages
         )
+        assert any("`## Implementation Example` section" in message for message in system_messages)


### PR DESCRIPTION
## What & why
PR #780 ("⚡ Bolt: Pre-compile regex patterns in LogicAnalyzer", merged 2026-06-12, commit `0521382`) was branched from a **stale base** and — despite its title — touched **36 files**, silently reverting the skill **plain-output sanitization** that #787 / #790 had landed the day before. That protection has been missing from `main` for ~3 days. This PR restores it.

## Root cause (forensics)
- `git log -S_sanitize_skill_definition_plain` shows the symbol was **added by #787** (`137f03b`) and **removed by #780** (`0521382`).
- #780's real change was ~10 lines in `app/heuristics/logic_analyzer.py`; the other 35 files were stale-base reversions (it also deleted `web/app/components/PremiumSelect.tsx`, cut `app/llm_engine/client.py` by ~80 lines, and removed ~200 lines of skills-generator tests).
- **No commit after #780 restored any of it** — the classic "branch drift reintroducing old changes" failure mode.

## What this restores
Verbatim from `fff3251` (the commit immediately before #780, the last good state). Nothing else touched these files in between, so the restore is clean and surgical:
- `app/llm_engine/client.py` — `_sanitize_skill_definition_plain()` + the `_SKILL_PLAIN_*` detection patterns.
- `api/routes/generators.py` — the boundary call: `if not req.include_example_code: result = _sanitize_skill_definition_plain(result)`.
- `tests/test_skills_generator.py` — the sanitizer test coverage.

## Validation
- `pytest tests/test_skills_generator.py` → **15/15 pass**.
- `pytest tests/` (full) → **1184 pass, 5 skipped, 1 failed**. The single failure (`test_operational_hardening.py::test_health_request_emits_completion_log`, a pytest live-logging `NullHandler.stream` artifact) **also fails on clean `main`** without this change — pre-existing and unrelated.
- Hard boundaries respected: no `.env`, provider, model, temperature, max_tokens, or deploy-config changes.

## ⚠️ Coordination with #806 (Codex's #763 work) — read before merging
This PR and **#806** modify the **same files** (`client.py`, `generators.py`, `tests/test_skills_generator.py`). They are **complementary, not duplicative**:
- **This PR** = *example code OFF* → strip any leaked code from skill output (the lost #787/#790 protection).
- **#806** = *example code ON* → validate code is present and warn if missing (#763).

They will conflict textually and must be sequenced. Recommendation: pick one ordering and rebase the other; ideally this sanitizer ends up alongside #806's new `example_code.py` detection. Note **#806's Smoke check is currently failing**, so it isn't merge-ready yet regardless.

Kept as **draft** pending that coordination decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)