### PR TITLE
fix(generators): unwrap example-code section to remove stray fence (#763)

### DIFF
--- a/app/llm_engine/prompts/agent_generator.md
+++ b/app/llm_engine/prompts/agent_generator.md
@@ -106,11 +106,11 @@ The output must strictly follow this Markdown structure:
 - Only include an example-code section when a later instruction explicitly enables example code. When enabled, the section is mandatory and must include a fenced pseudo-code block.
 
 ## OPTIONAL EXAMPLE CODE SECTION
-When explicitly enabled by a later instruction, you MUST append this section after `## Example Interaction` and include at least one fenced pseudo-code block:
+When explicitly enabled by a later instruction, you MUST append this section after `## Example Interaction` and include at least one fenced pseudo-code block. Output the heading and the code block directly — do NOT wrap them in an outer code fence:
 
-```markdown
 ## Example Code (Pseudo-code Skeleton)
 [Provide a short, realistic skeleton only. Use comments and TODO markers where integration details are unknown.]
+
 ```python
 # Pseudo-code only. Replace TODO items with real project APIs.
 
@@ -119,7 +119,6 @@ def run_agent_task(payload):
     # TODO: Call real project services or APIs confirmed in context.
     # TODO: Handle errors, retries, and logging with existing project utilities.
     return {"status": "not_implemented"}
-```
 ```
 
 ## INPUT HANDLING

--- a/app/llm_engine/prompts/skills_generator.md
+++ b/app/llm_engine/prompts/skills_generator.md
@@ -87,18 +87,17 @@ The output must strictly follow this Markdown structure:
 - Only include an implementation example section when a later instruction explicitly enables example code. When enabled, the section is mandatory and must include a fenced code block.
 
 ## OPTIONAL IMPLEMENTATION EXAMPLE SECTION
-When explicitly enabled by a later instruction, you MUST append this section after `## Implementation` and include at least one fenced code block:
+When explicitly enabled by a later instruction, you MUST append this section after `## Implementation` and include at least one fenced code block. Output the heading and the code block directly — do NOT wrap them in an outer code fence:
 
-```markdown
 ## Implementation Example
 [Short, practical code example aligned with the declared schemas and dependencies.]
+
 ```python
 def run_skill(input_payload):
     # TODO: Validate input based on Input Schema
     # TODO: Execute core skill logic
     # TODO: Return Output Schema-compliant response
     return {"status": "not_implemented"}
-```
 ```
 
 ## INPUT HANDLING

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -289,6 +289,18 @@ def test_example_code_strip_still_works():
     assert "## Swarm Stop Conditions" in multi_no_code
 
 
+def test_single_agent_example_section_not_wrapped_in_outer_fence():
+    """Issue #763: the enabled example-code section must NOT be wrapped in an outer
+    ```markdown fence. When it is, the LLM reproduces the wrapper and emits a stray
+    code fence that swallows the heading and breaks the rendered output."""
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    rendered = client._single_agent_prompt(include_example_code=True)
+    assert "## Example Code (Pseudo-code Skeleton)" in rendered
+    assert "```markdown\n## Example Code (Pseudo-code Skeleton)" not in rendered
+
+
 def test_inspect_agent_example_code_detects_valid_single_agent_section():
     inspection = inspect_agent_example_code(
         "# Agent\n\n## Example Code (Pseudo-code Skeleton)\n```python\npass\n```",

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -333,6 +333,18 @@ def test_skill_prompt_omits_examples_section_when_disabled():
     assert "Do not include fenced code blocks" in rendered
 
 
+def test_skill_implementation_example_not_wrapped_in_outer_fence():
+    """Issue #763: the enabled implementation-example section must NOT be wrapped in an
+    outer ```markdown fence. When it is, the LLM reproduces the wrapper and emits a stray
+    code fence that swallows the heading and breaks the rendered output."""
+    with patch("app.llm_engine.client.OpenAI"):
+        client = WorkerClient(api_key="test")
+
+    rendered = client._skill_prompt(include_example_code=True)
+    assert "## Implementation Example" in rendered
+    assert "```markdown\n## Implementation Example" not in rendered
+
+
 def test_worker_client_omits_skill_implementation_example_when_disabled():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")


### PR DESCRIPTION
## Summary
Fixes the rendering half of #763. The "Example Code" toggle already persists and the flag already reaches the backend (#806) — this PR fixes the **stray code fence** that appeared in the generated output.

## Root cause
The OPTIONAL example-code sections in `agent_generator.md` and `skills_generator.md` showed the section wrapped in an **outer ` ```markdown … ``` ` fence**. When `include_example_code=True` the prompt is sent verbatim (`_single_agent_prompt` / `_skill_prompt`), so the model reproduced that outer wrapper and emitted a stray ` ``` ` around the example section — which swallowed the `## Example Code` heading and broke the rendered markdown. `multi_agent_planner.md` never had the wrapper, so its output was already clean.

## Fix
- Unwrap the example-code section in both prompts to match the working `multi_agent_planner.md` pattern (heading + a single ` ```python ` block, no outer fence).
- Add an explicit "do NOT wrap them in an outer code fence" instruction.
- Add one regression test per generator asserting the enabled section is not wrapped.

## Tests
- New: `test_single_agent_example_section_not_wrapped_in_outer_fence`, `test_skill_implementation_example_not_wrapped_in_outer_fence` (red before fix, green after).
- **63 passed** across generator / multi-agent / context / hybrid suites. Inspection logic and the example-code-disabled (strip) path are unchanged.

## How to verify on the Vercel preview
**Agent Generator** → toggle **Example Code ON** → generate:
> Build an agent that watches a folder for new CSV files, validates each row against a fixed schema (id:int, email:string, amount:float), and moves invalid rows into a separate rejects.csv with the reason.

**Skills Generator** → toggle **Example Code ON** → generate:
> A skill that parses an incoming webhook payload, extracts order line items, and computes the order total including 20% VAT.

Expected: toggle stays ON; the `## Example Code (Pseudo-code Skeleton)` / `## Implementation Example` heading renders **as a heading** (not inside a code block); exactly one fenced code block follows; **no stray/empty ` ``` ` fence** above or below it.

Draft — does not auto-close #763. Close after preview verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
