### PR TITLE
🎨 Palette: Add Clear Input Buttons to Textareas

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-06-03 - Mutually Exclusive Button ARIA Grouping
 **Learning:** When using standard `<button>` tags to create mutually exclusive selection groups (like toggle groups or choice cards), relying solely on visual styling is insufficient for accessibility. Screen readers will treat them as independent, unrelated buttons without state.
 **Action:** Always wrap the buttons in a container with `role="radiogroup"` and a descriptive `aria-label`, and add `role="radio"` and `aria-checked={active}` to each button. This ensures the component is properly announced as a radio group and communicates selection state correctly.
+## 2024-06-17 - Add Clear Button to Input Forms
+**Learning:** For generative text inputs where users often paste large blocks of text, missing a quick way to clear the input creates friction. Users have to manually select all text and delete it.
+**Action:** Always consider adding a "Clear" button (with proper `type="button"`, `aria-label`, and `title` attributes) to large input fields (like textareas) to improve usability.

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -265,6 +265,18 @@ export default function AgentGenerator() {
                   }
                 }}
               />
+
+            {description && (
+              <button
+                type="button"
+                onClick={() => setDescription("")}
+                className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-500/50"
+                title="Clear input"
+                aria-label="Clear input"
+              >
+                Clear
+              </button>
+            )}
             </div>
 
             <button

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -316,6 +316,7 @@ export default function AgentPacksPage() {
               <label htmlFor="agent-pack-goal" className="text-sm font-medium text-zinc-300">
                 What should Claude do?
               </label>
+              <div className="relative group">
               <textarea
                 id="agent-pack-goal"
                 aria-label="Agent Pack Goal"
@@ -324,6 +325,19 @@ export default function AgentPacksPage() {
                 className="min-h-36 rounded-2xl border border-white/10 bg-black/20 p-4 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
                 placeholder="e.g. Review PRs for prompt leakage, unsafe settings, and missing regression tests."
               />
+
+            {request.goal && (
+              <button
+                type="button"
+                onClick={() => handleFieldChange("goal", "")}
+                className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500/50"
+                title="Clear input"
+                aria-label="Clear input"
+              >
+                Clear
+              </button>
+            )}
+            </div>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -257,6 +257,18 @@ export default function SkillsGenerator() {
                   }
                 }}
               />
+
+            {description && (
+              <button
+                type="button"
+                onClick={() => setDescription("")}
+                className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-yellow-500/50"
+                title="Clear input"
+                aria-label="Clear input"
+              >
+                Clear
+              </button>
+            )}
             </div>
 
             <button


### PR DESCRIPTION
💡 **What:**
Added a small, dark-themed "Clear" button to the main description textareas in the Agent Generator, Skills Generator, and Agent Packs pages.

🎯 **Why:**
Users frequently paste large blocks of text into these tools to generate agents or skills. If they make a mistake or want to start over, highlighting and deleting large amounts of text is annoying. This provides a 1-click way to start fresh.

📸 **Before/After:**
*(See attached screenshots from playwright tests)*

♿ **Accessibility:**
* Added `type="button"` to prevent accidental form submissions.
* Added `aria-label="Clear input"` for screen readers.
* Added `title="Clear input"` for tooltips.
* Ensured focus states match the surrounding theme for keyboard navigation (`focus-visible:ring-*`).

---
*PR created automatically by Jules for task [5630175457646940603](https://jules.google.com/task/5630175457646940603) started by @madara88645*