### PR TITLE
🎨 Palette: Add screen-reader-only labels to text areas for better accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-06-17 - Add Clear Button to Input Forms
 **Learning:** For generative text inputs where users often paste large blocks of text, missing a quick way to clear the input creates friction. Users have to manually select all text and delete it.
 **Action:** Always consider adding a "Clear" button (with proper `type="button"`, `aria-label`, and `title` attributes) to large input fields (like textareas) to improve usability.
+## 2026-06-20 - Adding Hidden Associated Labels to Textareas
+**Learning:** Next.js pages often use `aria-label` directly on `<textarea>` elements without associated DOM `<label>` elements. This violates complete semantic structure for some screen reader setups. Adding an explicit `<label htmlFor="...">` with the `sr-only` class satisfies accessibility criteria without disrupting the visual layout.
+**Action:** When auditing or implementing inputs/textareas, always ensure a corresponding DOM `<label>` exists. Use `sr-only` for visually hidden but programmatically associated labels.

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -344,6 +344,7 @@ export default function BenchmarkPage() {
         <div className="flex flex-1 flex-col overflow-visible md:min-h-0 md:flex-row md:overflow-hidden">
           <div className="z-20 flex w-full flex-col gap-4 border-b border-white/5 bg-black/20 p-4 sm:p-5 md:w-[350px] md:shrink-0 md:border-b-0 md:border-r">
             <div className="group relative flex-1">
+              <label htmlFor="benchmark-prompt" className="sr-only">Benchmark prompt input</label>
               <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-500/5 to-orange-500/5 opacity-0 transition-opacity duration-500 group-focus-within:opacity-100" />
               <textarea
                 id="benchmark-prompt"

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -127,6 +127,7 @@ export default function OfflinePage() {
                     <div className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/20 p-4 sm:p-5 md:min-h-0 md:w-[35%] md:border-b-0 md:border-r md:overflow-y-auto">
 
                         <div className="flex-1 flex flex-col relative group">
+                            <label htmlFor="offline-prompt" className="sr-only">Offline prompt input</label>
                             <textarea
                                 id="offline-prompt"
                                 aria-label="Offline prompt input"

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -259,9 +259,11 @@ export default function Home() {
           <div className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/10 p-4 sm:p-5 md:min-h-0 md:w-[35%] md:border-b-0 md:border-r md:overflow-y-auto">
 
             <div className="flex-1 flex flex-col relative group">
+              <label htmlFor="main-prompt" className="sr-only">Describe what you want compiled</label>
               <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-purple-500/5 rounded-2xl pointer-events-none opacity-0 group-focus-within:opacity-100 transition-opacity duration-500" />
               <div className="relative flex-1 flex flex-col">
                 <textarea
+                  id="main-prompt"
                   aria-label="Describe what you want compiled"
                   className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 sm:min-h-44 md:min-h-0"
                   placeholder="Paste a vague task, bug report, spec, or workflow request... e.g. 'Turn this GitHub issue into a safe implementation brief'"
@@ -533,7 +535,7 @@ export default function Home() {
                         onClick={() => {
                           setPrompt("Write a Python script that analyzes an nginx access.log file, counts requests by IP, and flags IPs with more than 100 requests in a minute.");
                           setTimeout(() => {
-                            const textarea = document.querySelector<HTMLTextAreaElement>('textarea[aria-label="Describe what you want compiled"]');
+                            const textarea = document.getElementById('main-prompt') as HTMLTextAreaElement;
                             if (textarea) textarea.focus();
                           }, 0);
                         }}

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -243,6 +243,7 @@ export default function SkillsGenerator() {
             ) : null}
 
             <div className="relative shrink-0 group">
+              <label htmlFor="skill-description" className="sr-only">Skill Description</label>
               <textarea
                 id="skill-description"
                 aria-label="Skill Description"


### PR DESCRIPTION
💡 What: Added explicitly associated `<label>` elements (visually hidden with `sr-only`) to the primary textareas across multiple core pages (`page.tsx`, `offline/page.tsx`, `benchmark/page.tsx`, `skills-generator/page.tsx`). Also refactored brittle `document.querySelector` usage to `document.getElementById` for better reliability.

🎯 Why: While the textareas previously used `aria-label`, adding a native, programmatically associated DOM `<label>` is the gold standard for semantic HTML and accessibility, ensuring proper announcement for all screen reader configurations.

📸 Before/After: Visually identical. The added labels utilize the `sr-only` utility class to remain completely hidden from sighted users while being fully accessible to assistive technologies.

♿ Accessibility:
- Added `id` and `htmlFor` pairings for critical input areas.
- Ensures screen readers can reliably associate the prompt input fields with their descriptive labels.
- Maintains compliance with semantic HTML structure criteria.

---
*PR created automatically by Jules for task [15659970204993290598](https://jules.google.com/task/15659970204993290598) started by @madara88645*