### PR TITLE
🎨 Palette: Add explicit accessible labels to textarea inputs

### DIFF
--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -345,6 +345,7 @@ export default function BenchmarkPage() {
           <div className="z-20 flex w-full flex-col gap-4 border-b border-white/5 bg-black/20 p-4 sm:p-5 md:w-[350px] md:shrink-0 md:border-b-0 md:border-r">
             <div className="group relative flex-1">
               <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-500/5 to-orange-500/5 opacity-0 transition-opacity duration-500 group-focus-within:opacity-100" />
+              <label htmlFor="benchmark-prompt" className="sr-only">Benchmark prompt input</label>
               <textarea
                 id="benchmark-prompt"
                 aria-label="Benchmark prompt input"

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -127,6 +127,7 @@ export default function OfflinePage() {
                     <div className="flex w-full flex-col gap-4 border-b border-white/5 bg-black/20 p-4 sm:p-5 md:min-h-0 md:w-[35%] md:border-b-0 md:border-r md:overflow-y-auto">
 
                         <div className="flex-1 flex flex-col relative group">
+                            <label htmlFor="offline-prompt" className="sr-only">Offline prompt input</label>
                             <textarea
                                 id="offline-prompt"
                                 aria-label="Offline prompt input"
@@ -219,6 +220,7 @@ export default function OfflinePage() {
                                 >
                                     {activeTab !== "json" && (
                                         <>
+                                            <label htmlFor="offline-output" className="sr-only">Compiled prompt output</label>
                                             <textarea
                                                 id="offline-output"
                                                 aria-label="Compiled prompt output"

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -565,7 +565,9 @@ export default function OptimizerPage() {
                             </div>
 
                             <div className="mt-3 flex flex-col gap-3">
+                                <label htmlFor="english-variant-output" className="sr-only">English compact suggestion</label>
                                 <textarea
+                                    id="english-variant-output"
                                     readOnly
                                     value={englishVariant}
                                     aria-label="English compact suggestion"

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -261,7 +261,9 @@ export default function Home() {
             <div className="flex-1 flex flex-col relative group">
               <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-purple-500/5 rounded-2xl pointer-events-none opacity-0 group-focus-within:opacity-100 transition-opacity duration-500" />
               <div className="relative flex-1 flex flex-col">
+                <label htmlFor="prompt-input" className="sr-only">Describe what you want compiled</label>
                 <textarea
+                  id="prompt-input"
                   aria-label="Describe what you want compiled"
                   className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 sm:min-h-44 md:min-h-0"
                   placeholder="Paste a vague task, bug report, spec, or workflow request... e.g. 'Turn this GitHub issue into a safe implementation brief'"
@@ -445,6 +447,7 @@ export default function Home() {
                           )}
                         </div>
 
+                        <label htmlFor="compiled-output" className="sr-only">Compiled prompt output</label>
                         <textarea
                           id="compiled-output"
                           aria-label="Compiled prompt output"

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -243,6 +243,7 @@ export default function SkillsGenerator() {
             ) : null}
 
             <div className="relative shrink-0 group">
+              <label htmlFor="skill-description" className="sr-only">Skill Description</label>
               <textarea
                 id="skill-description"
                 aria-label="Skill Description"


### PR DESCRIPTION
💡 What: Added visually hidden `<label>` elements (using `sr-only` class) to explicitly link to corresponding `<textarea>` elements via `htmlFor` and `id` across multiple frontend pages.
🎯 Why: To improve keyboard and screen reader accessibility by ensuring inputs lacking a visible label still have robust semantic HTML associations, meeting strict accessibility standards while preserving the existing visual design.
📸 Before/After: Visual UI remains unchanged (`sr-only` hides the label). Underlying HTML now features explicit `<label htmlFor="...">` and `<textarea id="...">` associations instead of relying solely on `aria-label`.
♿ Accessibility: Ensures semantic `<label>` associations for text areas in `benchmark`, `offline`, `optimizer`, `page`, and `skills-generator` components, enhancing support for assistive technologies.

---
*PR created automatically by Jules for task [15012421042599187676](https://jules.google.com/task/15012421042599187676) started by @madara88645*