### PR TITLE
feat(agent-packs): add post-generation install checklist (#814 M1)

### DIFF
--- a/web/app/agent-packs/components/InstallChecklist.tsx
+++ b/web/app/agent-packs/components/InstallChecklist.tsx
@@ -1,0 +1,56 @@
+import { CheckCircle2 } from "lucide-react";
+
+import type { InstallChecklistSection } from "../installChecklist";
+
+interface InstallChecklistProps {
+  sections: InstallChecklistSection[];
+  downloaded?: boolean;
+}
+
+export default function InstallChecklist({ sections, downloaded = false }: InstallChecklistProps) {
+  const titleId = "agent-pack-install-checklist-title";
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className="border-b border-white/5 px-4 py-4 sm:px-6"
+    >
+      <div className="rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h3 id={titleId} className="text-sm font-semibold text-cyan-100">
+              Install &amp; review checklist
+            </h3>
+            <p className="mt-1 text-xs leading-relaxed text-cyan-100/70">
+              Beta output is a starting point. Use this list to install files safely in your repo.
+            </p>
+          </div>
+          {downloaded ? (
+            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+              <CheckCircle2 size={12} aria-hidden="true" />
+              Downloaded
+            </span>
+          ) : null}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {sections.map((section) => (
+            <div key={section.id} className="rounded-xl border border-white/8 bg-black/20 p-3">
+              <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-400">
+                {section.title}
+              </h4>
+              <ul className="space-y-2 text-xs leading-relaxed text-zinc-300">
+                {section.items.map((item) => (
+                  <li key={`${section.id}-${item}`} className="flex gap-2">
+                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400/80" aria-hidden="true" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/app/agent-packs/installChecklist.test.ts
+++ b/web/app/agent-packs/installChecklist.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+
+import { buildInstallChecklist } from "./installChecklist";
+import type { AgentPackManifest } from "./types";
+
+const prReviewerManifest: AgentPackManifest = {
+  provider: "claude",
+  pack_type: "pr-reviewer",
+  download_name: "saas-pr-reviewer-claude",
+  preview_order: ["claude_md", "agents", "workflow"],
+  files: [
+    { path: "CLAUDE.md", content: "# Memory", kind: "claude_md" },
+    { path: ".claude/agents/pr-reviewer.md", content: "agent", kind: "agents" },
+    { path: ".github/workflows/claude.yml", content: "workflow", kind: "workflow" },
+  ],
+};
+
+const mcpStubManifest: AgentPackManifest = {
+  provider: "claude",
+  pack_type: "mcp-tool-stub",
+  download_name: "saas-mcp-stub-claude",
+  preview_order: ["files", "readme"],
+  files: [
+    { path: "server.py", content: "print('hi')", kind: "files" },
+    { path: "README.md", content: "setup", kind: "readme" },
+  ],
+};
+
+const projectPackManifest: AgentPackManifest = {
+  provider: "claude",
+  pack_type: "project-pack",
+  download_name: "saas-project-pack-claude",
+  preview_order: ["claude_md", "settings", "agents", "workflow", "mcp"],
+  files: [
+    { path: "CLAUDE.md", content: "# Memory", kind: "claude_md" },
+    { path: ".claude/settings.json", content: "{}", kind: "settings" },
+    { path: ".claude/agents/helper.md", content: "agent", kind: "agents" },
+    { path: ".github/workflows/claude.yml", content: "workflow", kind: "workflow" },
+    { path: ".claude/mcp/claude-desktop.json", content: "{}", kind: "mcp" },
+  ],
+};
+
+describe("buildInstallChecklist", () => {
+  test("includes generated file paths from the manifest", () => {
+    const sections = buildInstallChecklist(prReviewerManifest);
+    const generated = sections.find((section) => section.id === "generatedFiles");
+
+    expect(generated?.items).toEqual([
+      "Add CLAUDE.md to the matching path in your repository.",
+      "Add .claude/agents/pr-reviewer.md to the matching path in your repository.",
+      "Add .github/workflows/claude.yml to the matching path in your repository.",
+    ]);
+  });
+
+  test("flags workflow and agent files for review on pr-reviewer packs", () => {
+    const sections = buildInstallChecklist(prReviewerManifest);
+    const review = sections.find((section) => section.id === "reviewFirst");
+
+    expect(review?.items.some((item) => item.includes("pr-reviewer.md"))).toBe(true);
+    expect(review?.items.some((item) => item.includes("claude.yml"))).toBe(true);
+  });
+
+  test("adds executable and MCP validation guidance for mcp-tool-stub packs", () => {
+    const sections = buildInstallChecklist(mcpStubManifest);
+    const review = sections.find((section) => section.id === "reviewFirst");
+    const validation = sections.find((section) => section.id === "validationSteps");
+
+    expect(review?.items.some((item) => item.includes("server.py"))).toBe(true);
+    expect(validation?.items.some((item) => item.includes("server code"))).toBe(true);
+    expect(validation?.items.some((item) => item.includes("README"))).toBe(true);
+  });
+
+  test("includes project-pack specific validation steps", () => {
+    const sections = buildInstallChecklist(projectPackManifest);
+    const validation = sections.find((section) => section.id === "validationSteps");
+
+    expect(validation?.items.some((item) => item.includes("CLAUDE.md"))).toBe(true);
+    expect(validation?.items.some((item) => item.includes("settings.json"))).toBe(true);
+    expect(validation?.items.some((item) => item.includes("GitHub workflow"))).toBe(true);
+  });
+
+  test("updates next-step copy after download", () => {
+    const before = buildInstallChecklist(prReviewerManifest);
+    const after = buildInstallChecklist(prReviewerManifest, { downloaded: true });
+
+    expect(before.find((section) => section.id === "nextAction")?.title).toBe("Next step");
+    expect(after.find((section) => section.id === "nextAction")?.title).toBe("Downloaded — next step");
+    expect(after.find((section) => section.id === "nextAction")?.items[0]).toContain("Unpack the zip");
+  });
+});

--- a/web/app/agent-packs/installChecklist.ts
+++ b/web/app/agent-packs/installChecklist.ts
@@ -1,0 +1,166 @@
+import type { AgentPackFile, AgentPackFileKind, AgentPackManifest, AgentPackType } from "./types";
+
+export type InstallChecklistSectionId =
+  | "generatedFiles"
+  | "reviewFirst"
+  | "validationSteps"
+  | "nextAction";
+
+export interface InstallChecklistSection {
+  id: InstallChecklistSectionId;
+  title: string;
+  items: string[];
+}
+
+const REVIEW_KINDS: ReadonlySet<AgentPackFileKind> = new Set([
+  "settings",
+  "workflow",
+  "mcp",
+  "agents",
+]);
+
+const EXECUTABLE_EXTENSIONS = [".py", ".sh", ".js", ".ts", ".mjs"];
+
+function isExecutablePath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return EXECUTABLE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+function buildReviewItems(files: AgentPackFile[]): string[] {
+  const items: string[] = [];
+
+  for (const file of files) {
+    if (REVIEW_KINDS.has(file.kind)) {
+      items.push(`Review ${file.path} for permissions, secrets, and unsafe defaults before committing.`);
+      continue;
+    }
+
+    if (isExecutablePath(file.path)) {
+      items.push(`Inspect ${file.path} as untrusted code before running or deploying it.`);
+    }
+  }
+
+  return [...new Set(items)];
+}
+
+function buildValidationSteps(packType: AgentPackType, files: AgentPackFile[]): string[] {
+  const paths = new Set(files.map((file) => file.path));
+  const steps: string[] = [];
+
+  const hasClaudeMd = paths.has("CLAUDE.md");
+  const hasSettings = [...paths].some((path) => path.includes("settings.json"));
+  const hasWorkflow = files.some((file) => file.kind === "workflow");
+  const hasAgents = files.some((file) => file.kind === "agents");
+  const hasMcp = files.some((file) => file.kind === "mcp");
+  const hasReadme = files.some((file) => file.kind === "readme");
+
+  switch (packType) {
+    case "project-pack":
+      if (hasClaudeMd) {
+        steps.push("Place CLAUDE.md at your repository root so Claude Code can load repo memory.");
+      }
+      if (hasSettings) {
+        steps.push("Merge .claude/settings.json carefully and confirm tool permissions match your risk tolerance.");
+      }
+      if (hasAgents) {
+        steps.push("Copy generated agent files into .claude/agents/ and skim each prompt for your workflow.");
+      }
+      if (hasWorkflow) {
+        steps.push("Review the GitHub workflow YAML permissions and triggers before enabling CI.");
+      }
+      if (hasMcp) {
+        steps.push("Validate MCP config paths and only enable servers you trust.");
+      }
+      break;
+
+    case "pr-reviewer":
+      if (hasClaudeMd) {
+        steps.push("Add CLAUDE.md to the repo root so review guidance is available to Claude Code.");
+      }
+      if (hasAgents) {
+        steps.push("Install the pr-reviewer agent under .claude/agents/ and test it on a sample PR.");
+      }
+      if (hasWorkflow) {
+        steps.push("Confirm the workflow only runs with the scopes you expect on pull requests.");
+      }
+      break;
+
+    case "subagent":
+      if (hasAgents) {
+        steps.push("Drop the subagent markdown into .claude/agents/ and invoke it from Claude Code.");
+      }
+      if (hasReadme) {
+        steps.push("Read the README for install notes and example prompts before first use.");
+      }
+      break;
+
+    case "mcp-tool-stub":
+      if (paths.has("server.py") || files.some((file) => isExecutablePath(file.path))) {
+        steps.push("Review the generated server code, dependencies, and tool surface before running it.");
+      }
+      if (hasMcp) {
+        steps.push("Wire the MCP config into your Claude client only after reviewing allowed tools.");
+      }
+      if (hasReadme) {
+        steps.push("Follow the README setup steps and run a dry-run against a test workspace.");
+      }
+      break;
+  }
+
+  if (steps.length === 0) {
+    steps.push("Open each generated file in your editor and confirm paths match your repository layout.");
+  }
+
+  return steps;
+}
+
+function buildNextAction(downloaded: boolean): string[] {
+  if (downloaded) {
+    return [
+      "Unpack the zip into your repo, complete the review steps above, then commit only the files you trust.",
+    ];
+  }
+
+  return [
+    "Use Download Pack (or Copy All) to move files into your repo, then follow the review and validation steps.",
+  ];
+}
+
+export function buildInstallChecklist(
+  manifest: AgentPackManifest,
+  options: { downloaded?: boolean } = {},
+): InstallChecklistSection[] {
+  const { downloaded = false } = options;
+  const generatedFiles = manifest.files.map(
+    (file) => `Add ${file.path} to the matching path in your repository.`,
+  );
+
+  const reviewItems = buildReviewItems(manifest.files);
+  const validationSteps = buildValidationSteps(manifest.pack_type, manifest.files);
+
+  return [
+    {
+      id: "generatedFiles",
+      title: "Files in this pack",
+      items: generatedFiles,
+    },
+    {
+      id: "reviewFirst",
+      title: "Review before use",
+      items:
+        reviewItems.length > 0
+          ? reviewItems
+          : ["Skim every generated file for prompts, permissions, and project-specific assumptions."],
+    },
+    {
+      id: "validationSteps",
+      title: "Suggested validation",
+      items: validationSteps,
+    },
+    {
+      id: "nextAction",
+      title: downloaded ? "Downloaded — next step" : "Next step",
+      items: buildNextAction(downloaded),
+    },
+  ];
+}

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -88,8 +88,35 @@ describe("Agent Packs page", () => {
     expect(JSON.parse(options.body).pack_type).toBe("pr-reviewer");
 
     expect(await screen.findByText("Pack Preview")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Install & review checklist" })).toBeTruthy();
+    expect(screen.getByText("Review before use")).toBeTruthy();
     expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "agents" })).toBeTruthy();
+  });
+
+  test("renders pack-specific checklist guidance for project-pack output", async () => {
+    apiJson.mockResolvedValueOnce({
+      provider: "claude",
+      pack_type: "project-pack",
+      download_name: "saas-project-pack-claude",
+      preview_order: ["claude_md", "settings", "workflow"],
+      files: [
+        { path: "CLAUDE.md", content: "# Memory", kind: "claude_md" },
+        { path: ".claude/settings.json", content: "{}", kind: "settings" },
+        { path: ".github/workflows/claude.yml", content: "name: Claude", kind: "workflow" },
+      ],
+    });
+
+    render(<AgentPacksPage />);
+
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "Bootstrap a full Claude project pack." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+
+    expect(await screen.findByText("Install & review checklist")).toBeTruthy();
+    expect(screen.getByText(/Merge \.claude\/settings\.json carefully/i)).toBeTruthy();
+    expect(screen.getByText(/GitHub workflow YAML permissions/i)).toBeTruthy();
   });
 
   test("downloads the generated pack through the Claude download route", async () => {
@@ -121,6 +148,7 @@ describe("Agent Packs page", () => {
     expect(path).toBe("/agent-packs/claude/download");
     expect(JSON.parse(options.body).goal).toBe("Create a full project pack.");
     expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Downloaded")).toBeTruthy();
 
     // The blob URL is created for the download and cleaned up afterwards.
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
@@ -251,8 +279,9 @@ describe("Agent Packs page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /close pack preview/i }));
 
-    // The preview and its stale file-group labels are gone; the empty state returns.
+    // The preview, checklist, and stale file-group labels are gone; the empty state returns.
     await waitFor(() => expect(screen.queryByText("Pack Preview")).toBeNull());
+    expect(screen.queryByRole("heading", { name: "Install & review checklist" })).toBeNull();
     expect(screen.queryByRole("button", { name: "CLAUDE.md" })).toBeNull();
     expect(screen.getByText("Single-click pack generation")).toBeTruthy();
   });

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -8,6 +8,8 @@ import { Bot, Copy, Download, FileCode2, FolderArchive, ShieldCheck, Sparkles, X
 import { apiFetch, apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
 import InfoButton from "../components/InfoButton";
 import { showError } from "../lib/showError";
+import InstallChecklist from "./components/InstallChecklist";
+import { buildInstallChecklist } from "./installChecklist";
 import { agentPackProviders } from "./providerRegistry";
 import type {
   AgentPackFile,
@@ -85,6 +87,7 @@ export default function AgentPacksPage() {
   const [downloading, setDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copiedState, setCopiedState] = useState<"single" | "all" | null>(null);
+  const [downloaded, setDownloaded] = useState(false);
 
   const requestHeaders = useMemo(
     () => buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
@@ -108,6 +111,11 @@ export default function AgentPacksPage() {
     activeGroup?.files[0] ??
     null;
 
+  const installChecklist = useMemo(() => {
+    if (!manifest) return [];
+    return buildInstallChecklist(manifest, { downloaded });
+  }, [manifest, downloaded]);
+
   const handleFieldChange = <K extends keyof AgentPackRequest>(key: K, value: AgentPackRequest[K]) => {
     setRequest((prev) => ({ ...prev, [key]: value }));
   };
@@ -120,6 +128,7 @@ export default function AgentPacksPage() {
     setManifest(null);
     setActiveKind(null);
     setSelectedPath(null);
+    setDownloaded(false);
 
     try {
       const data = await apiJson<AgentPackManifest>("/agent-packs/claude", {
@@ -159,6 +168,7 @@ export default function AgentPacksPage() {
     setActiveKind(null);
     setSelectedPath(null);
     setCopiedState(null);
+    setDownloaded(false);
   };
 
   const handleDownload = async () => {
@@ -197,6 +207,7 @@ export default function AgentPacksPage() {
       anchor.click();
       anchor.remove();
       setTimeout(() => URL.revokeObjectURL(href), 0);
+      setDownloaded(true);
     } catch (err: unknown) {
       showError(err);
       setError(describeRequestError(err, { fallback: "Failed to download agent pack." }));
@@ -275,9 +286,8 @@ export default function AgentPacksPage() {
 
             <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm leading-relaxed text-amber-100/90">
               <div className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-amber-200">Experimental Feature</div>
-              Agent Packs is in active development and may produce incomplete or incorrect output for your specific project.
-              The generated files — Claude settings, agent definitions, and CI workflows — are a useful starting point,
-              but review and adjust each file carefully before committing. Some features may not work as expected in your repo.
+              Agent Packs is in beta and gives you a starting point, not a finished install. After generation, follow the
+              install checklist on the right, review sensitive files, then commit only what you trust.
             </div>
 
             <div className="grid gap-3 sm:grid-cols-2">
@@ -465,6 +475,8 @@ export default function AgentPacksPage() {
                     </button>
                   </div>
                 </div>
+
+                <InstallChecklist sections={installChecklist} downloaded={downloaded} />
 
                 <div className="flex flex-wrap gap-2 border-b border-white/5 px-4 py-3 sm:px-6">
                   {previewGroups.map((group) => (


### PR DESCRIPTION
## Summary
- Adds a manifest-driven install/review checklist on the Agent Packs preview panel after successful generation (issue #814 Milestone 1).
- Checklist sections cover generated file paths, review-first items (settings/workflows/agents/executables), pack-type validation steps, and next actions.
- Shortens the beta banner to point users at the checklist instead of a long warning wall.
- Marks the checklist as downloaded after a successful zip download.

## What this does for users
After generating a pack, solo developers get a concrete "what to do next" path: where files go, what to review first, and how to validate before committing.

## Risk
Low — additive frontend guidance only; no backend or generation behavior changes.

## Test plan
- [x] `cd web && npm run test -- app/agent-packs`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build`
- [ ] Manual: generate each pack type and confirm checklist content matches manifest files
- [ ] Manual: download pack and confirm "Downloaded" badge appears

Closes #814 for Milestone 1 scope.


Made with [Cursor](https://cursor.com)