### PR TITLE
feat: offline PR safety report analyzer and API

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -123,6 +123,7 @@ from api.routes.agent_packs import router as agent_packs_router  # noqa: E402
 from api.routes.export import router as export_router  # noqa: E402
 from api.routes.generators import router as generators_router  # noqa: E402
 from api.routes.meta import router as meta_router  # noqa: E402
+from api.routes.pr_safety import router as pr_safety_router  # noqa: E402
 from api.routes.rag import router as rag_router  # noqa: E402
 from app.routers.benchmark import router as benchmark_router  # noqa: E402
 from app.routers.jules import router as jules_router  # noqa: E402
@@ -132,6 +133,7 @@ app.include_router(compile_router)
 app.include_router(agent_packs_router)
 app.include_router(generators_router)
 app.include_router(export_router)
+app.include_router(pr_safety_router)
 app.include_router(rag_router)
 app.include_router(benchmark_router)
 app.include_router(jules_router)

--- a/api/routes/pr_safety.py
+++ b/api/routes/pr_safety.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from api.auth import rate_limit_by_ip
+from app.pr_safety.analyzer import analyze_pr_safety
+from app.pr_safety.models import PrSafetyReport
+
+router = APIRouter(tags=["pr-safety"])
+
+
+class PrSafetyReportRequest(BaseModel):
+    title: str = Field(..., min_length=1, description="Pull request title")
+    description: str = Field(..., min_length=1, description="Pull request description or body")
+    changed_files: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Changed file paths, one entry per path",
+    )
+    commits_behind: int | None = Field(
+        default=None,
+        ge=0,
+        description="Optional number of commits the branch is behind the base branch",
+    )
+
+
+@router.post("/pr-safety/report", response_model=PrSafetyReport)
+async def create_pr_safety_report(
+    req: PrSafetyReportRequest,
+    _: None = Depends(rate_limit_by_ip),
+) -> PrSafetyReport:
+    return analyze_pr_safety(
+        req.title,
+        req.description,
+        req.changed_files,
+        commits_behind=req.commits_behind,
+    )

--- a/app/pr_safety/analyzer.py
+++ b/app/pr_safety/analyzer.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from app.pr_safety.models import (
+    BranchFreshnessSection,
+    ChangedFilesSection,
+    FileGroup,
+    PrSafetyReport,
+    PrSafetyVerdict,
+    RiskyAreaHit,
+    RiskyAreasSection,
+    ScopeMatchSection,
+    TestCoverageSection,
+    TestGapSignal,
+)
+from app.pr_safety.path_rules import (
+    _SCOPE_FOCUS_TERMS,
+    detect_risky_areas,
+    extract_scope_terms,
+    group_changed_files,
+    list_source_files_needing_tests,
+    list_test_files,
+    normalize_paths,
+    path_reflects_scope_term,
+    top_level_directories,
+)
+
+STALE_COMMITS_THRESHOLD = 10
+SPLIT_FILE_COUNT_THRESHOLD = 15
+SPLIT_TOP_LEVEL_DIRS_THRESHOLD = 4
+SPLIT_MIN_FILES_FOR_DIRS = 8
+
+_HIGH_RISK_CATEGORIES = frozenset({"auth", "secrets", "migrations", "api", "infrastructure"})
+
+
+def analyze_pr_safety(
+    title: str,
+    description: str,
+    changed_files: list[str],
+    *,
+    commits_behind: int | None = None,
+) -> PrSafetyReport:
+    files = normalize_paths(changed_files)
+    grouped = group_changed_files(files)
+    risky_hits = _build_risky_areas(files)
+    test_section = _build_test_coverage(files)
+    branch_section = _build_branch_freshness(commits_behind)
+    scope_section = _build_scope_match(title, description, files)
+
+    verdict = _pick_verdict(
+        files=files,
+        risky_hits=risky_hits,
+        test_section=test_section,
+        branch_section=branch_section,
+        scope_section=scope_section,
+    )
+    recommendations = _build_recommendations(
+        verdict=verdict,
+        files=files,
+        grouped=grouped,
+        risky_hits=risky_hits,
+        test_section=test_section,
+        branch_section=branch_section,
+        scope_section=scope_section,
+    )
+
+    return PrSafetyReport(
+        verdict=verdict,
+        title=title.strip(),
+        changed_files=ChangedFilesSection(
+            total=len(files),
+            groups=[FileGroup(name=name, files=paths) for name, paths in sorted(grouped.items())],
+        ),
+        risky_areas=risky_hits,
+        test_coverage=test_section,
+        branch_freshness=branch_section,
+        scope_match=scope_section,
+        recommendations=recommendations,
+    )
+
+
+def _build_risky_areas(files: list[str]) -> RiskyAreasSection:
+    hits = [
+        RiskyAreaHit(category=category, file=file, reason=reason)
+        for category, file, reason in detect_risky_areas(files)
+    ]
+    status = "hit" if hits else "ok"
+    return RiskyAreasSection(hits=hits, status=status)
+
+
+def _build_test_coverage(files: list[str]) -> TestCoverageSection:
+    test_files = list_test_files(files)
+    source_files = list_source_files_needing_tests(files)
+    gaps: list[TestGapSignal] = []
+
+    if not source_files:
+        return TestCoverageSection(status="ok", gaps=gaps, test_files=test_files)
+
+    for source_file in source_files:
+        if _has_related_test_file(source_file, test_files):
+            continue
+        gaps.append(
+            TestGapSignal(
+                file=source_file,
+                reason="Source file changed without a matching test file in this PR",
+            )
+        )
+
+    status = "gap" if gaps else "ok"
+    return TestCoverageSection(status=status, gaps=gaps, test_files=test_files)
+
+
+def _has_related_test_file(source_file: str, test_files: list[str]) -> bool:
+    if not test_files:
+        return False
+
+    stem = source_file.rsplit("/", 1)[-1]
+    module = stem.rsplit(".", 1)[0]
+    candidates = {
+        module,
+        module.replace("_", "-"),
+        f"test_{module}",
+        f"{module}_test",
+    }
+
+    for test_file in test_files:
+        test_name = test_file.rsplit("/", 1)[-1].lower()
+        if any(candidate and candidate.lower() in test_name for candidate in candidates):
+            return True
+        if source_file.rsplit("/", 1)[-1] in test_file:
+            return True
+
+    return False
+
+
+def _build_branch_freshness(commits_behind: int | None) -> BranchFreshnessSection:
+    if commits_behind is None:
+        return BranchFreshnessSection(
+            status="unknown",
+            commits_behind=None,
+            notes=["Branch freshness was not provided"],
+        )
+
+    if commits_behind < 0:
+        commits_behind = 0
+
+    if commits_behind >= STALE_COMMITS_THRESHOLD:
+        return BranchFreshnessSection(
+            status="stale",
+            commits_behind=commits_behind,
+            notes=[f"Branch is {commits_behind} commits behind the base branch"],
+        )
+
+    return BranchFreshnessSection(
+        status="ok",
+        commits_behind=commits_behind,
+        notes=[f"Branch is {commits_behind} commits behind the base branch"],
+    )
+
+
+def _build_scope_match(title: str, description: str, files: list[str]) -> ScopeMatchSection:
+    if not files:
+        return ScopeMatchSection(status="mismatch", notes=["No changed files were provided"])
+
+    terms = extract_scope_terms(title, description)
+    focus_terms = [term for term in terms if term in _SCOPE_FOCUS_TERMS]
+
+    missing_terms = [
+        term
+        for term in focus_terms
+        if not any(path_reflects_scope_term(path, term) for path in files)
+    ]
+    notes: list[str] = []
+
+    if missing_terms:
+        notes.append(
+            "PR description mentions focus areas that are not reflected in changed files: "
+            + ", ".join(missing_terms)
+        )
+
+    top_levels = top_level_directories(files)
+    if len(top_levels) >= SPLIT_TOP_LEVEL_DIRS_THRESHOLD and len(files) >= SPLIT_MIN_FILES_FOR_DIRS:
+        narrow_scope = bool(focus_terms) and len(focus_terms) <= 2
+        if narrow_scope:
+            notes.append(
+                "PR scope appears narrow but changes span many top-level directories: "
+                + ", ".join(top_levels)
+            )
+
+    status = "mismatch" if notes else "ok"
+    return ScopeMatchSection(status=status, notes=notes)
+
+
+def _pick_verdict(
+    *,
+    files: list[str],
+    risky_hits: RiskyAreasSection,
+    test_section: TestCoverageSection,
+    branch_section: BranchFreshnessSection,
+    scope_section: ScopeMatchSection,
+) -> PrSafetyVerdict:
+    if branch_section.status == "stale":
+        return "rebase"
+
+    if _should_split(files):
+        return "split"
+
+    if _should_hold(risky_hits, test_section, scope_section):
+        return "hold"
+
+    return "merge"
+
+
+def _should_split(files: list[str]) -> bool:
+    if len(files) >= SPLIT_FILE_COUNT_THRESHOLD:
+        return True
+
+    top_levels = top_level_directories(files)
+    return (
+        len(top_levels) >= SPLIT_TOP_LEVEL_DIRS_THRESHOLD and len(files) >= SPLIT_MIN_FILES_FOR_DIRS
+    )
+
+
+def _should_hold(
+    risky_hits: RiskyAreasSection,
+    test_section: TestCoverageSection,
+    scope_section: ScopeMatchSection,
+) -> bool:
+    if scope_section.status == "mismatch":
+        return True
+    if test_section.status == "gap":
+        return True
+    if not risky_hits.hits:
+        return False
+
+    categories = {hit.category for hit in risky_hits.hits}
+    if categories & _HIGH_RISK_CATEGORIES:
+        return True
+
+    return len(risky_hits.hits) >= 2
+
+
+def _build_recommendations(
+    *,
+    verdict: PrSafetyVerdict,
+    files: list[str],
+    grouped: dict[str, list[str]],
+    risky_hits: RiskyAreasSection,
+    test_section: TestCoverageSection,
+    branch_section: BranchFreshnessSection,
+    scope_section: ScopeMatchSection,
+) -> list[str]:
+    recommendations: list[str] = []
+
+    if verdict == "rebase":
+        recommendations.append("Rebase onto the latest base branch before merging")
+    elif verdict == "split":
+        recommendations.append("Split this PR into smaller, focused changesets")
+    elif verdict == "hold":
+        recommendations.append("Hold merge until the flagged safety signals are addressed")
+    else:
+        recommendations.append("No blocking safety signals detected; proceed with normal review")
+
+    if branch_section.status == "stale" and verdict != "rebase":
+        recommendations.append("Consider rebasing to reduce merge conflict risk")
+
+    if scope_section.status == "mismatch":
+        recommendations.extend(scope_section.notes)
+
+    for gap in test_section.gaps[:5]:
+        recommendations.append(f"Add or update tests covering `{gap.file}`")
+
+    secret_hits = [hit for hit in risky_hits.hits if hit.category == "secrets"]
+    if secret_hits:
+        recommendations.append("Review environment and secret files carefully before merge")
+
+    auth_hits = [hit for hit in risky_hits.hits if hit.category == "auth"]
+    if auth_hits and test_section.status == "gap":
+        recommendations.append("Auth-related changes should include explicit test coverage")
+
+    if len(files) >= SPLIT_FILE_COUNT_THRESHOLD and verdict != "split":
+        recommendations.append("Large PRs are harder to review safely; consider splitting")
+
+    if grouped.get("docs") and len(grouped) == 1:
+        recommendations.append("Docs-only change; lightweight review should be sufficient")
+
+    return _dedupe_preserve_order(recommendations)
+
+
+def _dedupe_preserve_order(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result

--- a/app/pr_safety/models.py
+++ b/app/pr_safety/models.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+PrSafetyVerdict = Literal["merge", "hold", "split", "rebase"]
+
+SignalStatus = Literal["ok", "gap", "mismatch", "stale", "unknown", "hit"]
+
+
+class FileGroup(BaseModel):
+    name: str
+    files: list[str] = Field(default_factory=list)
+
+
+class ChangedFilesSection(BaseModel):
+    total: int = 0
+    groups: list[FileGroup] = Field(default_factory=list)
+
+
+class RiskyAreaHit(BaseModel):
+    category: str
+    file: str
+    reason: str
+
+
+class RiskyAreasSection(BaseModel):
+    hits: list[RiskyAreaHit] = Field(default_factory=list)
+    status: SignalStatus = "ok"
+
+
+class TestGapSignal(BaseModel):
+    file: str
+    reason: str
+
+
+class TestCoverageSection(BaseModel):
+    status: SignalStatus = "ok"
+    gaps: list[TestGapSignal] = Field(default_factory=list)
+    test_files: list[str] = Field(default_factory=list)
+
+
+class BranchFreshnessSection(BaseModel):
+    status: SignalStatus = "unknown"
+    commits_behind: int | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class ScopeMatchSection(BaseModel):
+    status: SignalStatus = "ok"
+    notes: list[str] = Field(default_factory=list)
+
+
+class PrSafetyReport(BaseModel):
+    verdict: PrSafetyVerdict
+    title: str
+    changed_files: ChangedFilesSection
+    risky_areas: RiskyAreasSection
+    test_coverage: TestCoverageSection
+    branch_freshness: BranchFreshnessSection
+    scope_match: ScopeMatchSection
+    recommendations: list[str] = Field(default_factory=list)

--- a/app/pr_safety/path_rules.py
+++ b/app/pr_safety/path_rules.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import re
+from fnmatch import fnmatch
+
+SOURCE_EXTENSIONS = {
+    ".py",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".go",
+    ".rs",
+    ".java",
+    ".kt",
+    ".rb",
+    ".php",
+    ".cs",
+    ".swift",
+    ".m",
+    ".mm",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".h",
+    ".hpp",
+}
+
+DOC_EXTENSIONS = {".md", ".rst", ".txt", ".adoc"}
+
+CONFIG_EXTENSIONS = {".yaml", ".yml", ".json", ".toml", ".ini", ".cfg", ".conf"}
+
+TEST_FILE_PATTERNS = (
+    "test_*.py",
+    "*_test.py",
+    "*_test.go",
+    "*.test.ts",
+    "*.test.tsx",
+    "*.test.js",
+    "*.test.jsx",
+    "*.spec.ts",
+    "*.spec.tsx",
+    "*.spec.js",
+    "*.spec.jsx",
+    "tests/*",
+    "test/*",
+    "__tests__/*",
+    "**/tests/*",
+    "**/test/*",
+    "**/__tests__/*",
+)
+
+RISKY_AREA_RULES: tuple[tuple[str, tuple[str, ...], str], ...] = (
+    (
+        "auth",
+        (
+            "*auth*",
+            "*login*",
+            "*session*",
+            "*permission*",
+            "*oauth*",
+            "*credential*",
+        ),
+        "Touches authentication or authorization code",
+    ),
+    (
+        "secrets",
+        (
+            ".env",
+            ".env.*",
+            "*secret*",
+            "*credentials*",
+            "*.pem",
+            "*.key",
+        ),
+        "Touches secret or environment configuration",
+    ),
+    (
+        "migrations",
+        (
+            "*/migrations/*",
+            "*/alembic/*",
+            "*migration*",
+        ),
+        "Touches database migration files",
+    ),
+    (
+        "ci",
+        (
+            ".github/workflows/*",
+            ".gitlab-ci.yml",
+            "azure-pipelines.yml",
+        ),
+        "Touches CI/CD workflow configuration",
+    ),
+    (
+        "api",
+        (
+            "api/routes/*",
+            "*/routes/*",
+            "*/endpoints/*",
+            "*/controllers/*",
+        ),
+        "Touches API route or controller code",
+    ),
+    (
+        "infrastructure",
+        (
+            "Dockerfile",
+            "docker-compose*.yml",
+            "docker-compose*.yaml",
+            "fly.toml",
+            "*.tf",
+            "terraform/*",
+            "infra/*",
+        ),
+        "Touches infrastructure or deployment configuration",
+    ),
+)
+
+GROUP_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("tests", TEST_FILE_PATTERNS),
+    ("docs", ("docs/*", "doc/*", "*.md", "*.rst", "README*", "CHANGELOG*")),
+    ("migrations", ("*/migrations/*", "*/alembic/*", "*migration*")),
+    ("ci", (".github/*", ".gitlab-ci.yml", "azure-pipelines.yml")),
+    ("auth", ("*auth*", "*login*", "*session*", "*permission*", "*oauth*")),
+    ("secrets", (".env", ".env.*", "*secret*", "*credentials*")),
+    ("config", ("*.yaml", "*.yml", "*.json", "*.toml", "*.ini", "*.cfg", "config/*")),
+)
+
+_SCOPE_FOCUS_TERMS = (
+    "auth",
+    "login",
+    "logout",
+    "signup",
+    "password",
+    "session",
+    "oauth",
+    "payment",
+    "billing",
+    "migration",
+    "database",
+    "api",
+    "endpoint",
+    "security",
+    "permission",
+    "deploy",
+    "docker",
+    "terraform",
+    "readme",
+    "docs",
+    "test",
+    "tests",
+)
+
+_STOP_WORDS = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "with",
+        "this",
+        "that",
+        "from",
+        "into",
+        "add",
+        "fix",
+        "update",
+        "change",
+        "changes",
+        "feat",
+        "chore",
+        "refactor",
+        "pull",
+        "request",
+        "make",
+        "use",
+        "using",
+        "new",
+        "only",
+        "also",
+        "will",
+        "should",
+        "have",
+        "has",
+        "been",
+        "are",
+        "was",
+        "were",
+    }
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9._/-]*[a-z0-9]|[a-z0-9]")
+
+
+def normalize_path(path: str) -> str:
+    return path.strip().replace("\\", "/")
+
+
+def normalize_paths(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for raw in paths:
+        path = normalize_path(raw)
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        normalized.append(path)
+    return normalized
+
+
+def _matches_any_pattern(path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch(path, pattern) for pattern in patterns)
+
+
+def is_test_file(path: str) -> bool:
+    normalized = normalize_path(path)
+    return _matches_any_pattern(normalized, TEST_FILE_PATTERNS)
+
+
+def is_doc_file(path: str) -> bool:
+    normalized = normalize_path(path)
+    if _matches_any_pattern(normalized, ("docs/*", "doc/*", "README*", "CHANGELOG*")):
+        return True
+    _, dot, ext = normalized.rpartition(".")
+    return bool(dot) and f".{ext.lower()}" in DOC_EXTENSIONS
+
+
+def is_config_file(path: str) -> bool:
+    normalized = normalize_path(path)
+    if _matches_any_pattern(
+        normalized, ("config/*", "*.yaml", "*.yml", "*.json", "*.toml", "*.ini", "*.cfg")
+    ):
+        return True
+    _, dot, ext = normalized.rpartition(".")
+    return bool(dot) and f".{ext.lower()}" in CONFIG_EXTENSIONS
+
+
+def is_source_file(path: str) -> bool:
+    normalized = normalize_path(path)
+    if is_test_file(normalized) or is_doc_file(normalized) or is_config_file(normalized):
+        return False
+    _, dot, ext = normalized.rpartition(".")
+    return bool(dot) and f".{ext.lower()}" in SOURCE_EXTENSIONS
+
+
+def group_changed_files(paths: list[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {
+        "source": [],
+        "tests": [],
+        "docs": [],
+        "config": [],
+        "migrations": [],
+        "ci": [],
+        "auth": [],
+        "secrets": [],
+        "other": [],
+    }
+
+    for path in normalize_paths(paths):
+        assigned = False
+        for group_name, patterns in GROUP_RULES:
+            if _matches_any_pattern(path, patterns):
+                groups[group_name].append(path)
+                assigned = True
+                break
+        if not assigned:
+            if is_source_file(path):
+                groups["source"].append(path)
+            elif is_doc_file(path):
+                groups["docs"].append(path)
+            elif is_config_file(path):
+                groups["config"].append(path)
+            else:
+                groups["other"].append(path)
+
+    return {name: files for name, files in groups.items() if files}
+
+
+def detect_risky_areas(paths: list[str]) -> list[tuple[str, str, str]]:
+    hits: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for path in normalize_paths(paths):
+        for category, patterns, reason in RISKY_AREA_RULES:
+            if not _matches_any_pattern(path, patterns):
+                continue
+            key = (category, path)
+            if key in seen:
+                continue
+            seen.add(key)
+            hits.append((category, path, reason))
+
+    return hits
+
+
+def list_test_files(paths: list[str]) -> list[str]:
+    return [path for path in normalize_paths(paths) if is_test_file(path)]
+
+
+def list_source_files_needing_tests(paths: list[str]) -> list[str]:
+    return [path for path in normalize_paths(paths) if is_source_file(path)]
+
+
+def top_level_directories(paths: list[str]) -> list[str]:
+    roots: set[str] = set()
+    for path in normalize_paths(paths):
+        parts = path.split("/")
+        if len(parts) > 1:
+            roots.add(parts[0])
+        else:
+            roots.add(path)
+    return sorted(roots)
+
+
+def extract_scope_terms(title: str, description: str) -> list[str]:
+    text = f"{title}\n{description}".lower()
+    tokens = _TOKEN_RE.findall(text)
+    terms: list[str] = []
+    seen: set[str] = set()
+
+    for token in tokens:
+        cleaned = token.strip("./")
+        if not cleaned or cleaned in _STOP_WORDS or len(cleaned) < 3:
+            continue
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        terms.append(cleaned)
+
+    for term in _SCOPE_FOCUS_TERMS:
+        if term in text and term not in seen:
+            seen.add(term)
+            terms.append(term)
+
+    return terms
+
+
+def path_reflects_scope_term(path: str, term: str) -> bool:
+    normalized = normalize_path(path).lower()
+    if term in normalized:
+        return True
+    stem = normalized.rsplit("/", 1)[-1]
+    stem = stem.rsplit(".", 1)[0]
+    return term in stem.replace("_", " ").replace("-", " ")

--- a/tests/test_pr_safety.py
+++ b/tests/test_pr_safety.py
@@ -1,0 +1,157 @@
+from app.pr_safety.analyzer import analyze_pr_safety
+from app.pr_safety.path_rules import top_level_directories
+
+
+def test_docs_only_pr_recommends_merge():
+    report = analyze_pr_safety(
+        title="docs: update README",
+        description="Document the new install steps for contributors.",
+        changed_files=["README.md", "docs/contributing.md"],
+    )
+
+    assert report.verdict == "merge"
+    assert report.changed_files.total == 2
+    assert "docs" in {group.name for group in report.changed_files.groups}
+    assert report.risky_areas.status == "ok"
+    assert report.test_coverage.status == "ok"
+    assert report.scope_match.status == "ok"
+    assert any("Docs-only" in item for item in report.recommendations)
+
+
+def test_auth_change_without_tests_recommends_hold():
+    report = analyze_pr_safety(
+        title="feat: add login flow",
+        description="Add session-based login endpoints for the API.",
+        changed_files=[
+            "api/routes/auth.py",
+            "app/models/user.py",
+        ],
+    )
+
+    assert report.verdict == "hold"
+    assert report.test_coverage.status == "gap"
+    assert {gap.file for gap in report.test_coverage.gaps} == {
+        "api/routes/auth.py",
+        "app/models/user.py",
+    }
+    assert any(hit.category == "auth" for hit in report.risky_areas.hits)
+    assert any("tests" in item.lower() for item in report.recommendations)
+
+
+def test_env_file_change_flags_risky_area_and_hold():
+    report = analyze_pr_safety(
+        title="chore: update local env template",
+        description="Refresh example environment variables for development.",
+        changed_files=[".env.example", "README.md"],
+    )
+
+    assert report.verdict == "hold"
+    assert any(hit.category == "secrets" for hit in report.risky_areas.hits)
+    assert any(hit.file == ".env.example" for hit in report.risky_areas.hits)
+    assert any("secret" in item.lower() for item in report.recommendations)
+
+
+def test_many_files_across_directories_recommends_split():
+    changed_files = [
+        "api/routes/users.py",
+        "web/app/dashboard/page.tsx",
+        "cli/commands/deploy.py",
+        "integrations/mcp-server/server.py",
+        "app/compiler.py",
+        "tests/test_compiler.py",
+        "docs/architecture.md",
+        "scripts/migrate.py",
+        "config/settings.yaml",
+        ".github/workflows/ci.yml",
+        "app/models_v2.py",
+        "app/emitters.py",
+        "api/main.py",
+        "web/app/page.tsx",
+        "tests/test_api.py",
+        "README.md",
+    ]
+
+    report = analyze_pr_safety(
+        title="feat: platform-wide refactor",
+        description="Refactor compiler, API, web UI, CLI, and integrations together.",
+        changed_files=changed_files,
+    )
+
+    assert report.verdict == "split"
+    assert report.changed_files.total == 16
+    assert len(top_level_directories(changed_files)) >= 4
+    assert any("split" in item.lower() for item in report.recommendations)
+
+
+def test_commits_behind_threshold_recommends_rebase():
+    report = analyze_pr_safety(
+        title="fix: handle null session",
+        description="Guard against missing session state in auth middleware.",
+        changed_files=["api/routes/auth.py", "tests/test_auth.py"],
+        commits_behind=12,
+    )
+
+    assert report.verdict == "rebase"
+    assert report.branch_freshness.status == "stale"
+    assert report.branch_freshness.commits_behind == 12
+    assert any("rebase" in item.lower() for item in report.recommendations)
+
+
+def test_matching_test_files_clear_test_gap():
+    report = analyze_pr_safety(
+        title="feat: add login flow",
+        description="Add session-based login endpoints for the API.",
+        changed_files=[
+            "api/routes/auth.py",
+            "tests/test_auth.py",
+        ],
+    )
+
+    assert report.test_coverage.status == "ok"
+    assert report.test_coverage.test_files == ["tests/test_auth.py"]
+    assert report.test_coverage.gaps == []
+    assert report.verdict in {"merge", "hold"}
+    if report.verdict == "hold":
+        assert report.risky_areas.hits
+
+
+def test_scope_mismatch_when_description_focus_is_missing_from_files():
+    report = analyze_pr_safety(
+        title="fix: login redirect bug",
+        description="Fix the login redirect bug in the auth middleware.",
+        changed_files=["docs/CONTRIBUTING.md"],
+    )
+
+    assert report.scope_match.status == "mismatch"
+    assert report.verdict == "hold"
+    assert any(
+        "login" in note.lower() or "auth" in note.lower() for note in report.scope_match.notes
+    )
+
+
+def test_unknown_branch_freshness_when_commits_behind_not_provided():
+    report = analyze_pr_safety(
+        title="docs: tweak changelog",
+        description="Clarify release notes.",
+        changed_files=["CHANGELOG.md"],
+    )
+
+    assert report.branch_freshness.status == "unknown"
+    assert report.branch_freshness.commits_behind is None
+
+
+def test_changed_files_are_grouped_deterministically():
+    report = analyze_pr_safety(
+        title="feat: auth and workflow updates",
+        description="Update auth routes and CI workflow.",
+        changed_files=[
+            "api/routes/auth.py",
+            ".github/workflows/ci.yml",
+            "tests/test_auth.py",
+        ],
+    )
+
+    groups = {group.name: group.files for group in report.changed_files.groups}
+    assert groups["auth"] == ["api/routes/auth.py"]
+    assert groups["ci"] == [".github/workflows/ci.yml"]
+    assert groups["tests"] == ["tests/test_auth.py"]

--- a/tests/test_pr_safety_api.py
+++ b/tests/test_pr_safety_api.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from app.pr_safety.analyzer import analyze_pr_safety
+
+client = TestClient(app)
+
+FIXTURE_PAYLOAD = {
+    "title": "feat: add login flow",
+    "description": "Add session-based login endpoints for the API.",
+    "changed_files": [
+        "api/routes/auth.py",
+        "tests/test_auth.py",
+    ],
+}
+
+
+def test_pr_safety_report_returns_expected_json_shape():
+    response = client.post("/pr-safety/report", json=FIXTURE_PAYLOAD)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["verdict"] in {"merge", "hold", "split", "rebase"}
+    assert data["title"] == FIXTURE_PAYLOAD["title"]
+    assert data["changed_files"]["total"] == 2
+    assert "groups" in data["changed_files"]
+    assert "hits" in data["risky_areas"]
+    assert "gaps" in data["test_coverage"]
+    assert "status" in data["branch_freshness"]
+    assert "status" in data["scope_match"]
+    assert isinstance(data["recommendations"], list)
+
+
+def test_pr_safety_report_matches_offline_analyzer_fixture():
+    response = client.post("/pr-safety/report", json=FIXTURE_PAYLOAD)
+    expected = analyze_pr_safety(
+        FIXTURE_PAYLOAD["title"],
+        FIXTURE_PAYLOAD["description"],
+        FIXTURE_PAYLOAD["changed_files"],
+    )
+
+    assert response.status_code == 200
+    assert response.json() == json.loads(expected.model_dump_json())
+
+
+def test_pr_safety_report_is_deterministic_for_fixture_input():
+    first = client.post("/pr-safety/report", json=FIXTURE_PAYLOAD)
+    second = client.post("/pr-safety/report", json=FIXTURE_PAYLOAD)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+
+
+def test_pr_safety_report_accepts_optional_commits_behind():
+    payload = {**FIXTURE_PAYLOAD, "commits_behind": 12}
+    response = client.post("/pr-safety/report", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["verdict"] == "rebase"
+    assert data["branch_freshness"]["commits_behind"] == 12
+    assert data["branch_freshness"]["status"] == "stale"
+
+
+def test_pr_safety_report_omits_commits_behind_by_default():
+    response = client.post("/pr-safety/report", json=FIXTURE_PAYLOAD)
+
+    assert response.status_code == 200
+    assert response.json()["branch_freshness"]["status"] == "unknown"
+    assert response.json()["branch_freshness"]["commits_behind"] is None
+
+
+def test_pr_safety_report_validation_error_when_required_fields_missing():
+    response = client.post("/pr-safety/report", json={})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    missing_fields = {item["loc"][-1] for item in detail}
+    assert missing_fields == {"title", "description", "changed_files"}
+
+
+def test_pr_safety_report_validation_error_when_changed_files_empty():
+    response = client.post(
+        "/pr-safety/report",
+        json={
+            "title": "docs: update README",
+            "description": "Refresh contributor docs.",
+            "changed_files": [],
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_pr_safety_report_does_not_require_external_api_keys(monkeypatch):
+    for key in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ADMIN_API_KEY",
+        "PROMPTC_SERVER_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    response = client.post("/pr-safety/report", json=FIXTURE_PAYLOAD)
+
+    assert response.status_code == 200
+    assert os.environ.get("OPENROUTER_API_KEY") is None


### PR DESCRIPTION
## Summary
- Add an offline, deterministic PR safety analyzer (`analyze_pr_safety`) that scores pasted PR context for merge readiness: file groups, risky paths, test gaps, branch staleness, scope mismatch, and a verdict (`merge` / `hold` / `split` / `rebase`).
- Expose the analyzer via `POST /pr-safety/report`, returning structured `PrSafetyReport` JSON with no LLM, GitHub API, auth, or external API keys required.
- Cover the analyzer and API with focused pytest suites (17 tests total).

## Test plan
- [x] `python -m pytest tests/test_pr_safety.py tests/test_pr_safety_api.py -v`
- [x] `ruff check api/routes/pr_safety.py api/main.py tests/test_pr_safety_api.py app/pr_safety/`
- [ ] `curl -X POST http://127.0.0.1:8080/pr-safety/report` with sample title/description/changed_files
- [ ] Confirm missing required fields return `422`


Made with [Cursor](https://cursor.com)