### PR TITLE
test: pure utility helpers in app/emitters.py have no test coverage

### DIFF
--- a/tests/test_emitters_utils.py
+++ b/tests/test_emitters_utils.py
@@ -6,8 +6,6 @@ no model imports) and are safe to call in isolation.
 
 from __future__ import annotations
 
-import pytest
-
 from app.emitters import (
     _clean_domain_suggestion_text,
     _contains_any_marker,
@@ -131,7 +129,7 @@ class TestCleanDomainSuggestionText:
 
     def test_whitespace_normalized(self) -> None:
         result = _clean_domain_suggestion_text("  Review   the code  ")
-        assert result == "Review   the code"
+        assert result == "Review the code"
 
     def test_ok_prefix_stripped_before_use(self) -> None:
         assert _clean_domain_suggestion_text("Ok: Use type hints") == "Use type hints"

--- a/tests/test_emitters_utils.py
+++ b/tests/test_emitters_utils.py
@@ -1,0 +1,137 @@
+"""Unit tests for pure utility helpers in app/emitters.py.
+
+Functions under test have no external dependencies (no env reads, no I/O,
+no model imports) and are safe to call in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.emitters import (
+    _clean_domain_suggestion_text,
+    _contains_any_marker,
+    _is_trivial_input,
+    _minimal_greeting_prompt,
+)
+
+
+class TestIsTrivialInput:
+    """Short/greeting inputs below the 30-char threshold in the general domain."""
+
+    def test_short_general_low_is_trivial(self) -> None:
+        assert _is_trivial_input("hi", "general", "low") is True
+
+    def test_short_general_none_complexity_is_trivial(self) -> None:
+        assert _is_trivial_input("hello", "general", None) is True  # type: ignore[arg-type]
+
+    def test_short_general_empty_complexity_is_trivial(self) -> None:
+        assert _is_trivial_input("hey", "general", "") is True
+
+    def test_non_general_domain_not_trivial(self) -> None:
+        assert _is_trivial_input("hi", "coding", "low") is False
+
+    def test_long_text_not_trivial(self) -> None:
+        long_text = "a" * 30
+        assert _is_trivial_input(long_text, "general", "low") is False
+
+    def test_high_complexity_not_trivial(self) -> None:
+        assert _is_trivial_input("hi", "general", "high") is False
+
+    def test_leading_trailing_whitespace_stripped_before_length_check(self) -> None:
+        # 28 spaces + "hi" = 30 chars total, but stripped = "hi" (2 chars) → trivial
+        assert _is_trivial_input("  hi  ", "general", "low") is True
+
+    def test_exactly_29_chars_is_trivial(self) -> None:
+        assert _is_trivial_input("a" * 29, "general", "low") is True
+
+
+class TestContainsAnyMarker:
+    """Fast-path substring search over a tuple of marker strings."""
+
+    def test_matching_marker_returns_true(self) -> None:
+        assert _contains_any_marker("merhaba arkadas", ("merhaba", "selam")) is True
+
+    def test_second_marker_matches(self) -> None:
+        assert _contains_any_marker("hey selam", ("merhaba", "selam")) is True
+
+    def test_no_matching_marker_returns_false(self) -> None:
+        assert _contains_any_marker("hello world", ("merhaba", "selam")) is False
+
+    def test_empty_text_returns_false(self) -> None:
+        assert _contains_any_marker("", ("merhaba",)) is False
+
+    def test_empty_markers_returns_false(self) -> None:
+        assert _contains_any_marker("merhaba", ()) is False
+
+    def test_case_sensitive_no_match(self) -> None:
+        assert _contains_any_marker("MERHABA", ("merhaba",)) is False
+
+    def test_partial_substring_match(self) -> None:
+        assert _contains_any_marker("slm nasilsin", ("slm",)) is True
+
+
+class TestMinimalGreetingPrompt:
+    """Language detection and prompt structure for short/greeting inputs."""
+
+    def test_english_text_returns_english_prompt(self) -> None:
+        result = _minimal_greeting_prompt("hi", "en")
+        assert 'User message: "hi"' in result
+        assert "Reply briefly" in result
+
+    def test_turkish_lang_returns_turkish_prompt(self) -> None:
+        result = _minimal_greeting_prompt("hey", "tr")
+        assert 'Kullanici mesaji: "hey"' in result
+        assert "Asagidaki" in result
+
+    def test_turkish_marker_in_english_lang_returns_turkish_prompt(self) -> None:
+        result = _minimal_greeting_prompt("merhaba", "en")
+        assert "Asagidaki" in result
+        assert 'Kullanici mesaji: "merhaba"' in result
+
+    def test_empty_text_en_defaults_to_hello(self) -> None:
+        result = _minimal_greeting_prompt("", "en")
+        assert 'User message: "hello"' in result
+
+    def test_empty_text_tr_defaults_to_merhaba(self) -> None:
+        result = _minimal_greeting_prompt("", "tr")
+        assert 'Kullanici mesaji: "merhaba"' in result
+
+    def test_whitespace_collapsed_in_output(self) -> None:
+        result = _minimal_greeting_prompt("hello   world", "en")
+        assert 'User message: "hello world"' in result
+
+    def test_slm_marker_triggers_turkish_prompt(self) -> None:
+        result = _minimal_greeting_prompt("slm", "en")
+        assert "Asagidaki" in result
+
+
+class TestCleanDomainSuggestionText:
+    """Strips short prefixes before named action markers."""
+
+    def test_no_prefix_returns_unchanged(self) -> None:
+        assert _clean_domain_suggestion_text("Include error handling") == "Include error handling"
+
+    def test_tip_prefix_stripped_before_include(self) -> None:
+        assert _clean_domain_suggestion_text("Tip: Include logging") == "Include logging"
+
+    def test_short_prefix_stripped_before_add(self) -> None:
+        assert _clean_domain_suggestion_text("A: Add validation") == "Add validation"
+
+    def test_numbered_prefix_stripped_before_consider(self) -> None:
+        assert _clean_domain_suggestion_text("1. Consider edge cases") == "Consider edge cases"
+
+    def test_long_prefix_not_stripped(self) -> None:
+        # Marker at position > 8 → not stripped
+        text = "Some long prefix Add something"
+        assert _clean_domain_suggestion_text(text) == text
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert _clean_domain_suggestion_text("") == ""
+
+    def test_whitespace_normalized(self) -> None:
+        result = _clean_domain_suggestion_text("  Review   the code  ")
+        assert result == "Review   the code"
+
+    def test_ok_prefix_stripped_before_use(self) -> None:
+        assert _clean_domain_suggestion_text("Ok: Use type hints") == "Use type hints"


### PR DESCRIPTION
## Summary

Adds `tests/test_emitters_utils.py` with unit tests for four pure helper functions in `app/emitters.py` that had zero coverage. These functions drive the conservative-mode greeting path and domain-suggestion deduplication logic.

### Functions under test

All four are side-effect-free (no env reads, no I/O, no model instantiation):

| Function | Role |
|---|---|
| `_is_trivial_input(text, domain, complexity)` | Gates conservative-mode template bypass for short/greeting inputs |
| `_contains_any_marker(text, markers)` | Fast-path substring check used for Turkish language detection |
| `_minimal_greeting_prompt(text, lang)` | Returns language-appropriate inline prompt for trivial inputs |
| `_clean_domain_suggestion_text(text)` | Strips short prefixes (≤8 chars) before named action markers |

### Test classes

**`TestIsTrivialInput`** (8 tests) — boundary conditions on the 30-char length gate, domain check, complexity values (`"low"`, `None`, `""`), and whitespace stripping before length measurement.

**`TestContainsAnyMarker`** (7 tests) — matching/non-matching markers, empty text, empty marker tuple, case sensitivity (no match on `"MERHABA"` vs `"merhaba"`), partial substring match.

**`TestMinimalGreetingPrompt`** (7 tests) — English vs Turkish output routing, empty-text defaults (`"hello"` / `"merhaba"`), whitespace collapsing, Turkish-marker detection when `lang="en"`, `"slm"` shorthand trigger.

**`TestCleanDomainSuggestionText`** (8 tests) — no-prefix pass-through, short-prefix stripping (`"Tip:"`, `"A:"`, `"1."`, `"Ok:"`), long-prefix not stripped (position > 8), empty string, whitespace normalization.

### Test count
30 tests total.

## Test plan
- [ ] `python -m pytest tests/test_emitters_utils.py -v` passes with 0 failures
- [ ] No source files modified — only new test file added
- [ ] No `.env`, config, lockfile, or CI changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPYz7KruCnV4om157tWdfb)_