### PR TITLE
docs(pr-safety): add GitHub Action advisory report sketch

### DIFF
--- a/docs/pr-safety-github-action.md
+++ b/docs/pr-safety-github-action.md
@@ -1,0 +1,49 @@
+# PR Safety — GitHub Action advisory sketch
+
+This is a **sketch** for running [PR Safety](pr-safety.md) inside CI as an **advisory
+artifact**. It is a future-facing exploration (#834 on the *Product Readiness: PR Safety
+Layer* milestone), not an active part of this repo's CI.
+
+Example workflow: [`examples/github/pr-safety-advisory.yml`](../examples/github/pr-safety-advisory.yml).
+It lives under `examples/` on purpose so it does **not** run here — copy it to
+`.github/workflows/` in your own project to try it.
+
+## Design principles (v0)
+
+- **Advisory only.** It posts the report to the GitHub **job summary**; it never blocks a
+  merge and never fails the build on a `hold` / `split` / `rebase` verdict
+  (`continue-on-error: true`).
+- **No merge gate.** It is not a required status check. Do not add it to branch protection.
+- **No secrets.** No GitHub App, no OAuth, no provider keys. `permissions: contents: read`.
+- **Offline.** It runs the in-repo deterministic analyzer (`app.pr_safety.analyzer`) on the
+  PR's own metadata; nothing leaves the runner.
+
+## How the sketch works
+
+On every `pull_request` event the job:
+
+1. Checks out the repo with full history (`fetch-depth: 0`).
+2. Derives the **changed files** from `git diff --name-only base...head`.
+3. Derives **commits behind** from `git rev-list --count head..base` (branch-freshness signal).
+4. Calls `analyze_pr_safety(title, body, changed_files, commits_behind=...)`.
+5. Writes a short Markdown summary (verdict + recommendations) to `$GITHUB_STEP_SUMMARY`.
+
+The reviewer then sees a verdict (`merge` / `hold` / `split` / `rebase`) and recommendations
+right in the PR's Checks tab — a fast read on merge readiness, alongside (not instead of)
+human review.
+
+## Explicitly out of scope for v0
+
+- ❌ Merge blocking / required checks / branch-protection changes.
+- ❌ Auto-commenting on the PR, GitHub App, or OAuth installation flow.
+- ❌ Secrets or provider credentials.
+- ❌ Repo-aware fetching beyond the PR's own diff (tracked separately as #833).
+
+## Possible later iterations (not now)
+
+- Render the full Markdown report (the same one the `/pr-safety` UI exports) instead of the
+  compact summary.
+- Optionally post the summary as a sticky PR comment (write permission, still advisory).
+- Offer it as a reusable composite action.
+
+These belong to later, opt-in tiers and are intentionally left as ideas here.

--- a/examples/github/pr-safety-advisory.yml
+++ b/examples/github/pr-safety-advisory.yml
@@ -1,0 +1,82 @@
+# PR Safety — advisory report (EXAMPLE / SKETCH, not an active workflow)
+#
+# This file lives under examples/ on purpose: it does NOT run in this repo.
+# To try it, copy it to .github/workflows/ in your own project.
+#
+# It is ADVISORY ONLY:
+#   - posts the offline PR Safety report to the GitHub job summary
+#   - never blocks a merge, never fails the build on a "hold"/"split" verdict
+#   - needs no secrets, no GitHub App, no OAuth, no provider keys
+#
+# v0 runs the in-repo offline analyzer (app.pr_safety.analyzer) on the PR's
+# own metadata. Nothing leaves the runner.
+name: PR Safety (advisory)
+
+on:
+  pull_request:
+
+# Read-only; advisory summaries do not need write access.
+permissions:
+  contents: read
+
+jobs:
+  pr-safety:
+    runs-on: ubuntu-latest
+    # Advisory: a non-green verdict must never fail the job.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Generate offline PR Safety report
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import os, subprocess
+          from app.pr_safety.analyzer import analyze_pr_safety
+
+          base = os.environ["BASE_SHA"]
+          head = os.environ["HEAD_SHA"]
+
+          changed = subprocess.run(
+              ["git", "diff", "--name-only", f"{base}...{head}"],
+              capture_output=True, text=True, check=True,
+          ).stdout.split()
+
+          # How far HEAD is behind base (advisory branch-freshness signal).
+          commits_behind = int(subprocess.run(
+              ["git", "rev-list", "--count", f"{head}..{base}"],
+              capture_output=True, text=True, check=True,
+          ).stdout.strip() or "0")
+
+          report = analyze_pr_safety(
+              os.environ.get("PR_TITLE", ""),
+              os.environ.get("PR_BODY", "") or "(no description)",
+              changed or ["(no files)"],
+              commits_behind=commits_behind,
+          )
+
+          print("## PR Safety — advisory report")
+          print()
+          print(f"**Verdict:** `{report.verdict}`")
+          print(f"**Changed files:** {report.changed_files.total}")
+          print()
+          if report.recommendations:
+              print("### Recommendations")
+              for rec in report.recommendations:
+                  print(f"- {rec}")
+          print()
+          print("_Offline heuristic advisory — not a merge gate._")
+          PY


### PR DESCRIPTION
## Summary
Adds an **advisory-only GitHub Action sketch** for running PR Safety in CI (#834). It surfaces the offline verdict as a CI **job summary** — never as a merge gate.

Implements #834 (milestone: **Product Readiness: PR Safety Layer**).

## What it adds
- **`examples/github/pr-safety-advisory.yml`** — an **inert example workflow**. It lives under `examples/` (not `.github/workflows/`) so it does **not** run in this repo. On `pull_request` it derives changed files + commits-behind from the PR's own diff, runs the in-repo offline `analyze_pr_safety(...)`, and writes verdict + recommendations to `$GITHUB_STEP_SUMMARY`.
- **`docs/pr-safety-github-action.md`** — explains the advisory-only design and what is deliberately out of scope.

## Guardrails (by design)
- ✅ Advisory only (`continue-on-error: true`); a non-green verdict never fails the build.
- ✅ `permissions: contents: read`; **no secrets**, no GitHub App, no OAuth.
- ❌ No merge blocking, no required check, no branch-protection changes.
- ❌ No auto-commenting, no repo-aware fetching beyond the PR diff (#833).

## Verification
- YAML parses cleanly (`yaml.safe_load`).
- The analyzer call used in the sketch was run locally against a sample PR → `verdict: hold`, 5 recommendations.

## Changed files (2)
- `examples/github/pr-safety-advisory.yml` (new)
- `docs/pr-safety-github-action.md` (new)

## Risk
**Very low** — example + docs only; the workflow is inert in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
