### PR TITLE
docs(pr-safety): add a Try PR Safety CTA to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Prompt Compiler** turns vague requests into structured prompts, execution plans, and policy-checked workflows — so you can go from idea to safe, usable AI output in seconds.
 
-Try it now at [prcompiler.com](https://prcompiler.com) | [VS Code extension](integrations/vscode-extension) | [GitHub artifacts](docs/pattern-library.md)
+Try it now at [prcompiler.com](https://prcompiler.com) | [PR Safety report](docs/pr-safety.md) | [VS Code extension](integrations/vscode-extension) | [GitHub artifacts](docs/pattern-library.md)
 
 ---
 
@@ -41,6 +41,14 @@ Switch between the output tabs in the UI to inspect each layer, and copy any res
 <p align="center">
   <img src="docs/images/comp1.PNG" alt="Prompt Compiler - Main View" width="100%">
 </p>
+
+---
+
+### PR Safety — Merge Readiness Layer
+
+Before you merge an AI-agent PR, **PR Safety** tells you whether it's safe to **merge, hold, split, or rebase** — based on scope, changed files, risky areas, test coverage, and branch freshness. It's an offline, deterministic advisory (no GitHub API, no AI, no sign-in) and never blocks a merge.
+
+Open **PR Safety** in the sidebar (or visit `/pr-safety`), paste a PR's details, and copy a GitHub-ready Markdown report. See the [PR Safety guide](docs/pr-safety.md).
 
 ---
 


### PR DESCRIPTION
## Summary
Adds a lightweight, shareable **CTA** for PR Safety so the v0 layer is discoverable from the project's front door (objective 5 of the launch loop). Docs/README only.

## Changes
- Adds a **"PR Safety report"** link to the README "Try it now" line.
- Adds a short **"PR Safety — Merge Readiness Layer"** subsection under Key Features, linking [`docs/pr-safety.md`](docs/pr-safety.md).

## Why README (not the flagship app header)
The sidebar already links PR Safety on every page. The compiler page header is busy and stateful, so a marketing CTA there is a design call best left to you. The README is the highest-visibility, lowest-risk surface for a "try it / share it" link.

## Changed files (1)
- `README.md`

## Risk
**Very low** — README only, no code, link target verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
