### PR TITLE
fix(agent-packs): stop browser timeout on slow Claude pack generation

### DIFF
--- a/web/app/agent-packs/claude/download/route.ts
+++ b/web/app/agent-packs/claude/download/route.ts
@@ -1,7 +1,8 @@
-import { proxyBackendRequest } from "@/lib/server/backendProxy";
+import { AGENT_PACK_UPSTREAM_TIMEOUT_MS, proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
   return proxyBackendRequest(request, "/agent-packs/claude/download", {
     retryNetworkErrors: true,
+    upstreamTimeoutMs: AGENT_PACK_UPSTREAM_TIMEOUT_MS,
   });
 }

--- a/web/app/agent-packs/claude/route.ts
+++ b/web/app/agent-packs/claude/route.ts
@@ -1,7 +1,8 @@
-import { proxyBackendRequest } from "@/lib/server/backendProxy";
+import { AGENT_PACK_UPSTREAM_TIMEOUT_MS, proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
   return proxyBackendRequest(request, "/agent-packs/claude", {
     retryNetworkErrors: true,
+    upstreamTimeoutMs: AGENT_PACK_UPSTREAM_TIMEOUT_MS,
   });
 }

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -3,7 +3,7 @@
 import { toast } from "sonner";
 
 import { useMemo, useState } from "react";
-import { Bot, Copy, Download, FileCode2, FolderArchive, ShieldCheck, Sparkles, X } from "lucide-react";
+import { Bot, Copy, Download, FileCode2, FolderArchive, Loader2, ShieldCheck, Sparkles, X } from "lucide-react";
 
 import { apiFetch, apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
 import InfoButton from "../components/InfoButton";
@@ -427,7 +427,27 @@ export default function AgentPacksPage() {
           </section>
 
           <section className="relative flex min-h-[380px] w-full flex-col bg-black/20 md:min-h-0 md:w-[62%]">
-            {manifest ? (
+            {loading ? (
+              <div
+                className="flex flex-1 flex-col items-center justify-center gap-6 p-8 text-center"
+                role="status"
+                aria-live="polite"
+              >
+                <div className="relative">
+                  <div className="absolute inset-0 rounded-full bg-cyan-500/30 blur-[45px]" />
+                  <div className="relative flex h-24 w-24 items-center justify-center rounded-[28px] border border-white/10 bg-gradient-to-br from-zinc-900 to-black shadow-2xl">
+                    <Loader2 size={40} className="animate-spin text-cyan-300/80" aria-hidden="true" />
+                  </div>
+                </div>
+                <div className="max-w-sm space-y-2">
+                  <h3 className="text-lg font-medium text-zinc-200">Generating your agent pack…</h3>
+                  <p className="text-sm leading-relaxed text-zinc-500">
+                    Claude is drafting and assembling your repo-ready files. This usually takes around
+                    20–30 seconds — keep this tab open while it finishes.
+                  </p>
+                </div>
+              </div>
+            ) : manifest ? (
               <div className="flex min-h-0 flex-1 flex-col">
                 <div className="flex flex-col gap-3 border-b border-white/5 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
                   <div>

--- a/web/lib/server/backendProxy.ts
+++ b/web/lib/server/backendProxy.ts
@@ -1,5 +1,10 @@
 const DEFAULT_BACKEND_API_BASE = "http://127.0.0.1:8080";
 const DEFAULT_UPSTREAM_TIMEOUT_MS = 25_000;
+// Agent Pack generation runs a single LLM `generate_agent` call (max_tokens=4000)
+// that legitimately takes ~24s, while the backend's own hard LLM timeout is 30s
+// (and up to 99s in production). The 25s default proxy budget cuts that off before
+// the backend even finishes, so these routes get a larger, route-scoped budget.
+export const AGENT_PACK_UPSTREAM_TIMEOUT_MS = 60_000;
 const NETWORK_ERROR_DETAIL =
   "The service is temporarily unavailable or still waking up. Please retry in a few seconds.";
 const TIMEOUT_ERROR_DETAIL =


### PR DESCRIPTION
## Root cause (decision-first)

Generating a Claude Agent Pack is slow because it makes **one inherent LLM call** — `compiler.generate_agent(...)` → `WorkerClient.generate_agent` → a single OpenRouter completion with `max_tokens=4000`. For a `pr-reviewer` pack this is ~24s of genuine model time. There is **no redundant compilation, duplicate generation, or accidental extra network call** in the path: `build_manifest` calls `generate_agent` exactly once, and the RAG `context_strategist.process(..., expand_with_llm=False)` does only local retrieval (no LLM call).

The latency is therefore **provider-inherent** and out of scope to change (the task forbids touching LLM/provider/prompt/temperature/max_tokens). The actual *bug* is a **timeout mismatch**:

- Backend hard LLM timeout: **30s** default (`LLM_TIMEOUT`), and **99s in production** (asserted in `scripts/verify_client_config.py`).
- Next.js proxy upstream timeout: **25s** (`DEFAULT_UPSTREAM_TIMEOUT_MS` in `web/lib/server/backendProxy.ts`).

So the proxy aborts at 25s — *before* the backend's own budget — and the `/agent-packs` page surfaces "The backend did not respond within the upstream timeout" even while the backend is still successfully generating. This is **pre-existing** (not caused by the install-checklist feature #823) and affects production.

## The change (small, scoped, reversible — 4 files, no backend/LLM/env changes)

1. **`web/lib/server/backendProxy.ts`** — add exported `AGENT_PACK_UPSTREAM_TIMEOUT_MS = 60_000`. The global 25s default is **unchanged**.
2. **`web/app/agent-packs/claude/route.ts`** + **`.../claude/download/route.ts`** — pass `upstreamTimeoutMs: AGENT_PACK_UPSTREAM_TIMEOUT_MS` so only these two routes get the 60s budget (≈2.5× the observed ~24s, comfortably above the backend's 30s budget).
3. **`web/app/agent-packs/page.tsx`** — add a clear loading affordance (spinner + "this usually takes ~20–30s, keep this tab open") to the preview panel during generation, replacing the static empty state while `loading` is true.

## Before / after timing

- **Backend `/agent-packs/claude` (pr-reviewer):** ~24s, single `generate_agent` LLM call (per task repro). Could not re-time locally — no `OPENROUTER_API_KEY` in this sandbox, so the call short-circuits with "API Key is missing" instead of running.
- **Before:** browser request through the proxy aborts at **25s** → 504 "did not respond within the upstream timeout", intermittently failing a ~24s generation.
- **After:** proxy budget for these routes is **60s**, so a ~24s generation completes and returns to the browser; the user sees an explicit progress state meanwhile.
- **Production check:** `curl -X POST https://prcompiler.com/agent-packs/claude ...` returned **403 in 0.37s** — the edge/WAF blocks a raw curl with no browser origin, so production timing could not be measured directly from here. The 25s-proxy-vs-30s/99s-backend mismatch applies to the production deployment too.

## Files changed
- `web/lib/server/backendProxy.ts`
- `web/app/agent-packs/claude/route.ts`
- `web/app/agent-packs/claude/download/route.ts`
- `web/app/agent-packs/page.tsx`

## Tests / build
- Backend: `python -m pytest tests/ -q` → **1293 passed, 7 skipped**
- Backend (focused): `tests/test_agent_packs_api.py` → **23 passed**
- Frontend: `npm run test` → **141 passed (25 files)** (the ECONNREFUSED lines are expected logs from network-failure tests)
- Frontend: `npm run build` → **success**

Draft — please review, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5U7Z8bGnudrq6zQ6p6HL5

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5U7Z8bGnudrq6zQ6p6HL5)_