### PR TITLE
chore(packaging): rename PyPI distribution to prcompiler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "promptc"
+name = "prcompiler"
 version = "2.0.46"
 description = "Prompt Compiler App: compile free-text prompts into structured IR + prompts + plan"
 authors = [ { name = "madara88645" } ]
@@ -34,7 +34,7 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]
-exclude = ["tests*", "docs*", "examples*", "promptc.egg-info*"]
+exclude = ["tests*", "docs*", "examples*", "prcompiler.egg-info*"]
 
 [tool.setuptools.package-data]
 app = [


### PR DESCRIPTION
## Neden
PyPI'daki `promptc` adı **alakasız başka bir paketin** (v0.1.0, "context exposure" — author: Eden). Bu yüzden `v*` tag'lerinde tetiklenen **Publish to PyPI** workflow'u bu adla hiçbir zaman yayınlayamaz; bir release tag'i atıldığında publish job'ı sessizce kırmızıya düşer. `prompt-compiler` de dolu (Jordan Taylor). `prcompiler` boş ve **domain ile aynı** (prcompiler.com).

## Değişiklik (yalnızca metadata)
- `pyproject.toml` → `name`: `promptc` → `prcompiler`
- `pyproject.toml` → `packages.find` exclude: `promptc.egg-info*` → `prcompiler.egg-info*` (yeni artefakt adıyla eşleşsin)

## DeğişMEYEN'ler (kasıtlı)
- **CLI komutu hâlâ `promptc`** (`[project.scripts]` aynı) → kullanıcılar `pip install prcompiler` der ama yine `promptc compile ...` yazar.
- `~/.promptc/` veri klasörü ve `PROMPTC_` env prefix'i aynı.

## Doğrulama
`python -m build` → `prcompiler-2.0.46.tar.gz` üretiyor; `PKG-INFO` Name=prcompiler, console script `promptc = cli.main:app`, `app`/`cli`/`api` paketleri yerinde.

## ⚠️ Bu PR yetmez — manuel adım gerekli
Merge sonrası PyPI'a *gerçekten* basabilmek için **trusted publishing** ayarı yapılmalı (PyPI hesabında, repo `madara88645/Compiler` güvenilir yayıncı olarak tanımlanır). Bu kod değil; ben yapamam.

## Kapsam dışı (not)
`python -m build` çıktısında `web/node_modules/`, `marketing/` gibi klasörlerin de pakete girdiği görüldü — önceden var olan ayrı bir paketleme hijyeni sorunu, bu PR'a dahil değil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)