### PR TITLE
CLI Phase 2: compile/pack output & UX

### DIFF
--- a/app/agents/context_strategist.py
+++ b/app/agents/context_strategist.py
@@ -4,10 +4,13 @@ Responsible for semantic retrieval, query expansion, and context re-ranking.
 """
 import json
 import re
-import sys
 from typing import List, Dict, Any, Optional
 from app.rag.simple_index import search_hybrid
 from app.llm_engine.client import WorkerClient
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ContextStrategist:
@@ -98,7 +101,7 @@ class ContextStrategist:
             data = json.loads(response)
             return self._normalize_queries(data, prompt)
         except Exception as e:
-            print(f"[STRATEGIST] Query expansion failed: {e}", file=sys.stderr)
+            logger.debug("Query expansion failed: %s", e)
             return self._normalize_queries([], prompt)
 
     _ARTIFACT_LIKE_RE = re.compile(

--- a/app/utils.py
+++ b/app/utils.py
@@ -7,9 +7,12 @@ def _render_prompt_pack_md(
     plan: str,
     expanded: str,
     title: str = "Prompt Pack",
+    header: str = "",
 ) -> str:
     """Render a prompt pack in Markdown format."""
     parts = [f"# {title}"]
+    if header:
+        parts.append(f"\n\n{header}")
     if system_prompt:
         parts.append(f"\n\n## System Prompt\n\n{system_prompt}")
     if user_prompt:
@@ -21,9 +24,17 @@ def _render_prompt_pack_md(
     return "".join(parts).strip()
 
 
-def _render_prompt_pack_txt(system_prompt: str, user_prompt: str, plan: str, expanded: str) -> str:
+def _render_prompt_pack_txt(
+    system_prompt: str,
+    user_prompt: str,
+    plan: str,
+    expanded: str,
+    header: str = "",
+) -> str:
     """Render a prompt pack in Plain Text format."""
     parts = []
+    if header:
+        parts.append(f"{header}\n")
     if system_prompt:
         parts.append(f"--- System Prompt ---\n{system_prompt}")
     if user_prompt:

--- a/cli/commands/core.py
+++ b/cli/commands/core.py
@@ -950,12 +950,30 @@ def pack_command(
         heur = HEURISTIC2_VERSION
         ir_ver = "v2"
 
+    if v1:
+        _domain = "—"
+        _persona = getattr(ir, "persona", "—")
+        _risk = "—"
+    else:
+        _ir2_json = ir2.model_dump()
+        _domain = _ir2_json.get("domain") or "—"
+        _persona = _ir2_json.get("persona") or "—"
+        _risk = ((_ir2_json.get("metadata") or {}).get("policy_summary") or {}).get(
+            "risk_level"
+        ) or "—"
+    pack_header = (
+        f"Domain: {_domain} | Persona: {_persona} | Risk: {_risk} | IR version: {ir_ver}"
+    )
     fmt_l = (format or "md").lower()
     if fmt_l in {"md", "markdown"}:
-        payload = _render_prompt_pack_md(system_prompt, user_prompt, plan, expanded)
+        payload = _render_prompt_pack_md(
+            system_prompt, user_prompt, plan, expanded, header=pack_header
+        )
         default_name = "prompt_pack.md"
     elif fmt_l == "txt":
-        payload = _render_prompt_pack_txt(system_prompt, user_prompt, plan, expanded)
+        payload = _render_prompt_pack_txt(
+            system_prompt, user_prompt, plan, expanded, header=pack_header
+        )
         default_name = "prompt_pack.txt"
     elif fmt_l == "json":
         # Bolt Optimization: orjson.dumps is significantly faster than json.dumps for CLI output serialization

--- a/cli/commands/core.py
+++ b/cli/commands/core.py
@@ -386,7 +386,9 @@ def compile_cmd(
     ),
     v1: bool = typer.Option(False, "--v1", help="Use legacy IR v1 output and render prompts"),
     render_v2: bool = typer.Option(
-        False, "--render-v2", help="Render prompts using IR v2 emitters"
+        False,
+        "--render-v2",
+        help="Deprecated for compile (IR v2 prompts now render by default); still used by batch --format md.",
     ),
     out: Path = typer.Option(None, "--out", help="Write output to a file (overwrites)"),
     out_dir: Path = typer.Option(

--- a/cli/commands/core.py
+++ b/cli/commands/core.py
@@ -195,9 +195,7 @@ def _run_compile(
     # Resolve quiet vs json_only
     if json_only and quiet:
         quiet = False
-    system_prompt = (
-        emit_system_prompt(ir) if ir else (emit_system_prompt_v2(ir2) if ir2 else "")
-    )
+    system_prompt = emit_system_prompt(ir) if ir else (emit_system_prompt_v2(ir2) if ir2 else "")
     if quiet:
         print(system_prompt)
         return
@@ -963,9 +961,7 @@ def pack_command(
         _risk = ((_ir2_json.get("metadata") or {}).get("policy_summary") or {}).get(
             "risk_level"
         ) or "—"
-    pack_header = (
-        f"Domain: {_domain} | Persona: {_persona} | Risk: {_risk} | IR version: {ir_ver}"
-    )
+    pack_header = f"Domain: {_domain} | Persona: {_persona} | Risk: {_risk} | IR version: {ir_ver}"
     fmt_l = (format or "md").lower()
     if fmt_l in {"md", "markdown"}:
         payload = _render_prompt_pack_md(

--- a/cli/commands/core.py
+++ b/cli/commands/core.py
@@ -41,6 +41,7 @@ from app.resources import get_ir_schema_json
 
 from app import get_version
 from app.analytics import AnalyticsManager, create_record_from_ir
+from cli.render import get_console, render_summary_card, render_prompt_sections
 # from app.history import get_history_manager
 
 
@@ -195,21 +196,17 @@ def _run_compile(
     if json_only and quiet:
         quiet = False
     system_prompt = (
-        emit_system_prompt(ir)
-        if ir
-        else (emit_system_prompt_v2(ir2) if (ir2 and render_v2) else "")
+        emit_system_prompt(ir) if ir else (emit_system_prompt_v2(ir2) if ir2 else "")
     )
     if quiet:
         print(system_prompt)
         return
-    user_prompt = (
-        emit_user_prompt(ir) if ir else (emit_user_prompt_v2(ir2) if (ir2 and render_v2) else "")
-    )
-    plan = emit_plan(ir) if ir else (emit_plan_v2(ir2) if (ir2 and render_v2) else "")
+    user_prompt = emit_user_prompt(ir) if ir else (emit_user_prompt_v2(ir2) if ir2 else "")
+    plan = emit_plan(ir) if ir else (emit_plan_v2(ir2) if ir2 else "")
     expanded = (
         emit_expanded_prompt(ir, diagnostics=diagnostics)
         if ir
-        else (emit_expanded_prompt_v2(ir2, diagnostics=diagnostics) if (ir2 and render_v2) else "")
+        else (emit_expanded_prompt_v2(ir2, diagnostics=diagnostics) if ir2 else "")
     )
     if json_only:
         data = ir_json
@@ -229,7 +226,7 @@ def _run_compile(
             payload = orjson.dumps(data, option=orjson.OPT_INDENT_2).decode("utf-8")
             default_name = "ir.json"
         if out or out_dir:
-            if fmt_l == "md" and (ir or (ir2 and render_v2)):
+            if fmt_l == "md" and (ir or ir2):
                 # Support --format md to save prompts as Markdown (v1 or v2 rendering)
                 md_parts = []
                 if system_prompt:
@@ -252,7 +249,7 @@ def _run_compile(
         # Print to console
         if fmt_l in {"yaml", "yml"} and yaml is not None:
             typer.echo(payload)
-        elif fmt_l == "md" and (ir or (ir2 and render_v2)):
+        elif fmt_l == "md" and (ir or ir2):
             # Print a minimal markdown block to console when requested
             md_parts = []
             if system_prompt:
@@ -272,19 +269,13 @@ def _run_compile(
         else:
             typer.echo(payload)
         return
-    if ir:
-        print(f"[bold white]Persona:[/bold white] {ir.persona} (heuristics v{HEURISTIC_VERSION})")
-        print(f"[bold white]Role:[/bold white] {ir.role}")
-    else:
-        print(f"[bold white]IR v2[/bold white] (heuristics v{HEURISTIC2_VERSION})")
-    print("\n[bold blue]IR JSON:[/bold blue]")
-    ir_json = ir_json
+    # Phase 2: human-first console output is rendered below (after the save branch).
     # Bolt Optimization: orjson.dumps is significantly faster than json.dumps for CLI output serialization
     rendered = orjson.dumps(ir_json, option=orjson.OPT_INDENT_2).decode("utf-8")
     if out or out_dir:
         fmt_l = (fmt or "json").lower()
         # Support --format md to save prompts as Markdown (v1 or v2 rendering)
-        if fmt_l == "md" and (ir or (ir2 and render_v2)):
+        if fmt_l == "md" and (ir or ir2):
             md_parts = []
             if system_prompt:
                 md_parts.append("# System Prompt\n\n" + system_prompt)
@@ -307,12 +298,13 @@ def _run_compile(
             return
         _write_output(rendered, out, out_dir, default_name="ir.json")
         return
-    print(rendered)
-    if ir or (ir2 and render_v2):
-        print("\n[bold green]System Prompt:[/bold green]\n" + system_prompt)
-        print("\n[bold magenta]User Prompt:[/bold magenta]\n" + user_prompt)
-        print("\n[bold yellow]Plan:[/bold yellow]\n" + plan)
-        print("\n[bold cyan]Expanded Prompt:[/bold cyan]\n" + expanded)
+    console = get_console()
+    if ir:
+        print(f"[bold white]Persona:[/bold white] {ir.persona} (heuristics v{HEURISTIC_VERSION})")
+        print(f"[bold white]Role:[/bold white] {ir.role}")
+    else:
+        render_summary_card(console, ir_json)
+    render_prompt_sections(console, system_prompt, user_prompt, plan, expanded)
 
     # Save to history - DISABLED (legacy module removed)
     # try:

--- a/cli/render.py
+++ b/cli/render.py
@@ -1,0 +1,54 @@
+"""CLI presentation helpers (human-tier output only).
+
+IMPORTANT: machine-output paths (--json-only / --out / --format / --quiet /
+batch) must NOT use these helpers — they must emit plain, unstyled payloads so
+piping and golden-file tests stay stable.
+"""
+from __future__ import annotations
+
+from rich.console import Console
+from rich.markup import escape
+from rich.panel import Panel
+
+SECTION_TITLES = {
+    "system": "System Prompt",
+    "user": "User Prompt",
+    "plan": "Plan",
+    "expanded": "Expanded Prompt",
+}
+
+
+def get_console() -> Console:
+    """Return a Console for human CLI output."""
+    return Console()
+
+
+def render_summary_card(console: Console, ir_json: dict) -> None:
+    """Print a compact summary panel from an IR v2 dict (model_dump())."""
+    policy = (ir_json.get("metadata") or {}).get("policy_summary") or {}
+    rows = [
+        ("Persona", str(ir_json.get("persona") or "—")),
+        ("Domain", str(ir_json.get("domain") or "—")),
+        ("Risk", str(policy.get("risk_level") or "—")),
+        ("Output", str(ir_json.get("output_format") or "—")),
+        ("Goals", str(len(ir_json.get("goals") or []))),
+        ("Constraints", str(len(ir_json.get("constraints") or []))),
+    ]
+    body = "\n".join(f"{escape(k)}: {escape(v)}" for k, v in rows)
+    console.print(Panel(body, title="Summary", expand=False))
+
+
+def render_prompt_sections(
+    console: Console, system: str, user: str, plan: str, expanded: str
+) -> None:
+    """Print each non-empty prompt section under a rule, markup-safe."""
+    sections = [
+        (SECTION_TITLES["system"], system),
+        (SECTION_TITLES["user"], user),
+        (SECTION_TITLES["plan"], plan),
+        (SECTION_TITLES["expanded"], expanded),
+    ]
+    for title, text in sections:
+        if text:
+            console.rule(title)
+            console.print(text, markup=False)

--- a/docs/superpowers/plans/2026-06-24-cli-phase2-output-ux.md
+++ b/docs/superpowers/plans/2026-06-24-cli-phase2-output-ux.md
@@ -1,0 +1,512 @@
+# CLI Phase 2 — compile/pack Output & UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `promptc compile` show a readable summary card + rendered System/User/Plan/Expanded prompts by default (raw IR behind `--json-only`), centralize rich rendering in a new `cli/render.py`, add a metadata header to `pack`, fix the dead `--quiet` flag, and silence the noisy `[STRATEGIST]` stderr line.
+
+**Architecture:** A new `cli/render.py` owns human-tier rich rendering. `_run_compile` (in `cli/commands/core.py`) stops gating the v2 emitter strings on `--render-v2` (which also fixes `--quiet`) and replaces its default raw-IR dump with a summary card + sections via `cli/render.py`. `pack` gains a metadata header passed into the existing `app/utils.py` renderers. One log-level fix in `app/agents/context_strategist.py`. Emitters/heuristics are untouched; machine-output paths (`--json-only`/`--out`/`--format`/`--quiet`) stay plain.
+
+**Tech Stack:** Python 3.10+, Typer, Rich (`Console`/`Panel`/`rule`/`markup.escape`), pytest + `typer.testing.CliRunner` + `Console(record=True)`.
+
+**Branch:** `feat/cli-phase2-output-ux` (exists; spec committed at `ff52b986`). One PR, four clean commits + a test-update/verify task.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `app/agents/context_strategist.py` | Agent 6 (RAG retrieval + query expansion) | Modify — line 101 `print`→`logger.debug` |
+| `cli/render.py` | Human-tier CLI rendering helpers | **Create** |
+| `cli/commands/core.py` | `_run_compile` + `pack_command` | Modify — default render via `cli/render.py`; pass pack header |
+| `app/utils.py` | `_render_prompt_pack_md/txt` (CLI-only) | Modify — optional metadata header |
+| `tests/test_cli_phase2.py` | New tests for all of the above | **Create** |
+| Existing compile tests | Some assert default output is raw IR JSON | Update to use `--json-only` |
+
+---
+
+## Task 1: Silence the `[STRATEGIST]` query-expansion noise
+
+**Files:**
+- Modify: `app/agents/context_strategist.py` (imports + line 101)
+- Test: `tests/test_cli_phase2.py` (new)
+
+Context: `_expand_query` (line 77) calls the LLM; on any failure (e.g. no `OPENROUTER_API_KEY` → 401) it currently does `print(f"[STRATEGIST] Query expansion failed: {e}", file=sys.stderr)` (line 101), which fires on every offline run and looks like an error. It already falls back gracefully to `_normalize_queries([], prompt)`. Downgrade to `logger.debug`, matching the rest of the codebase.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_cli_phase2.py`:
+
+```python
+def test_strategist_expansion_failure_is_silent(capsys):
+    from app.agents.context_strategist import ContextStrategist
+
+    class _BoomClient:
+        def _call_api(self, *args, **kwargs):
+            raise RuntimeError("no api key")
+
+    strat = ContextStrategist(client=_BoomClient())
+    result = strat._expand_query("write a haiku about the sea")
+    captured = capsys.readouterr()
+    assert "[STRATEGIST]" not in captured.err
+    assert isinstance(result, list)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli_phase2.py::test_strategist_expansion_failure_is_silent -v`
+Expected: FAIL — stderr contains `[STRATEGIST] Query expansion failed: no api key`.
+
+- [ ] **Step 3: Add a module logger to `app/agents/context_strategist.py`**
+
+After the existing imports (the block ending with `from app.llm_engine.client import WorkerClient`, line 10), add:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+- [ ] **Step 4: Replace the print with logger.debug**
+
+At line 101, change:
+
+```python
+            print(f"[STRATEGIST] Query expansion failed: {e}", file=sys.stderr)
+```
+
+to:
+
+```python
+            logger.debug("Query expansion failed: %s", e)
+```
+
+- [ ] **Step 5: Drop the now-possibly-unused `sys` import if ruff flags it**
+
+Run: `python -m ruff check app/agents/context_strategist.py`
+If it reports `F401` for `import sys` (line 7), remove that line. If `sys` is still used elsewhere in the file, leave it. Re-run ruff until clean.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_cli_phase2.py::test_strategist_expansion_failure_is_silent -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/agents/context_strategist.py tests/test_cli_phase2.py
+git commit -m "fix(cli): silence [STRATEGIST] query-expansion failures (logger.debug)"
+```
+
+---
+
+## Task 2: Create `cli/render.py` (human-tier rendering helpers)
+
+**Files:**
+- Create: `cli/render.py`
+- Test: `tests/test_cli_phase2.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_cli_phase2.py`:
+
+```python
+from rich.console import Console
+
+from cli.render import render_summary_card, render_prompt_sections
+
+
+def test_summary_card_shows_key_fields():
+    console = Console(record=True, width=80)
+    ir = {
+        "persona": "assistant",
+        "domain": "software",
+        "output_format": "text",
+        "goals": ["g1"],
+        "constraints": ["c1", "c2"],
+        "metadata": {"policy_summary": {"risk_level": "low"}},
+    }
+    render_summary_card(console, ir)
+    out = console.export_text()
+    assert "assistant" in out
+    assert "software" in out
+    assert "low" in out
+
+
+def test_prompt_sections_preserve_bracket_tokens():
+    console = Console(record=True, width=80)
+    render_prompt_sections(console, "Use [clarify] and [policy] here", "", "", "")
+    out = console.export_text()
+    assert "[clarify]" in out
+    assert "[policy]" in out
+    assert "System Prompt" in out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_cli_phase2.py -k "summary_card or bracket_tokens" -v`
+Expected: FAIL — `cli.render` does not exist.
+
+- [ ] **Step 3: Create `cli/render.py`**
+
+```python
+"""CLI presentation helpers (human-tier output only).
+
+IMPORTANT: machine-output paths (--json-only / --out / --format / --quiet /
+batch) must NOT use these helpers — they must emit plain, unstyled payloads so
+piping and golden-file tests stay stable.
+"""
+from __future__ import annotations
+
+from rich.console import Console
+from rich.markup import escape
+from rich.panel import Panel
+
+SECTION_TITLES = {
+    "system": "System Prompt",
+    "user": "User Prompt",
+    "plan": "Plan",
+    "expanded": "Expanded Prompt",
+}
+
+
+def get_console() -> Console:
+    """Return a Console for human CLI output."""
+    return Console()
+
+
+def render_summary_card(console: Console, ir_json: dict) -> None:
+    """Print a compact summary panel from an IR v2 dict (model_dump())."""
+    policy = (ir_json.get("metadata") or {}).get("policy_summary") or {}
+    rows = [
+        ("Persona", str(ir_json.get("persona") or "—")),
+        ("Domain", str(ir_json.get("domain") or "—")),
+        ("Risk", str(policy.get("risk_level") or "—")),
+        ("Output", str(ir_json.get("output_format") or "—")),
+        ("Goals", str(len(ir_json.get("goals") or []))),
+        ("Constraints", str(len(ir_json.get("constraints") or []))),
+    ]
+    body = "\n".join(f"{escape(k)}: {escape(v)}" for k, v in rows)
+    console.print(Panel(body, title="Summary", expand=False))
+
+
+def render_prompt_sections(
+    console: Console, system: str, user: str, plan: str, expanded: str
+) -> None:
+    """Print each non-empty prompt section under a rule, markup-safe."""
+    sections = [
+        (SECTION_TITLES["system"], system),
+        (SECTION_TITLES["user"], user),
+        (SECTION_TITLES["plan"], plan),
+        (SECTION_TITLES["expanded"], expanded),
+    ]
+    for title, text in sections:
+        if text:
+            console.rule(title)
+            console.print(text, markup=False)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_cli_phase2.py -k "summary_card or bracket_tokens" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/render.py tests/test_cli_phase2.py
+git commit -m "feat(cli): add cli/render.py human-tier rendering helpers"
+```
+
+---
+
+## Task 3: Human-first `compile` default (and fix `--quiet`)
+
+**Files:**
+- Modify: `cli/commands/core.py` (`_run_compile`, lines ~197-315)
+- Test: `tests/test_cli_phase2.py`
+
+Context: In `_run_compile`, the v2 emitter strings are gated on `(ir2 and render_v2)` (lines 197-213). With the default (`render_v2=False`) they are all `""`, so `--quiet` prints a blank line and the default path dumps only raw IR JSON (`print(rendered)`, line ~310). We (a) compute v2 emitters whenever `ir2` exists — which also makes `--quiet` honest — and (b) replace the default human block with the summary card + sections.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_cli_phase2.py`:
+
+```python
+import json as _json
+
+from typer.testing import CliRunner
+
+from cli.main import app as _app
+
+_runner = CliRunner()
+
+
+def test_compile_default_shows_rendered_sections_not_raw_ir():
+    result = _runner.invoke(_app, ["compile", "write a haiku about the sea"])
+    assert result.exit_code == 0
+    assert "System Prompt" in result.stdout
+    assert "User Prompt" in result.stdout
+    # Default no longer dumps the raw IR JSON object
+    assert '"version": "2.0"' not in result.stdout
+
+
+def test_compile_json_only_still_outputs_valid_json():
+    result = _runner.invoke(_app, ["compile", "write a haiku", "--json-only"])
+    assert result.exit_code == 0
+    parsed = _json.loads(result.stdout)
+    assert parsed.get("version") == "2.0"
+
+
+def test_compile_quiet_emits_nonempty_system_prompt():
+    result = _runner.invoke(_app, ["compile", "write a haiku", "--quiet"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() != ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_cli_phase2.py -k "compile_default or quiet_emits" -v`
+Expected: FAIL — default shows raw IR (no "System Prompt"); `--quiet` stdout is empty. (`json_only` test may already pass.)
+
+- [ ] **Step 3: Compute v2 emitters unconditionally**
+
+In `cli/commands/core.py`, in `_run_compile`, replace the gated emitter block (lines 197-213) so the `and render_v2` conditions become "whenever ir2 exists":
+
+```python
+    # Resolve quiet vs json_only
+    if json_only and quiet:
+        quiet = False
+    system_prompt = (
+        emit_system_prompt(ir) if ir else (emit_system_prompt_v2(ir2) if ir2 else "")
+    )
+    if quiet:
+        print(system_prompt)
+        return
+    user_prompt = emit_user_prompt(ir) if ir else (emit_user_prompt_v2(ir2) if ir2 else "")
+    plan = emit_plan(ir) if ir else (emit_plan_v2(ir2) if ir2 else "")
+    expanded = (
+        emit_expanded_prompt(ir, diagnostics=diagnostics)
+        if ir
+        else (emit_expanded_prompt_v2(ir2, diagnostics=diagnostics) if ir2 else "")
+    )
+```
+
+- [ ] **Step 4: Allow `--format md` to include v2 prompts**
+
+Still in `_run_compile`, the `--format md` guards read `(ir or (ir2 and render_v2))` at lines ~232, ~255, ~287. Change each of those three conditions to `(ir or ir2)` so saved/printed Markdown includes the v2 prompts now that they are always computed. (Search the function for `ir2 and render_v2` and replace each occurrence with `ir2`.)
+
+- [ ] **Step 5: Replace the default human-output block with the summary card + sections**
+
+In `_run_compile`, replace the default rendering block (the lines that print Persona/Role or "IR v2", then `print("\n[bold blue]IR JSON:[/bold blue]")`, build `rendered`, and the `if ir or (ir2 and render_v2):` section dump — lines ~275-315, but NOT the `if out or out_dir:` save branch in between) with this. Keep the `if out or out_dir:` save branch intact (it writes files and returns before reaching here).
+
+Add this import near the top of `cli/commands/core.py` with the other `from app...`/`from cli...` imports:
+
+```python
+from cli.render import get_console, render_summary_card, render_prompt_sections
+```
+
+Then the default console path becomes:
+
+```python
+    if ir:
+        # Legacy v1 path keeps its existing simple rendering.
+        print(f"[bold white]Persona:[/bold white] {ir.persona} (heuristics v{HEURISTIC_VERSION})")
+        print(f"[bold white]Role:[/bold white] {ir.role}")
+        console = get_console()
+        render_prompt_sections(console, system_prompt, user_prompt, plan, expanded)
+        return
+    # Default v2 path: human-first summary card + rendered prompts.
+    console = get_console()
+    render_summary_card(console, ir_json)
+    render_prompt_sections(console, system_prompt, user_prompt, plan, expanded)
+```
+
+Note: the raw `rendered = orjson.dumps(...)` default dump and the `print("\n[bold blue]IR JSON:[/bold blue]")` line are removed from this default path. Raw IR remains available via `--json-only` (unchanged) and the `--out`/`--format` save branches (unchanged).
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run: `python -m pytest tests/test_cli_phase2.py -k "compile_default or json_only or quiet_emits" -v`
+Expected: PASS.
+
+- [ ] **Step 7: Update existing tests that assumed the old default**
+
+Run the CLI test files to find breakage from the default change:
+Run: `python -m pytest tests/ -k "cli or compile" -q`
+For every failure where a test invoked `compile` WITHOUT `--json-only` and asserted raw-IR/JSON output, update that test to add `--json-only` (the machine contract is unchanged there) or to assert the new rendered sections. Do NOT change `--json-only`/`--out`/`--quiet` behavior. Re-run until green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cli/commands/core.py tests/test_cli_phase2.py
+git add -u tests/
+git commit -m "feat(cli): human-first compile output by default; fix --quiet"
+```
+
+---
+
+## Task 4: Add a metadata header to `pack` output
+
+**Files:**
+- Modify: `app/utils.py` (`_render_prompt_pack_md`, `_render_prompt_pack_txt`)
+- Modify: `cli/commands/core.py` (`pack_command`, lines ~944-967)
+- Test: `tests/test_cli_phase2.py`
+
+Context: `pack_command` already computes `ir2`/`ir`, the four prompt strings, and `ir_ver` (`"v1"`/`"v2"`). The renderers in `app/utils.py` take only the four strings. Add an optional `header` string param so the command can prepend a compact metadata block.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_cli_phase2.py`:
+
+```python
+def test_pack_md_includes_metadata_header():
+    result = _runner.invoke(_app, ["pack", "build a rest api", "--format", "md"])
+    assert result.exit_code == 0
+    assert "Domain:" in result.stdout
+    assert "IR version:" in result.stdout
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli_phase2.py::test_pack_md_includes_metadata_header -v`
+Expected: FAIL — no header in pack output.
+
+- [ ] **Step 3: Add an optional `header` param to the renderers in `app/utils.py`**
+
+Replace the two functions with:
+
+```python
+def _render_prompt_pack_md(
+    system_prompt: str,
+    user_prompt: str,
+    plan: str,
+    expanded: str,
+    title: str = "Prompt Pack",
+    header: str = "",
+) -> str:
+    """Render a prompt pack in Markdown format."""
+    parts = [f"# {title}"]
+    if header:
+        parts.append(f"\n\n{header}")
+    if system_prompt:
+        parts.append(f"\n\n## System Prompt\n\n{system_prompt}")
+    if user_prompt:
+        parts.append(f"\n\n## User Prompt\n\n{user_prompt}")
+    if plan:
+        parts.append(f"\n\n## Plan\n\n{plan}")
+    if expanded:
+        parts.append(f"\n\n## Expanded Prompt\n\n{expanded}")
+    return "".join(parts).strip()
+
+
+def _render_prompt_pack_txt(
+    system_prompt: str,
+    user_prompt: str,
+    plan: str,
+    expanded: str,
+    header: str = "",
+) -> str:
+    """Render a prompt pack in Plain Text format."""
+    parts = []
+    if header:
+        parts.append(f"{header}\n")
+    if system_prompt:
+        parts.append(f"--- System Prompt ---\n{system_prompt}")
+    if user_prompt:
+        parts.append(f"\n\n--- User Prompt ---\n{user_prompt}")
+    if plan:
+        parts.append(f"\n\n--- Plan ---\n{plan}")
+    if expanded:
+        parts.append(f"\n\n--- Expanded Prompt ---\n{expanded}")
+    return "".join(parts).strip()
+```
+
+- [ ] **Step 4: Build and pass the header in `pack_command`**
+
+In `cli/commands/core.py`, inside `pack_command`, just before the `fmt_l = (format or "md").lower()` line (line ~961), add:
+
+```python
+    if v1:
+        _domain = "—"
+        _persona = getattr(ir, "persona", "—")
+        _risk = "—"
+    else:
+        _ir2_json = ir2.model_dump()
+        _domain = _ir2_json.get("domain") or "—"
+        _persona = _ir2_json.get("persona") or "—"
+        _risk = ((_ir2_json.get("metadata") or {}).get("policy_summary") or {}).get(
+            "risk_level"
+        ) or "—"
+    pack_header = (
+        f"Domain: {_domain} | Persona: {_persona} | Risk: {_risk} | IR version: {ir_ver}"
+    )
+```
+
+Then update the md and txt calls (lines ~963 and ~966) to pass the header:
+
+```python
+        payload = _render_prompt_pack_md(
+            system_prompt, user_prompt, plan, expanded, header=pack_header
+        )
+```
+```python
+        payload = _render_prompt_pack_txt(
+            system_prompt, user_prompt, plan, expanded, header=pack_header
+        )
+```
+
+(The `json` format branch is left unchanged — it already carries `ir_version`/`heuristic_version`.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_cli_phase2.py::test_pack_md_includes_metadata_header -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/utils.py cli/commands/core.py tests/test_cli_phase2.py
+git commit -m "feat(cli): add metadata header to pack output"
+```
+
+---
+
+## Task 5: Full verification + draft PR
+
+- [ ] **Step 1: ruff + full suite**
+
+Run: `python -m ruff check cli/ app/ tests/test_cli_phase2.py`
+Run: `python -m pytest tests/ -q`
+Expected: ruff clean; suite green (with any Task 3 Step 7 test updates applied).
+
+- [ ] **Step 2: Clean-venv smoke test (real published behavior)**
+
+```bash
+SCRATCH="/private/tmp/claude-501/-Users-mehmetozel-Developer-personal-Compiler/23364b9e-b080-4fdf-bcd9-67c530a7cb8f/scratchpad"
+rm -rf "$SCRATCH/dist2" "$SCRATCH/smoke-venv2"
+python -m build --wheel --outdir "$SCRATCH/dist2"
+python -m venv "$SCRATCH/smoke-venv2"
+"$SCRATCH/smoke-venv2/bin/pip" install -q "$SCRATCH"/dist2/prcompiler-*.whl
+"$SCRATCH/smoke-venv2/bin/promptc" compile "write a haiku about the sea"
+```
+Expected: output shows a Summary panel + System/User/Plan/Expanded sections, NO leading `[STRATEGIST]` line, NO raw IR JSON dump.
+
+- [ ] **Step 3: Push and open a DRAFT PR**
+
+```bash
+git push -u origin feat/cli-phase2-output-ux
+gh pr create --draft --base main --head feat/cli-phase2-output-ux \
+  --title "CLI Phase 2: compile/pack output & UX" \
+  --body "Human-first compile output (summary card + rendered prompts by default; raw IR via --json-only), new cli/render.py, pack metadata header, fixed --quiet, and silenced the [STRATEGIST] stderr noise. Emitters/heuristics untouched; machine paths stay plain. Spec: docs/superpowers/specs/2026-06-24-cli-phase2-output-ux-design.md"
+```
+
+- [ ] **Step 4: Report** changed files, smoke-test output, CI status. Do NOT merge without explicit user approval.
+
+---
+
+## Self-Review (completed by author)
+
+- **Spec coverage:** (A) `cli/render.py` → Task 2. (B) compile human-first + `--quiet` → Task 3. (C) pack header → Task 4. (D) `[STRATEGIST]` noise → Task 1. Machine paths stay plain (Task 3 keeps `--json-only`/`--out`/`--quiet` branches). All covered. Spec's optional `.txt` "### Context" cleanup is intentionally dropped: on inspection that bleed comes from emitter *content* (out of scope — emitters untouched), not from `_render_prompt_pack_txt`, which already uses `--- X ---` delimiters.
+- **Placeholder scan:** none — every code step shows concrete content. Task 3 Step 7 is a discovery-and-fix step with an exact command and explicit criteria, not a placeholder.
+- **Type/name consistency:** `get_console`, `render_summary_card(console, ir_json)`, `render_prompt_sections(console, system, user, plan, expanded)`, `SECTION_TITLES`, `pack_header`, `header=` param are used identically across Tasks 2-4. Summary card reads `metadata.policy_summary.risk_level` — verified against a real `compile --json-only` dump.
+- **Risk:** Task 3 changes the flagship default; Step 7 explicitly updates tests that relied on the old default. Reversible.

--- a/docs/superpowers/specs/2026-06-24-cli-phase2-output-ux-design.md
+++ b/docs/superpowers/specs/2026-06-24-cli-phase2-output-ux-design.md
@@ -1,0 +1,126 @@
+# CLI Phase 2 — compile/pack Output & UX
+
+**Date:** 2026-06-24
+**Scope:** `compile` and `pack` output only. New `cli/render.py`; edits to `cli/commands/core.py`, `app/utils.py`, and a one-line fix in `app/agents/context_strategist.py`.
+**Status:** Approved design → ready for implementation plan.
+**Predecessor:** Phase 1 (declutter + `--version` + install fix) merged as #844.
+
+## Özet (TR)
+Flagship `compile`'ın varsayılan çıktısı şu an insan için bozuk: `--render-v2` False varsayılan
+ve prompt bölümleri ona bağlı olduğu için kullanıcı sadece 200+ satır ham IR JSON görüyor,
+kopyalanabilir prompt yok. Faz 2: varsayılanı **insan-öncelikli** yapar (özet kart +
+System/User/Plan/Expanded), ham IR'ı `--json-only`'ye taşır, `pack` çıktısına başlık ekler,
+ölü `--quiet` flag'ini düzeltir ve her offline run'da stderr'e basılan `[STRATEGIST]` gürültü
+satırını `logger.debug`'a indirir. Tüm rich render tek bir `cli/render.py`'de toplanır;
+makine yolları (`--json-only`/`--out`/`--format`/`--quiet`) düz kalır.
+
+## Context / Problem (verified against source)
+`promptc compile "..."` today prints **only raw IR JSON** and no usable prompt. Confirmed:
+`render_v2` defaults to `False` (`cli/commands/core.py:396`), and the prompt sections are gated
+on `if ir or (ir2 and render_v2)` (`core.py:311`). With the default v2 path (`v1=False`,
+`render_v2=False`) that condition is always false, so only `print(rendered)` (raw orjson IR,
+`core.py:310`) runs. Observed directly in the Phase 1 install smoke test.
+
+Other verified issues:
+- **`[STRATEGIST]` noise:** `app/agents/context_strategist.py:101` is an unconditional
+  `print(f"[STRATEGIST] Query expansion failed: {e}", file=sys.stderr)` — it fires on every
+  no-credential/offline run and reads like an error. (It goes to **stderr**, not stdout; the
+  survey's "corrupts pack JSON" claim was an overstatement, but the noisy stderr line on normal
+  runs is still wrong — everywhere else this is `logger.debug`.)
+- **Rendering inconsistency:** `compile` uses bare rich `print` with inline markup; `fix`/`compare`
+  use `Console`+`Panel`+`Table`; `pack` uses plain `typer.echo`. A `Console()` is defined at
+  `core.py:52` but the central command doesn't use it.
+- **Latent markup bug:** emitter strings contain tokens like `[clarify]`, `[policy]`, `[task]`
+  that rich's markup parser silently swallows on the `print(...[bold]...)` path.
+- **Dead `--quiet`:** documented as "print only system prompt" but emits a blank line on the
+  default v2 path.
+- **`pack` polish:** `_render_prompt_pack_md/_render_prompt_pack_txt` (in `app/utils.py`) are used
+  **only** by the pack command (`core.py:963/966`) — no API usage — so changing them is CLI-scoped
+  and safe. The `.txt` form currently bleeds markdown (`### Context`).
+
+## Goals
+- `promptc compile "..."` (no flags) shows a concise summary card + rendered System / User / Plan /
+  Expanded prompts — usable, copy-pasteable output.
+- Raw IR JSON is available via `--json-only` (unchanged, parseable contract).
+- One consistent rich "house style" for human output, centralized in `cli/render.py`.
+- `--quiet` prints the real v2 system prompt; `pack` output gets a compact metadata header and a
+  clean plain-text `.txt`.
+- Normal offline runs no longer print an error-looking `[STRATEGIST]` line.
+
+## Non-Goals (explicit)
+- **No changes to `app/emitters.py` content** or the heuristics/compiler. Emitters return
+  display-agnostic strings by design; rendering only reformats them.
+- **Upstream IR/heuristic bugs are out of scope** (constraint "garbage" text, `under 200 words`→
+  `budget:200` misparse, Goals==Tasks duplication). These live in the shared v2 layer and need a
+  separate, larger PR with broader test coverage.
+- **Secondary commands deferred:** `validate` / `compare` / `diff` polish (schema dump, Turkish
+  leak, exit codes) is a later phase.
+- No new output flags beyond what exists (`--json-only`, `--quiet`, `--out`, `--format`, `--diagnostics`).
+- Machine-output paths stay plain — never routed through rich.
+
+## Design
+
+### A) `cli/render.py` (new — CLI presentation layer)
+Single home for human-tier rendering. Pure presentation; takes already-computed strings/dicts.
+- `get_console() -> Console` — shared Console factory.
+- `render_summary_card(console, ir2: dict) -> None` — a rich `Panel`/`Table` showing
+  Persona, Domain, Risk (`policy.risk_level`/`metadata`), #Goals, #Constraints, output format.
+- `render_prompt_sections(console, system, user, plan, expanded) -> None` — one `console.rule()` +
+  body per section, rendered with `markup=False` / `rich.markup.escape` so `[clarify]` etc. are not
+  swallowed. Fixes the latent markup bug.
+- Section-title constants (System Prompt / User Prompt / Plan / Expanded) shared so headers aren't
+  duplicated across the console view and pack.
+Hard rule baked into the module's docstring: machine-output paths must NOT use these helpers.
+
+### B) `compile` (`cli/commands/core.py`)
+- **Default (no output flags):** compute the v2 emitter strings regardless of `render_v2`, then
+  `render_summary_card(...)` + `render_prompt_sections(...)`. Remove the default `print(rendered)`
+  raw-IR dump.
+- `--json-only`: unchanged — plain raw IR JSON to stdout (parseable).
+- `--quiet`: emit the real v2 system prompt (plain stdout). Fixes the dead flag.
+- `--out` / `--format` / `--from-file` write paths: unchanged (plain).
+- `--render-v2`: now redundant (default renders); keep as an accepted no-op for back-compat.
+- `--diagnostics`: keep current meaning (risk & ambiguity in expanded). If it remains a no-op on
+  the v2 path, make it append the diagnostics block to the rendered Expanded section.
+
+### C) `pack` (`app/utils.py` + `cli/commands/core.py`)
+- In `_render_prompt_pack_md` and `_render_prompt_pack_txt`: prepend a compact header
+  (Domain / Risk / Persona / IR version).
+- In `_render_prompt_pack_txt`: replace markdown bleed (`### Context`) with plain `--- Context ---`
+  and emoji constraint labels with plain text (e.g. `Restriction:` / `Flow:`).
+- These return plain strings (the copy/paste/file artifact); they do NOT use rich.
+
+### D) `[STRATEGIST]` noise fix (`app/agents/context_strategist.py:101`)
+Replace `print(f"[STRATEGIST] Query expansion failed: {e}", file=sys.stderr)` with a
+`logger.debug(...)` call (add/Reuse a module logger, matching `app/llm_engine/client.py`). Standalone
+and independently valuable — ships as its own small PR first.
+
+## Files Affected
+- `cli/render.py` — new presentation module.
+- `cli/commands/core.py` — compile default/quiet rendering wiring; pack header pass-through.
+- `app/utils.py` — pack header + plain-text `.txt` cleanup (CLI-only functions).
+- `app/agents/context_strategist.py` — one-line `print`→`logger.debug`.
+- `tests/test_cli_phase2.py` (new) + updates to existing tests that assert default-compile-is-JSON.
+
+## Testing & Verification
+- `cli/render.py` unit tests: summary card contains the expected fields; `render_prompt_sections`
+  output preserves `[clarify]`-style tokens (markup not swallowed).
+- `compile` default (CliRunner): stdout contains "System Prompt"/"User Prompt"/"Plan"/"Expanded"
+  and summary fields; stdout does NOT contain a raw IR dump (`"version": "2.0"`).
+- `--json-only`: stdout parses as JSON (contract preserved).
+- `--quiet`: stdout non-empty (the system prompt).
+- `pack`: output contains the new header; `.txt` contains no `### ` markdown headers.
+- Update any existing golden/compile test that asserted the old default JSON output.
+- Full pytest suite green; ruff clean; CI green.
+
+## Risks
+- **Medium.** The flagship default output changes (behavior change), so existing tests/scripts that
+  relied on default-is-JSON must switch to `--json-only`; golden tests get updated. Also touches
+  `app/utils.py` (pack, CLI-only) and a one-line `app/agents` fix. Mitigated by: machine paths stay
+  plain, emitters untouched, focused scope, and the change is reversible. `prcompiler` is a new PyPI
+  name with no install base, so the default flip is least disruptive now.
+
+## Rollout (small & reversible)
+- **PR-A:** `[STRATEGIST]` noise fix (Section D) — standalone, tiny, ships first.
+- **PR-B:** `cli/render.py` + compile human-first default + pack header + `--quiet` fix (Sections A–C).
+- Both draft until CI green + clean-venv check that `promptc compile "..."` shows rendered prompts.

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -71,3 +71,10 @@ def test_compile_quiet_emits_nonempty_system_prompt():
     result = _runner.invoke(_app, ["compile", "write a haiku", "--quiet"])
     assert result.exit_code == 0
     assert result.stdout.strip() != ""
+
+
+def test_pack_md_includes_metadata_header():
+    result = _runner.invoke(_app, ["pack", "build a rest api", "--format", "md"])
+    assert result.exit_code == 0
+    assert "Domain:" in result.stdout
+    assert "IR version:" in result.stdout

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -41,3 +41,33 @@ def test_prompt_sections_preserve_bracket_tokens():
     assert "[clarify]" in out
     assert "[policy]" in out
     assert "System Prompt" in out
+
+
+import json as _json
+
+from typer.testing import CliRunner
+
+from cli.main import app as _app
+
+_runner = CliRunner()
+
+
+def test_compile_default_shows_rendered_sections_not_raw_ir():
+    result = _runner.invoke(_app, ["compile", "write a haiku about the sea"])
+    assert result.exit_code == 0
+    assert "System Prompt" in result.stdout
+    assert "User Prompt" in result.stdout
+    assert '"version": "2.0"' not in result.stdout
+
+
+def test_compile_json_only_still_outputs_valid_json():
+    result = _runner.invoke(_app, ["compile", "write a haiku", "--json-only"])
+    assert result.exit_code == 0
+    parsed = _json.loads(result.stdout)
+    assert parsed.get("version") == "2.0"
+
+
+def test_compile_quiet_emits_nonempty_system_prompt():
+    result = _runner.invoke(_app, ["compile", "write a haiku", "--quiet"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() != ""

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -1,3 +1,14 @@
+import json as _json
+
+from rich.console import Console
+from typer.testing import CliRunner
+
+from cli.main import app as _app
+from cli.render import render_prompt_sections, render_summary_card
+
+_runner = CliRunner()
+
+
 def test_strategist_expansion_failure_is_silent(capsys):
     from app.agents.context_strategist import ContextStrategist
 
@@ -10,11 +21,6 @@ def test_strategist_expansion_failure_is_silent(capsys):
     captured = capsys.readouterr()
     assert "[STRATEGIST]" not in captured.err
     assert isinstance(result, list)
-
-
-from rich.console import Console
-
-from cli.render import render_summary_card, render_prompt_sections
 
 
 def test_summary_card_shows_key_fields():
@@ -41,15 +47,6 @@ def test_prompt_sections_preserve_bracket_tokens():
     assert "[clarify]" in out
     assert "[policy]" in out
     assert "System Prompt" in out
-
-
-import json as _json
-
-from typer.testing import CliRunner
-
-from cli.main import app as _app
-
-_runner = CliRunner()
 
 
 def test_compile_default_shows_rendered_sections_not_raw_ir():

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -1,0 +1,12 @@
+def test_strategist_expansion_failure_is_silent(capsys):
+    from app.agents.context_strategist import ContextStrategist
+
+    class _BoomClient:
+        def _call_api(self, *args, **kwargs):
+            raise RuntimeError("no api key")
+
+    strat = ContextStrategist(client=_BoomClient())
+    result = strat._expand_query("write a haiku about the sea")
+    captured = capsys.readouterr()
+    assert "[STRATEGIST]" not in captured.err
+    assert isinstance(result, list)

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -10,3 +10,34 @@ def test_strategist_expansion_failure_is_silent(capsys):
     captured = capsys.readouterr()
     assert "[STRATEGIST]" not in captured.err
     assert isinstance(result, list)
+
+
+from rich.console import Console
+
+from cli.render import render_summary_card, render_prompt_sections
+
+
+def test_summary_card_shows_key_fields():
+    console = Console(record=True, width=80)
+    ir = {
+        "persona": "assistant",
+        "domain": "software",
+        "output_format": "text",
+        "goals": ["g1"],
+        "constraints": ["c1", "c2"],
+        "metadata": {"policy_summary": {"risk_level": "low"}},
+    }
+    render_summary_card(console, ir)
+    out = console.export_text()
+    assert "assistant" in out
+    assert "software" in out
+    assert "low" in out
+
+
+def test_prompt_sections_preserve_bracket_tokens():
+    console = Console(record=True, width=80)
+    render_prompt_sections(console, "Use [clarify] and [policy] here", "", "", "")
+    out = console.export_text()
+    assert "[clarify]" in out
+    assert "[policy]" in out
+    assert "System Prompt" in out

--- a/tests/test_cli_phase2.py
+++ b/tests/test_cli_phase2.py
@@ -78,3 +78,10 @@ def test_pack_md_includes_metadata_header():
     assert result.exit_code == 0
     assert "Domain:" in result.stdout
     assert "IR version:" in result.stdout
+
+
+def test_compile_json_only_format_md_emits_markdown():
+    result = _runner.invoke(_app, ["compile", "write a haiku", "--json-only", "--format", "md"])
+    assert result.exit_code == 0
+    assert "# System Prompt" in result.stdout
+    assert "# IR JSON" in result.stdout


### PR DESCRIPTION
Phase 2 of the CLI cleanup: make `promptc compile` human-readable by default and unify output styling.

## Changes
- **Human-first `compile` default:** instead of dumping ~200 lines of raw IR JSON, the default now prints a **Summary panel** (Persona / Domain / Risk / Output / #Goals / #Constraints) + rendered **System / User / Plan / Expanded** sections. Raw IR remains available via `--json-only`.
- **New `cli/render.py`:** shared human-tier helpers (`get_console`, `render_summary_card`, `render_prompt_sections`, `SECTION_TITLES`). Markup-safe (`[clarify]`/`[policy]` tokens no longer swallowed).
- **Fixed `--quiet`:** v2 emitters now compute unconditionally, so `--quiet` prints the real system prompt (was a silent empty line).
- **`pack` metadata header:** `Domain | Persona | Risk | IR version` prepended to md/txt output.
- **Silenced `[STRATEGIST]` noise:** the query-expansion failure `print(..., stderr)` is now `logger.debug` — offline runs no longer look like errors.

## Out of scope (unchanged, by design)
- `app/emitters.py` / heuristics content untouched.
- Machine-output paths stay plain: `--json-only` (JSON), `--out`/`--format`, `--quiet` are not routed through rich. (`--json-only --format md` now correctly emits markdown — covered by a new test.)

## Verification
- 8 Phase 2 tests + regression sweeps green; ruff clean; spec + code-quality review both approved.
- Clean-venv smoke test: `pip install prcompiler` → `promptc compile "..."` shows the Summary panel + sections, no `[STRATEGIST]` line, no raw IR dump.

## ⚠️ Known issue surfaced by the smoke test (separate, pre-existing — NOT fixed here)
On a machine with a populated local RAG index, the Context Strategist injects indexed files into the System Prompt's `### Context` section, so the (now prominently rendered) default output can show **absolute paths to unrelated local files**. This is pre-existing (the snippets were already in the IR metadata before this PR) and lives in the RAG/emitter layer, which is out of Phase 2's scope. Recommended follow-up: make RAG retrieval opt-in / offline-by-default for `compile`.

Spec: `docs/superpowers/specs/2026-06-24-cli-phase2-output-ux-design.md`
Plan: `docs/superpowers/plans/2026-06-24-cli-phase2-output-ux.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)