### PR TITLE
🎨 Palette: [UX improvement] Add aria-live to CopyButton

### DIFF
--- a/web/app/components/CopyButton.tsx
+++ b/web/app/components/CopyButton.tsx
@@ -38,6 +38,7 @@ export default function CopyButton({
       className={`${baseClasses} ${variantClasses} ${className}`}
       title={copied ? "Copied!" : label}
       aria-label={copied ? "Copied" : label}
+      aria-live="polite"
     >
       {copied ? (
         <>


### PR DESCRIPTION
💡 **What:** Added `aria-live="polite"` to the `CopyButton` component.
🎯 **Why:** To ensure that when the button state changes (from "Copy to Clipboard" to "Copied!"), screen readers announce the change to visually impaired users without interrupting their workflow.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers now accurately announce when the text has been successfully copied to the clipboard.

---
*PR created automatically by Jules for task [12188755222273525496](https://jules.google.com/task/12188755222273525496) started by @madara88645*