### PR TITLE
Add path-safe repo context layer

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -4,7 +4,7 @@ import time
 import functools
 import uuid
 import anyio
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
@@ -19,7 +19,13 @@ from api.shared import (
     safety_refusal_prompt_fields,
 )
 from app.compiler import HEURISTIC_VERSION, HEURISTIC2_VERSION
-from app.compiler import compile_text, compile_text_v2, generate_trace, optimize_ir
+from app.compiler import (
+    _attach_repo_context_metadata,
+    compile_text,
+    compile_text_v2,
+    generate_trace,
+    optimize_ir,
+)
 from app.emitters import (
     emit_expanded_prompt,
     emit_expanded_prompt_v2,
@@ -39,6 +45,12 @@ from app.optimizer.language_costs import (
     estimate_prompt_cost,
 )
 from app.optimizer.postprocess import strip_wrapper_labels
+from app.repo_context import (
+    RepoContextInput,
+    RepoContextMode,
+    rag_results_to_envelope,
+    render_repo_context_for_llm,
+)
 from app.validator import validate_prompt
 
 router = APIRouter(tags=["compile"])
@@ -74,6 +86,14 @@ class CompileRequest(BaseModel):
         max_length=40,
         description='Optional prompt compiler mode, e.g. "conservative" or "default".',
     )
+    repo_context: RepoContextInput | None = Field(
+        default=None,
+        description="Optional path-safe repository context. Omitted by default.",
+    )
+    repo_context_mode: RepoContextMode = Field(
+        default="compact",
+        description="How much optional repository context to render when repo_context is supplied.",
+    )
 
     @field_validator("tags")
     @classmethod
@@ -84,6 +104,16 @@ class CompileRequest(BaseModel):
         if any(len(t) > 100 for t in normalized):
             raise ValueError("Tag length must not exceed 100 characters")
         return normalized[:20]
+
+
+def _repo_context_payload(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return value
+    return None
 
 
 class CompileResponse(BaseModel):
@@ -356,7 +386,13 @@ def compile_endpoint(
 
     ir = optimize_ir(compile_text(req.text))
     trace_lines = generate_trace(ir) if req.trace else None
-    ir2 = compile_text_v2(req.text, offline_only=not req.v2)
+    repo_context_payload = _repo_context_payload(req.repo_context)
+    ir2 = compile_text_v2(
+        req.text,
+        offline_only=not req.v2,
+        repo_context=repo_context_payload,
+        repo_context_mode=req.repo_context_mode,
+    )
 
     # The heuristic v2 pipeline runs the SafetyHandler (injection / secret-exfiltration
     # scan). The LLM worker path below rebuilds ir2 and does NOT run that scan, so capture
@@ -371,8 +407,19 @@ def compile_endpoint(
     if req.v2:
         try:
             compiler = _get_compiler()
-            worker_res = compiler.compile(req.text, mode=mode)
+            worker_res = compiler.compile(
+                req.text,
+                mode=mode,
+                repo_context=repo_context_payload,
+                repo_context_mode=req.repo_context_mode,
+            )
             ir2, used_fallback = _coerce_fast_ir(req.text, worker_res)
+            if ir2 is not None:
+                _attach_repo_context_metadata(
+                    ir2,
+                    repo_context_payload,
+                    repo_context_mode=req.repo_context_mode,
+                )
 
             # Re-apply the heuristic safety verdict — the worker IR does not run the
             # SafetyHandler, so without this an unsafe prompt would lose its
@@ -424,13 +471,15 @@ def compile_endpoint(
 
             critic = CriticAgent()
             context_str = ""
-            if ir2 and ir2.metadata.get("context_snippets"):
-                snippets = ir2.metadata["context_snippets"]
-                context_str = "\n\n".join(
-                    [
-                        f"--- File: {item.get('path')} ---\n{item.get('snippet', '')}"
-                        for item in snippets
-                    ]
+            if ir2 and ir2.metadata.get("repo_context"):
+                context_str = render_repo_context_for_llm(
+                    ir2.metadata["repo_context"],
+                    mode=req.repo_context_mode,
+                )
+            elif ir2 and ir2.metadata.get("context_snippets"):
+                context_str = render_repo_context_for_llm(
+                    rag_results_to_envelope(ir2.metadata["context_snippets"]),
+                    mode=req.repo_context_mode,
                 )
             critique_result = critic.critique(
                 user_request=req.text,
@@ -637,8 +686,7 @@ async def optimize_endpoint(
 
         if optimized_cost.tokens > source_cost.tokens > 0:
             warnings.append(
-                "Optimized output uses more tokens than the input; "
-                "consider keeping the original."
+                "Optimized output uses more tokens than the input; consider keeping the original."
             )
 
         english_variant = ""

--- a/api/routes/generators.py
+++ b/api/routes/generators.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import time
-from typing import Literal
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 
 from api.auth import rate_limit_by_ip
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from api.shared import logger
 from app.llm_engine.client import _sanitize_skill_definition_plain
@@ -17,6 +16,7 @@ from app.github_repo_context import (
     analyze_public_github_repo,
 )
 from app.llm_engine.example_code import inspect_agent_example_code, inspect_skill_example_code
+from app.repo_context import GitHubRepoContextPayload, RepoContextInput, RepoContextMode
 
 
 def _safe_repo_full_name(repo_url: str) -> str | None:
@@ -66,33 +66,6 @@ def _get_compiler():
     return api_main.get_compiler()
 
 
-RepoContextMode = Literal["full", "compact"]
-
-
-class GitHubRepoContextPayload(BaseModel):
-    normalized_repo_url: str = Field(..., min_length=1, max_length=500)
-    repo_full_name: str = Field(..., min_length=1, max_length=255)
-    requested_ref: str | None = Field(default=None, max_length=255)
-    requested_subdir: str | None = Field(default=None, max_length=500)
-    default_branch: str | None = Field(default=None, max_length=255)
-    summary: str = Field(..., min_length=1, max_length=1_500)
-    summary_compact: str | None = Field(default=None, max_length=400)
-    highlights: list[str] = Field(default_factory=list, max_length=6)
-    files_used: list[str] = Field(default_factory=list, max_length=6)
-    detected_stack: list[str] = Field(default_factory=list, max_length=6)
-
-    # Security: Enforce strict length limits on list elements to prevent DoS via massive strings
-    @field_validator("highlights", "files_used", "detected_stack", mode="after")
-    @classmethod
-    def validate_list_items_length(cls, items: list[str]) -> list[str]:
-        if not items:
-            return items
-        for item in items:
-            if len(item) > 1024:
-                raise ValueError("Item in list exceeds maximum length of 1024 characters")
-        return items
-
-
 class GitHubRepoContextRequest(BaseModel):
     repo_url: str = Field(..., min_length=1, max_length=500)
 
@@ -103,7 +76,7 @@ class SkillGenRequest(BaseModel):
         default=False,
         description="Whether generated skill definition should include implementation example code",
     )
-    repo_context: GitHubRepoContextPayload | None = None
+    repo_context: RepoContextInput | None = None
     repo_context_mode: RepoContextMode = Field(
         default="full",
         description="Whether to use the full or the compact repo brief in the generator prompt.",
@@ -121,7 +94,7 @@ class AgentGenRequest(BaseModel):
     description: str = Field(..., min_length=1, max_length=_MAX_DESCRIPTION_CHARS)
     multi_agent: bool = Field(default=False, description="Generate a multi-agent swarm if true")
     include_example_code: bool = Field(default=False, description="Include pseudo-code example")
-    repo_context: GitHubRepoContextPayload | None = None
+    repo_context: RepoContextInput | None = None
     repo_context_mode: RepoContextMode = Field(
         default="full",
         description="Whether to use the full or the compact repo brief in the generator prompt.",

--- a/api/routes/pr_safety.py
+++ b/api/routes/pr_safety.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from api.auth import rate_limit_by_ip
 from app.pr_safety.analyzer import analyze_pr_safety
 from app.pr_safety.models import PrSafetyReport
+from app.repo_context import RepoContextInput, RepoContextMode
 
 router = APIRouter(tags=["pr-safety"])
 
@@ -22,6 +23,14 @@ class PrSafetyReportRequest(BaseModel):
         default=None,
         ge=0,
         description="Optional number of commits the branch is behind the base branch",
+    )
+    repo_context: RepoContextInput | None = Field(
+        default=None,
+        description="Reserved optional repo context for future repo-aware PR Safety checks.",
+    )
+    repo_context_mode: RepoContextMode = Field(
+        default="compact",
+        description="Reserved repo context rendering mode for future repo-aware PR Safety checks.",
     )
 
 

--- a/app/compiler.py
+++ b/app/compiler.py
@@ -52,6 +52,7 @@ from .heuristics.handlers.format_enforcer import FormatEnforcerHandler
 from .heuristics.handlers.paradox_resolver import ParadoxResolverHandler
 from .heuristics.handlers.deduplicator import DeduplicatorHandler
 from .heuristics.handlers.schema_sanitizer import SchemaSanitizerHandler
+from app.repo_context import coerce_repo_context_envelope
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +225,38 @@ def _mk_id(text: str) -> str:
     return hashlib.sha1(text.strip().lower().encode("utf-8")).hexdigest()[:10]
 
 
-def compile_text_v2(text: str, offline_only: bool = False) -> IRv2:
+def _attach_repo_context_metadata(
+    ir2: IRv2,
+    repo_context: dict[str, Any] | None,
+    *,
+    repo_context_mode: str = "compact",
+) -> None:
+    envelope = coerce_repo_context_envelope(repo_context)
+    if envelope is None:
+        return
+
+    mode = (repo_context_mode or "compact").strip().lower()
+    if mode not in {"full", "compact"}:
+        mode = "compact"
+    payload = envelope.model_dump(mode="json")
+    payload["mode"] = mode
+    ir2.metadata["repo_context"] = payload
+    ir2.diagnostics.append(
+        DiagnosticItem(
+            severity="info",
+            message="Repository context attached",
+            suggestion="Repo context is opt-in and rendered through the path-safe context layer.",
+            category="context",
+        )
+    )
+
+
+def compile_text_v2(
+    text: str,
+    offline_only: bool = False,
+    repo_context: dict[str, Any] | None = None,
+    repo_context_mode: str = "compact",
+) -> IRv2:
     # Reuse v1 heuristics to keep behavior; map to richer IRv2 model
     ir1 = compile_text(text)
 
@@ -316,36 +348,7 @@ def compile_text_v2(text: str, offline_only: bool = False) -> IRv2:
     # Run Schema Sanitizer to fix any generated schema types
     SchemaSanitizerHandler().handle(ir2, ir1)
 
-    # -------------------------------------------------------------------------
-    # -------------------------------------------------------------------------
-    # NEW: Agent 6 - The Context Strategist
-    # -------------------------------------------------------------------------
-    if not offline_only:
-        try:
-            from app.agents.context_strategist import ContextStrategist
-
-            # Initialize Strategist (uses WorkerClient internally)
-            strategist = ContextStrategist()
-            context_results = strategist.retrieve(text, limit=3)
-
-            if context_results:
-                ir2.metadata["context_snippets"] = context_results
-                # Notify user via diagnostics
-                snippet_files = [r.get("path", "unknown").split("/")[-1] for r in context_results]
-                ir2.diagnostics.append(
-                    DiagnosticItem(
-                        severity="info",
-                        message=f"Strategist retrieved {len(context_results)} relevant sources",
-                        suggestion=f"Sources: {', '.join(snippet_files)}",
-                        category="context",
-                    )
-                )
-        except Exception:
-            logger.exception(
-                "Context Strategist failed; continuing without retrieved context",
-                extra={"offline_only": offline_only, "text_length": len(text)},
-            )
-    # -------------------------------------------------------------------------
+    _attach_repo_context_metadata(ir2, repo_context, repo_context_mode=repo_context_mode)
 
     plugin_ctx = PluginContext(
         text=text,

--- a/app/emitters.py
+++ b/app/emitters.py
@@ -4,6 +4,18 @@ import itertools
 import os
 from .models import IR
 from .models_v2 import IRv2, ConstraintV2, StepV2
+from app.repo_context import rag_results_to_envelope, render_repo_context_for_llm
+
+
+def _render_repo_context_metadata(ir: IRv2, *, mode: str) -> str:
+    metadata = ir.metadata or {}
+    repo_context = metadata.get("repo_context")
+    if repo_context:
+        return render_repo_context_for_llm(repo_context, mode=mode)
+    context_snippets = metadata.get("context_snippets")
+    if context_snippets:
+        return render_repo_context_for_llm(rag_results_to_envelope(context_snippets), mode=mode)
+    return ""
 
 
 def emit_system_prompt(ir: IR) -> str:
@@ -505,15 +517,9 @@ def emit_system_prompt_v2(ir: IRv2) -> str:
     if ir.banned:
         parts.append("Avoid: " + ", ".join(ir.banned))
 
-    # --- Agent 6: The Strategist (Render Context) ---
-    context_snippets = (ir.metadata or {}).get("context_snippets")
-    if context_snippets:
-        parts.append("\n### Context (Code & Knowledge)")
-        for i, snippet in enumerate(context_snippets, 1):
-            path = snippet.get("path", "unknown")
-            content = snippet.get("snippet", "").strip()
-            parts.append(f"#### File: {path}\n```\n{content}\n```")
-    # ------------------------------------------------
+    repo_context_block = _render_repo_context_metadata(ir, mode="full")
+    if repo_context_block:
+        parts.append("\n" + repo_context_block)
     return "\n".join(parts)
 
 
@@ -668,25 +674,9 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
         for suggestion in optional_suggestions:
             ctx_lines.append(f"- {suggestion}")
 
-    # --- Agent 6: Context Injection ---
-    context_snippets = (ir.metadata or {}).get("context_snippets")
-    if context_snippets:
-        header = (
-            "Bağlam (Kod ve Bilgi)"
-            if lang == "tr"
-            else (
-                "Contexto (Código y Conocimiento)" if lang == "es" else "Context (Code & Knowledge)"
-            )
-        )
-        ctx_lines.append(f"{header}:")
-        for s in context_snippets:
-            path = s.get("path", "unknown").split("/")[-1]  # Short filename
-            content = s.get("snippet", "").strip().replace("\n", " ")  # Flatten for compactness
-            # Truncate if too long to avoid bloating the prompt
-            if len(content) > 300:
-                content = content[:300] + "..."
-            ctx_lines.append(f"- {path}: {content}")
-    # ----------------------------------
+    repo_context_block = _render_repo_context_metadata(ir, mode="compact")
+    if repo_context_block:
+        ctx_lines.append(repo_context_block)
 
     fmt_line = (
         f"Biçim: {ir.output_format}, Uzunluk: {ir.length_hint}"

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -17,6 +17,7 @@ except ImportError:
 from openai import OpenAI, APIError
 from .schemas import WorkerResponse, QualityReport, LLMFixResponse
 from app.heuristics.security import scan_text
+from app.repo_context import render_repo_context_for_llm
 
 OPENROUTER_DEFAULT_MODEL = "openai/gpt-oss-20b"
 OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
@@ -440,50 +441,7 @@ class WorkerClient:
         mode = str(repo_context.get("mode") or "full").strip().lower()
         if mode not in {"full", "compact"}:
             mode = "full"
-        repo_full_name = str(repo_context.get("repo_full_name") or "").strip()
-        normalized_url = str(repo_context.get("normalized_repo_url") or "").strip()
-        default_branch = str(repo_context.get("default_branch") or "").strip()
-        detected_stack = repo_context.get("detected_stack") or []
-        highlights = repo_context.get("highlights") or []
-        files_used = repo_context.get("files_used") or []
-        summary_full = str(repo_context.get("summary") or "").strip()
-        summary_compact = str(repo_context.get("summary_compact") or "").strip()
-        active_summary = summary_compact if mode == "compact" and summary_compact else summary_full
-
-        lines = [
-            "## Repo Context (ground truth)",
-            "Treat the facts in this section as the only verified information about the user's "
-            "repository. Only reference tools, APIs, file paths, manifests, or conventions that are "
-            "visible here. Do NOT invent libraries, endpoints, file paths, or capabilities that are "
-            "not listed below. If something is missing, mark it as a TODO or open question instead "
-            "of guessing.",
-            "",
-        ]
-        if repo_full_name:
-            lines.append(f"- Repo: {repo_full_name}")
-        if normalized_url:
-            lines.append(f"- URL: {normalized_url}")
-        if default_branch:
-            lines.append(f"- Default branch: {default_branch}")
-        if isinstance(detected_stack, list) and detected_stack:
-            lines.append(f"- Detected stack: {', '.join(str(item) for item in detected_stack)}")
-        if isinstance(files_used, list) and files_used:
-            lines.append(f"- Brief built from: {', '.join(str(item) for item in files_used)}")
-        if isinstance(highlights, list) and highlights:
-            lines.append("- Highlights:")
-            for item in highlights:
-                lines.append(f"  - {item}")
-        if active_summary:
-            lines.append("")
-            lines.append(f"### Repo brief ({mode})")
-            lines.append(active_summary)
-        lines.append("")
-        lines.append(
-            "Reminder: this brief is README + manifest level only. Do NOT make file-level "
-            'implementation claims (no "in `src/foo.py` we…" unless that file is listed in '
-            "'Brief built from'). Use TODO markers when uncertain."
-        )
-        return "\n".join(lines)
+        return render_repo_context_for_llm(repo_context, mode=mode)
 
     def _single_agent_prompt(self, include_example_code: bool) -> str:
         prompt = (

--- a/app/llm_engine/hybrid.py
+++ b/app/llm_engine/hybrid.py
@@ -10,6 +10,7 @@ from cachetools import TTLCache
 
 from .rag import ContextStrategist, SQLiteVectorDB
 import os
+from app.repo_context.adapters import coerce_repo_context_envelope, repo_context_cache_fingerprint
 
 logger = logging.getLogger("promptc.llm.hybrid")
 _WORKER_MAX_ATTEMPTS = 2
@@ -33,9 +34,15 @@ class HybridCompiler:
         # Cache: 100 items, expires in 1 hour
         self.cache = TTLCache(maxsize=100, ttl=3600)
 
-    def compile(self, text: str, mode: Optional[str] = None) -> WorkerResponse:
+    def compile(
+        self,
+        text: str,
+        mode: Optional[str] = None,
+        repo_context: dict[str, Any] | None = None,
+        repo_context_mode: str = "compact",
+    ) -> WorkerResponse:
         """
-        Attempt to compile using the Worker LLM with RAG context.
+        Attempt to compile using the Worker LLM with optional repo context.
         Falls back to local heuristics if LLM fails.
         """
         # 1. Fast Checks (Heuristic Guardrails)
@@ -43,22 +50,29 @@ class HybridCompiler:
             return self._fallback(text, "Input was empty")
 
         # 2. Check Cache
-        cache_key = (text, (mode or self.default_mode or "conservative").strip().lower())
+        context_fingerprint = repo_context_cache_fingerprint(repo_context)
+        cache_key = (
+            text,
+            (mode or self.default_mode or "conservative").strip().lower(),
+            context_fingerprint,
+        )
         if cache_key in self.cache:
             return self.cache[cache_key]
 
         # 3. Worker LLM (Slow but Smart)
         try:
-            # --- RAG: Context Strategist ---
-            # Retrieve relevant code context using Agent 6
-            rag_context = self.context_strategist.process(text)
+            normalized_context = self._merge_generator_context(
+                None,
+                repo_context,
+                repo_context_mode,
+            )
 
             # Pass context to Worker. Retry once for transient worker/API failures before
             # dropping to the deterministic heuristic fallback.
             resolved_mode = mode or self.default_mode
             for attempt in range(1, _WORKER_MAX_ATTEMPTS + 1):
                 try:
-                    res = self.worker.process(text, context=rag_context, mode=resolved_mode)
+                    res = self.worker.process(text, context=normalized_context, mode=resolved_mode)
                     break
                 except Exception as e:
                     if attempt < _WORKER_MAX_ATTEMPTS:
@@ -70,7 +84,7 @@ class HybridCompiler:
                                 "text_length": len(text),
                                 "attempt": attempt,
                                 "max_attempts": _WORKER_MAX_ATTEMPTS,
-                                "rag_context_available": bool(rag_context),
+                                "repo_context_available": bool(normalized_context),
                             },
                         )
                         continue
@@ -82,7 +96,7 @@ class HybridCompiler:
                             "mode": resolved_mode,
                             "text_length": len(text),
                             "attempts": attempt,
-                            "rag_context_available": bool(rag_context),
+                            "repo_context_available": bool(normalized_context),
                         },
                     )
                     return self._fallback(text, f"{e} after {attempt} attempts")
@@ -148,7 +162,7 @@ class HybridCompiler:
                     "mode": mode or self.default_mode,
                     "text_length": len(text),
                     "attempts": 0,
-                    "rag_context_available": False,
+                    "repo_context_available": False,
                 },
             )
             return self._fallback(text, str(e))
@@ -219,7 +233,7 @@ class HybridCompiler:
         try:
             # Retrieve relevant code context using Agent 6
             rag_context = self._merge_generator_context(
-                self.context_strategist.process(text, expand_with_llm=False),
+                None,
                 repo_context,
                 repo_context_mode,
             )
@@ -246,7 +260,7 @@ class HybridCompiler:
         try:
             # Retrieve relevant code context using Agent 6
             rag_context = self._merge_generator_context(
-                self.context_strategist.process(text, expand_with_llm=False),
+                None,
                 repo_context,
                 repo_context_mode,
             )
@@ -266,23 +280,22 @@ class HybridCompiler:
         repo_context_mode: str = "full",
     ) -> Any:
         """
-        Merge an optional repo_context payload into the existing RAG context.
+        Merge an optional repo_context payload into an existing context object.
 
-        rag_context is whatever ``ContextStrategist.process`` returned and may be a
-        dict, a string, or None depending on configuration. When no repo_context
-        is supplied this method passes rag_context through unchanged so existing
-        non-dict callers keep working; only when wrapping repo_context do we coerce
-        rag_context into a dict.
+        When no repo_context is supplied this method passes the original context
+        through unchanged so existing non-dict callers keep working; only when
+        wrapping repo_context do we coerce the context into a dict.
         """
         if not repo_context:
+            return rag_context
+        envelope = coerce_repo_context_envelope(repo_context)
+        if envelope is None:
             return rag_context
         merged: dict[str, Any] = dict(rag_context) if isinstance(rag_context, dict) else {}
         mode = (repo_context_mode or "full").strip().lower()
         if mode not in {"full", "compact"}:
             mode = "full"
-        merged["repo_context"] = {
-            "source": "github_public_repo",
-            "mode": mode,
-            **repo_context,
-        }
+        payload = envelope.model_dump(mode="json")
+        payload["mode"] = mode
+        merged["repo_context"] = payload
         return merged

--- a/app/repo_context/__init__.py
+++ b/app/repo_context/__init__.py
@@ -1,0 +1,37 @@
+from .adapters import (
+    coerce_repo_context_envelope,
+    github_payload_to_envelope,
+    rag_results_to_envelope,
+    sanitize_display_path,
+)
+from .models import (
+    GitHubRepoContextPayload,
+    RepoContextBudget,
+    RepoContextEnvelope,
+    RepoContextIdentity,
+    RepoContextInput,
+    RepoContextMode,
+    RepoContextSafety,
+    RepoContextSnippet,
+    RepoContextSource,
+    RepoContextSummary,
+)
+from .render import render_repo_context_for_llm
+
+__all__ = [
+    "GitHubRepoContextPayload",
+    "RepoContextBudget",
+    "RepoContextEnvelope",
+    "RepoContextIdentity",
+    "RepoContextInput",
+    "RepoContextMode",
+    "RepoContextSafety",
+    "RepoContextSnippet",
+    "RepoContextSource",
+    "RepoContextSummary",
+    "coerce_repo_context_envelope",
+    "github_payload_to_envelope",
+    "rag_results_to_envelope",
+    "render_repo_context_for_llm",
+    "sanitize_display_path",
+]

--- a/app/repo_context/adapters.py
+++ b/app/repo_context/adapters.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    GitHubRepoContextPayload,
+    RepoContextBudget,
+    RepoContextEnvelope,
+    RepoContextIdentity,
+    RepoContextSafety,
+    RepoContextSnippet,
+    RepoContextSummary,
+)
+
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<!https:)(?<!http:)(?:~[/\\]|[A-Za-z]:[\\/]|/(?:Users|home|var|tmp|private|opt|Volumes)/)[^\s`'\"\)]*"
+)
+_SAFE_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._ -]+")
+
+
+def redact_absolute_paths(text: str) -> str:
+    return _ABSOLUTE_PATH_RE.sub("[path-redacted]", str(text or ""))
+
+
+def contains_absolute_path(text: str) -> bool:
+    return bool(_ABSOLUTE_PATH_RE.search(str(text or "")))
+
+
+def sanitize_display_path(raw_path: Any, *, cwd: Path | None = None) -> str:
+    text = str(raw_path or "").strip().replace("\x00", "")
+    if not text or text in {".", ".."}:
+        return "unknown"
+
+    normalized = text.replace("\\", "/")
+    is_absolute = (
+        normalized.startswith("/")
+        or normalized.startswith("~/")
+        or bool(_WINDOWS_DRIVE_RE.match(text))
+    )
+
+    if is_absolute:
+        try:
+            base = (cwd or Path.cwd()).resolve()
+            relative = Path(text).expanduser().resolve(strict=False).relative_to(base)
+            return sanitize_display_path(str(relative), cwd=cwd)
+        except Exception:
+            normalized = Path(normalized).name or "unknown"
+
+    parts = []
+    for part in normalized.split("/"):
+        part = part.strip()
+        if not part or part in {".", ".."}:
+            continue
+        safe = _SAFE_SEGMENT_RE.sub("_", part).strip(" .")
+        if safe:
+            parts.append(safe[:80])
+
+    if not parts:
+        return "unknown"
+    return "/".join(parts[-8:])[:240]
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        key = item.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(item)
+    return result
+
+
+def _clean_text(value: Any, *, max_chars: int) -> str:
+    text = redact_absolute_paths(str(value or "")).strip()
+    if len(text) > max_chars:
+        return text[: max_chars - 3].rstrip() + "..."
+    return text
+
+
+def github_payload_to_envelope(
+    payload: dict[str, Any] | GitHubRepoContextPayload,
+) -> RepoContextEnvelope:
+    github_payload = (
+        payload
+        if isinstance(payload, GitHubRepoContextPayload)
+        else GitHubRepoContextPayload.model_validate(payload)
+    )
+    requested_ref = github_payload.requested_ref or None
+    files_used = _dedupe([sanitize_display_path(path) for path in github_payload.files_used])
+    highlights = [_clean_text(item, max_chars=500) for item in github_payload.highlights]
+    summary_full = _clean_text(github_payload.summary, max_chars=1_500)
+    summary_compact = _clean_text(github_payload.summary_compact or "", max_chars=400) or None
+    snippets = [
+        RepoContextSnippet(
+            display_path="repo highlights", content=item, source_label="GitHub brief"
+        )
+        for item in highlights[:6]
+        if item
+    ]
+
+    return RepoContextEnvelope(
+        source_type="github_public",
+        repo_identity=RepoContextIdentity(
+            name=github_payload.repo_full_name,
+            url=github_payload.normalized_repo_url,
+            default_branch=github_payload.default_branch,
+            ref=requested_ref,
+        ),
+        summary=RepoContextSummary(full=summary_full, compact=summary_compact),
+        detected_stack=[_clean_text(item, max_chars=120) for item in github_payload.detected_stack],
+        files_used=files_used,
+        snippets=snippets,
+        budget=RepoContextBudget(max_chars=4_000),
+        safety=RepoContextSafety(path_safe=True, contains_absolute_paths=False),
+    )
+
+
+def rag_results_to_envelope(
+    results: list[dict[str, Any]], *, max_chars: int = 4_000
+) -> RepoContextEnvelope:
+    snippets: list[RepoContextSnippet] = []
+    files_used: list[str] = []
+    used_chars = 0
+    truncated = False
+
+    for item in results:
+        display_path = sanitize_display_path(
+            item.get("display_path") or item.get("path") or item.get("file") or "unknown"
+        )
+        content = _clean_text(item.get("content") or item.get("snippet") or "", max_chars=700)
+        if not content:
+            continue
+        block_size = len(display_path) + len(content) + 32
+        if used_chars + block_size > max_chars:
+            truncated = True
+            break
+        snippets.append(
+            RepoContextSnippet(
+                display_path=display_path,
+                content=content,
+                score=item.get("hybrid_score") or item.get("similarity") or item.get("score"),
+                source_label=str(item.get("source_label") or "RAG index"),
+            )
+        )
+        files_used.append(display_path)
+        used_chars += block_size
+
+    return RepoContextEnvelope(
+        source_type="rag_index",
+        summary=RepoContextSummary(
+            full="Opt-in local indexed context retrieved from the RAG index.",
+            compact="Opt-in RAG context.",
+        ),
+        files_used=_dedupe(files_used),
+        snippets=snippets,
+        budget=RepoContextBudget(max_chars=max_chars, used_chars=used_chars, truncated=truncated),
+        safety=RepoContextSafety(path_safe=True, contains_absolute_paths=False),
+    )
+
+
+def coerce_repo_context_envelope(value: Any) -> RepoContextEnvelope | None:
+    if value is None:
+        return None
+    if isinstance(value, RepoContextEnvelope):
+        return value
+    if isinstance(value, GitHubRepoContextPayload):
+        return github_payload_to_envelope(value)
+    if not isinstance(value, dict):
+        return None
+    if value.get("source_type"):
+        envelope = RepoContextEnvelope.model_validate(value)
+        return RepoContextEnvelope(
+            **{
+                **envelope.model_dump(),
+                "files_used": [sanitize_display_path(path) for path in envelope.files_used],
+                "snippets": [
+                    {
+                        **snippet.model_dump(),
+                        "display_path": sanitize_display_path(snippet.display_path),
+                        "content": _clean_text(snippet.content, max_chars=2_000),
+                    }
+                    for snippet in envelope.snippets
+                ],
+                "safety": RepoContextSafety(
+                    path_safe=True, contains_absolute_paths=False
+                ).model_dump(),
+            }
+        )
+    if value.get("normalized_repo_url") or value.get("repo_full_name"):
+        return github_payload_to_envelope(value)
+    if value.get("context_snippets"):
+        snippets = value.get("context_snippets")
+        if isinstance(snippets, list):
+            return rag_results_to_envelope(snippets)
+    return None
+
+
+def repo_context_cache_fingerprint(value: Any) -> str:
+    envelope = coerce_repo_context_envelope(value)
+    if envelope is None:
+        return ""
+    payload = envelope.model_dump(mode="json")
+    compact = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(compact.encode("utf-8")).hexdigest()[:16]

--- a/app/repo_context/models.py
+++ b/app/repo_context/models.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+RepoContextSource: TypeAlias = Literal["github_public", "rag_index", "local_upload", "manual"]
+RepoContextMode: TypeAlias = Literal["full", "compact"]
+
+
+class RepoContextIdentity(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str | None = Field(default=None, max_length=255)
+    url: str | None = Field(default=None, max_length=500)
+    default_branch: str | None = Field(default=None, max_length=255)
+    ref: str | None = Field(default=None, max_length=255)
+
+
+class RepoContextSummary(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    full: str = Field(default="", max_length=1_500)
+    compact: str | None = Field(default=None, max_length=400)
+
+
+class RepoContextSnippet(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    display_path: str = Field(..., min_length=1, max_length=240)
+    content: str = Field(default="", max_length=2_000)
+    score: float | None = None
+    source_label: str | None = Field(default=None, max_length=120)
+
+
+class RepoContextBudget(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    max_chars: int = Field(default=4_000, ge=200, le=20_000)
+    used_chars: int = Field(default=0, ge=0, le=20_000)
+    truncated: bool = False
+
+
+class RepoContextSafety(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    path_safe: bool = True
+    contains_absolute_paths: bool = False
+
+
+class RepoContextEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source_type: RepoContextSource
+    repo_identity: RepoContextIdentity = Field(default_factory=RepoContextIdentity)
+    summary: RepoContextSummary = Field(default_factory=RepoContextSummary)
+    detected_stack: list[str] = Field(default_factory=list, max_length=12)
+    files_used: list[str] = Field(default_factory=list, max_length=24)
+    snippets: list[RepoContextSnippet] = Field(default_factory=list, max_length=12)
+    budget: RepoContextBudget = Field(default_factory=RepoContextBudget)
+    safety: RepoContextSafety = Field(default_factory=RepoContextSafety)
+
+    @field_validator("detected_stack", "files_used", mode="after")
+    @classmethod
+    def validate_short_list_items(cls, items: list[str]) -> list[str]:
+        return [str(item).strip()[:240] for item in items if str(item).strip()]
+
+
+class GitHubRepoContextPayload(BaseModel):
+    """Backward-compatible public payload for /repo-context/github and generator requests."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    normalized_repo_url: str = Field(..., min_length=1, max_length=500)
+    repo_full_name: str = Field(..., min_length=1, max_length=255)
+    requested_ref: str | None = Field(default=None, max_length=255)
+    requested_subdir: str | None = Field(default=None, max_length=500)
+    default_branch: str | None = Field(default=None, max_length=255)
+    summary: str = Field(..., min_length=1, max_length=1_500)
+    summary_compact: str | None = Field(default=None, max_length=400)
+    highlights: list[str] = Field(default_factory=list, max_length=6)
+    files_used: list[str] = Field(default_factory=list, max_length=6)
+    detected_stack: list[str] = Field(default_factory=list, max_length=6)
+
+    @field_validator("highlights", "files_used", "detected_stack", mode="after")
+    @classmethod
+    def validate_list_items_length(cls, items: list[str]) -> list[str]:
+        for item in items:
+            if len(item) > 1024:
+                raise ValueError("Item in list exceeds maximum length of 1024 characters")
+        return items
+
+
+RepoContextInput: TypeAlias = RepoContextEnvelope | GitHubRepoContextPayload

--- a/app/repo_context/render.py
+++ b/app/repo_context/render.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .adapters import coerce_repo_context_envelope, redact_absolute_paths, sanitize_display_path
+from .models import RepoContextEnvelope, RepoContextMode
+
+
+def _append_with_budget(lines: list[str], line: str, *, max_chars: int) -> bool:
+    candidate_len = sum(len(existing) + 1 for existing in lines) + len(line) + 1
+    if candidate_len > max_chars:
+        return False
+    lines.append(line)
+    return True
+
+
+def render_repo_context_for_llm(
+    repo_context: RepoContextEnvelope | dict[str, Any],
+    *,
+    mode: RepoContextMode | str = "compact",
+    max_chars: int | None = None,
+) -> str:
+    envelope = coerce_repo_context_envelope(repo_context)
+    if envelope is None:
+        return ""
+
+    resolved_mode = "compact" if str(mode or "compact").strip().lower() == "compact" else "full"
+    default_budget = 1_400 if resolved_mode == "compact" else 4_000
+    budget = max_chars or min(envelope.budget.max_chars or default_budget, default_budget)
+    active_summary = (
+        envelope.summary.compact
+        if resolved_mode == "compact" and envelope.summary.compact
+        else envelope.summary.full
+    )
+
+    lines = [
+        "## Repo Context (ground truth)",
+        "Treat this as verified repository context. Only reference tools, APIs, file paths, manifests, or conventions visible here. If something is missing, mark it as a TODO or open question instead of guessing.",
+        "",
+    ]
+
+    identity = envelope.repo_identity
+    if identity.name:
+        _append_with_budget(
+            lines, f"- Repo: {redact_absolute_paths(identity.name)}", max_chars=budget
+        )
+    if identity.url:
+        _append_with_budget(
+            lines, f"- URL: {redact_absolute_paths(identity.url)}", max_chars=budget
+        )
+    if identity.default_branch:
+        _append_with_budget(
+            lines,
+            f"- Default branch: {redact_absolute_paths(identity.default_branch)}",
+            max_chars=budget,
+        )
+    if identity.ref:
+        _append_with_budget(
+            lines, f"- Ref: {redact_absolute_paths(identity.ref)}", max_chars=budget
+        )
+    if envelope.detected_stack:
+        stack = ", ".join(redact_absolute_paths(str(item)) for item in envelope.detected_stack)
+        _append_with_budget(lines, f"- Detected stack: {stack}", max_chars=budget)
+    if envelope.files_used:
+        files = ", ".join(sanitize_display_path(path) for path in envelope.files_used)
+        _append_with_budget(lines, f"- Brief built from: {files}", max_chars=budget)
+
+    if active_summary:
+        _append_with_budget(lines, "", max_chars=budget)
+        _append_with_budget(lines, f"### Repo brief ({resolved_mode})", max_chars=budget)
+        _append_with_budget(lines, redact_absolute_paths(active_summary), max_chars=budget)
+
+    if envelope.snippets:
+        _append_with_budget(lines, "", max_chars=budget)
+        _append_with_budget(lines, "### Context snippets", max_chars=budget)
+        for snippet in envelope.snippets:
+            path = sanitize_display_path(snippet.display_path)
+            content = redact_absolute_paths(snippet.content).strip()
+            if not content:
+                continue
+            block = f"#### File: {path}\n```\n{content}\n```"
+            if not _append_with_budget(lines, block, max_chars=budget):
+                _append_with_budget(
+                    lines, "- Additional snippets omitted due to context budget.", max_chars=budget
+                )
+                break
+
+    _append_with_budget(lines, "", max_chars=budget)
+    _append_with_budget(
+        lines,
+        "Reminder: this context is bounded and path-safe. Do not make file-level implementation claims unless the file is listed above.",
+        max_chars=budget,
+    )
+
+    rendered = "\n".join(lines).rstrip()
+    if len(rendered) > budget:
+        rendered = rendered[: budget - 3].rstrip() + "..."
+    return redact_absolute_paths(rendered)

--- a/docs/superpowers/plans/2026-06-25-repo-context-layer.md
+++ b/docs/superpowers/plans/2026-06-25-repo-context-layer.md
@@ -1,0 +1,27 @@
+# Repo Context Layer Implementation Plan
+
+## Summary
+
+Add a shared repo-context module, route existing GitHub generator context through it, and stop default compile/RAG context injection. Keep public API behavior stable while ensuring LLM-rendered context is path-safe and opt-in.
+
+## Implementation Steps
+
+1. Add `app/repo_context/` with shared Pydantic models, source adapters, path sanitizer, and `render_repo_context_for_llm()`.
+2. Move the generator route's legacy `GitHubRepoContextPayload` model to the shared module and re-export it from `api.routes.generators`.
+3. Replace `WorkerClient._render_repo_context_block()` body with the shared renderer.
+4. Update `HybridCompiler.compile()`, `generate_agent()`, and `generate_skill()` so repo/RAG context is attached only when explicitly supplied.
+5. Update `compile_text_v2()` and `/compile` to accept optional `repo_context`; attach the normalized envelope into IR metadata for rendered prompt output.
+6. Update emitters and compile critique context to render repo/RAG context through the shared path-safe renderer.
+7. Add/update tests for GitHub normalization, RAG path sanitization, compact/full rendering, compile no-auto-RAG, explicit context, and API backwards compatibility.
+
+## Validation
+
+- `pytest tests/test_repo_context_layer.py tests/test_context_generation.py tests/test_rag_pipeline.py tests/test_hybrid.py -q`
+- `pytest tests/test_repo_context.py tests/test_generators.py tests/test_pr_safety_api.py -q`
+- `cd web && npm run test -- agent-generator/page.test.tsx skills-generator/page.test.tsx`
+
+## Safety Notes
+
+- No `cli/` edits.
+- No `.env`, secrets, auth, DB, deploy config, dependency, model, provider, temperature, max token, or response-format changes.
+- First PR should be draft because it touches shared context flow and prompt rendering.

--- a/docs/superpowers/specs/2026-06-25-repo-context-layer-design.md
+++ b/docs/superpowers/specs/2026-06-25-repo-context-layer-design.md
@@ -1,0 +1,54 @@
+# Repo Context Layer Design
+
+## Problem
+
+Compiler has two separate context paths today:
+
+- Generator pages can analyze a public GitHub repository and pass a shallow repo brief into the agent/skill LLM call.
+- Compile v2 can auto-retrieve local RAG snippets and render them into prompts.
+
+Those paths are not feature-agnostic, and the compile path can leak local absolute paths from a populated RAG index into rendered prompts. Repo context needs one shared, explicit, path-safe shape that every feature can consume.
+
+## Goals
+
+- Provide one `RepoContextEnvelope` for GitHub brief, RAG index, local upload, and future manual context sources.
+- Keep context opt-in for compile and generators; no automatic local RAG injection by default.
+- Preserve the existing `/repo-context/github` public response shape for compatibility.
+- Render LLM context through one path-safe renderer.
+- Keep PR Safety behavior unchanged while leaving a typed future entry point.
+
+## Non-Goals
+
+- No local clone crawler in this PR.
+- No GitHub PR fetch or GitHub App behavior in this PR.
+- No provider, prompt, temperature, response format, dependency, auth, DB, secret, or deploy changes.
+- No `cli/` changes.
+
+## Interface
+
+`RepoContextEnvelope` is the internal cross-feature format:
+
+- `source_type`: `github_public`, `rag_index`, `local_upload`, or `manual`
+- `repo_identity`: repo name, URL, default branch, optional ref
+- `summary`: full and compact text
+- `detected_stack`: short stack signals
+- `files_used`: safe display paths only
+- `snippets`: safe display path, content, score, source label
+- `budget`: max chars, used chars, truncated
+- `safety`: path-safe booleans
+
+The existing `GitHubRepoContextPayload` remains the API compatibility wrapper for `/repo-context/github` and existing generator UI requests.
+
+## Behavior
+
+- GitHub repo analysis still returns the legacy top-level JSON payload.
+- Generator requests normalize any supplied legacy repo payload into `RepoContextEnvelope` before calling the worker.
+- Compile accepts optional `repo_context`; when omitted, no RAG/repo context is attached.
+- RAG results are only used when explicitly supplied and are normalized into safe display paths.
+- Rendered LLM context must not include `/Users/...`, `/home/...`, `~/...`, or Windows drive absolute paths.
+
+## Risks
+
+- Existing tests that assumed auto-RAG need to be updated to the new opt-in contract.
+- Cached compile results must include repo-context fingerprint when context is supplied.
+- The legacy GitHub response must remain stable so current UI does not break.

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -38,8 +38,7 @@ def test_hybrid_compiler_generate_agent(mock_worker_client):
 
     result = compiler.generate_agent("Test Agent")
     assert result == "# Mock Agent System Prompt"
-    # HybridCompiler now injects context, so we expect the context argument
-    # We can use ANY for the context content since it depends on the mock vector db
+    # The worker call keeps the context argument, but default generation remains opt-in.
     from unittest.mock import ANY
 
     mock_worker_client.generate_agent.assert_called_with(
@@ -103,8 +102,9 @@ def test_worker_client_generate_agent_timeout_returns_quickly():
         time.sleep(0.2)
         return "# Agent System Prompt"
 
-    with patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01), patch.object(
-        client, "_call_api", side_effect=slow_call_api
+    with (
+        patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01),
+        patch.object(client, "_call_api", side_effect=slow_call_api),
     ):
         started_at = time.perf_counter()
         with pytest.raises(RuntimeError, match="Agent generation timed out after 0.01s."):
@@ -181,6 +181,37 @@ def test_api_generate_agent_endpoint():
         )
 
 
+def test_api_generate_agent_endpoint_accepts_repo_context_envelope():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_agent.return_value = "# Mock API Agent"
+        repo_context = {
+            "source_type": "manual",
+            "repo_identity": {"name": "foo/bar", "url": "https://github.com/foo/bar"},
+            "summary": {"full": "Manual repo context.", "compact": "Manual context."},
+            "files_used": ["README.md"],
+            "snippets": [
+                {
+                    "display_path": "app/main.py",
+                    "content": "FastAPI app entrypoint.",
+                    "source_label": "manual",
+                }
+            ],
+        }
+
+        client = TestClient(app)
+        response = client.post(
+            "/agent-generator/generate",
+            json={"description": "Test Agent Request", "repo_context": repo_context},
+        )
+
+        assert response.status_code == 200
+        kwargs = mock_compiler.generate_agent.call_args.kwargs
+        assert kwargs["repo_context"]["source_type"] == "manual"
+        assert kwargs["repo_context"]["repo_identity"]["name"] == "foo/bar"
+        assert kwargs["repo_context"]["summary"]["compact"] == "Manual context."
+        assert kwargs["repo_context_mode"] == "full"
+
+
 def test_api_generate_agent_endpoint_with_example_code_enabled():
     with patch("api.main.hybrid_compiler") as mock_compiler:
         mock_compiler.generate_agent.return_value = (
@@ -239,15 +270,15 @@ def test_single_agent_template_includes_new_sections():
     # Both enabled and disabled example-code modes should include the new sections.
     for include_example_code in (True, False):
         rendered = client._single_agent_prompt(include_example_code)
-        assert (
-            "## Tools & Integrations" in rendered
-        ), f"Missing '## Tools & Integrations' (include_example_code={include_example_code})"
-        assert (
-            "## Stop Conditions" in rendered
-        ), f"Missing '## Stop Conditions' (include_example_code={include_example_code})"
-        assert (
-            "## Self-Verification" in rendered
-        ), f"Missing '## Self-Verification' (include_example_code={include_example_code})"
+        assert "## Tools & Integrations" in rendered, (
+            f"Missing '## Tools & Integrations' (include_example_code={include_example_code})"
+        )
+        assert "## Stop Conditions" in rendered, (
+            f"Missing '## Stop Conditions' (include_example_code={include_example_code})"
+        )
+        assert "## Self-Verification" in rendered, (
+            f"Missing '## Self-Verification' (include_example_code={include_example_code})"
+        )
 
 
 def test_multi_agent_template_includes_topology_and_io():
@@ -257,18 +288,18 @@ def test_multi_agent_template_includes_topology_and_io():
 
     for include_example_code in (True, False):
         rendered = client._multi_agent_prompt(include_example_code)
-        assert (
-            "> **Topology:**" in rendered
-        ), f"Missing '> **Topology:**' declaration guidance (include_example_code={include_example_code})"
-        assert (
-            "## Inputs" in rendered
-        ), f"Missing '## Inputs' (include_example_code={include_example_code})"
-        assert (
-            "## Outputs" in rendered
-        ), f"Missing '## Outputs' (include_example_code={include_example_code})"
-        assert (
-            "## Swarm Stop Conditions" in rendered
-        ), f"Missing '## Swarm Stop Conditions' (include_example_code={include_example_code})"
+        assert "> **Topology:**" in rendered, (
+            f"Missing '> **Topology:**' declaration guidance (include_example_code={include_example_code})"
+        )
+        assert "## Inputs" in rendered, (
+            f"Missing '## Inputs' (include_example_code={include_example_code})"
+        )
+        assert "## Outputs" in rendered, (
+            f"Missing '## Outputs' (include_example_code={include_example_code})"
+        )
+        assert "## Swarm Stop Conditions" in rendered, (
+            f"Missing '## Swarm Stop Conditions' (include_example_code={include_example_code})"
+        )
 
 
 def test_example_code_strip_still_works():

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -100,7 +100,6 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
     compiler = HybridCompiler()
     # Mock context strategist
     compiler.context_strategist = MagicMock()
-    compiler.context_strategist.process.return_value = {"file1.py": "content"}
     repo_context = {
         "normalized_repo_url": "https://github.com/openai/openai-python",
         "repo_full_name": "openai/openai-python",
@@ -116,15 +115,32 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
 
     # Test generate_agent with context
     compiler.generate_agent("Test Agent", repo_context=repo_context)
-    compiler.context_strategist.process.assert_called_with("Test Agent", expand_with_llm=False)
+    compiler.context_strategist.process.assert_not_called()
     mock_worker_client.generate_agent.assert_called_with(
         "Test Agent",
         context={
-            "file1.py": "content",
             "repo_context": {
-                "source": "github_public_repo",
+                "source_type": "github_public",
                 "mode": "full",
-                **repo_context,
+                "repo_identity": {
+                    "name": "openai/openai-python",
+                    "url": "https://github.com/openai/openai-python",
+                    "default_branch": "main",
+                    "ref": None,
+                },
+                "summary": {"full": "Python SDK repository.", "compact": None},
+                "detected_stack": ["Python"],
+                "files_used": ["README.md"],
+                "snippets": [
+                    {
+                        "display_path": "repo highlights",
+                        "content": "README present",
+                        "score": None,
+                        "source_label": "GitHub brief",
+                    }
+                ],
+                "budget": {"max_chars": 4000, "used_chars": 0, "truncated": False},
+                "safety": {"path_safe": True, "contains_absolute_paths": False},
             },
         },
         multi_agent=False,
@@ -133,15 +149,32 @@ def test_hybrid_compiler_context_awareness(mock_worker_client):
 
     # Test generate_skill with context
     compiler.generate_skill("Test Skill", repo_context=repo_context)
-    compiler.context_strategist.process.assert_called_with("Test Skill", expand_with_llm=False)
+    compiler.context_strategist.process.assert_not_called()
     mock_worker_client.generate_skill.assert_called_with(
         "Test Skill",
         context={
-            "file1.py": "content",
             "repo_context": {
-                "source": "github_public_repo",
+                "source_type": "github_public",
                 "mode": "full",
-                **repo_context,
+                "repo_identity": {
+                    "name": "openai/openai-python",
+                    "url": "https://github.com/openai/openai-python",
+                    "default_branch": "main",
+                    "ref": None,
+                },
+                "summary": {"full": "Python SDK repository.", "compact": None},
+                "detected_stack": ["Python"],
+                "files_used": ["README.md"],
+                "snippets": [
+                    {
+                        "display_path": "repo highlights",
+                        "content": "README present",
+                        "score": None,
+                        "source_label": "GitHub brief",
+                    }
+                ],
+                "budget": {"max_chars": 4000, "used_chars": 0, "truncated": False},
+                "safety": {"path_safe": True, "contains_absolute_paths": False},
             },
         },
         include_example_code=False,

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -59,7 +59,7 @@ def test_compile_cache_hit(compiler):
         optimized_content="content",
     )
     # Manually seed cache
-    compiler.cache[(text, "conservative")] = res1
+    compiler.cache[(text, "conservative", "")] = res1
 
     # Compile
     res2 = compiler.compile(text)
@@ -86,17 +86,13 @@ def test_compile_success(mock_detect_risk_flags, compiler):
     )
 
     compiler.worker.process.return_value = mock_res
-    compiler.context_strategist.process.return_value = "Mock context"
-
     res = compiler.compile(text)
 
     assert res is mock_res
-    compiler.context_strategist.process.assert_called_once_with(text)
-    compiler.worker.process.assert_called_once_with(
-        text, context="Mock context", mode="conservative"
-    )
+    compiler.context_strategist.process.assert_not_called()
+    compiler.worker.process.assert_called_once_with(text, context=None, mode="conservative")
     # Verify cached
-    assert compiler.cache[(text, "conservative")] is mock_res
+    assert compiler.cache[(text, "conservative", "")] is mock_res
 
 
 @patch("app.llm_engine.hybrid.detect_risk_flags")
@@ -115,15 +111,14 @@ def test_compile_retries_worker_exception_then_succeeds(mock_detect_risk_flags, 
         ir=mock_ir, diagnostics=[], thought_process="Success", optimized_content="Optimized."
     )
 
-    compiler.context_strategist.process.return_value = "Mock context"
     compiler.worker.process.side_effect = [Exception("temporary worker error"), mock_res]
 
     res = compiler.compile(text)
 
     assert res is mock_res
-    compiler.context_strategist.process.assert_called_once_with(text)
+    compiler.context_strategist.process.assert_not_called()
     assert compiler.worker.process.call_count == 2
-    compiler.worker.process.assert_called_with(text, context="Mock context", mode="conservative")
+    compiler.worker.process.assert_called_with(text, context=None, mode="conservative")
 
 
 @patch("app.llm_engine.hybrid.detect_risk_flags")
@@ -182,7 +177,6 @@ def test_compile_worker_failure_fallback(compiler):
 
 def test_compile_logs_context_and_falls_back_after_two_worker_failures(compiler, caplog):
     text = "fail me twice"
-    compiler.context_strategist.process.return_value = "Mock context"
     compiler.worker.process.side_effect = [Exception("first error"), Exception("second error")]
 
     with patch("app.llm_engine.hybrid.compile_text_v2") as mock_compile_v2:
@@ -208,9 +202,45 @@ def test_compile_logs_context_and_falls_back_after_two_worker_failures(compiler,
         and record.attempts == 2
         and record.mode == "conservative"
         and record.text_length == len(text)
-        and record.rag_context_available is True
+        and record.repo_context_available is False
         for record in caplog.records
     )
+
+
+@patch("app.llm_engine.hybrid.detect_risk_flags")
+def test_compile_with_explicit_repo_context(mock_detect_risk_flags, compiler):
+    mock_detect_risk_flags.return_value = []
+    text = "compile with repo context"
+    mock_ir = IRv2(
+        language="en",
+        persona="expert",
+        role="tester",
+        domain="general",
+        output_format="text",
+        length_hint="medium",
+    )
+    mock_res = WorkerResponse(
+        ir=mock_ir, diagnostics=[], thought_process="Success", optimized_content="Optimized."
+    )
+    compiler.worker.process.return_value = mock_res
+
+    compiler.compile(
+        text,
+        repo_context={
+            "normalized_repo_url": "https://github.com/openai/openai-python",
+            "repo_full_name": "openai/openai-python",
+            "default_branch": "main",
+            "summary": "Python SDK repository.",
+            "highlights": ["README present"],
+            "files_used": ["README.md"],
+            "detected_stack": ["Python"],
+        },
+    )
+
+    compiler.context_strategist.process.assert_not_called()
+    _, kwargs = compiler.worker.process.call_args
+    assert kwargs["context"]["repo_context"]["source_type"] == "github_public"
+    assert kwargs["context"]["repo_context"]["repo_identity"]["name"] == "openai/openai-python"
 
 
 def test_compile_absolute_worst_case_fallback(compiler):
@@ -230,15 +260,14 @@ def test_compile_absolute_worst_case_fallback(compiler):
 
 def test_generate_agent_success(compiler):
     text = "make an agent"
-    compiler.context_strategist.process.return_value = "Mock agent context"
     compiler.worker.generate_agent.return_value = "Agent System Prompt"
 
     res = compiler.generate_agent(text, multi_agent=True, include_example_code=True)
 
     assert res == "Agent System Prompt"
-    compiler.context_strategist.process.assert_called_once_with(text, expand_with_llm=False)
+    compiler.context_strategist.process.assert_not_called()
     compiler.worker.generate_agent.assert_called_once_with(
-        text, context="Mock agent context", multi_agent=True, include_example_code=True
+        text, context=None, multi_agent=True, include_example_code=True
     )
 
 
@@ -253,15 +282,14 @@ def test_generate_agent_failure(compiler):
 
 def test_generate_skill_success(compiler):
     text = "make a skill"
-    compiler.context_strategist.process.return_value = "Mock skill context"
     compiler.worker.generate_skill.return_value = "Skill Definition"
 
     res = compiler.generate_skill(text, include_example_code=True)
 
     assert res == "Skill Definition"
-    compiler.context_strategist.process.assert_called_once_with(text, expand_with_llm=False)
+    compiler.context_strategist.process.assert_not_called()
     compiler.worker.generate_skill.assert_called_once_with(
-        text, context="Mock skill context", include_example_code=True
+        text, context=None, include_example_code=True
     )
 
 

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -19,19 +19,20 @@ def test_hybrid_compiler_multi_agent(mock_worker_client):
     compiler.worker = mock_worker_client
     # Mock context strategist
     compiler.context_strategist = MagicMock()
-    compiler.context_strategist.process.return_value = {}
 
     # Test single agent
     compiler.generate_agent("Task 1", multi_agent=False)
     mock_worker_client.generate_agent.assert_called_with(
-        "Task 1", context={}, multi_agent=False, include_example_code=False
+        "Task 1", context=None, multi_agent=False, include_example_code=False
     )
+    compiler.context_strategist.process.assert_not_called()
 
     # Test multi agent
     compiler.generate_agent("Task 2", multi_agent=True)
     mock_worker_client.generate_agent.assert_called_with(
-        "Task 2", context={}, multi_agent=True, include_example_code=False
+        "Task 2", context=None, multi_agent=True, include_example_code=False
     )
+    compiler.context_strategist.process.assert_not_called()
 
 
 def test_api_multi_agent_flag():

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -5,7 +5,7 @@ from app.emitters import emit_system_prompt_v2
 
 @patch("app.agents.context_strategist.search_hybrid")
 @patch("app.agents.context_strategist.ContextStrategist._expand_query")
-def test_rag_integration_in_compiler(mock_expand, mock_search):
+def test_compile_v2_does_not_auto_inject_rag_context(mock_expand, mock_search):
     # Setup mock return values
     mock_expand.return_value = ["login screen", "auth implementation"]
     mock_search.return_value = [
@@ -13,23 +13,43 @@ def test_rag_integration_in_compiler(mock_expand, mock_search):
         {"path": "app/models.py", "snippet": "class User:\n    pass"},
     ]
 
-    # Run compiler with a prompt that "should" trigger retrieval
     prompt = "create a login screen using auth.py"
     ir2 = compile_text_v2(prompt)
 
-    # 1. Assert Strategy Agent fetched context
-    assert "context_snippets" in ir2.metadata
-    assert len(ir2.metadata["context_snippets"]) == 2
-    assert ir2.metadata["context_snippets"][0]["path"] == "app/auth.py"
+    assert "context_snippets" not in ir2.metadata
+    assert "repo_context" not in ir2.metadata
+    mock_expand.assert_not_called()
+    mock_search.assert_not_called()
 
-    # 2. Assert Diagnostics alerted the user
-    # Find the 'context' category diagnostic
-    diag = next((d for d in ir2.diagnostics if d.category == "context"), None)
-    assert diag is not None
-    assert "Strategist retrieved 2 relevant sources" in diag.message
-
-    # 3. Assert System Prompt includes the snippets
     sys_prompt = emit_system_prompt_v2(ir2)
-    assert "### Context (Code & Knowledge)" in sys_prompt
-    assert "#### File: app/auth.py" in sys_prompt
+    assert "Repo Context (ground truth)" not in sys_prompt
+
+
+def test_explicit_repo_context_renders_path_safe_rag_context():
+    absolute_path = "/Users/memo/project/app/auth.py"
+    ir2 = compile_text_v2(
+        "create a login screen using auth.py",
+        repo_context={
+            "source_type": "rag_index",
+            "summary": {"full": "Local indexed context.", "compact": "Indexed context."},
+            "files_used": [absolute_path],
+            "snippets": [
+                {
+                    "display_path": absolute_path,
+                    "content": "def login():\n    return '/Users/memo/private/.env'",
+                    "source_label": "RAG index",
+                }
+            ],
+            "budget": {"max_chars": 4000, "used_chars": 0, "truncated": False},
+            "safety": {"path_safe": True, "contains_absolute_paths": False},
+        },
+        repo_context_mode="full",
+    )
+
+    assert "repo_context" in ir2.metadata
+    sys_prompt = emit_system_prompt_v2(ir2)
+    assert "## Repo Context (ground truth)" in sys_prompt
+    assert "#### File: auth.py" in sys_prompt
     assert "def login():" in sys_prompt
+    assert "/Users/" not in sys_prompt
+    assert "[path-redacted]" in sys_prompt

--- a/tests/test_repo_context_layer.py
+++ b/tests/test_repo_context_layer.py
@@ -1,0 +1,79 @@
+from app.repo_context import (
+    github_payload_to_envelope,
+    rag_results_to_envelope,
+    render_repo_context_for_llm,
+    sanitize_display_path,
+)
+
+
+GITHUB_PAYLOAD = {
+    "normalized_repo_url": "https://github.com/openai/openai-python",
+    "repo_full_name": "openai/openai-python",
+    "requested_ref": None,
+    "requested_subdir": None,
+    "default_branch": "main",
+    "summary": "Python SDK repo full summary content.",
+    "summary_compact": "Python SDK repo compact summary content.",
+    "highlights": ["Python package", "README present"],
+    "files_used": ["README.md", "pyproject.toml"],
+    "detected_stack": ["Python", "httpx"],
+}
+
+
+def test_github_payload_normalizes_to_repo_context_envelope():
+    envelope = github_payload_to_envelope(GITHUB_PAYLOAD)
+
+    assert envelope.source_type == "github_public"
+    assert envelope.repo_identity.name == "openai/openai-python"
+    assert envelope.repo_identity.url == "https://github.com/openai/openai-python"
+    assert envelope.summary.full == "Python SDK repo full summary content."
+    assert envelope.summary.compact == "Python SDK repo compact summary content."
+    assert envelope.files_used == ["README.md", "pyproject.toml"]
+    assert envelope.safety.path_safe is True
+    assert envelope.safety.contains_absolute_paths is False
+
+
+def test_renderer_uses_full_or_compact_summary():
+    envelope = github_payload_to_envelope(GITHUB_PAYLOAD)
+
+    compact = render_repo_context_for_llm(envelope, mode="compact")
+    full = render_repo_context_for_llm(envelope, mode="full")
+
+    assert "Python SDK repo compact summary content." in compact
+    assert "Python SDK repo full summary content." not in compact
+    assert "Python SDK repo full summary content." in full
+    assert "Python SDK repo compact summary content." not in full
+
+
+def test_rag_adapter_and_renderer_redact_absolute_paths():
+    envelope = rag_results_to_envelope(
+        [
+            {
+                "path": "/Users/memo/dev/project/app/auth.py",
+                "snippet": "Read from /Users/memo/.promptc_uploads/secret.txt",
+                "score": 0.9,
+            },
+            {
+                "path": "C:\\Users\\memo\\dev\\project\\web\\page.tsx",
+                "snippet": "Open C:\\Users\\memo\\.env",
+                "score": 0.8,
+            },
+        ]
+    )
+
+    rendered = render_repo_context_for_llm(envelope, mode="full")
+
+    assert "auth.py" in rendered
+    assert "page.tsx" in rendered
+    assert "/Users/" not in rendered
+    assert "C:\\Users" not in rendered
+    assert "C:/Users" not in rendered
+    assert "[path-redacted]" in rendered
+    assert envelope.safety.path_safe is True
+    assert envelope.safety.contains_absolute_paths is False
+
+
+def test_sanitize_display_path_keeps_relative_paths_and_strips_absolute_roots():
+    assert sanitize_display_path("app/api/routes.py") == "app/api/routes.py"
+    assert sanitize_display_path("/Users/memo/dev/project/app/api/routes.py") == "routes.py"
+    assert sanitize_display_path("C:\\Users\\memo\\project\\app\\auth.py") == "auth.py"

--- a/tests/test_skills_generator.py
+++ b/tests/test_skills_generator.py
@@ -227,11 +227,15 @@ def test_hybrid_compiler_generate_skill(mock_worker_client):
     args, kwargs = mock_worker_client.generate_skill.call_args
     assert args == ("Test Skill",)
     assert kwargs["include_example_code"] is False
-    assert kwargs["context"]["repo_context"] == {
-        "source": "github_public_repo",
-        "mode": "full",
-        **repo_context,
+    assert kwargs["context"]["repo_context"]["source_type"] == "github_public"
+    assert kwargs["context"]["repo_context"]["mode"] == "full"
+    assert kwargs["context"]["repo_context"]["repo_identity"] == {
+        "name": "openai/openai-python",
+        "url": "https://github.com/openai/openai-python",
+        "default_branch": "main",
+        "ref": None,
     }
+    assert kwargs["context"]["repo_context"]["summary"]["full"] == "Python SDK repository."
 
 
 def test_api_generate_skill_endpoint():
@@ -272,6 +276,37 @@ def test_api_generate_skill_endpoint():
             },
             repo_context_mode="full",
         )
+
+
+def test_api_generate_skill_endpoint_accepts_repo_context_envelope():
+    with patch("api.main.hybrid_compiler") as mock_compiler:
+        mock_compiler.generate_skill.return_value = "# Mock API Skill"
+        repo_context = {
+            "source_type": "manual",
+            "repo_identity": {"name": "foo/bar", "url": "https://github.com/foo/bar"},
+            "summary": {"full": "Manual repo context.", "compact": "Manual context."},
+            "files_used": ["README.md"],
+            "snippets": [
+                {
+                    "display_path": "skills/example.py",
+                    "content": "Example skill implementation.",
+                    "source_label": "manual",
+                }
+            ],
+        }
+
+        client = TestClient(app)
+        response = client.post(
+            "/skills-generator/generate",
+            json={"description": "Test Skill Request", "repo_context": repo_context},
+        )
+
+        assert response.status_code == 200
+        kwargs = mock_compiler.generate_skill.call_args.kwargs
+        assert kwargs["repo_context"]["source_type"] == "manual"
+        assert kwargs["repo_context"]["repo_identity"]["name"] == "foo/bar"
+        assert kwargs["repo_context"]["summary"]["compact"] == "Manual context."
+        assert kwargs["repo_context_mode"] == "full"
 
 
 def test_api_generate_skill_endpoint_with_example_code_enabled():

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -151,11 +151,45 @@ export type RagStats = {
 export type GitHubRepoContextPayload = {
   normalized_repo_url: string;
   repo_full_name: string;
+  requested_ref?: string | null;
+  requested_subdir?: string | null;
   default_branch: string | null;
   summary: string;
+  summary_compact?: string | null;
   highlights: string[];
   files_used: string[];
   detected_stack: string[];
+};
+
+export type RepoContextEnvelope = {
+  source_type: "github_public" | "rag_index" | "local_upload" | "manual";
+  repo_identity?: {
+    name?: string | null;
+    url?: string | null;
+    default_branch?: string | null;
+    ref?: string | null;
+  };
+  summary?: {
+    full?: string;
+    compact?: string | null;
+  };
+  detected_stack?: string[];
+  files_used?: string[];
+  snippets?: Array<{
+    display_path: string;
+    content: string;
+    score?: number | null;
+    source_label?: string | null;
+  }>;
+  budget?: {
+    max_chars: number;
+    used_chars: number;
+    truncated: boolean;
+  };
+  safety?: {
+    path_safe: boolean;
+    contains_absolute_paths: boolean;
+  };
 };
 
 export type GeneratorExampleCodeMetadata = {


### PR DESCRIPTION
## Summary
- Add a shared RepoContextEnvelope layer with source adapters and a single path-safe LLM renderer.
- Preserve the existing GitHub repo brief response shape while letting generators accept the shared envelope or legacy payload.
- Stop default local RAG context injection in compile/generator paths; repo context is opt-in and rendered through the shared layer.

## Tests
- .venv/bin/python -m pytest tests/test_repo_context_layer.py tests/test_rag_pipeline.py tests/test_context_generation.py tests/test_hybrid.py tests/test_generators.py tests/test_repo_context.py tests/test_agent_generator.py tests/test_skills_generator.py tests/test_multi_agent.py tests/test_pr_safety_api.py tests/test_compile_policy_api.py tests/test_auth_fast_path.py tests/test_api_hardening.py -q
- .venv/bin/python -m pytest tests/test_agent_generator.py tests/test_skills_generator.py tests/test_hybrid.py -q
- .venv/bin/ruff check app/repo_context app/compiler.py app/emitters.py app/llm_engine/client.py app/llm_engine/hybrid.py api/routes/compile.py api/routes/generators.py api/routes/pr_safety.py tests/test_repo_context_layer.py tests/test_rag_pipeline.py tests/test_hybrid.py tests/test_context_generation.py tests/test_agent_generator.py tests/test_skills_generator.py tests/test_multi_agent.py
- .venv/bin/ruff format --check app/repo_context app/compiler.py app/emitters.py app/llm_engine/client.py app/llm_engine/hybrid.py api/routes/compile.py api/routes/generators.py api/routes/pr_safety.py tests/test_repo_context_layer.py tests/test_rag_pipeline.py tests/test_hybrid.py tests/test_context_generation.py tests/test_agent_generator.py tests/test_skills_generator.py tests/test_multi_agent.py
- npm run test -- app/agent-generator/page.test.tsx app/skills-generator/page.test.tsx lib/api/promptc.test.ts

## Safety
- Draft PR because this touches shared context and prompt rendering paths.
- No cli/ edits.
- No env, secrets, auth policy, DB, deploy config, dependency, provider, model, temperature, max_tokens, or response_format changes.
- PR Safety request type is prepared for future repo_context input, but analyzer behavior is unchanged.