### PR TITLE
fix(logic): strip only the matched negation clause (count=1)

### DIFF
--- a/app/heuristics/logic_analyzer.py
+++ b/app/heuristics/logic_analyzer.py
@@ -302,8 +302,9 @@ class LogicAnalyzer:
 
     def _strip_negation(self, sentence: str, pattern: re.Pattern) -> str:
         """Remove negation word from sentence."""
-        # Bolt Optimization: Use the already compiled pattern.sub instead of re-compiling dynamically in the loop
-        result = pattern.sub(" ", sentence)
+        # Preserve later negations in the same sentence so anti-pattern guidance
+        # only flips the clause that matched this detection (count=1, not all).
+        result = pattern.sub(" ", sentence, count=1)
         return " ".join(result.split())  # Normalize whitespace
 
     def _create_anti_pattern(self, stripped: str, negation_word: str) -> str:

--- a/tests/test_logic_analyzer.py
+++ b/tests/test_logic_analyzer.py
@@ -1,6 +1,17 @@
 from app.heuristics.logic_analyzer import LogicAnalyzer
 
 
+def test_detect_negations_preserves_later_negations_in_same_sentence():
+    analyzer = LogicAnalyzer()
+
+    negations = analyzer.detect_negations("Do not use JOIN operations and do not nest subqueries.")
+
+    assert len(negations) == 1
+    assert negations[0].negation_word == "do not"
+    assert negations[0].stripped_text == "use JOIN operations and do not nest subqueries."
+    assert negations[0].anti_pattern == "Instead: use JOIN operations and do not nest subqueries."
+
+
 def test_detect_dependencies_keeps_because_matches_with_fast_path():
     analyzer = LogicAnalyzer()
 


### PR DESCRIPTION
## What

`LogicAnalyzer._strip_negation` used `pattern.sub(" ", sentence)`, which removes **every** occurrence of the negation word in a sentence. For inputs with two negations — e.g. `"Do not use JOIN operations and do not nest subqueries."` — the later `do not` was also wiped, producing wrong `stripped_text` and `anti_pattern` guidance.

## Fix

Pass `count=1` so only the clause that matched this detection is flipped. Adds a regression test asserting the second negation is preserved.

## Notes

- Recreates the change from stale PR #826 (22 commits behind main) on current main, cleanly formatted against pinned ruff v0.1.14.
- Test-first: the new test fails on `main` and passes with the fix. Full `tests/test_logic_analyzer.py` green (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)