### PR TITLE
test(optimizer): increase coverage for quick actions and optimizer callbacks

### DIFF
--- a/tests/test_optimizer_callbacks.py
+++ b/tests/test_optimizer_callbacks.py
@@ -1,0 +1,121 @@
+from unittest.mock import patch
+from app.optimizer.callbacks import InteractiveCallback
+from app.optimizer.models import Candidate, EvaluationResult
+
+
+def test_interactive_callback_should_pause():
+    # interactive_every = 0 (disabled)
+    cb = InteractiveCallback(interactive_every=0)
+    assert cb.should_pause(0) is False
+    assert cb.should_pause(1) is False
+    assert cb.should_pause(2) is False
+
+    # interactive_every = 2
+    cb2 = InteractiveCallback(interactive_every=2)
+    assert cb2.should_pause(0) is False
+    assert cb2.should_pause(1) is False
+    assert cb2.should_pause(2) is True
+    assert cb2.should_pause(3) is False
+    assert cb2.should_pause(4) is True
+
+
+def test_interactive_callback_methods():
+    # Empty methods should execute without side-effects
+    cb = InteractiveCallback(interactive_every=2)
+    cb.on_start("initial", 1.0)
+    cb.on_generation_start(1)
+    assert cb._generation_count == 1
+
+    cand = Candidate(prompt_text="hello", generation=0)
+    res = EvaluationResult(
+        score=0.5, passed_count=5, failed_count=5, error_count=0, avg_latency_ms=100.0
+    )
+    cb.on_candidate_evaluated(cand, res)
+    cb.on_new_best(cand, 0.9)
+    cb.on_complete(cand)
+
+
+@patch("rich.prompt.Prompt.ask")
+def test_human_intervention_choice_1(mock_ask):
+    cb = InteractiveCallback(interactive_every=1)
+    cand = Candidate(prompt_text="best prompt", generation=0)
+
+    # Choice 1: Continue (no change)
+    mock_ask.return_value = "1"
+    res = cb.on_human_intervention_needed(cand, 1)
+    assert res is None
+
+
+@patch("rich.prompt.Prompt.ask")
+def test_human_intervention_choice_2(mock_ask):
+    cb = InteractiveCallback(interactive_every=1)
+    cand = Candidate(prompt_text="best prompt", generation=0)
+
+    # Choice 2 with empty feedback
+    mock_ask.side_effect = ["2", ""]
+    res = cb.on_human_intervention_needed(cand, 1)
+    assert res is None
+
+    # Choice 2 with actual feedback
+    mock_ask.side_effect = ["2", "make it more professional"]
+    res2 = cb.on_human_intervention_needed(cand, 1)
+    assert res2 == {"type": "feedback", "content": "make it more professional"}
+
+
+@patch("rich.prompt.Prompt.ask")
+@patch("builtins.input")
+def test_human_intervention_choice_3_cancel(mock_input, mock_ask):
+    cb = InteractiveCallback(interactive_every=1)
+    cand = Candidate(prompt_text="best prompt", generation=0)
+
+    # Choice 3: Manual edit -> Cancel
+    mock_ask.return_value = "3"
+    mock_input.side_effect = ["CANCEL"]
+    res = cb.on_human_intervention_needed(cand, 1)
+    assert res is None
+
+
+@patch("rich.prompt.Prompt.ask")
+@patch("builtins.input")
+@patch("app.optimizer.utils.validate_human_input")
+def test_human_intervention_choice_3_success(mock_validate, mock_input, mock_ask):
+    cb = InteractiveCallback(interactive_every=1)
+    cand = Candidate(prompt_text="best prompt", generation=0)
+
+    mock_ask.return_value = "3"
+    mock_input.side_effect = ["modified prompt line 1", "modified prompt line 2", "END"]
+    mock_validate.return_value = True
+
+    res = cb.on_human_intervention_needed(cand, 1)
+    assert res == {"type": "edit", "content": "modified prompt line 1\nmodified prompt line 2"}
+    mock_validate.assert_called_once_with(
+        "best prompt", "modified prompt line 1\nmodified prompt line 2"
+    )
+
+
+@patch("rich.prompt.Prompt.ask")
+@patch("builtins.input")
+@patch("app.optimizer.utils.validate_human_input")
+def test_human_intervention_choice_3_validation_fail(mock_validate, mock_input, mock_ask):
+    cb = InteractiveCallback(interactive_every=1)
+    cand = Candidate(prompt_text="best prompt", generation=0)
+
+    mock_ask.return_value = "3"
+    mock_input.side_effect = ["modified prompt", "END"]
+    mock_validate.return_value = False
+
+    res = cb.on_human_intervention_needed(cand, 1)
+    assert res is None
+
+
+@patch("rich.prompt.Prompt.ask")
+@patch("builtins.input")
+def test_human_intervention_choice_3_empty_input(mock_input, mock_ask):
+    cb = InteractiveCallback(interactive_every=1)
+    cand = Candidate(prompt_text="best prompt", generation=0)
+
+    mock_ask.return_value = "3"
+    mock_input.side_effect = ["END"]
+
+    res = cb.on_human_intervention_needed(cand, 1)
+    assert res is None

--- a/tests/test_quick_actions.py
+++ b/tests/test_quick_actions.py
@@ -1,0 +1,184 @@
+# ruff: noqa: E402
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock the missing modules in sys.modules before importing app.quick_actions
+mock_search_history = MagicMock()
+mock_search_history.get_search_history_manager = MagicMock()
+
+mock_snippets = MagicMock()
+mock_snippets.get_snippets_manager = MagicMock()
+
+sys.modules["app.search_history"] = mock_search_history
+sys.modules["app.snippets"] = mock_snippets
+
+# Now we can safely import app.quick_actions
+import pytest
+from app.quick_actions import QuickActions, get_quick_actions
+
+
+def test_get_quick_actions_singleton():
+    with patch("app.quick_actions.get_search_history_manager"), patch(
+        "app.quick_actions.get_favorites_manager"
+    ), patch("app.quick_actions.get_templates_manager"), patch(
+        "app.quick_actions.get_snippets_manager"
+    ):
+        inst1 = get_quick_actions()
+        inst2 = get_quick_actions()
+        assert inst1 is inst2
+
+
+@pytest.fixture
+def mock_managers():
+    with patch("app.quick_actions.get_search_history_manager") as m_hist, patch(
+        "app.quick_actions.get_favorites_manager"
+    ) as m_fav, patch("app.quick_actions.get_templates_manager") as m_temp, patch(
+        "app.quick_actions.get_snippets_manager"
+    ) as m_snip:
+        hist_mgr = MagicMock()
+        fav_mgr = MagicMock()
+        temp_mgr = MagicMock()
+        snip_mgr = MagicMock()
+
+        m_hist.return_value = hist_mgr
+        m_fav.return_value = fav_mgr
+        m_temp.return_value = temp_mgr
+        m_snip.return_value = snip_mgr
+
+        yield hist_mgr, fav_mgr, temp_mgr, snip_mgr
+
+
+def test_get_last_search(mock_managers):
+    hist_mgr, _, _, _ = mock_managers
+
+    # 1. Test empty search history
+    hist_mgr.get_recent.return_value = []
+    actions = QuickActions()
+    assert actions.get_last_search() is None
+
+    # 2. Test search history present
+    mock_entry = MagicMock()
+    mock_entry.query = "summarize PDF"
+    mock_entry.result_count = 5
+    mock_entry.timestamp = "2026-06-26"
+    mock_entry.types_filter = None
+    mock_entry.min_score = 0.8
+    hist_mgr.get_recent.return_value = [mock_entry]
+
+    res = actions.get_last_search()
+    assert res is not None
+    assert res["query"] == "summarize PDF"
+    assert res["result_count"] == 5
+    assert res["min_score"] == 0.8
+
+
+def test_get_top_favorites(mock_managers):
+    _, fav_mgr, _, _ = mock_managers
+
+    # 1. Test empty favorites
+    fav_mgr.get_all.return_value = []
+    actions = QuickActions()
+    assert actions.get_top_favorites() == []
+
+    # 2. Test sorting favorites by score
+    fav1 = MagicMock()
+    fav1.id = "f1"
+    fav1.prompt_text = "prompt 1"
+    fav1.score = 0.5
+    fav1.domain = "dev"
+    fav1.tags = ["tag1"]
+    fav1.notes = "note1"
+    fav1.use_count = 1
+    fav1.timestamp = "time1"
+
+    fav2 = MagicMock()
+    fav2.id = "f2"
+    fav2.prompt_text = "prompt 2"
+    fav2.score = 0.9
+
+    fav_mgr.get_all.return_value = [fav1, fav2]
+
+    res = actions.get_top_favorites(limit=1)
+    assert len(res) == 1
+    assert res[0]["id"] == "f2"  # Higher score first
+    assert res[0]["score"] == 0.9
+
+
+def test_get_random_template(mock_managers):
+    _, _, temp_mgr, _ = mock_managers
+
+    # 1. Empty templates
+    temp_mgr.list_templates.return_value = []
+    actions = QuickActions()
+    assert actions.get_random_template() is None
+
+    # 2. Template present
+    tpl = MagicMock()
+    tpl.name = "template 1"
+    tpl.description = "desc 1"
+    tpl.template_text = "text 1"
+    tpl.category = "general"
+    tpl.tags = []
+    tpl.variables = []
+
+    temp_mgr.list_templates.return_value = [tpl]
+    res = actions.get_random_template()
+    assert res is not None
+    assert res["name"] == "template 1"
+
+
+def test_get_random_snippet(mock_managers):
+    _, _, _, snip_mgr = mock_managers
+
+    # 1. Empty snippets
+    snip_mgr.get_all.return_value = []
+    actions = QuickActions()
+    assert actions.get_random_snippet() is None
+
+    # 2. Snippet present
+    snip = MagicMock()
+    snip.title = "snip 1"
+    snip.content = "content 1"
+    snip.category = "code"
+    snip.description = "desc 1"
+    snip.tags = []
+    snip.use_count = 5
+
+    snip_mgr.get_all.return_value = [snip]
+    res = actions.get_random_snippet()
+    assert res is not None
+    assert res["title"] == "snip 1"
+
+
+def test_get_random_item(mock_managers):
+    _, _, temp_mgr, snip_mgr = mock_managers
+    actions = QuickActions()
+
+    # Mock template and snippet
+    tpl = MagicMock(name="tpl")
+    tpl.name = "template 1"
+    tpl.variables = []
+    temp_mgr.list_templates.return_value = [tpl]
+
+    snip = MagicMock(name="snip")
+    snip.title = "snip 1"
+    snip_mgr.get_all.return_value = [snip]
+
+    # Test specific item_type 'template'
+    res = actions.get_random_item(item_type="template")
+    assert res["type"] == "template"
+    assert res["data"]["name"] == "template 1"
+
+    # Test specific item_type 'snippet'
+    res = actions.get_random_item(item_type="snippet")
+    assert res["type"] == "snippet"
+    assert res["data"]["title"] == "snip 1"
+
+    # Test random selection (none requested)
+    res_rand = actions.get_random_item()
+    assert res_rand["type"] in ["template", "snippet"]
+
+    # Test empty database fallback
+    temp_mgr.list_templates.return_value = []
+    snip_mgr.get_all.return_value = []
+    assert actions.get_random_item() is None


### PR DESCRIPTION
This PR increases test coverage for app/quick_actions.py (from 0% to 100%) and app/optimizer/callbacks.py (from 19% to 90%). Note: app/quick_actions.py has broken/missing imports (app.search_history and app.snippets) in production, which was bypassed in tests using sys.modules patching. No production code was modified.