### PR TITLE
fix(rag): make local RAG context retrieval opt-in (default off)

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -65,6 +65,7 @@ class CompileRequest(BaseModel):
     trace: bool = False
     v2: bool = True
     render_v2_prompts: bool = False
+    enable_context_retrieval: bool = False
     record_analytics: bool = False
     user_level: str = Field(default="intermediate", max_length=100)
     task_type: str = Field(default="general", max_length=100)
@@ -356,7 +357,11 @@ def compile_endpoint(
 
     ir = optimize_ir(compile_text(req.text))
     trace_lines = generate_trace(ir) if req.trace else None
-    ir2 = compile_text_v2(req.text, offline_only=not req.v2)
+    ir2 = compile_text_v2(
+        req.text,
+        offline_only=not req.v2,
+        enable_context_retrieval=req.enable_context_retrieval,
+    )
 
     # The heuristic v2 pipeline runs the SafetyHandler (injection / secret-exfiltration
     # scan). The LLM worker path below rebuilds ir2 and does NOT run that scan, so capture
@@ -371,7 +376,9 @@ def compile_endpoint(
     if req.v2:
         try:
             compiler = _get_compiler()
-            worker_res = compiler.compile(req.text, mode=mode)
+            worker_res = compiler.compile(
+                req.text, mode=mode, enable_context_retrieval=req.enable_context_retrieval
+            )
             ir2, used_fallback = _coerce_fast_ir(req.text, worker_res)
 
             # Re-apply the heuristic safety verdict — the worker IR does not run the

--- a/app/compiler.py
+++ b/app/compiler.py
@@ -224,7 +224,9 @@ def _mk_id(text: str) -> str:
     return hashlib.sha1(text.strip().lower().encode("utf-8")).hexdigest()[:10]
 
 
-def compile_text_v2(text: str, offline_only: bool = False) -> IRv2:
+def compile_text_v2(
+    text: str, offline_only: bool = False, enable_context_retrieval: bool = False
+) -> IRv2:
     # Reuse v1 heuristics to keep behavior; map to richer IRv2 model
     ir1 = compile_text(text)
 
@@ -320,7 +322,7 @@ def compile_text_v2(text: str, offline_only: bool = False) -> IRv2:
     # -------------------------------------------------------------------------
     # NEW: Agent 6 - The Context Strategist
     # -------------------------------------------------------------------------
-    if not offline_only:
+    if enable_context_retrieval:
         try:
             from app.agents.context_strategist import ContextStrategist
 
@@ -343,7 +345,10 @@ def compile_text_v2(text: str, offline_only: bool = False) -> IRv2:
         except Exception:
             logger.exception(
                 "Context Strategist failed; continuing without retrieved context",
-                extra={"offline_only": offline_only, "text_length": len(text)},
+                extra={
+                    "enable_context_retrieval": enable_context_retrieval,
+                    "text_length": len(text),
+                },
             )
     # -------------------------------------------------------------------------
 

--- a/app/llm_engine/hybrid.py
+++ b/app/llm_engine/hybrid.py
@@ -33,10 +33,18 @@ class HybridCompiler:
         # Cache: 100 items, expires in 1 hour
         self.cache = TTLCache(maxsize=100, ttl=3600)
 
-    def compile(self, text: str, mode: Optional[str] = None) -> WorkerResponse:
+    def compile(
+        self,
+        text: str,
+        mode: Optional[str] = None,
+        enable_context_retrieval: bool = False,
+    ) -> WorkerResponse:
         """
         Attempt to compile using the Worker LLM with RAG context.
         Falls back to local heuristics if LLM fails.
+
+        Local RAG retrieval is opt-in: unless ``enable_context_retrieval`` is True,
+        no local index content is read or sent to the worker LLM.
         """
         # 1. Fast Checks (Heuristic Guardrails)
         if not text or not text.strip():
@@ -49,9 +57,12 @@ class HybridCompiler:
 
         # 3. Worker LLM (Slow but Smart)
         try:
-            # --- RAG: Context Strategist ---
-            # Retrieve relevant code context using Agent 6
-            rag_context = self.context_strategist.process(text)
+            # --- RAG: Context Strategist (opt-in) ---
+            # Retrieve relevant code context using Agent 6 only when explicitly
+            # enabled; otherwise no local index content is read or transmitted.
+            rag_context = (
+                self.context_strategist.process(text) if enable_context_retrieval else None
+            )
 
             # Pass context to Worker. Retry once for transient worker/API failures before
             # dropping to the deterministic heuristic fallback.

--- a/cli/commands/compile_cmd.py
+++ b/cli/commands/compile_cmd.py
@@ -60,13 +60,14 @@ def _run_compile(
     out: Path | None = None,
     out_dir: Path | None = None,
     fmt: str | None = None,
+    enable_context_retrieval: bool = False,
 ):
     t0 = time.time()
     if v1:
         ir = optimize_ir(compile_text(full_text))
         ir2 = None
     else:
-        ir2 = compile_text_v2(full_text)
+        ir2 = compile_text_v2(full_text, enable_context_retrieval=enable_context_retrieval)
         # For rendering, continue to use v1 emitters if needed; here we print IR JSON by default
         ir = None
     if persona and (ir is not None):
@@ -315,6 +316,11 @@ def compile_cmd(
         "--render-v2",
         help="Deprecated for compile (IR v2 prompts now render by default); still used by batch --format md.",
     ),
+    rag: bool = typer.Option(
+        False,
+        "--rag/--no-rag",
+        help="Inject relevant snippets from the local RAG index into the prompt (off by default).",
+    ),
     out: Path = typer.Option(None, "--out", help="Write output to a file (overwrites)"),
     out_dir: Path = typer.Option(
         None, "--out-dir", help="Write output to a directory (creates if missing)"
@@ -362,6 +368,7 @@ def compile_cmd(
         out=out,
         out_dir=out_dir,
         fmt=format,
+        enable_context_retrieval=rag,
     )
 
 

--- a/docs/superpowers/specs/2026-06-27-rag-context-opt-in-design.md
+++ b/docs/superpowers/specs/2026-06-27-rag-context-opt-in-design.md
@@ -1,0 +1,62 @@
+# RAG Context Injection → Opt-In (Default Off)
+
+**Date:** 2026-06-27
+**Status:** Approved (design) — pending implementation
+**Branch:** `fix/rag-context-opt-in` (off `origin/main`)
+**Type:** Behavior change + bug fix (path/context leak). Ship as **Draft PR** (prompt-output change → manual review).
+
+## Problem
+
+`compile_text_v2(text, offline_only=False)` defaults `offline_only=False`. In that mode the **Context Strategist** (`app/compiler.py:323`) runs automatically: it queries the machine-local SQLite FTS5 RAG index (`app.rag.simple_index.search_hybrid`) plus a silent LLM query-expansion network call, and writes the hits into `ir2.metadata["context_snippets"]`. The emitters (`app/emitters.py:509` system prompt, `:672` compact block) render those snippets verbatim into the compiled System Prompt as `#### File: {path}` + fenced content.
+
+Effect: on any machine with a populated local RAG index (e.g. a dev box), **every `compile` leaks local file paths and snippets into the output prompt** — even when irrelevant to the request. This violates the conservative-mode rule ("avoid hallucinated requirements / fake APIs") and pollutes the user-facing prompt. It also fires an unannounced network call.
+
+The CLI `compile` command (`cli/commands/compile_cmd.py:69`, via `_run_compile`) calls `compile_text_v2(full_text)` with no args → default-on → this is the leak the user observed locally. The API v2 path (`api/routes/compile.py:359`, `offline_only=not req.v2`) has the same default-on behavior for v2 requests.
+
+## Root-cause note: `offline_only` is overloaded
+
+`offline_only` currently gates **two** independent things:
+- Schema Generator (`app/compiler.py:292`) — offline intelligence.
+- Context Strategist / RAG retrieval (`app/compiler.py:323`).
+
+So we must NOT simply flip `offline_only`, which would also kill schema generation. The fix introduces a **dedicated, independent flag** for context retrieval.
+
+## Design (approach C — core default opt-in)
+
+Make RAG/context retrieval **opt-in everywhere**, default off, via a new core parameter. All callers become safe by default; CLI and API opt in explicitly.
+
+### 1. Core — `app/compiler.py`
+- Signature: `def compile_text_v2(text: str, offline_only: bool = False, enable_context_retrieval: bool = False) -> IRv2`.
+- Change the Context Strategist gate at line 323 from `if not offline_only:` to **`if enable_context_retrieval:`** (decoupled from `offline_only`).
+- `offline_only` now gates ONLY the Schema Generator (line 292) — overload resolved.
+- **Decision (approved):** gate on `enable_context_retrieval` **alone**, not `enable_context_retrieval and not offline_only`. Rationale: opt-in is an explicit caller choice; local FTS retrieval works offline; query-expansion already fails silently. `offline_only=True` callers never pass the new flag, so they stay off.
+
+### 2. CLI — `cli/commands/compile_cmd.py`
+- Add `--rag / --no-rag` Typer option to the `compile` command (and `batch`), **default `False`**.
+- Thread it through `_run_compile(...)` → `compile_text_v2(full_text, enable_context_retrieval=rag)`.
+- Default off → CLI leak closed. `--rag` lets power users opt in.
+- Other CLI call sites (`transform.py:308`, `analytics.py:84`) keep the default (off) — out of scope to expose flags there now.
+
+### 3. API — `api/routes/compile.py`
+- Add `enable_context_retrieval: bool = False` to `CompileRequest`.
+- Line 359: `compile_text_v2(req.text, offline_only=not req.v2, enable_context_retrieval=req.enable_context_retrieval)`.
+- Schema-gen behavior (the `offline_only=not req.v2` part) unchanged. Default off → web/API no longer leak. Response snippet passthrough (`:427`, CriticAgent context) unchanged — degrades gracefully to empty when off.
+
+### 4. Web — no code change
+With default off, the "N Sources" badge (`web/app/page.tsx:409`) simply does not render (graceful — that badge was surfacing the leaked context). **Approved:** the web Sources feature goes dormant by default; a UI opt-in toggle is a **separate future task**, out of scope here.
+
+## Testing (TDD — red first)
+
+- **Leak guard (new):** `compile_text_v2(text)` with defaults → Context Strategist not invoked, `context_snippets` absent from metadata, even with a populated index. (Patch `search_hybrid` to assert-not-called.)
+- **Opt-in path:** `compile_text_v2(text, enable_context_retrieval=True)` with `search_hybrid` + `_expand_query` mocked → snippets present. (Update existing `tests/test_rag_pipeline.py`, which currently assumes default-on.)
+- **Emitter:** no `context_snippets` → System Prompt has no `### Context` section.
+- **CLI:** `compile` without `--rag` → output has no Context section; with `--rag` → strategist attempted (mocked).
+- **API:** request without flag → response has no context; with flag → context present.
+
+## Out of scope / constraints
+
+- Does NOT touch the larger `#849` repo-context architecture (this is the lite fix; #849 may supersede later).
+- No changes to `.env`, providers, LLM prompt format/temperature/max_tokens, deploy config, or dependencies.
+- Branch off fresh `origin/main` (local `test/logic-analyzer-coverage` was 14 commits behind, pre core.py split).
+- CI gotcha: format changed files with `uvx ruff@0.1.14 check --fix` and `uvx ruff@0.1.14 format` before pushing (Smoke pins ruff 0.1.14).
+- Ship as **Draft PR**; manual review of compiled prompt output before merge.

--- a/tests/test_cli_rag_opt_in.py
+++ b/tests/test_cli_rag_opt_in.py
@@ -1,0 +1,34 @@
+"""CLI `compile` RAG context retrieval is opt-in (default off) — path-leak guard."""
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from cli.main import app as _app
+
+_runner = CliRunner()
+
+
+@patch("app.agents.context_strategist.search_hybrid")
+@patch("app.agents.context_strategist.ContextStrategist._expand_query")
+def test_cli_compile_does_not_retrieve_by_default(mock_expand, mock_search):
+    mock_expand.return_value = ["login form"]
+    mock_search.return_value = [{"path": "/Users/dev/private/secret.py", "snippet": "x"}]
+
+    result = _runner.invoke(_app, ["compile", "make a login form", "--json-only"])
+
+    assert result.exit_code == 0, result.output
+    # Local RAG index must NOT be queried unless explicitly enabled.
+    mock_search.assert_not_called()
+    assert "secret.py" not in result.output
+
+
+@patch("app.agents.context_strategist.search_hybrid")
+@patch("app.agents.context_strategist.ContextStrategist._expand_query")
+def test_cli_compile_rag_flag_enables_retrieval(mock_expand, mock_search):
+    mock_expand.return_value = ["login form"]
+    mock_search.return_value = [{"path": "app/auth.py", "snippet": "def login(): pass"}]
+
+    result = _runner.invoke(_app, ["compile", "make a login form", "--rag", "--json-only"])
+
+    assert result.exit_code == 0, result.output
+    mock_search.assert_called()

--- a/tests/test_compile_rag_opt_in_api.py
+++ b/tests/test_compile_rag_opt_in_api.py
@@ -1,0 +1,35 @@
+"""POST /compile RAG context retrieval is opt-in (default off) — path-leak guard."""
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+@patch("app.agents.context_strategist.search_hybrid")
+@patch("app.agents.context_strategist.ContextStrategist._expand_query")
+def test_compile_api_no_retrieval_by_default(mock_expand, mock_search):
+    mock_expand.return_value = ["login form"]
+    mock_search.return_value = [{"path": "/Users/dev/private/secret.py", "snippet": "x"}]
+
+    resp = client.post("/compile", json={"text": "make a login form", "v2": False})
+
+    assert resp.status_code == 200
+    mock_search.assert_not_called()
+
+
+@patch("app.agents.context_strategist.search_hybrid")
+@patch("app.agents.context_strategist.ContextStrategist._expand_query")
+def test_compile_api_opt_in_enables_retrieval(mock_expand, mock_search):
+    mock_expand.return_value = ["login form"]
+    mock_search.return_value = [{"path": "app/auth.py", "snippet": "def login(): pass"}]
+
+    resp = client.post(
+        "/compile",
+        json={"text": "make a login form", "v2": False, "enable_context_retrieval": True},
+    )
+
+    assert resp.status_code == 200
+    mock_search.assert_called()

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -43,6 +43,50 @@ def test_compile_empty_input(compiler):
     assert any("Input was empty" in d.message for d in res.diagnostics)
 
 
+def _worker_response():
+    return WorkerResponse(
+        ir=IRv2(
+            language="en",
+            persona="assistant",
+            role="test",
+            domain="general",
+            output_format="text",
+            length_hint="short",
+        ),
+        diagnostics=[],
+        thought_process="ok",
+        optimized_content="content",
+    )
+
+
+def test_worker_compile_does_not_retrieve_rag_by_default(compiler):
+    """Worker path must NOT query the local RAG index unless explicitly enabled (leak guard)."""
+    compiler.worker.process.return_value = _worker_response()
+
+    compiler.compile("make a login form")
+
+    # Local index never queried...
+    compiler.context_strategist.process.assert_not_called()
+    # ...and no local context is transmitted to the worker LLM.
+    _, kwargs = compiler.worker.process.call_args
+    assert kwargs.get("context") is None
+
+
+def test_worker_compile_retrieves_rag_when_enabled(compiler):
+    compiler.worker.process.return_value = _worker_response()
+    compiler.context_strategist.process.return_value = {
+        "snippets": [{"file": "app/auth.py", "content": "def login(): pass"}]
+    }
+
+    compiler.compile("make a login form", enable_context_retrieval=True)
+
+    compiler.context_strategist.process.assert_called_once_with("make a login form")
+    _, kwargs = compiler.worker.process.call_args
+    assert kwargs.get("context") == {
+        "snippets": [{"file": "app/auth.py", "content": "def login(): pass"}]
+    }
+
+
 def test_compile_cache_hit(compiler):
     text = "test query"
     res1 = WorkerResponse(
@@ -88,7 +132,7 @@ def test_compile_success(mock_detect_risk_flags, compiler):
     compiler.worker.process.return_value = mock_res
     compiler.context_strategist.process.return_value = "Mock context"
 
-    res = compiler.compile(text)
+    res = compiler.compile(text, enable_context_retrieval=True)
 
     assert res is mock_res
     compiler.context_strategist.process.assert_called_once_with(text)
@@ -118,7 +162,7 @@ def test_compile_retries_worker_exception_then_succeeds(mock_detect_risk_flags, 
     compiler.context_strategist.process.return_value = "Mock context"
     compiler.worker.process.side_effect = [Exception("temporary worker error"), mock_res]
 
-    res = compiler.compile(text)
+    res = compiler.compile(text, enable_context_retrieval=True)
 
     assert res is mock_res
     compiler.context_strategist.process.assert_called_once_with(text)
@@ -197,7 +241,7 @@ def test_compile_logs_context_and_falls_back_after_two_worker_failures(compiler,
         mock_compile_v2.return_value = mock_ir
 
         with caplog.at_level("WARNING", logger="promptc.llm.hybrid"):
-            res = compiler.compile(text)
+            res = compiler.compile(text, enable_context_retrieval=True)
 
     assert compiler.worker.process.call_count == 2
     assert res.ir is mock_ir

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -13,9 +13,9 @@ def test_rag_integration_in_compiler(mock_expand, mock_search):
         {"path": "app/models.py", "snippet": "class User:\n    pass"},
     ]
 
-    # Run compiler with a prompt that "should" trigger retrieval
+    # Run compiler with a prompt that "should" trigger retrieval (opt-in)
     prompt = "create a login screen using auth.py"
-    ir2 = compile_text_v2(prompt)
+    ir2 = compile_text_v2(prompt, enable_context_retrieval=True)
 
     # 1. Assert Strategy Agent fetched context
     assert "context_snippets" in ir2.metadata
@@ -33,3 +33,24 @@ def test_rag_integration_in_compiler(mock_expand, mock_search):
     assert "### Context (Code & Knowledge)" in sys_prompt
     assert "#### File: app/auth.py" in sys_prompt
     assert "def login():" in sys_prompt
+
+
+@patch("app.agents.context_strategist.search_hybrid")
+@patch("app.agents.context_strategist.ContextStrategist._expand_query")
+def test_rag_disabled_by_default_no_context_leak(mock_expand, mock_search):
+    """Default compile must NOT retrieve local RAG context (path-leak guard)."""
+    mock_expand.return_value = ["login form"]
+    mock_search.return_value = [
+        {"path": "/Users/dev/private/secret_local_file.py", "snippet": "TOKEN = 'leak'"},
+    ]
+
+    ir2 = compile_text_v2("create a login screen using auth.py")
+
+    # Strategist never queried the local index
+    mock_search.assert_not_called()
+    # No snippets injected into IR metadata
+    assert "context_snippets" not in ir2.metadata
+    # System Prompt has no Context section and no leaked local path
+    sys_prompt = emit_system_prompt_v2(ir2)
+    assert "### Context (Code & Knowledge)" not in sys_prompt
+    assert "secret_local_file.py" not in sys_prompt


### PR DESCRIPTION
## Problem

`compile_text_v2` and `HybridCompiler.compile` auto-injected snippets from the machine-local RAG index (SQLite FTS5) into the compiled prompt **and** the worker LLM call whenever running online. On a machine with a populated index this leaked local file paths and content — into the rendered System Prompt (heuristic path) and to the third-party worker LLM (v2 path) — even when irrelevant to the request, plus fired an unannounced network call. This violates conservative-mode expectations.

Root cause: `offline_only` was overloaded (it gated both the Schema Generator and RAG retrieval), and retrieval defaulted on.

## Fix — opt-in everywhere (default off)

A dedicated `enable_context_retrieval` flag (default `False`), decoupled from `offline_only`:

- **Core** (`app/compiler.py`): gate the `app/agents` Context Strategist on the flag; `offline_only` now only gates the Schema Generator.
- **Worker** (`app/llm_engine/hybrid.py`): gate the `HybridCompiler` RAG strategist on the flag; when off, no local context is read or sent to the worker LLM (`context=None`).
- **CLI** (`cli/commands/compile_cmd.py`): new `compile --rag/--no-rag` (default off).
- **API** (`api/routes/compile.py`): new `CompileRequest.enable_context_retrieval` (default off), threaded to both the heuristic and worker paths.

CLI and web/API no longer leak local index content by default; opting in restores retrieval.

## Tests (TDD)

- Core / CLI / API / worker default-off leak guards (strategist not called, no `context_snippets`, `context=None` to the worker) + opt-in paths.
- Updated existing `test_rag_pipeline.py` / `test_hybrid.py` to the opt-in contract.
- 235 affected tests green; `ruff@0.1.14` clean.

## Out of scope

- The larger repo-context architecture (#849) is untouched.
- `generate_agent` / `generate_skill` keep their intentional `repo_context` input (by design, not a leak).
- No web code change — the "Sources" badge simply stays dormant by default.
- No `.env` / provider / prompt-format / deploy / dependency changes.

**Draft:** prompt-output behavior change — please review the compiled prompt before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
