### PR TITLE
🎨 Palette: [UX improvement] Add Clear buttons to PR Safety textareas

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-06-17 - Add Clear Button to Input Forms
 **Learning:** For generative text inputs where users often paste large blocks of text, missing a quick way to clear the input creates friction. Users have to manually select all text and delete it.
 **Action:** Always consider adding a "Clear" button (with proper `type="button"`, `aria-label`, and `title` attributes) to large input fields (like textareas) to improve usability.
+## 2024-06-27 - Add Clear Button to Input Forms (Re-applied)
+**Learning:** For generative text inputs where users often paste large blocks of text, missing a quick way to clear the input creates friction. This applies to multiple areas of the app, like the PR Safety feature.
+**Action:** Always consider adding a "Clear" button (with proper `type="button"`, `aria-label`, and `title` attributes) to large input fields (like textareas) to improve usability. Make sure to wrap the `<textarea>` in a `<div className="relative group">` to allow absolute positioning of the clear button inside it.

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -226,6 +226,7 @@ export default function PrSafetyPage() {
               <label htmlFor="pr-description" className="text-sm font-medium text-zinc-300">
                 PR Description
               </label>
+              <div className="relative group">
               <textarea
                 id="pr-description"
                 aria-label="PR Description"
@@ -234,6 +235,18 @@ export default function PrSafetyPage() {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
               />
+              {description && (
+                <button
+                  type="button"
+                  onClick={() => setDescription("")}
+                  className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-rose-500/50"
+                  title="Clear input"
+                  aria-label="Clear input"
+                >
+                  Clear
+                </button>
+              )}
+              </div>
             </div>
 
             <div className="flex flex-col gap-2">
@@ -241,6 +254,7 @@ export default function PrSafetyPage() {
                 Changed Files
               </label>
               <p className="text-xs text-zinc-500">One file path per line.</p>
+              <div className="relative group">
               <textarea
                 id="pr-changed-files"
                 aria-label="Changed Files"
@@ -249,6 +263,18 @@ export default function PrSafetyPage() {
                 value={changedFilesText}
                 onChange={(e) => setChangedFilesText(e.target.value)}
               />
+              {changedFilesText && (
+                <button
+                  type="button"
+                  onClick={() => setChangedFilesText("")}
+                  className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-rose-500/50"
+                  title="Clear input"
+                  aria-label="Clear input"
+                >
+                  Clear
+                </button>
+              )}
+              </div>
               <p className="text-[11px] text-zinc-600">
                 {parsedFiles.length} file{parsedFiles.length === 1 ? "" : "s"} detected
               </p>


### PR DESCRIPTION
💡 What: Added "Clear" buttons to the PR Description and Changed Files textarea inputs on the PR Safety page.
🎯 Why: Users often paste large blocks of text into these fields. Without a clear button, users have to manually select all text and delete it, which creates friction.
📸 Before/After: See screenshots in PR.
♿ Accessibility: Ensure the buttons have `type="button"`, `title="Clear input"`, and `aria-label="Clear input"`.

---
*PR created automatically by Jules for task [2331790150007551442](https://jules.google.com/task/2331790150007551442) started by @madara88645*