### PR TITLE
fix(api): protect public /benchmark endpoint from Denial-of-Wallet

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -2,6 +2,7 @@ import ipaddress
 import logging
 import time
 import secrets
+from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
 from typing import Dict
@@ -85,6 +86,7 @@ def _get_route_group(path: str) -> str:
         "/agent-generator",
         "/skills-generator",
         "/repo-context",
+        "/benchmark",
     ]
     for r in heavy_routes:
         if path.startswith(r):
@@ -97,6 +99,53 @@ def _get_route_group_and_limit(path: str) -> tuple[str, int]:
     if group == "heavy":
         return group, HEAVY_RATE_LIMIT_MAX_REQUESTS
     return group, RATE_LIMIT_MAX_REQUESTS
+
+
+# --- Benchmark Denial-of-Wallet backstop -----------------------------------
+# /benchmark/run is public (no API key) but triggers server-side LLM calls.
+# Per-IP rate limiting can be bypassed by rotating IPs, so we add a global
+# daily cap on the total number of benchmark runs across all callers.
+DEFAULT_BENCHMARK_DAILY_RUN_LIMIT = 500
+_BENCHMARK_DAILY_LOCK = Lock()
+_BENCHMARK_DAILY_STATE = {
+    "date": datetime.now(timezone.utc).date().isoformat(),
+    "count": 0,
+}
+
+
+def _benchmark_daily_limit() -> int:
+    raw = os.environ.get("BENCHMARK_DAILY_RUN_LIMIT", "").strip()
+    if not raw:
+        return DEFAULT_BENCHMARK_DAILY_RUN_LIMIT
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_BENCHMARK_DAILY_RUN_LIMIT
+    return value if value > 0 else DEFAULT_BENCHMARK_DAILY_RUN_LIMIT
+
+
+def reset_benchmark_daily_state() -> None:
+    """Reset the global benchmark daily-cap counter (day rollover and tests)."""
+    with _BENCHMARK_DAILY_LOCK:
+        _BENCHMARK_DAILY_STATE["date"] = datetime.now(timezone.utc).date().isoformat()
+        _BENCHMARK_DAILY_STATE["count"] = 0
+
+
+def enforce_benchmark_daily_cap() -> None:
+    """Raise HTTP 429 once the global daily benchmark-run budget is exhausted."""
+    today = datetime.now(timezone.utc).date().isoformat()
+    with _BENCHMARK_DAILY_LOCK:
+        if _BENCHMARK_DAILY_STATE["date"] != today:
+            _BENCHMARK_DAILY_STATE["date"] = today
+            _BENCHMARK_DAILY_STATE["count"] = 0
+
+        if _BENCHMARK_DAILY_STATE["count"] >= _benchmark_daily_limit():
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Daily benchmark limit reached. Please try again tomorrow.",
+            )
+
+        _BENCHMARK_DAILY_STATE["count"] += 1
 
 
 def _is_plausible_ip(value: str) -> bool:

--- a/api/auth.py
+++ b/api/auth.py
@@ -74,11 +74,17 @@ RATE_LIMIT_MAX_REQUESTS = 10
 HEAVY_RATE_LIMIT_MAX_REQUESTS = 2
 PUBLIC_HEAVY_RATE_LIMIT = 20
 PUBLIC_DEFAULT_RATE_LIMIT = 60
+# Benchmark gets its own generous per-IP bucket (no human reaches it; it only
+# stops a single IP from draining the global daily pool), decoupled from the
+# shared "heavy" bucket so heavy /compile use never blocks benchmarking.
+PUBLIC_BENCHMARK_RATE_LIMIT = 30
 
 _rate_limit_cleanup_counter = 0
 
 
 def _get_route_group(path: str) -> str:
+    if path.startswith("/benchmark"):
+        return "benchmark"
     heavy_routes = [
         "/compile",
         "/optimize",
@@ -86,7 +92,6 @@ def _get_route_group(path: str) -> str:
         "/agent-generator",
         "/skills-generator",
         "/repo-context",
-        "/benchmark",
     ]
     for r in heavy_routes:
         if path.startswith(r):
@@ -101,11 +106,23 @@ def _get_route_group_and_limit(path: str) -> tuple[str, int]:
     return group, RATE_LIMIT_MAX_REQUESTS
 
 
+def _public_rate_limit_for(group: str) -> int:
+    """Per-IP request budget for a public route group (reads live module constants)."""
+    if group == "benchmark":
+        return PUBLIC_BENCHMARK_RATE_LIMIT
+    if group == "heavy":
+        return PUBLIC_HEAVY_RATE_LIMIT
+    return PUBLIC_DEFAULT_RATE_LIMIT
+
+
 # --- Benchmark Denial-of-Wallet backstop -----------------------------------
 # /benchmark/run is public (no API key) but triggers server-side LLM calls.
 # Per-IP rate limiting can be bypassed by rotating IPs, so we add a global
-# daily cap on the total number of benchmark runs across all callers.
-DEFAULT_BENCHMARK_DAILY_RUN_LIMIT = 500
+# daily cap on the total number of benchmark runs across all callers. This is a
+# catastrophic backstop, not a normal-traffic limiter: set high enough that a
+# legitimate visitor essentially never hits it, while still bounding worst-case
+# spend from large-scale abuse. Tunable via BENCHMARK_DAILY_RUN_LIMIT.
+DEFAULT_BENCHMARK_DAILY_RUN_LIMIT = 10000
 _BENCHMARK_DAILY_LOCK = Lock()
 _BENCHMARK_DAILY_STATE = {
     "date": datetime.now(timezone.utc).date().isoformat(),
@@ -206,7 +223,7 @@ def rate_limit_by_ip(request: Request) -> None:
     """Public-route rate limiter keyed by (client_ip, route_group)."""
     now = time.time()
     route_group = _get_route_group(request.url.path)
-    max_requests = PUBLIC_HEAVY_RATE_LIMIT if route_group == "heavy" else PUBLIC_DEFAULT_RATE_LIMIT
+    max_requests = _public_rate_limit_for(route_group)
     client_ip = _resolve_client_ip(request)
     store_key = f"ip:{client_ip}:{route_group}"
     _enforce_rate_limit(store_key, max_requests, now)

--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from api.auth import rate_limit_by_ip
+from api.auth import rate_limit_by_ip, enforce_benchmark_daily_cap
 from pydantic import BaseModel, Field, field_validator
 
 from api.shared import logger
@@ -298,6 +298,9 @@ async def benchmark_run(
     """
     Run an A/B benchmark comparing raw vs compiled prompt quality.
     """
+    # Global daily backstop against anonymous Denial-of-Wallet abuse.
+    enforce_benchmark_daily_cap()
+
     t0 = time.time()
 
     # --- Step A: Generate with raw prompt ---------------------------------

--- a/tests/test_benchmark_dow_protection.py
+++ b/tests/test_benchmark_dow_protection.py
@@ -1,0 +1,90 @@
+"""
+Denial-of-Wallet protection for the public /benchmark/run endpoint.
+
+The benchmark endpoint is intentionally public (no API key) but triggers
+server-side LLM generation, so it must be protected from anonymous abuse
+WITHOUT requiring end-user credentials. Two layers:
+
+1. Per-IP rate limiting: /benchmark belongs to the "heavy" route group.
+2. A global daily cap on benchmark runs (a backstop that per-IP limits
+   cannot provide, since an attacker can rotate IPs).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Bare app with only the benchmark router mounted (matches test_benchmark_api)."""
+    from app.routers.benchmark import router
+
+    test_app = FastAPI()
+    test_app.include_router(router)
+    return TestClient(test_app)
+
+
+@pytest.fixture
+def reset_daily_cap():
+    """Isolate the global benchmark daily-cap state for cap tests."""
+    import api.auth as auth
+
+    auth.reset_benchmark_daily_state()
+    yield
+    auth.reset_benchmark_daily_state()
+
+
+def _post(client, ip: str):
+    return client.post(
+        "/benchmark/run",
+        json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
+        headers={"x-forwarded-for": ip},
+    )
+
+
+def test_benchmark_route_is_in_heavy_rate_limit_group():
+    """/benchmark/run must be classified 'heavy' so its per-IP limit is the strict one."""
+    from api.auth import _get_route_group
+
+    assert _get_route_group("/benchmark/run") == "heavy"
+
+
+def test_benchmark_daily_cap_blocks_globally_after_limit(client, monkeypatch, reset_daily_cap):
+    """Once the global daily run limit is hit, further runs get 429 even from new IPs."""
+    monkeypatch.setenv("BENCHMARK_DAILY_RUN_LIMIT", "2")
+
+    with patch(
+        "app.routers.benchmark._generate_llm_output", side_effect=lambda *a, **k: "out"
+    ), patch("app.routers.benchmark._judge_with_llm", return_value=None):
+        # Two distinct IPs each succeed (proves the cap is global, not per-IP).
+        assert _post(client, "1.1.1.1").status_code == 200
+        assert _post(client, "2.2.2.2").status_code == 200
+        # A third run from yet another IP is blocked by the global daily cap.
+        blocked = _post(client, "3.3.3.3")
+
+    assert blocked.status_code == 429
+    assert "daily" in blocked.json()["detail"].lower()
+
+
+def test_benchmark_daily_cap_resets_on_new_utc_day(client, monkeypatch, reset_daily_cap):
+    """A counter left over from a previous day must not block today's runs."""
+    import api.auth as auth
+
+    monkeypatch.setenv("BENCHMARK_DAILY_RUN_LIMIT", "1")
+    # Simulate yesterday's bucket already maxed out.
+    auth._BENCHMARK_DAILY_STATE["date"] = "2000-01-01"
+    auth._BENCHMARK_DAILY_STATE["count"] = 9999
+
+    with patch(
+        "app.routers.benchmark._generate_llm_output", side_effect=lambda *a, **k: "out"
+    ), patch("app.routers.benchmark._judge_with_llm", return_value=None):
+        response = _post(client, "1.1.1.1")
+
+    assert response.status_code == 200
+    today = datetime.now(timezone.utc).date().isoformat()
+    assert auth._BENCHMARK_DAILY_STATE["date"] == today
+    assert auth._BENCHMARK_DAILY_STATE["count"] == 1

--- a/tests/test_benchmark_dow_protection.py
+++ b/tests/test_benchmark_dow_protection.py
@@ -5,9 +5,12 @@ The benchmark endpoint is intentionally public (no API key) but triggers
 server-side LLM generation, so it must be protected from anonymous abuse
 WITHOUT requiring end-user credentials. Two layers:
 
-1. Per-IP rate limiting: /benchmark belongs to the "heavy" route group.
-2. A global daily cap on benchmark runs (a backstop that per-IP limits
-   cannot provide, since an attacker can rotate IPs).
+1. Per-IP rate limiting: /benchmark has its own dedicated route group with a
+   generous limit (no human hits it; it only protects the daily pool from a
+   single flooding IP), decoupled from the shared "heavy" bucket.
+2. A high global daily cap on benchmark runs (a catastrophic backstop that
+   per-IP limits cannot provide, since an attacker can rotate IPs). Tuned so a
+   legitimate visitor essentially never hits it.
 """
 
 from datetime import datetime, timezone
@@ -46,11 +49,21 @@ def _post(client, ip: str):
     )
 
 
-def test_benchmark_route_is_in_heavy_rate_limit_group():
-    """/benchmark/run must be classified 'heavy' so its per-IP limit is the strict one."""
-    from api.auth import _get_route_group
+def test_benchmark_has_dedicated_rate_limit_group():
+    """/benchmark has its own per-IP group, decoupled from the shared 'heavy' bucket (e.g. /compile)."""
+    from api.auth import _get_route_group, _public_rate_limit_for, PUBLIC_BENCHMARK_RATE_LIMIT
 
-    assert _get_route_group("/benchmark/run") == "heavy"
+    assert _get_route_group("/benchmark/run") == "benchmark"
+    assert _get_route_group("/compile") == "heavy"
+    assert _public_rate_limit_for("benchmark") == PUBLIC_BENCHMARK_RATE_LIMIT
+
+
+def test_benchmark_daily_default_allows_high_legitimate_use(monkeypatch):
+    """The default daily cap is a catastrophic backstop, not a normal-traffic limiter — keep it high."""
+    monkeypatch.delenv("BENCHMARK_DAILY_RUN_LIMIT", raising=False)
+    from api.auth import _benchmark_daily_limit
+
+    assert _benchmark_daily_limit() >= 1000
 
 
 def test_benchmark_daily_cap_blocks_globally_after_limit(client, monkeypatch, reset_daily_cap):


### PR DESCRIPTION
## Summary
`/benchmark/run` is intentionally public (no API key) but triggers server-side LLM generation. It was guarded only by per-IP rate limiting in the **default** group (60 req/min/IP), so anonymous abuse could burn the server's OpenRouter credits (Denial of Wallet).

This replaces #882, which added `Depends(verify_api_key)`. That approach would have returned `403` to every public visitor — the Next.js proxy forwards no server-side key and the project rule forbids end-user API keys for public web flows.

## Approach (no end-user credentials)
The endpoint stays keyless. Limits are tuned so a legitimate visitor essentially never gets blocked — they only stop large-scale abuse.

- **Dedicated per-IP group:** `/benchmark` gets its own per-IP bucket (`PUBLIC_BENCHMARK_RATE_LIMIT`, 30/min), decoupled from the shared `heavy` bucket so heavy `/compile` use never blocks benchmarking. No human reaches 30 runs/min (each run is 2 LLM calls); it only stops a single IP from draining the daily pool.
- **Global daily cap (catastrophic backstop):** total benchmark runs/day across all callers, `BENCHMARK_DAILY_RUN_LIMIT` (default **10,000**); returns `429` when exhausted, resets at UTC midnight. Set high enough that even a viral adoption day stays well under it, while still bounding worst-case spend.

## Tests
- `tests/test_benchmark_dow_protection.py`: dedicated-group classification + decoupling from `/compile`, generous high default cap, global cap -> `429` across rotating IPs, UTC day-rollover reset.
- Existing auth / rate-limit / public / benchmark suites green (82 passed).
- `ruff@0.1.14` check + format clean.

## Config
- `BENCHMARK_DAILY_RUN_LIMIT` (env, default 10000) — the daily wallet ceiling.
- `PUBLIC_BENCHMARK_RATE_LIMIT` (constant, 30/min) — per-IP burst guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
