### PR TITLE
fix(emitters): basename RAG snippet paths in v2 system prompt

### DIFF
--- a/app/emitters.py
+++ b/app/emitters.py
@@ -510,7 +510,9 @@ def emit_system_prompt_v2(ir: IRv2) -> str:
     if context_snippets:
         parts.append("\n### Context (Code & Knowledge)")
         for i, snippet in enumerate(context_snippets, 1):
-            path = snippet.get("path", "unknown")
+            # Basename only — never leak absolute local paths into the system
+            # prompt (matches the path-safe rendering used by the other v2 emitter).
+            path = (snippet.get("path") or "unknown").split("/")[-1]
             content = snippet.get("snippet", "").strip()
             parts.append(f"#### File: {path}\n```\n{content}\n```")
     # ------------------------------------------------

--- a/tests/test_emitters_path_safety.py
+++ b/tests/test_emitters_path_safety.py
@@ -1,0 +1,40 @@
+"""Path-safety of the v2 system-prompt context rendering.
+
+When local RAG retrieval is enabled (#877, opt-in), retrieved snippets can carry
+absolute local filesystem paths. Those paths must not leak into the system prompt
+sent to the LLM — only the basename should be shown, matching how the other v2
+emitter already renders snippet paths.
+"""
+
+from __future__ import annotations
+
+from app.emitters import emit_system_prompt_v2
+from app.models_v2 import IRv2
+
+
+def _ir_with_snippet(path: str) -> IRv2:
+    ir = IRv2(
+        language="en",
+        persona="expert",
+        role="tester",
+        domain="general",
+        output_format="text",
+        length_hint="medium",
+    )
+    ir.metadata["context_snippets"] = [{"path": path, "snippet": "def login():\n    pass"}]
+    return ir
+
+
+def test_system_prompt_v2_does_not_leak_absolute_snippet_path():
+    ir = _ir_with_snippet("/Users/dev/private/secret_module.py")
+    out = emit_system_prompt_v2(ir)
+    # The local absolute path must not leak into the LLM system prompt.
+    assert "/Users/" not in out
+    # The file is still identified, by basename only.
+    assert "secret_module.py" in out
+
+
+def test_system_prompt_v2_keeps_relative_snippet_path_basename():
+    ir = _ir_with_snippet("app/auth.py")
+    out = emit_system_prompt_v2(ir)
+    assert "auth.py" in out

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -31,7 +31,8 @@ def test_rag_integration_in_compiler(mock_expand, mock_search):
     # 3. Assert System Prompt includes the snippets
     sys_prompt = emit_system_prompt_v2(ir2)
     assert "### Context (Code & Knowledge)" in sys_prompt
-    assert "#### File: app/auth.py" in sys_prompt
+    # Snippet paths render basename-only (path-safe) — see test_emitters_path_safety.
+    assert "#### File: auth.py" in sys_prompt
     assert "def login():" in sys_prompt
 
 


### PR DESCRIPTION
## Problem
The v2 system-prompt context block rendered the raw snippet `path`. When local RAG retrieval is enabled (#877, opt-in), a retrieved snippet can carry an absolute local filesystem path, so something like `/Users/dev/private/secret.py` would leak into the system prompt sent to the LLM.

## Fix
Render the **basename only** in the `#### File:` header, matching the path-safe rendering already used by the other v2 emitter (which uses `.split("/")[-1]`). One-line change in `app/emitters.py`.

## Tests
- New `tests/test_emitters_path_safety.py`: an absolute snippet path must not leak (`/Users/` absent) and the file is still identified by basename.
- Updated `test_rag_integration_in_compiler` to assert the basename header (`#### File: auth.py`), reflecting the intended path-safe behavior.

## Verification
- Focused emitter/RAG tests green.
- Full backend suite: 1531 passed, 5 skipped, 0 failed.
- `ruff check` + `ruff format --check` clean on changed files.

## Scope
Out of scope by design (YAGNI): redacting absolute paths inside snippet *content* — the other emitter doesn't do that either; it's a separate concern. This PR only closes the file-header leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)