### PR TITLE
feat(readiness): executable .md/.json export (Slice 2)

### DIFF
--- a/api/routes/agent_packs.py
+++ b/api/routes/agent_packs.py
@@ -41,7 +41,7 @@ async def download_claude_agent_pack(
     adapter = AGENT_PACK_ADAPTERS["claude"]
 
     try:
-        manifest = adapter.build_manifest(req, compiler, include_readiness=False)
+        manifest = adapter.build_manifest(req, compiler)
         return create_download_response(manifest)
     except Exception as exc:
         logger.exception(

--- a/api/routes/agent_packs.py
+++ b/api/routes/agent_packs.py
@@ -41,7 +41,7 @@ async def download_claude_agent_pack(
     adapter = AGENT_PACK_ADAPTERS["claude"]
 
     try:
-        manifest = adapter.build_manifest(req, compiler)
+        manifest = adapter.build_manifest(req, compiler, include_readiness=False)
         return create_download_response(manifest)
     except Exception as exc:
         logger.exception(

--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -42,6 +42,7 @@ from app.optimizer.language_costs import (
 from app.optimizer.postprocess import strip_wrapper_labels
 from app.readiness.analyzer import analyze_readiness
 from app.readiness.language_guard import output_language_mismatch
+from app.readiness.markdown import report_to_markdown
 from app.validator import validate_prompt
 
 router = APIRouter(tags=["compile"])
@@ -102,6 +103,13 @@ class CompileResponse(BaseModel):
     trace: list[str] | None = None
     critique: dict | None = None
     readiness: dict | None = None
+    readiness_markdown: str = ""
+
+
+class CompileExportResponse(BaseModel):
+    markdown: str
+    json_payload: dict = Field(serialization_alias="json")
+    filename: str
 
 
 class OptimizeRequest(BaseModel):
@@ -283,6 +291,7 @@ def _fast_compile_payload(
         or emit_expanded_prompt_v2(ir2, diagnostics=req.diagnostics)
     )
     ir_dump = ir2.model_dump()
+    readiness_report = analyze_readiness(req.text, ir2)
 
     return (
         {
@@ -302,6 +311,8 @@ def _fast_compile_payload(
             "heuristic2_version": "v2-fast",
             "trace": [],
             "critique": None,
+            "readiness": readiness_report.model_dump(),
+            "readiness_markdown": report_to_markdown(readiness_report),
         },
         used_fallback,
     )
@@ -344,12 +355,7 @@ def _build_offline_quality_report(req: ValidateRequest) -> QualityReport:
     )
 
 
-@router.post("/compile", response_model=CompileResponse)
-def compile_endpoint(
-    req: CompileRequest,
-    request: Request,
-    _: None = Depends(rate_limit_by_ip),
-):
+def _compile_response(req: CompileRequest, request: Request) -> CompileResponse:
     t0 = time.time()
     rid = uuid.uuid4().hex[:12]
 
@@ -464,7 +470,9 @@ def compile_endpoint(
                 extra={"request_id": rid},
             )
 
-    readiness = analyze_readiness(req.text, ir2).model_dump()
+    readiness_report = analyze_readiness(req.text, ir2)
+    readiness = readiness_report.model_dump()
+    readiness_markdown = report_to_markdown(readiness_report)
     elapsed = int((time.time() - t0) * 1000)
 
     # Block compilation ONLY when the safety scan flags the input as unsafe
@@ -493,6 +501,7 @@ def compile_endpoint(
             trace=trace_lines,
             critique=critique_result,
             readiness=readiness,
+            readiness_markdown=readiness_markdown,
         )
 
     return CompileResponse(
@@ -517,6 +526,40 @@ def compile_endpoint(
         trace=trace_lines,
         critique=critique_result,
         readiness=readiness,
+        readiness_markdown=readiness_markdown,
+    )
+
+
+@router.post("/compile", response_model=CompileResponse)
+def compile_endpoint(
+    req: CompileRequest,
+    request: Request,
+    _: None = Depends(rate_limit_by_ip),
+):
+    return _compile_response(req, request)
+
+
+def _render_compile_export(compiled: CompileResponse) -> str:
+    return (
+        "# Prompt Compiler Export\n\n"
+        f"## System Prompt\n\n{compiled.system_prompt.strip()}\n\n"
+        f"## User Prompt\n\n{compiled.user_prompt.strip()}\n\n"
+        f"## Plan\n\n{compiled.plan.strip()}\n\n"
+        f"{compiled.readiness_markdown.rstrip()}\n"
+    )
+
+
+@router.post("/compile/export", response_model=CompileExportResponse)
+def compile_export_endpoint(
+    req: CompileRequest,
+    request: Request,
+    _: None = Depends(rate_limit_by_ip),
+):
+    compiled = _compile_response(req, request)
+    return CompileExportResponse(
+        markdown=_render_compile_export(compiled),
+        json_payload=compiled.model_dump(mode="json"),
+        filename=f"prompt-compile-{compiled.request_id}.md",
     )
 
 

--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -65,26 +65,14 @@ class AgentPackManifest(BaseModel):
 class AgentPackAdapter(Protocol):
     provider: str
 
-    def build_manifest(
-        self,
-        req: AgentPackRequest,
-        compiler: Any,
-        *,
-        include_readiness: bool = True,
-    ) -> AgentPackManifest:
+    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest:
         ...
 
 
 class ClaudeAgentPackAdapter:
     provider = "claude"
 
-    def build_manifest(
-        self,
-        req: AgentPackRequest,
-        compiler: Any,
-        *,
-        include_readiness: bool = True,
-    ) -> AgentPackManifest:
+    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest:
         raw_files: list[dict[str, str]]
 
         if req.pack_type == "mcp-tool-stub":
@@ -109,12 +97,13 @@ class ClaudeAgentPackAdapter:
             else:
                 raw_files = to_claude_pr_reviewer_pack(agent_ir)
 
-        if include_readiness:
-            readiness_markdown = report_to_markdown(analyze_readiness(req.goal))
-            for file in raw_files:
-                if file["path"].endswith(".md"):
-                    file["content"] = f"{file['content'].rstrip()}\n\n{readiness_markdown}"
-                    break
+        # Surface the readiness verdict in the first markdown file of the pack so the
+        # exported artifact (preview and download alike) carries the same guidance.
+        readiness_markdown = report_to_markdown(analyze_readiness(req.goal))
+        for file in raw_files:
+            if file["path"].endswith(".md"):
+                file["content"] = f"{file['content'].rstrip()}\n\n{readiness_markdown}"
+                break
 
         files = [
             AgentPackFile(

--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -16,6 +16,8 @@ from .claude_code import (
     to_claude_subagent_bundle,
 )
 from .skill_ir import parse_skill_markdown
+from app.readiness.analyzer import analyze_readiness
+from app.readiness.markdown import report_to_markdown
 
 PackType = Literal["project-pack", "subagent", "pr-reviewer", "mcp-tool-stub"]
 RiskMode = Literal["balanced", "strict"]
@@ -63,14 +65,26 @@ class AgentPackManifest(BaseModel):
 class AgentPackAdapter(Protocol):
     provider: str
 
-    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest:
+    def build_manifest(
+        self,
+        req: AgentPackRequest,
+        compiler: Any,
+        *,
+        include_readiness: bool = True,
+    ) -> AgentPackManifest:
         ...
 
 
 class ClaudeAgentPackAdapter:
     provider = "claude"
 
-    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest:
+    def build_manifest(
+        self,
+        req: AgentPackRequest,
+        compiler: Any,
+        *,
+        include_readiness: bool = True,
+    ) -> AgentPackManifest:
         raw_files: list[dict[str, str]]
 
         if req.pack_type == "mcp-tool-stub":
@@ -94,6 +108,13 @@ class ClaudeAgentPackAdapter:
                 raw_files = to_claude_subagent_bundle(agent_ir)
             else:
                 raw_files = to_claude_pr_reviewer_pack(agent_ir)
+
+        if include_readiness:
+            readiness_markdown = report_to_markdown(analyze_readiness(req.goal))
+            for file in raw_files:
+                if file["path"].endswith(".md"):
+                    file["content"] = f"{file['content'].rstrip()}\n\n{readiness_markdown}"
+                    break
 
         files = [
             AgentPackFile(

--- a/docs/superpowers/specs/2026-06-29-readiness-slice2-export-CODEX-TASK.md
+++ b/docs/superpowers/specs/2026-06-29-readiness-slice2-export-CODEX-TASK.md
@@ -1,0 +1,63 @@
+# Codex Task — Readiness Slice 2: executable .md/.json export
+
+**Mode:** autonomous loop. Keep editing until the threshold below is green, then stop.
+
+## Goal
+Make the compile output **exportable as an executable-feeling `.md` document and a
+machine-readable `.json` object**, and wire the already-built readiness markdown
+into the product surfaces.
+
+## Background (already shipped)
+- Slice 1 (#879) computes a `ReadinessReport{verdict, signals, questions}` via
+  `app/readiness/analyzer.py::analyze_readiness` and surfaces it on the `/compile`
+  response as `readiness` (a dict).
+- `app/readiness/markdown.py::report_to_markdown(report)` already renders a report
+  as markdown (`## Readiness: <verdict> — <title>` + `### Signals` / `### Clarify first`)
+  but is **not wired into any API/output** yet. Reuse it — do not reimplement it.
+
+## Contract to implement
+1. **`POST /compile`** response gains a `readiness_markdown: str` field, built by
+   passing the same `ReadinessReport` through `report_to_markdown`.
+2. **`POST /compile/export`** (new endpoint; same request body as `/compile`) returns:
+   ```json
+   { "markdown": "<self-contained document>", "json": { ... }, "filename": "<name>.md" }
+   ```
+   - `markdown` is one self-contained document containing, as `##` sections:
+     **System Prompt**, **User Prompt**, **Plan**, and the **Readiness** section
+     (the latter from `report_to_markdown`, i.e. the literal `## Readiness:` header).
+     It must embed the real compiled prompt text, not empty placeholders.
+   - `json` is the structured result and must include at least the keys
+     `readiness` (dict with `verdict`), `system_prompt`, `user_prompt`, `plan`.
+   - `filename` ends with `.md`.
+3. **Agent pack manifests** (`POST /agent-packs/claude`, see `app/adapters/agent_packs.py`)
+   include the readiness markdown section, so at least one manifest file's `content`
+   contains the `## Readiness:` header. Analyze readiness from the request `goal`.
+
+## Threshold = definition of done
+- `python -m pytest tests/test_readiness_export.py -q` — **all pass**.
+- `python -m pytest tests/ -q` — **full suite stays green** (no regressions).
+- `tests/test_readiness_export.py` is the locked threshold: **do not modify, weaken,
+  or delete any assertion in it.** If a test seems wrong, stop and flag it rather than
+  editing it.
+
+## Likely files to touch
+- `api/routes/compile.py` — add `readiness_markdown` to `CompileResponse`; add the
+  `/compile/export` endpoint (reuse the existing compile path, don't fork the logic).
+- `app/readiness/` — if you add a JSON helper, keep it symmetric with `report_to_markdown`.
+- `app/adapters/agent_packs.py` — inject the readiness section into the built files.
+- `web/lib/api/types.ts` — keep the TS types in sync if you change response shapes.
+
+## Hard rules (from repo CLAUDE.md)
+- Do NOT touch `.env`/secrets, auth provider settings, or LLM prompt text /
+  response-format / temperature / max_tokens.
+- OpenRouter is the only cloud provider — do not add Groq/OpenAI fallbacks.
+- No end-user API-key requirements for public web flows.
+- Keep changes small and scoped to this task. No unrelated refactors.
+- Before finishing, lint changed files the way CI does (Smoke pins ruff 0.1.14):
+  `uvx ruff@0.1.14 check --fix` and `uvx ruff@0.1.14 format` on changed files.
+
+## Run commands
+```bash
+python -m pytest tests/test_readiness_export.py -q      # the threshold
+python -m pytest tests/ -q                              # full suite (no regressions)
+```

--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -146,7 +146,9 @@ def test_agent_packs_download_returns_plain_file_for_single_file_manifest():
 
         assert response.status_code == 200
         assert response.headers["content-disposition"] == 'attachment; filename="review-agent.md"'
-        assert response.text == "hello"
+        # The downloaded pack carries the readiness section (consistent with the manifest).
+        assert response.text.startswith("hello")
+        assert "## Readiness:" in response.text
 
 
 def test_agent_packs_endpoint_validation_errors():

--- a/tests/test_readiness_export.py
+++ b/tests/test_readiness_export.py
@@ -1,0 +1,122 @@
+"""Threshold tests for Readiness Slice 2 — executable .md/.json export.
+
+These tests are the DEFINITION OF DONE for the Slice 2 task. An autonomous
+agent (Codex) should implement the feature until every test here passes,
+WITHOUT weakening or deleting any assertion in this file. The full existing
+suite must also stay green (no regressions).
+
+Contract being locked in:
+  * POST /compile          -> response gains `readiness_markdown` (str) built
+                              from app.readiness.markdown.report_to_markdown.
+  * POST /compile/export   -> {"markdown": str, "json": dict, "filename": str}
+                              markdown is a self-contained document with the
+                              System Prompt, User Prompt, Plan and Readiness
+                              sections; json carries the structured result.
+  * Agent pack manifests   -> include the readiness markdown section so the
+                              exported pack surfaces the readiness verdict.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+# A prompt that yields a non-trivial readiness verdict ("clarify" + an
+# unverifiable_reference signal), so the readiness sections are never empty.
+EXPORT_TEXT = "use the AcmeCloud SDK to deploy my model"
+
+VALID_VERDICTS = {"ready", "clarify", "risky", "noise"}
+
+
+def _compile(text: str = EXPORT_TEXT, **extra) -> dict:
+    payload = {"text": text, "v2": False, "render_v2_prompts": True}
+    payload.update(extra)
+    resp = client.post("/compile", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _export(text: str = EXPORT_TEXT, **extra) -> dict:
+    payload = {"text": text, "v2": False, "render_v2_prompts": True}
+    payload.update(extra)
+    resp = client.post("/compile/export", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# --- 1. readiness_markdown wired into the /compile response -----------------
+
+
+def test_compile_response_includes_readiness_markdown():
+    body = _compile()
+    assert "readiness_markdown" in body, "compile response must expose readiness_markdown"
+    md = body["readiness_markdown"]
+    assert isinstance(md, str) and md.strip()
+    # Built from report_to_markdown -> "## Readiness: <verdict> — <title>"
+    assert "## Readiness:" in md
+    # Anti-gaming: the structured verdict must actually appear in the markdown.
+    assert body["readiness"]["verdict"] in md
+
+
+# --- 2. /compile/export returns markdown + json + filename ------------------
+
+
+def test_compile_export_returns_markdown_json_and_filename():
+    body = _export()
+    assert isinstance(body.get("markdown"), str) and body["markdown"].strip()
+    assert isinstance(body.get("json"), dict) and body["json"]
+    assert isinstance(body.get("filename"), str) and body["filename"].endswith(".md")
+
+
+# --- 3. export markdown contains all sections + real content ----------------
+
+
+def test_compile_export_markdown_contains_all_sections():
+    md = _export()["markdown"]
+    assert "## System Prompt" in md
+    assert "## User Prompt" in md
+    assert "## Plan" in md
+    assert "## Readiness:" in md
+
+
+def test_compile_export_markdown_embeds_real_prompt_content():
+    compiled = _compile()
+    md = _export()["markdown"]
+    # The export must embed the actual compiled system prompt, not an empty
+    # placeholder section (anti-gaming).
+    sys_prompt = compiled["system_prompt"]
+    assert sys_prompt[:30] in md
+
+
+# --- 4. export json is structured and carries readiness + prompts ----------
+
+
+def test_compile_export_json_has_readiness_and_prompts():
+    data = _export()["json"]
+    assert isinstance(data.get("readiness"), dict)
+    assert data["readiness"].get("verdict") in VALID_VERDICTS
+    for key in ("system_prompt", "user_prompt", "plan"):
+        assert key in data, f"export json missing '{key}'"
+
+
+# --- 5. agent pack manifests surface the readiness section ------------------
+
+
+def _agent_pack_payload(pack_type: str = "project-pack") -> dict:
+    return {
+        "project_type": "web app",
+        "stack": "FastAPI + Next.js",
+        "goal": EXPORT_TEXT,
+        "pack_type": pack_type,
+    }
+
+
+def test_agent_pack_includes_readiness_section():
+    resp = client.post("/agent-packs/claude", json=_agent_pack_payload())
+    assert resp.status_code == 200, resp.text
+    manifest = resp.json()
+    all_content = "\n".join(f["content"] for f in manifest["files"])
+    assert "## Readiness:" in all_content, "agent pack must surface the readiness section"

--- a/web/lib/api/promptc.ts
+++ b/web/lib/api/promptc.ts
@@ -257,6 +257,7 @@ export function normalizeCompileResponse(value: unknown): CompileResponse {
     heuristic2_version: readString(record.heuristic2_version) || undefined,
     trace: Array.isArray(record.trace) ? readStringList(record.trace) : undefined,
     critique: normalizeCritique(record.critique),
+    readiness_markdown: readString(record.readiness_markdown),
   };
 }
 

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -100,6 +100,7 @@ export type CompileResponse = {
   trace?: string[];
   critique?: Critique | null;
   readiness?: ReadinessReport | null;
+  readiness_markdown: string;
 };
 
 export type CompileMode = "conservative" | "default";


### PR DESCRIPTION
## What
Readiness Slice 2 — make the compile output exportable and surface the readiness verdict across product surfaces.

- `POST /compile` now returns `readiness_markdown` (built from the existing `report_to_markdown`).
- New `POST /compile/export` → `{ markdown, json, filename }`: a self-contained document with **System Prompt / User Prompt / Plan / Readiness** sections plus the structured JSON. Reuses the compile path (no forked logic) and is rate-limited like `/compile`.
- Agent pack readiness is injected into the pack's first markdown file — **preview and download alike** (consistent; the unused `include_readiness` flag was dropped on review).
- Bonus: the fast compile path now also returns readiness (closes the prior `readiness: null` gap).
- Frontend TS types kept in sync.

## How it was built
Implemented by an autonomous Codex loop against a locked test threshold
(`tests/test_readiness_export.py`, 6 tests = definition of done), then reviewed:
the agent-pack download was made consistent with the manifest (readiness now ships
in the downloaded pack too), and the single-file download test was updated accordingly.

## Verification
- Threshold `tests/test_readiness_export.py`: 6/6 pass.
- Full backend suite: 1535 passed, 5 skipped, 0 failed.
- `uvx ruff@0.1.14 check` + `format` clean (matches CI Smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)