### PR TITLE
feat(cli): offline compile-export command

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -317,6 +317,13 @@ python -m cli.main compile "summarize this PDF for a non-technical audience"
 python -m cli.main github render --type pr-review-brief --from-file prompt.txt
 ```
 
+**Compile export (offline):**
+
+```bash
+python -m cli.main compile-export "summarize this PDF for a non-technical audience"
+python -m cli.main compile-export "summarize this PDF" --out-dir ./exports
+```
+
 **After `pip install -e .`, use the `promptc` shorthand:**
 
 ```bash
@@ -327,7 +334,7 @@ promptc compile "build a login flow for a FastAPI app"
 **CLI tests:**
 
 ```bash
-pytest tests/test_cli_console_refactor.py tests/test_cli_new_features.py tests/test_cli_extras.py -v
+pytest tests/test_cli_compile_export.py tests/test_cli_console_refactor.py tests/test_cli_new_features.py tests/test_cli_extras.py -v
 ```
 
 ---

--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -19,6 +19,7 @@ from api.shared import (
     resolve_mode,
     safety_refusal_prompt_fields,
 )
+from app.compile_export import render_compile_export
 from app.compiler import HEURISTIC_VERSION, HEURISTIC2_VERSION
 from app.compiler import compile_text, compile_text_v2, generate_trace, optimize_ir
 from app.emitters import (
@@ -539,16 +540,6 @@ def compile_endpoint(
     return _compile_response(req, request)
 
 
-def _render_compile_export(compiled: CompileResponse) -> str:
-    return (
-        "# Prompt Compiler Export\n\n"
-        f"## System Prompt\n\n{compiled.system_prompt.strip()}\n\n"
-        f"## User Prompt\n\n{compiled.user_prompt.strip()}\n\n"
-        f"## Plan\n\n{compiled.plan.strip()}\n\n"
-        f"{compiled.readiness_markdown.rstrip()}\n"
-    )
-
-
 @router.post("/compile/export", response_model=CompileExportResponse)
 def compile_export_endpoint(
     req: CompileRequest,
@@ -557,7 +548,12 @@ def compile_export_endpoint(
 ):
     compiled = _compile_response(req, request)
     return CompileExportResponse(
-        markdown=_render_compile_export(compiled),
+        markdown=render_compile_export(
+            system_prompt=compiled.system_prompt,
+            user_prompt=compiled.user_prompt,
+            plan=compiled.plan,
+            readiness_markdown=compiled.readiness_markdown,
+        ),
         json_payload=compiled.model_dump(mode="json"),
         filename=f"prompt-compile-{compiled.request_id}.md",
     )

--- a/app/compile_export.py
+++ b/app/compile_export.py
@@ -1,0 +1,20 @@
+"""Shared rendering for compile export documents."""
+
+from __future__ import annotations
+
+
+def render_compile_export(
+    *,
+    system_prompt: str,
+    user_prompt: str,
+    plan: str,
+    readiness_markdown: str,
+) -> str:
+    """Render a self-contained Markdown document from compiled prompt fields."""
+    return (
+        "# Prompt Compiler Export\n\n"
+        f"## System Prompt\n\n{system_prompt.strip()}\n\n"
+        f"## User Prompt\n\n{user_prompt.strip()}\n\n"
+        f"## Plan\n\n{plan.strip()}\n\n"
+        f"{readiness_markdown.rstrip()}\n"
+    )

--- a/cli/commands/_base.py
+++ b/cli/commands/_base.py
@@ -43,3 +43,8 @@ def _main(
 def version():
     """Print package version."""
     rich_print(get_version())
+
+
+# Register the standalone export command for lightweight consumers that import
+# `cli.commands._base.app` directly rather than the full core command aggregator.
+from cli.commands import compile_export as _compile_export  # noqa: E402,F401

--- a/cli/commands/compile_export.py
+++ b/cli/commands/compile_export.py
@@ -1,0 +1,63 @@
+"""Offline `compile-export` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import orjson
+import typer
+
+from app.compile_export import render_compile_export
+from app.compiler import compile_text_v2
+from app.emitters import (
+    emit_expanded_prompt_v2,
+    emit_plan_v2,
+    emit_system_prompt_v2,
+    emit_user_prompt_v2,
+)
+from app.readiness.analyzer import analyze_readiness
+from app.readiness.markdown import report_to_markdown
+from cli.commands._base import app
+from cli.commands._helpers import _write_output
+
+
+@app.command("compile-export")
+def compile_export_cmd(
+    text: str = typer.Argument(..., help="Prompt text to compile and export"),
+    out_dir: Path | None = typer.Option(
+        None,
+        "--out-dir",
+        help="Write compile-export.md and compile-export.json to this directory",
+    ),
+) -> None:
+    """Compile a prompt offline and export executable Markdown plus structured JSON."""
+    ir = compile_text_v2(text, enable_context_retrieval=False)
+    system_prompt = emit_system_prompt_v2(ir)
+    user_prompt = emit_user_prompt_v2(ir)
+    plan = emit_plan_v2(ir)
+    readiness_report = analyze_readiness(text, ir)
+    readiness_markdown = report_to_markdown(readiness_report)
+
+    data = {
+        "ir": ir.model_dump(),
+        "system_prompt": system_prompt,
+        "user_prompt": user_prompt,
+        "plan": plan,
+        "expanded_prompt": emit_expanded_prompt_v2(ir),
+        "readiness": readiness_report.model_dump(),
+        "readiness_markdown": readiness_markdown,
+    }
+    markdown = render_compile_export(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        plan=plan,
+        readiness_markdown=readiness_markdown,
+    )
+
+    if out_dir is None:
+        typer.echo(markdown)
+        return
+
+    _write_output(markdown, None, out_dir, default_name="compile-export.md")
+    json_output = orjson.dumps(data, option=orjson.OPT_INDENT_2).decode("utf-8")
+    _write_output(json_output, None, out_dir, default_name="compile-export.json")

--- a/docs/superpowers/specs/2026-06-29-cli-compile-export-CODEX-TASK.md
+++ b/docs/superpowers/specs/2026-06-29-cli-compile-export-CODEX-TASK.md
@@ -1,0 +1,60 @@
+# Codex Task — CLI `compile-export` command
+
+**Mode:** autonomous loop. Keep editing until the threshold below is green, then stop.
+
+## Goal
+Bring the executable export from #887 to the command line: a `compile-export`
+command that writes the compile output as an executable-feeling `.md` document and
+a structured `.json` file, mirroring the `POST /compile/export` endpoint.
+
+## Background (already shipped, #887)
+- `POST /compile/export` returns `{ markdown, json, filename }`.
+- The markdown is a self-contained document with these `##` sections:
+  **System Prompt**, **User Prompt**, **Plan**, and **Readiness** (the latter from
+  `app/readiness/markdown.py::report_to_markdown`, i.e. the literal `## Readiness:`).
+- The rendering helper is `api/routes/compile.py::_render_compile_export`.
+- The CLI is **typer**-based (`cli/commands/_base.py::app`); `cli/commands/compile_cmd.py`
+  already has `_run_compile` and uses `cli/commands/_helpers.py::_write_output`.
+
+## Contract to implement
+Add a typer command named **`compile-export`** (so `runner.invoke(app, ["compile-export", ...])`
+works):
+- Positional arg: `TEXT` — the request text.
+- Option: `--out-dir PATH` — optional output directory.
+- Behavior:
+  - With `--out-dir DIR`: write `DIR/compile-export.md` (the self-contained export
+    document) and `DIR/compile-export.json` (the structured result). Create the dir
+    if needed.
+  - Without `--out-dir`: print the export markdown to stdout.
+- The markdown must contain `## System Prompt`, `## User Prompt`, `## Plan`, and the
+  `## Readiness:` section, and embed the real compiled prompt text (no placeholders).
+- The JSON must include at least `readiness` (dict with `verdict`), `system_prompt`,
+  `user_prompt`, `plan`.
+- Must run **fully offline / deterministically** (no LLM/network call) — mirror the
+  existing CLI compile default. Tests run in CI without network.
+
+## DRY note
+Prefer extracting the export markdown rendering into a small shared helper under
+`app/` (used by both the endpoint and the CLI) rather than importing the API layer
+from the CLI or duplicating the renderer. The threshold pins behaviour, not
+internals — pick the cleanest implementation.
+
+## Threshold = definition of done
+- `python -m pytest tests/test_cli_compile_export.py -q` — **all pass**.
+- `python -m pytest tests/ -q` — **full suite stays green** (no regressions).
+- `tests/test_cli_compile_export.py` is the locked threshold: **do not modify, weaken,
+  or delete any assertion.** If a test seems wrong, stop and flag it.
+
+## Hard rules (from repo CLAUDE.md)
+- Do NOT touch `.env`/secrets, auth settings, or LLM prompt text / response-format /
+  temperature / max_tokens.
+- OpenRouter is the only cloud provider — no Groq/OpenAI fallbacks.
+- Keep changes small and scoped. No unrelated refactors beyond the optional DRY extract.
+- Lint changed files the way CI does (Smoke pins ruff 0.1.14):
+  `uvx ruff@0.1.14 check --fix` and `uvx ruff@0.1.14 format`.
+
+## Run commands
+```bash
+python -m pytest tests/test_cli_compile_export.py -q   # the threshold
+python -m pytest tests/ -q                             # full suite (no regressions)
+```

--- a/tests/test_cli_compile_export.py
+++ b/tests/test_cli_compile_export.py
@@ -1,0 +1,79 @@
+"""Threshold tests for the CLI `compile-export` command (Codex task).
+
+Definition of done: add a `compile-export` CLI command that produces the same
+executable .md / .json bundle as the POST /compile/export endpoint (#887), but
+written to disk (or stdout) from the command line. The command must run fully
+offline/deterministically (no LLM/network), like the existing CLI compile path.
+
+Do NOT modify, weaken, or delete any assertion in this file. The full existing
+suite must also stay green.
+
+Contract being locked in:
+  * `compile-export TEXT`                  -> prints the export markdown to stdout.
+  * `compile-export TEXT --out-dir DIR`    -> writes DIR/compile-export.md and
+                                              DIR/compile-export.json.
+  * The markdown has the same sections as /compile/export:
+    `## System Prompt`, `## User Prompt`, `## Plan`, `## Readiness:`.
+  * The JSON carries at least `readiness` (with `verdict`), `system_prompt`,
+    `user_prompt`, `plan`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from cli.commands._base import app
+
+runner = CliRunner()
+
+# A prompt with a non-trivial readiness verdict ("clarify"), so sections are never empty.
+EXPORT_TEXT = "use the AcmeCloud SDK to deploy my model"
+VALID_VERDICTS = {"ready", "clarify", "risky", "noise"}
+
+
+def test_compile_export_to_stdout_has_all_sections():
+    result = runner.invoke(app, ["compile-export", EXPORT_TEXT])
+    assert result.exit_code == 0, result.output
+    out = result.stdout
+    assert "## System Prompt" in out
+    assert "## User Prompt" in out
+    assert "## Plan" in out
+    assert "## Readiness:" in out
+
+
+def test_compile_export_writes_md_and_json(tmp_path: Path):
+    result = runner.invoke(app, ["compile-export", EXPORT_TEXT, "--out-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    md = tmp_path / "compile-export.md"
+    js = tmp_path / "compile-export.json"
+    assert md.exists(), "expected compile-export.md to be written"
+    assert js.exists(), "expected compile-export.json to be written"
+
+    md_text = md.read_text(encoding="utf-8")
+    assert "## System Prompt" in md_text
+    assert "## User Prompt" in md_text
+    assert "## Plan" in md_text
+    assert "## Readiness:" in md_text
+
+
+def test_compile_export_json_is_valid_and_structured(tmp_path: Path):
+    result = runner.invoke(app, ["compile-export", EXPORT_TEXT, "--out-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    data = json.loads((tmp_path / "compile-export.json").read_text(encoding="utf-8"))
+    assert isinstance(data.get("readiness"), dict)
+    assert data["readiness"].get("verdict") in VALID_VERDICTS
+    for key in ("system_prompt", "user_prompt", "plan"):
+        assert key in data, f"export json missing '{key}'"
+
+
+def test_compile_export_markdown_embeds_real_prompt(tmp_path: Path):
+    result = runner.invoke(app, ["compile-export", EXPORT_TEXT, "--out-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    data = json.loads((tmp_path / "compile-export.json").read_text(encoding="utf-8"))
+    md_text = (tmp_path / "compile-export.md").read_text(encoding="utf-8")
+    # Anti-gaming: the export must embed the real compiled system prompt, not a placeholder.
+    assert data["system_prompt"][:30] in md_text

--- a/tests/test_cli_phase3.py
+++ b/tests/test_cli_phase3.py
@@ -18,6 +18,7 @@ EXPECTED_TOP_LEVEL_COMMANDS = {
     "batch",
     "compare",
     "compile",
+    "compile-export",
     "diff",
     "fix",
     "json-path",


### PR DESCRIPTION
## What
Brings the executable export from #887 to the command line.

- New `compile-export TEXT [--out-dir DIR]` CLI command (typer): compiles **offline/deterministically** and either prints the export markdown to stdout or writes `compile-export.md` + `compile-export.json` to a directory.
- The markdown mirrors `/compile/export`: **System Prompt / User Prompt / Plan / Readiness** sections; the JSON carries `readiness`, prompts, and the IR.
- DRY: extracts the export rendering into a shared `app/compile_export.py` used by both the endpoint and the CLI (single source of truth; the endpoint was refactored to use it).
- Documents the command in `agents.md` and adds it to the expected-commands test.

## How it was built
Implemented by an autonomous Codex loop against a locked test threshold
(`tests/test_cli_compile_export.py`, 4 tests = definition of done), then reviewed.

## Verification
- Threshold `tests/test_cli_compile_export.py`: 4/4 pass.
- Full backend suite green (the only local failure is a pre-existing, environment-dependent opportunistic check that hits a server on :8000 — it also fails on clean main and passes in CI).
- `uvx ruff@0.1.14 check` + `format` clean (matches CI Smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)