### PR TITLE
feat(pr-safety): POST /pr-safety/report/export endpoint

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -191,7 +191,7 @@ pytest -q \
 **Test all API routes:**
 
 ```bash
-pytest tests/test_compile_policy_api.py tests/test_agent_generator.py tests/test_skills_generator.py tests/test_optimize_api.py tests/test_benchmark_api.py tests/test_rag_upload.py tests/test_security_headers.py -v
+pytest tests/test_compile_policy_api.py tests/test_agent_generator.py tests/test_skills_generator.py tests/test_optimize_api.py tests/test_benchmark_api.py tests/test_rag_upload.py tests/test_security_headers.py tests/test_pr_safety_export.py -v
 ```
 
 **Live optimizer tests (opt-in only; requires upstream credentials):**
@@ -218,6 +218,11 @@ curl -s -X POST http://127.0.0.1:8080/compile \
 curl -s -X POST http://127.0.0.1:8080/compile/fast \
   -H "Content-Type: application/json" \
   -d '{"text": "create a marketing email", "mode": "default"}' | python -m json.tool
+
+# PR Safety report export
+curl -s -X POST http://127.0.0.1:8080/pr-safety/report/export \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Add auth checks","description":"Adds session validation.","changed_files":["app/auth.py","tests/test_auth.py"],"commits_behind":0}' | python -m json.tool
 ```
 
 **Auth testing — bypass vs. enforce:**
@@ -335,6 +340,12 @@ promptc compile "build a login flow for a FastAPI app"
 
 ```bash
 pytest tests/test_cli_compile_export.py tests/test_cli_console_refactor.py tests/test_cli_new_features.py tests/test_cli_extras.py -v
+```
+
+**macOS port-8000 test note:** `tests/test_cli_new_features.py` probes `127.0.0.1:8000` when the port is open. If an unrelated local service owns that port, stop it or isolate only that port while running the suite:
+
+```bash
+sandbox-exec -p '(version 1)(allow default)(deny network-outbound (remote tcp "localhost:8000"))' python -m pytest tests/ -q
 ```
 
 ---

--- a/api/routes/pr_safety.py
+++ b/api/routes/pr_safety.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 
 from api.auth import rate_limit_by_ip
 from app.pr_safety.analyzer import analyze_pr_safety
+from app.pr_safety.markdown import report_to_markdown
 from app.pr_safety.models import PrSafetyReport
 
 router = APIRouter(tags=["pr-safety"])
@@ -25,14 +26,37 @@ class PrSafetyReportRequest(BaseModel):
     )
 
 
-@router.post("/pr-safety/report", response_model=PrSafetyReport)
-async def create_pr_safety_report(
-    req: PrSafetyReportRequest,
-    _: None = Depends(rate_limit_by_ip),
-) -> PrSafetyReport:
+class PrSafetyExportResponse(BaseModel):
+    markdown: str
+    json_payload: dict = Field(serialization_alias="json")
+    filename: str
+
+
+def _build_pr_safety_report(req: PrSafetyReportRequest) -> PrSafetyReport:
     return analyze_pr_safety(
         req.title,
         req.description,
         req.changed_files,
         commits_behind=req.commits_behind,
+    )
+
+
+@router.post("/pr-safety/report", response_model=PrSafetyReport)
+async def create_pr_safety_report(
+    req: PrSafetyReportRequest,
+    _: None = Depends(rate_limit_by_ip),
+) -> PrSafetyReport:
+    return _build_pr_safety_report(req)
+
+
+@router.post("/pr-safety/report/export", response_model=PrSafetyExportResponse)
+async def export_pr_safety_report(
+    req: PrSafetyReportRequest,
+    _: None = Depends(rate_limit_by_ip),
+) -> PrSafetyExportResponse:
+    report = _build_pr_safety_report(req)
+    return PrSafetyExportResponse(
+        markdown=report_to_markdown(report),
+        json_payload=report.model_dump(mode="json"),
+        filename="pr-safety-report.md",
     )

--- a/docs/superpowers/specs/2026-06-29-pr-safety-report-export-CODEX-TASK.md
+++ b/docs/superpowers/specs/2026-06-29-pr-safety-report-export-CODEX-TASK.md
@@ -1,0 +1,56 @@
+# Codex Task — `POST /pr-safety/report/export`
+
+**Mode:** autonomous loop. Keep editing until the threshold below is green, then stop.
+
+## Goal
+Expose the existing GitHub-ready PR Safety markdown through the API, mirroring
+`POST /compile/export` (#887). Today the markdown renderer is CLI-only; web, CI, and
+the planned GitHub Action have no server-side way to fetch it.
+
+## Background (already shipped)
+- `POST /pr-safety/report` (`api/routes/pr_safety.py`) returns a structured
+  `PrSafetyReport` (verdict, title, changed_files, risky_areas, test_coverage,
+  branch_freshness, scope_match, recommendations).
+- `app/pr_safety/markdown.py::report_to_markdown(report: PrSafetyReport) -> str`
+  already renders that report as a GitHub-ready markdown document
+  (`# PR Safety Report`, `**Verdict:**`, `## Changed files`, `## Risky areas`, …).
+  It is offline/deterministic and currently used **only** by `cli/commands/pr_safety.py`.
+- For reference, `POST /compile/export` returns `{ markdown, json, filename }`.
+
+## Contract to implement
+Add **`POST /pr-safety/report/export`** taking the same request body as
+`/pr-safety/report` (`PrSafetyReportRequest`) and returning:
+```json
+{ "markdown": "<report_to_markdown output>", "json": { ...PrSafetyReport... }, "filename": "<name>.md" }
+```
+- Reuse the **existing** report-building path (do not fork the analyzer) and the
+  **existing** `report_to_markdown` (do not write a second renderer).
+- `json` must be the same structured `PrSafetyReport` as `/pr-safety/report`.
+- `filename` ends with `.md`.
+- Keep it rate-limited like the other pr-safety / compile routes.
+
+## Threshold = definition of done
+- `python -m pytest tests/test_pr_safety_export.py -q` — **all pass**.
+- `python -m pytest tests/ -q` — **full suite stays green** (no regressions).
+- `tests/test_pr_safety_export.py` is the locked threshold: **do not modify, weaken,
+  or delete any assertion.** If a test seems wrong, stop and flag it.
+
+## Likely files to touch
+- `api/routes/pr_safety.py` — add the endpoint + a small response model
+  (`{ markdown, json, filename }`); reuse the analyzer call already used by
+  `/pr-safety/report` and `app/pr_safety/markdown.py::report_to_markdown`.
+- `web/lib/api/*` — only if you change shared response shapes (keep TS types in sync).
+
+## Hard rules (from repo CLAUDE.md)
+- Do NOT touch `.env`/secrets, auth settings, or LLM prompt text / params.
+- OpenRouter is the only cloud provider — no Groq/OpenAI fallbacks.
+- No end-user API-key requirements for public web flows.
+- Keep changes small and scoped. No unrelated refactors.
+- Lint changed files the way CI does (Smoke pins ruff 0.1.14):
+  `uvx ruff@0.1.14 check --fix` and `uvx ruff@0.1.14 format`.
+
+## Run commands
+```bash
+python -m pytest tests/test_pr_safety_export.py -q   # the threshold
+python -m pytest tests/ -q                           # full suite (no regressions)
+```

--- a/tests/test_pr_safety_export.py
+++ b/tests/test_pr_safety_export.py
@@ -1,0 +1,71 @@
+"""Threshold tests for POST /pr-safety/report/export (Codex task).
+
+The PR Safety markdown renderer (app/pr_safety/markdown.py::report_to_markdown) is
+GitHub-ready but currently CLI-only. Expose it through the API, mirroring
+POST /compile/export, so web/CI/GitHub-Action consumers can fetch the server-side
+markdown + structured JSON.
+
+Do NOT modify, weaken, or delete any assertion in this file. The full existing
+suite must also stay green.
+
+Contract being locked in:
+  * POST /pr-safety/report/export  (same request body as /pr-safety/report)
+      -> { "markdown": str, "json": dict, "filename": str }
+  * markdown is report_to_markdown(report) — same offline GitHub-ready document.
+  * json is the structured PrSafetyReport (identical to /pr-safety/report).
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+PAYLOAD = {
+    "title": "Add OAuth login",
+    "description": "Implements POST /login with password authentication and session tokens.",
+    "changed_files": ["app/auth/login.py", "app/auth/session.py", "tests/test_login.py"],
+    "commits_behind": 2,
+}
+
+VALID_VERDICTS = {"merge", "hold", "split", "rebase"}
+
+
+def _export() -> dict:
+    resp = client.post("/pr-safety/report/export", json=PAYLOAD)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_pr_safety_export_returns_markdown_json_filename():
+    body = _export()
+    assert isinstance(body.get("markdown"), str) and body["markdown"].strip()
+    assert isinstance(body.get("json"), dict) and body["json"]
+    assert isinstance(body.get("filename"), str) and body["filename"].endswith(".md")
+
+
+def test_pr_safety_export_markdown_has_sections():
+    md = _export()["markdown"]
+    assert "# PR Safety Report" in md
+    assert "**Verdict:**" in md
+    assert "## Changed files" in md
+    assert "## Risky areas" in md
+
+
+def test_pr_safety_export_json_matches_report_endpoint():
+    report = client.post("/pr-safety/report", json=PAYLOAD)
+    assert report.status_code == 200, report.text
+    report_json = report.json()
+    exported = _export()["json"]
+    assert exported["verdict"] in VALID_VERDICTS
+    assert exported["verdict"] == report_json["verdict"]
+    assert exported["title"] == PAYLOAD["title"]
+    assert exported["changed_files"]["total"] == report_json["changed_files"]["total"]
+
+
+def test_pr_safety_export_markdown_embeds_real_report_data():
+    # Anti-gaming: the rendered markdown reflects the actual report input,
+    # not a hardcoded template.
+    assert PAYLOAD["title"] in _export()["markdown"]


### PR DESCRIPTION
## What
Expose the existing GitHub-ready PR Safety markdown through the API, mirroring `POST /compile/export` (#887). The renderer was previously CLI-only.

- New `POST /pr-safety/report/export` (same request body as `/pr-safety/report`) → `{ markdown, json, filename }`.
- `markdown` = the existing `app/pr_safety/markdown.py::report_to_markdown` (offline, GitHub-ready) — no second renderer.
- `json` = the structured `PrSafetyReport`, identical to `/pr-safety/report`.
- Report-building extracted into a shared `_build_pr_safety_report` helper used by both routes (no forked analyzer). Rate-limited like the other routes.

## How it was built
Implemented by an autonomous Codex loop against a locked test threshold
(`tests/test_pr_safety_export.py`, 4 tests = definition of done), then reviewed.

## Verification
- Threshold `tests/test_pr_safety_export.py`: 4/4 pass.
- Full backend suite: 1544 passed, 5 skipped, 0 failed (one local opportunistic :8000 check deselected — it also fails on clean main and passes in CI).
- `uvx ruff@0.1.14 check` + `format` clean (matches CI Smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)