### PR TITLE
🎨 Palette: [UX improvement] Add example button to Offline heuristics tool

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-06-27 - Add Clear Button to Input Forms (Re-applied)
 **Learning:** For generative text inputs where users often paste large blocks of text, missing a quick way to clear the input creates friction. This applies to multiple areas of the app, like the PR Safety feature.
 **Action:** Always consider adding a "Clear" button (with proper `type="button"`, `aria-label`, and `title` attributes) to large input fields (like textareas) to improve usability. Make sure to wrap the `<textarea>` in a `<div className="relative group">` to allow absolute positioning of the clear button inside it.
+## 2024-05-19 - Added example button to offline heuristics tool
+**Learning:** The "or try an example" button pattern used in the Prompt Compiler and Agent Generator tools is highly effective at reducing friction for new users facing an empty text area. The offline heuristics tool was missing this helpful empty state.
+**Action:** Replicate the exact UX pattern (a muted, subtle button that populates the textarea and focuses it) in `web/app/offline/page.tsx` when the input is empty.

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -182,6 +182,21 @@ export default function OfflinePage() {
                                         </>
                                     )}
                                 </button>
+                                {!prompt.trim() && (
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setPrompt("Create a Python script that monitors a local log directory for new .log files, parses them for ERROR level messages, and outputs a summary report.");
+                                            setTimeout(() => {
+                                                const textarea = document.getElementById('offline-prompt');
+                                                if (textarea) textarea.focus();
+                                            }, 0);
+                                        }}
+                                        className="text-xs text-zinc-400/80 hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded px-2 py-1 mx-auto"
+                                    >
+                                        or try an example
+                                    </button>
+                                )}
                             </div>
                         </div>
 


### PR DESCRIPTION
💡 What: Added an "or try an example" button below the "Run Heuristics" button in the offline heuristics tool's empty state.
🎯 Why: To solve the "blank canvas" problem for new users, reducing friction by providing a demonstrative example of how to use the tool, matching the UX patterns established in other generators.
📸 Before/After: Added a small, subtle text button that disappears once the textarea is populated.
♿ Accessibility: Button includes focus-visible styling and is implemented as a semantic `<button type="button">`. Clicking the button automatically shifts keyboard focus to the populated textarea.

---
*PR created automatically by Jules for task [8908237308050158093](https://jules.google.com/task/8908237308050158093) started by @madara88645*