### PR TITLE
feat(web): make ReadinessBanner a self-describing traffic light

### DIFF
--- a/web/app/components/ReadinessBanner.test.tsx
+++ b/web/app/components/ReadinessBanner.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import ReadinessBanner from "./ReadinessBanner";
+import ReadinessBanner, { VERDICT_META, READINESS_FOOTER } from "./ReadinessBanner";
 
 describe("ReadinessBanner", () => {
   it("renders nothing when there is no report", () => {
@@ -8,7 +8,7 @@ describe("ReadinessBanner", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows the verdict title and a clarification question", () => {
+  it("shows the verdict title, plain-language meaning, signal, question, footer, and dot", () => {
     render(
       <ReadinessBanner
         report={{
@@ -19,7 +19,27 @@ describe("ReadinessBanner", () => {
       />,
     );
     expect(screen.getByText(/clarify before compiling/i)).toBeInTheDocument();
+    expect(screen.getByText(VERDICT_META.clarify.meaning)).toBeInTheDocument();
     expect(screen.getByText(/couldn't be verified/i)).toBeInTheDocument();
     expect(screen.getByText(/real, documented tool/i)).toBeInTheDocument();
+    expect(screen.getByText(READINESS_FOOTER)).toBeInTheDocument();
+    expect(screen.getByTestId("readiness-dot")).toBeInTheDocument();
+  });
+
+  it("compact variant shows title and meaning but hides signals, questions, and footer", () => {
+    render(
+      <ReadinessBanner
+        variant="compact"
+        report={{
+          verdict: "noise",
+          signals: [{ kind: "noise", message: "Nothing actionable here." }],
+          questions: ["What do you want to build?"],
+        }}
+      />,
+    );
+    expect(screen.getByText(VERDICT_META.noise.title)).toBeInTheDocument();
+    expect(screen.getByText(VERDICT_META.noise.meaning)).toBeInTheDocument();
+    expect(screen.queryByText(/nothing actionable here/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(READINESS_FOOTER)).not.toBeInTheDocument();
   });
 });

--- a/web/app/components/ReadinessBanner.tsx
+++ b/web/app/components/ReadinessBanner.tsx
@@ -2,35 +2,90 @@
 
 import type { ReadinessReport, ReadinessVerdict } from "../../lib/api/types";
 
-const VERDICT_META: Record<ReadinessVerdict, { title: string; tone: string }> = {
-  ready: { title: "Ready to compile", tone: "text-green-300 border-green-500/40 bg-green-500/10" },
-  clarify: { title: "Clarify before compiling", tone: "text-amber-300 border-amber-500/40 bg-amber-500/10" },
-  risky: { title: "Risky — review first", tone: "text-red-300 border-red-500/40 bg-red-500/10" },
-  noise: { title: "Not a real task", tone: "text-zinc-300 border-zinc-500/40 bg-zinc-500/10" },
+export const VERDICT_META: Record<
+  ReadinessVerdict,
+  { title: string; tone: string; dot: string; meaning: string }
+> = {
+  ready: {
+    title: "Ready to compile",
+    tone: "text-green-300 border-green-500/40 bg-green-500/10",
+    dot: "bg-green-400",
+    meaning: "Clear and safe — go ahead and spend the run.",
+  },
+  clarify: {
+    title: "Clarify before compiling",
+    tone: "text-amber-300 border-amber-500/40 bg-amber-500/10",
+    dot: "bg-amber-400",
+    meaning: "Answer a question or two first so you don't waste a run.",
+  },
+  risky: {
+    title: "Risky — review first",
+    tone: "text-red-300 border-red-500/40 bg-red-500/10",
+    dot: "bg-red-400",
+    meaning: "Touches something sensitive — review before running.",
+  },
+  noise: {
+    title: "Not a real task",
+    tone: "text-zinc-300 border-zinc-500/40 bg-zinc-500/10",
+    dot: "bg-zinc-400",
+    meaning: "Nothing concrete to compile yet.",
+  },
 };
 
-export default function ReadinessBanner({ report }: { report?: ReadinessReport | null }) {
+export const READINESS_FOOTER =
+  "Deterministic rule-based check — runs before any LLM or agent call, never guesses.";
+
+export default function ReadinessBanner({
+  report,
+  variant = "full",
+}: {
+  report?: ReadinessReport | null;
+  variant?: "full" | "compact";
+}) {
   if (!report) return null;
   const meta = VERDICT_META[report.verdict];
+  const compact = variant === "compact";
   return (
-    <div className={`rounded-xl border px-4 py-3 mb-3 ${meta.tone}`} role="status" aria-live="polite">
-      <div className="text-sm font-bold">{meta.title}</div>
-      {report.signals.length > 0 && (
-        <ul className="mt-2 space-y-1">
-          {report.signals.map((s, i) => (
-            <li key={`${s.kind}-${i}`} className="text-xs text-zinc-200">{s.message}</li>
-          ))}
-        </ul>
-      )}
-      {report.questions.length > 0 && (
-        <div className="mt-2">
-          <div className="text-[11px] uppercase tracking-wide opacity-70">Clarify first</div>
-          <ul className="mt-1 space-y-1">
-            {report.questions.map((q, i) => (
-              <li key={`q-${i}`} className="text-xs text-zinc-100">· {q}</li>
-            ))}
-          </ul>
-        </div>
+    <div
+      className={`rounded-xl border mb-3 ${meta.tone} ${compact ? "px-3 py-2" : "px-4 py-3"}`}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          data-testid="readiness-dot"
+          aria-hidden="true"
+          className={`h-2 w-2 shrink-0 rounded-full ${meta.dot}`}
+        />
+        <span className="text-sm font-bold">{meta.title}</span>
+      </div>
+      <div className={`mt-1 text-zinc-200 opacity-90 ${compact ? "text-[11px]" : "text-xs"}`}>
+        {meta.meaning}
+      </div>
+
+      {!compact && (
+        <>
+          {report.signals.length > 0 && (
+            <ul className="mt-2 space-y-1">
+              {report.signals.map((s, i) => (
+                <li key={`${s.kind}-${i}`} className="text-xs text-zinc-200">{s.message}</li>
+              ))}
+            </ul>
+          )}
+          {report.questions.length > 0 && (
+            <div className="mt-2">
+              <div className="text-[11px] uppercase tracking-wide opacity-70">Clarify first</div>
+              <ul className="mt-1 space-y-1">
+                {report.questions.map((q, i) => (
+                  <li key={`q-${i}`} className="text-xs text-zinc-100">· {q}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div className="mt-3 border-t border-white/10 pt-2 text-[10px] text-zinc-400">
+            {READINESS_FOOTER}
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## What & why

PR 2 of the landing-first UX roadmap. Today the readiness banner is colored but unexplained — and it only appears *after* a compile. This makes it self-describing so it can become the spine of the product story (and be reused by the landing legend + demo in later PRs).

### Changes (`ReadinessBanner.tsx` + test only)
- **Export `VERDICT_META`** (was private) with two new fields per verdict: `dot` (colored-circle class) and `meaning` (one plain-language sentence).
- Render a **colored dot** next to the title (`aria-hidden`; color is decorative, the title carries the meaning) and the **`meaning`** as a subtitle.
- Add a **footer** framing the check: `Deterministic rule-based check — runs before any LLM or agent call, never guesses.`
- Add an optional **`variant: "full" | "compact"`** prop (default `"full"`) for future inline/preflight use. `compact` shows only dot + title + meaning.
- Export `READINESS_FOOTER`.

### Scope / safety
- **Regression-safe:** default `variant="full"` preserves the existing live-banner behavior; the sole current caller (`page.tsx`) is unaffected.
- No backend / API / type changes. No new dependencies.

### Verification
- `npm run lint` clean · `npm run test` 149/149 pass (updated `ReadinessBanner.test.tsx` covers meaning, footer, dot, and the compact variant) · `npm run build` succeeds
- Adversarial 3-lens review (regression / a11y / design): **GO, no blocking issues.**

### Deliberately not changed
- The always-on `meaning` subtitle is kept even when signals exist — it's the action framing and keeps the live banner consistent with the upcoming static legend (PR 3). Minor wording echo on the rare `noise` verdict is accepted.

Part of the landing-first, readiness-led UX roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)