### PR TITLE
[codex] make Agent Packs request-grounded offline

### DIFF
--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -8,14 +8,14 @@ from zipfile import ZIP_DEFLATED, ZipFile
 from fastapi.responses import Response
 from pydantic import BaseModel, Field, model_validator
 
-from .agent_ir import parse_agent_markdown
+from .agent_ir import AgentExportIR, parse_agent_markdown
 from .claude_code import (
     to_claude_mcp_tool_stub,
     to_claude_pr_reviewer_pack,
     to_claude_project_pack,
     to_claude_subagent_bundle,
 )
-from .skill_ir import parse_skill_markdown
+from .skill_ir import SkillExportIR, SkillParam, parse_skill_markdown
 from app.readiness.analyzer import analyze_readiness
 from app.readiness.markdown import report_to_markdown
 
@@ -80,7 +80,7 @@ class ClaudeAgentPackAdapter:
                 _build_skill_brief(req),
                 include_example_code=False,
             )
-            skill_ir = parse_skill_markdown(skill_definition)
+            skill_ir = _build_skill_ir(req, skill_definition)
             raw_files = to_claude_mcp_tool_stub(skill_ir)
         else:
             system_prompt = compiler.generate_agent(
@@ -88,7 +88,7 @@ class ClaudeAgentPackAdapter:
                 multi_agent=False,
                 include_example_code=False,
             )
-            agent_ir = parse_agent_markdown(system_prompt)
+            agent_ir = _build_agent_ir(req, system_prompt)
 
             if req.pack_type == "project-pack":
                 raw_files = to_claude_project_pack(agent_ir)
@@ -257,3 +257,245 @@ def _normalize_pack_path(path: str) -> str:
         raise ValueError(f"manifest file path contains unsafe segments: {path}")
 
     return normalized
+
+
+def _build_agent_ir(req: AgentPackRequest, generated_markdown: str) -> AgentExportIR:
+    """Build request-grounded IR even when the optional generator is unavailable.
+
+    Agent packs are downloadable artifacts, so a worker error must never be parsed as
+    an agent named ``error``. The generated text can enrich the pack, but the request
+    remains the source of truth for project identity, scope, and conservative limits.
+    """
+
+    parsed = parse_agent_markdown(generated_markdown or "")
+    use_generated = _agent_output_is_usable(parsed, generated_markdown)
+
+    generated_goals = parsed.goals if use_generated else []
+    generated_constraints = parsed.constraints if use_generated else []
+    generated_workflows = parsed.workflows if use_generated else []
+    generated_stack = parsed.tech_stack if use_generated else []
+
+    goals = _unique_lines([req.goal, *generated_goals])
+    constraints = _unique_lines(
+        [
+            *_explicit_goal_constraints(req.goal),
+            "Do not invent repository files, commands, APIs, or test results; verify them from the repository.",
+            (
+                "Treat secrets, production data, destructive operations, dependency changes, pushes, and deploys "
+                "as approval-gated."
+                if req.risk_mode == "strict"
+                else "Prefer the smallest reversible change and preserve behavior outside the stated goal."
+            ),
+            *generated_constraints,
+        ]
+    )
+    workflows = _unique_lines(
+        [
+            f"Read repository instructions and inspect the files relevant to this goal: {req.goal}",
+            (
+                f"Map the existing implementation and tests before editing; treat {req.stack} as declared context, "
+                "not proof of repository commands or APIs."
+            ),
+            _pack_specific_workflow(req.pack_type),
+            (
+                "Discover the repository's existing validation commands, run the smallest relevant checks, "
+                "and report commands, results, remaining risk, and files changed."
+            ),
+            *generated_workflows,
+        ]
+    )
+    tech_stack = _unique_lines([req.stack, *generated_stack])
+
+    rendered = _render_agent_markdown(
+        name=_agent_name(req),
+        role=_agent_role(req),
+        goals=goals,
+        constraints=constraints,
+        workflows=workflows,
+        tech_stack=tech_stack,
+    )
+    grounded = parse_agent_markdown(rendered)
+    if req.pack_type == "pr-reviewer":
+        grounded.allowed_tools = ["Read", "Glob", "Grep", "Bash"]
+    return grounded
+
+
+def _build_skill_ir(req: AgentPackRequest, generated_markdown: str) -> SkillExportIR:
+    parsed = parse_skill_markdown(generated_markdown or "")
+    use_generated = _skill_output_is_usable(parsed, generated_markdown)
+
+    purpose_parts = [
+        req.goal.rstrip("."),
+        f"Project: {req.project_type}",
+        f"Declared stack: {req.stack}",
+    ]
+    if use_generated and parsed.purpose:
+        purpose_parts.append(parsed.purpose.rstrip("."))
+
+    return SkillExportIR(
+        name=parsed.name if use_generated else _tool_name_from_goal(req.goal),
+        purpose=". ".join(_unique_lines(purpose_parts)) + ".",
+        when_to_use=(
+            parsed.when_to_use
+            if use_generated and parsed.when_to_use
+            else f"Use for the stated {req.project_type} workflow after reviewing repository-specific contracts."
+        ),
+        params=(
+            parsed.params
+            if use_generated and parsed.params
+            else [
+                SkillParam(
+                    name="request",
+                    type="str",
+                    description="The concrete, repository-grounded operation to perform.",
+                )
+            ]
+        ),
+        output_type=parsed.output_type if use_generated else "str",
+        output_description=(
+            parsed.output_description
+            if use_generated and parsed.output_description
+            else "A reviewable result for the stated goal, including limitations and unresolved TODOs."
+        ),
+        dependencies=parsed.dependencies if use_generated else [],
+        error_handling=_unique_lines(
+            [
+                "Reject an empty request.",
+                "Return a clear error when required repository context is unavailable; do not invent data.",
+                *(parsed.error_handling if use_generated else []),
+            ]
+        ),
+        testing_strategy=_unique_lines(
+            [
+                "Verify one valid request and one missing-context failure without network side effects.",
+                *(parsed.testing_strategy if use_generated else []),
+            ]
+        ),
+        performance_notes=parsed.performance_notes if use_generated else [],
+        examples=parsed.examples if use_generated else [],
+        implementation=(
+            parsed.implementation
+            if use_generated and parsed.implementation
+            else (
+                "Validate the request. Resolve repository-specific clients and contracts from the host project. "
+                "Perform the read-only operation described by the goal. Return a structured, reviewable result. "
+                "Keep unknown integration details as TODOs."
+            )
+        ),
+        raw_definition=generated_markdown.strip() if use_generated else "",
+    )
+
+
+def _agent_output_is_usable(ir: AgentExportIR, markdown: str) -> bool:
+    lowered = (markdown or "").strip().lower()
+    if not lowered or "failed to generate" in lowered or "api key is missing" in lowered:
+        return False
+    if ir.name.strip().lower() in {"error", "ai agent"}:
+        return False
+    return bool(ir.role or ir.goals or ir.constraints or ir.workflows)
+
+
+def _skill_output_is_usable(ir: SkillExportIR, markdown: str) -> bool:
+    lowered = (markdown or "").strip().lower()
+    if not lowered or "failed to generate" in lowered or "api key is missing" in lowered:
+        return False
+    if ir.name.strip().lower() in {"error", "skill_name"}:
+        return False
+    return bool(ir.purpose or ir.params or ir.implementation)
+
+
+def _agent_name(req: AgentPackRequest) -> str:
+    suffix = {
+        "project-pack": "Maintainer",
+        "subagent": "Focused Agent",
+        "pr-reviewer": "PR Reviewer",
+        "mcp-tool-stub": "Tool",
+    }[req.pack_type]
+    return f"{req.project_type} {suffix}"
+
+
+def _agent_role(req: AgentPackRequest) -> str:
+    if req.pack_type == "pr-reviewer":
+        return (
+            f"You are a read-only pull request reviewer for {req.project_type}. "
+            f"The declared technology context is {req.stack}."
+        )
+    if req.pack_type == "subagent":
+        return (
+            f"You are a focused Claude Code subagent for {req.project_type}. "
+            f"The declared technology context is {req.stack}."
+        )
+    return (
+        f"You maintain {req.project_type} while staying inside the requested scope. "
+        f"The declared technology context is {req.stack}."
+    )
+
+
+def _pack_specific_workflow(pack_type: PackType) -> str:
+    if pack_type == "pr-reviewer":
+        return (
+            "Review the diff and nearby tests without editing; report only actionable findings with file evidence, "
+            "then state whether the change is safe to merge."
+        )
+    if pack_type == "subagent":
+        return (
+            "Confirm the requested outcome and boundaries, then make or recommend only the smallest evidence-backed "
+            "change needed for that outcome."
+        )
+    return (
+        "Confirm the requested outcome and boundaries, implement the smallest scoped change, and keep unrelated "
+        "product flows untouched."
+    )
+
+
+def _explicit_goal_constraints(goal: str) -> list[str]:
+    constraints: list[str] = []
+    for marker in ("without ", "never ", "do not ", "before "):
+        index = goal.lower().find(marker)
+        if index >= 0:
+            clause = goal[index:].strip().rstrip(".")
+            if clause:
+                constraints.append(clause[0].upper() + clause[1:])
+    return constraints
+
+
+def _render_agent_markdown(
+    *,
+    name: str,
+    role: str,
+    goals: list[str],
+    constraints: list[str],
+    workflows: list[str],
+    tech_stack: list[str],
+) -> str:
+    def bullets(items: list[str]) -> str:
+        return "\n".join(f"- {item}" for item in items)
+
+    return (
+        f"# {name}\n\n"
+        f"## Role\n{role}\n\n"
+        f"## Goals\n{bullets(goals)}\n\n"
+        f"## Constraints\n{bullets(constraints)}\n\n"
+        f"## Workflows\n{bullets(workflows)}\n\n"
+        f"## Tech Stack\n{bullets(tech_stack)}"
+    )
+
+
+def _tool_name_from_goal(goal: str) -> str:
+    first_clause = re.split(r"\band\b|[.;]", goal, maxsplit=1, flags=re.IGNORECASE)[0]
+    words = re.findall(r"[a-z0-9]+", first_clause.lower())
+    stop_words = {"a", "an", "the", "one", "to", "for", "with", "scoped"}
+    meaningful = [word for word in words if word not in stop_words][:4]
+    return "_".join(meaningful) or "repository_task"
+
+
+def _unique_lines(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = " ".join((value or "").split()).strip()
+        key = normalized.casefold()
+        if normalized and key not in seen:
+            seen.add(key)
+            result.append(normalized)
+    return result

--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -271,6 +271,8 @@ def _project_settings_json(ir: AgentExportIR) -> str:
             "deny": [
                 "Read(./.env)",
                 "Read(./.env.*)",
+                "Read(./**/.env)",
+                "Read(./**/.env.*)",
                 "Read(./secrets/**)",
                 "Read(./**/*.pem)",
                 "Read(./**/*.key)",

--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -85,12 +85,13 @@ def to_claude_subagent(ir: AgentExportIR) -> dict[str, str]:
     slug = _slugify(ir.name)
     tools = ", ".join(ir.allowed_tools or ["Read", "Edit", "Write"])
     description = ir.role or (ir.goals[0] if ir.goals else f"Specialized assistant for {ir.name}")
+    description_json = json.dumps(" ".join(description.split()))
     clean_prompt = _strip_markdown_fences(ir.raw_system_prompt)
     content = textwrap.dedent(
         f"""\
 ---
 name: {slug}
-description: {description}
+description: {description_json}
 tools: {tools}
 ---
 
@@ -105,36 +106,35 @@ def to_claude_project_pack(ir: AgentExportIR) -> list[dict[str, str]]:
         {"path": "CLAUDE.md", "content": _project_claude_md(ir)},
         {"path": ".claude/settings.json", "content": _project_settings_json(ir)},
         to_claude_subagent(ir),
-        {
-            "path": ".claude/agents/compiler-architect.md",
-            "content": _named_subagent("compiler-architect"),
-        },
-        {
-            "path": ".claude/agents/prompt-safety-reviewer.md",
-            "content": _named_subagent("prompt-safety-reviewer"),
-        },
-        {"path": ".claude/agents/mcp-integrator.md", "content": _named_subagent("mcp-integrator")},
-        {
-            "path": ".claude/agents/frontend-polisher.md",
-            "content": _named_subagent("frontend-polisher"),
-        },
-        {"path": ".github/workflows/claude.yml", "content": _github_action_workflow()},
-        {"path": ".claude/mcp/claude-desktop.json", "content": _mcp_config_snippet(ir)},
+        {"path": ".github/workflows/claude.yml", "content": _github_action_workflow(ir)},
+        {"path": ".claude/mcp/README.md", "content": _mcp_integration_notes(ir)},
     ]
     return files
 
 
 def to_claude_subagent_bundle(ir: AgentExportIR) -> list[dict[str, str]]:
     subagent = to_claude_subagent(ir)
+    goals = "\n".join(f"- {goal}" for goal in ir.goals) or "- Follow the agent goal."
     readme = textwrap.dedent(
         f"""\
-# Claude Subagent Bundle
+# {ir.name} Subagent Bundle
 
 Drop `{subagent["path"]}` into your repo, then ask Claude Code to use the `{_slugify(ir.name)}` subagent.
 
-Recommended usage:
-- Keep `CLAUDE.md` in the repo root for shared guidance.
-- Add `.claude/settings.json` if you want permission guardrails alongside this agent.
+## Declared technology context
+
+{", ".join(ir.tech_stack) or "Confirm the repository stack before acting."}
+
+## Intended outcome
+
+{goals}
+
+## Install and verify
+
+1. Review the agent instructions against the repository's own guidance.
+2. Copy the file to the exact path shown above.
+3. Invoke the subagent on a representative, non-production task.
+4. Confirm its proposed files and validation commands before allowing edits.
 """
     )
     return [
@@ -150,8 +150,8 @@ def to_claude_pr_reviewer_pack(ir: AgentExportIR) -> list[dict[str, str]]:
         {"path": "CLAUDE.md", "content": _pr_reviewer_memory(ir)},
         {"path": ".claude/settings.json", "content": _project_settings_json(ir)},
         reviewer,
-        {"path": ".github/workflows/claude.yml", "content": _github_action_workflow()},
-        {"path": "README.md", "content": _pr_reviewer_readme()},
+        {"path": ".github/workflows/claude.yml", "content": _github_action_workflow(ir)},
+        {"path": "README.md", "content": _pr_reviewer_readme(ir)},
     ]
     return files
 
@@ -184,9 +184,25 @@ if __name__ == "__main__":
         f"""\
 # {tool_name} MCP Tool Stub
 
-Generated from Prompt Compiler for Claude Code / MCP workflows.
+## Purpose
 
-Purpose: {ir.purpose}
+{ir.purpose or f"Execute {tool_name}."}
+
+## Input
+
+{_skill_params_markdown(ir)}
+
+## Output
+
+{ir.output_description or f"Returns {ir.output_type}."}
+
+## Implementation checklist
+
+{_skill_implementation_markdown(ir)}
+
+## Safety and verification
+
+{_skill_safety_markdown(ir)}
 """
     )
     return [
@@ -204,36 +220,46 @@ def _project_claude_md(ir: AgentExportIR) -> str:
         "\n".join(f"- {constraint}" for constraint in ir.constraints[:4])
         or "- Do not leak secrets."
     )
-    mcp_servers = ", ".join(ir.mcp_servers) if ir.mcp_servers else "none yet"
+    workflows = (
+        "\n".join(f"{index}. {step}" for index, step in enumerate(ir.workflows, start=1))
+        or "1. Inspect the repository before changing it."
+    )
+    stack = "\n".join(f"- {item}" for item in ir.tech_stack) or "- Confirm from repository files."
     return textwrap.dedent(
         f"""\
-# Prompt Compiler Claude Code Memory
+# {ir.name} Project Guidance
 
-## Project Summary
-Prompt Compiler is a FastAPI + Next.js product that turns vague requests into structured prompts, execution plans, policy layers, agent packs, and workflow artifacts.
+## Project context
 
-## Working Rules
-- Start from repo-root commands.
-- Prefer targeted tests before broad suites.
-- Respect API/auth boundaries and never expose secrets.
-- Keep provider integrations framework-agnostic unless the export surface is explicitly Claude-native.
+{ir.role or f"Work on {ir.name}."}
 
-## Domain Concepts
+## Objectives
+
 {goals}
 
 ## Constraints
+
 {constraints}
 
-## Runbook
-- Backend: `python -m uvicorn api.main:app --reload --port 8080`
-- Frontend: `cd web && npm run dev`
-- Python tests: `python -m pytest tests/ -q`
-- Frontend tests: `cd web && npm run test`
+## Workflow
 
-## Claude-Native Notes
+{workflows}
+
+## Declared technology context
+
+{stack}
+
+## Validation contract
+
+- Read repository instructions and package configuration before choosing commands.
+- Run the smallest relevant existing checks first, then the broader repository gate when available.
+- Do not claim a test, build, deploy, or manual check passed unless it actually ran.
+- Report changed files, out-of-scope changes, validation results, remaining risk, and one next step.
+
+## Claude Code configuration
+
 - Permission mode: `{ir.permission_mode}`
-- Suggested tools: {", ".join(ir.allowed_tools)}
-- Suggested MCP servers: {mcp_servers}
+- Suggested tools: {", ".join(ir.allowed_tools) or "Read, Glob, Grep"}
 """
     )
 
@@ -246,29 +272,19 @@ def _project_settings_json(ir: AgentExportIR) -> str:
                 "Read(./.env)",
                 "Read(./.env.*)",
                 "Read(./secrets/**)",
-                "Read(./users.db)",
-                "Read(./web/.env.local)",
+                "Read(./**/*.pem)",
+                "Read(./**/*.key)",
             ],
             "ask": [
                 "Bash(git push:*)",
+                "Bash(git commit:*)",
                 "Bash(fly:*)",
+                "Bash(vercel:*)",
+                "Bash(kubectl:*)",
             ],
         }
     }
     return json.dumps(settings, indent=2)
-
-
-def _mcp_config_snippet(ir: AgentExportIR) -> str:
-    command = ["python", "integrations/mcp-server/server.py"]
-    config = {
-        "mcpServers": {
-            _slugify(ir.name): {
-                "command": command[0],
-                "args": command[1:],
-            }
-        }
-    }
-    return json.dumps(config, indent=2)
 
 
 def _named_subagent(name: str) -> str:
@@ -303,8 +319,16 @@ tools: {tools[name]}
     )
 
 
-def _github_action_workflow() -> str:
-    return textwrap.dedent(
+def _github_action_workflow(ir: AgentExportIR | None = None) -> str:
+    goal = _workflow_scalar(
+        ir.goals[0] if ir and ir.goals else "Review the referenced issue or pull request."
+    )
+    constraint = _workflow_scalar(
+        ir.constraints[0]
+        if ir and ir.constraints
+        else "Do not expose secrets or make changes outside the requested scope."
+    )
+    template = textwrap.dedent(
         """\
 name: Claude Code
 
@@ -324,11 +348,20 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: >
-            Follow CLAUDE.md, inspect the referenced issue or PR context,
-            and respond or create changes only when the request is actionable.
+            Follow CLAUDE.md and inspect the referenced issue or pull request.
+            Goal: __PACK_GOAL__
+            Constraint: __PACK_CONSTRAINT__
+            Use repository evidence, report validation honestly, and require human review before merge.
           claude_args: "--max-turns 5"
 """
     )
+    return template.replace("__PACK_GOAL__", goal).replace("__PACK_CONSTRAINT__", constraint)
+
+
+def _workflow_scalar(value: str) -> str:
+    """Keep request text inside the workflow's folded scalar."""
+
+    return " ".join(value.split()).replace("${{", "$ {{")
 
 
 def _pr_reviewer_memory(ir: AgentExportIR) -> str:
@@ -338,38 +371,94 @@ def _pr_reviewer_memory(ir: AgentExportIR) -> str:
     )
     return textwrap.dedent(
         f"""\
-# Claude PR Reviewer Memory
+# {ir.name} Guidance
 
 ## Mission
-Review pull requests with a focus on prompt safety, secret handling, permission boundaries, and missing tests.
+{ir.role or "Review pull requests for concrete regressions, risk, and missing tests."}
 
-## Repo Context
-- Project type: repo-specific software product
-- Default review posture: skeptical, concrete, and test-aware
+## Declared technology context
+{chr(10).join(f"- {item}" for item in ir.tech_stack) or "- Confirm from repository files."}
 
 ## Review Checklist
 {goals}
 
 ## Guardrails
-- Do not expose secrets or credentials.
-- Flag unsafe `.claude/settings.json` permissions.
-- Call out prompt leakage, weak validation, and missing regression coverage.
+{chr(10).join(f"- {item}" for item in ir.constraints) or "- Do not expose secrets or credentials."}
+
+## Review output
+- Lead with actionable findings, ordered by severity, and cite the affected file or diff evidence.
+- Separate blockers from non-blocking suggestions.
+- Report missing or unverified tests explicitly; never infer that CI passed.
+- End with a concise merge recommendation and remaining risk.
 """
     )
 
 
-def _pr_reviewer_readme() -> str:
+def _pr_reviewer_readme(ir: AgentExportIR) -> str:
+    goals = "\n".join(f"- {goal}" for goal in ir.goals) or "- Review the pull request."
     return textwrap.dedent(
-        """\
-# Claude PR Reviewer Pack
+        f"""\
+# {ir.name} Pack
 
-This pack gives Claude Code a dedicated `pr-reviewer` subagent plus review-focused repo memory.
+This pack gives Claude Code a dedicated `pr-reviewer` subagent and repository guidance for:
 
-Suggested prompts:
-- `Use the pr-reviewer subagent to review this pull request for prompt leakage and unsafe settings.`
-- `Review this diff for missing tests, secret exposure, and MCP misconfiguration.`
+{goals}
+
+## Verify before enabling automation
+
+1. Review `CLAUDE.md` and `.claude/agents/pr-reviewer.md` against the repository's policies.
+2. Confirm the declared technology context: {", ".join(ir.tech_stack) or "not provided"}.
+3. Add `ANTHROPIC_API_KEY` to GitHub Actions only if your organization approves that integration.
+4. Test the reviewer on a non-sensitive pull request and inspect its file citations and test claims.
 """
     )
+
+
+def _mcp_integration_notes(ir: AgentExportIR) -> str:
+    return textwrap.dedent(
+        f"""\
+# MCP integration notes for {ir.name}
+
+No MCP server configuration is generated because the request did not provide a verified command or server path.
+
+Before adding an MCP server:
+
+1. Identify an existing server entry point in the repository.
+2. Run it locally and confirm its tool schema.
+3. Add the verified command to the host client's MCP configuration.
+4. Keep secrets in the host environment; do not write credentials into this pack.
+"""
+    )
+
+
+def _skill_params_markdown(ir: SkillExportIR) -> str:
+    if not ir.params:
+        return "- No parameters declared; add a reviewed input contract before implementation."
+    return "\n".join(
+        (
+            f"- `{param.name}` (`{param.type}`, "
+            f"{'required' if param.required else 'optional'}): "
+            f"{param.description or 'Define and validate this value.'}"
+        )
+        for param in ir.params
+    )
+
+
+def _skill_implementation_markdown(ir: SkillExportIR) -> str:
+    implementation = (ir.implementation or "").strip()
+    if not implementation:
+        return "- Resolve repository-specific APIs and implement the TODO in `server.py`."
+    sentences = [sentence.strip() for sentence in implementation.split(". ") if sentence.strip()]
+    return "\n".join(f"- {sentence.rstrip('.')}." for sentence in sentences)
+
+
+def _skill_safety_markdown(ir: SkillExportIR) -> str:
+    items = [*ir.error_handling, *ir.testing_strategy]
+    if not items:
+        items = [
+            "Validate inputs, surface missing context, and test without production side effects."
+        ]
+    return "\n".join(f"- {item}" for item in items)
 
 
 def _ordered_tools(tools: list[str]) -> list[str]:

--- a/docs/evaluations/agent-packs-output-value.md
+++ b/docs/evaluations/agent-packs-output-value.md
@@ -1,0 +1,83 @@
+# Agent Packs output-value evaluation
+
+Date: 2026-06-30
+
+## Method
+
+Each candidate surface was called directly through its offline Python path with six realistic developer inputs.
+Every input was repeated three times. Outputs were judged skeptically as `ADDS_VALUE`, `NEUTRAL`, or
+`WORSE_THAN_NOTHING`; an output only added value when it supplied correct, request-specific substance that a
+developer could act on.
+
+All 108 measured outputs were byte-stable across their three repetitions.
+
+## Baseline scorecard
+
+| Surface | Adds value | Neutral | Worse than nothing | Main defect |
+|---|---:|---:|---:|---|
+| Agent Generator | 0/6 | 0/6 | 6/6 | The no-key path returns the same API-key error for every request. |
+| Skills Generator | 0/6 | 0/6 | 6/6 | The no-key path returns the same API-key error for every request. |
+| **Agent Packs** | **0/6** | **0/6** | **6/6** | It converts generator errors into installable-looking, unrelated artifacts and labels them ready. |
+| Token/Prompt Optimizer | 0/6 | 6/6 | 0/6 | It removes minor whitespace but does not improve realistic prompt substance. |
+| PR Safety report | 4/6 | 2/6 | 0/6 | Useful risk/test guidance, with two noisy scope-mismatch signals. |
+| RAG retrieval | 6/6 | 0/6 | 0/6 | Correct source ranked first for every query; lower results sometimes contain lexical noise. |
+
+Agent Packs was selected because its failure is more dangerous than the explicit Agent/Skills errors: the user
+receives a downloadable artifact that appears usable while containing false or unrelated instructions.
+
+## Agent Packs baseline evidence
+
+| Case | Requested artifact | Verdict | Specific defects |
+|---|---|---|---|
+| 1 | Strict FastAPI webhook project pack | WORSE_THAN_NOTHING | `CLAUDE.md` describes Prompt Compiler, the main agent is `.claude/agents/error.md`, and the runbook invents Next.js commands. |
+| 2 | Next.js accessibility subagent | WORSE_THAN_NOTHING | The only agent is named `error`; the README tells the user to invoke that broken agent. |
+| 3 | Python release PR reviewer | WORSE_THAN_NOTHING | The reviewer body is an API-key error and the checklist ignores release/publishing risk. |
+| 4 | Read-only GitHub issue MCP stub | WORSE_THAN_NOTHING | Emits `FastMCP("error")`, an `error()` tool with no parameters, and an empty purpose. |
+| 5 | Rust CLI project pack | WORSE_THAN_NOTHING | Repeats the Prompt Compiler FastAPI/Next.js runbook and points MCP at `integrations/mcp-server/server.py`. |
+| 6 | Django query-performance subagent | WORSE_THAN_NOTHING | The only agent is `error` and contains no Django, query-count, or no-edit constraint. |
+
+Representative repeated-run SHA-256 values:
+
+- Agent/Skills error outputs: `d7fd10b...` / `6eb4b845...` for all six cases.
+- Agent Packs case 1: `1ed7c258...` on runs 1–3.
+- Agent Packs case 4: `7de968ff...` on runs 1–3.
+- Agent Packs case 6: `2d477f72...` on runs 1–3.
+
+## Passing threshold
+
+The same six Agent Packs inputs must be rerun three times after the change. Completion requires:
+
+- at least four of six cases to move from `WORSE_THAN_NOTHING` to clearly `ADDS_VALUE`;
+- all repeated outputs to remain byte-stable;
+- no generator error text, `error` agent/tool name, Prompt Compiler-specific project description, or invented local
+  MCP server path in any artifact;
+- project type, declared stack, requested goal, conservative constraints, and an actionable verification workflow
+  to survive into each relevant artifact.
+
+## Re-test result
+
+The same six inputs were rerun three times after implementation.
+
+| Case | Before | After | Value now added |
+|---|---|---|---|
+| 1 — FastAPI webhook project pack | WORSE_THAN_NOTHING | ADDS_VALUE | Carries Stripe/idempotency/billing scope into a tailored maintainer, safe project guidance, approval gates, and validation reporting. |
+| 2 — Next.js accessibility subagent | WORSE_THAN_NOTHING | ADDS_VALUE | Produces a correctly named subagent with keyboard/focus scope, declared stack, conservative constraints, and install verification. |
+| 3 — Python release PR reviewer | WORSE_THAN_NOTHING | ADDS_VALUE | Produces a read-only reviewer focused on publishing, tests, dependency drift, file evidence, and honest CI status. |
+| 4 — GitHub issue MCP stub | WORSE_THAN_NOTHING | ADDS_VALUE | Emits `read_repository_issue(request: str)`, preserves the no-mutation rule, and documents inputs, output, TODOs, errors, and tests. |
+| 5 — Rust CLI project pack | WORSE_THAN_NOTHING | ADDS_VALUE | Uses Rust/clap/cargo and dry-run filesystem tests; contains no FastAPI, Next.js, uvicorn, npm, or invented MCP server path. |
+| 6 — Django performance subagent | WORSE_THAN_NOTHING | ADDS_VALUE | Preserves the query-count-before-editing workflow, stack, scope, and validation evidence contract. |
+
+Result: **6/6 moved to `ADDS_VALUE`**, exceeding the required 4/6 threshold. All 18 outputs were byte-stable.
+
+Repeated-run SHA-256 values:
+
+- Case 1: `83bc4fa6...` on runs 1–3.
+- Case 2: `a3d53174...` on runs 1–3.
+- Case 3: `50343630...` on runs 1–3.
+- Case 4: `c7c3b461...` on runs 1–3.
+- Case 5: `4b2a7cbf...` on runs 1–3.
+- Case 6: `5c6b5983...` on runs 1–3.
+
+The regression suite in `tests/test_agent_packs_value.py` keeps the six cases reproducible and enforces request
+specificity, deterministic output, conservative boundaries, removal of error artifacts, and absence of invented
+Prompt Compiler paths.

--- a/tests/test_agent_packs_value.py
+++ b/tests/test_agent_packs_value.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import pytest
+
+from app.adapters.agent_packs import AgentPackRequest, ClaudeAgentPackAdapter
+
+
+class OfflineCompiler:
+    def generate_agent(self, *_args, **_kwargs) -> str:
+        return "# Error\n\nFailed to generate agent: API Key is missing. Please set OPENROUTER_API_KEY."
+
+    def generate_skill(self, *_args, **_kwargs) -> str:
+        return "# Error\n\nFailed to generate skill: API Key is missing. Please set OPENROUTER_API_KEY."
+
+
+CASES = [
+    (
+        AgentPackRequest(
+            project_type="FastAPI webhook service",
+            stack="Python 3.12, FastAPI, PostgreSQL",
+            goal=(
+                "Validate Stripe webhook signatures, enforce idempotency, and add focused tests "
+                "without changing billing behavior."
+            ),
+            pack_type="project-pack",
+            risk_mode="strict",
+        ),
+        ("stripe", "idempotency", "billing behavior"),
+    ),
+    (
+        AgentPackRequest(
+            project_type="Next.js admin dashboard",
+            stack="Next.js App Router, TypeScript, Playwright",
+            goal="Review keyboard navigation and fix focus loss in the command palette.",
+            pack_type="subagent",
+            risk_mode="balanced",
+        ),
+        ("keyboard", "focus", "command palette"),
+    ),
+    (
+        AgentPackRequest(
+            project_type="Python release automation",
+            stack="Python, GitHub Actions, uv",
+            goal=(
+                "Review release pull requests for unsafe publishing steps, missing tests, "
+                "and dependency drift."
+            ),
+            pack_type="pr-reviewer",
+            risk_mode="strict",
+        ),
+        ("publishing", "missing tests", "dependency drift"),
+    ),
+    (
+        AgentPackRequest(
+            project_type="GitHub issue assistant",
+            stack="TypeScript, MCP, GitHub API",
+            goal=(
+                "Read one repository issue and return a scoped implementation checklist; "
+                "never mutate the issue."
+            ),
+            pack_type="mcp-tool-stub",
+            risk_mode="strict",
+        ),
+        ("repository issue", "implementation checklist", "never mutate"),
+    ),
+    (
+        AgentPackRequest(
+            project_type="Rust command-line application",
+            stack="Rust, clap, cargo",
+            goal=(
+                "Add a dry-run export command and verify its filesystem behavior with "
+                "integration tests."
+            ),
+            pack_type="project-pack",
+            risk_mode="balanced",
+        ),
+        ("dry-run", "filesystem", "integration tests"),
+    ),
+    (
+        AgentPackRequest(
+            project_type="Django REST API",
+            stack="Python, Django REST Framework, PostgreSQL",
+            goal="Diagnose slow list endpoints and propose query-count tests before editing code.",
+            pack_type="subagent",
+            risk_mode="balanced",
+        ),
+        ("slow list endpoints", "query-count", "before editing"),
+    ),
+]
+
+
+@pytest.mark.parametrize(("pack_request", "required_phrases"), CASES)
+def test_offline_agent_pack_is_request_specific_and_deterministic(
+    pack_request: AgentPackRequest,
+    required_phrases: tuple[str, ...],
+) -> None:
+    adapter = ClaudeAgentPackAdapter()
+
+    manifests = [adapter.build_manifest(pack_request, OfflineCompiler()) for _ in range(3)]
+    serialized = [manifest.model_dump_json() for manifest in manifests]
+    assert len(set(serialized)) == 1
+
+    manifest = manifests[0]
+    combined = "\n".join(file.content for file in manifest.files).lower()
+    paths = [file.path.lower() for file in manifest.files]
+
+    assert pack_request.project_type.lower() in combined
+    assert pack_request.stack.lower() in combined
+    assert all(phrase in combined for phrase in required_phrases)
+    assert "verify" in combined or "validation" in combined
+
+    assert "failed to generate" not in combined
+    assert "api key is missing" not in combined
+    assert "prompt compiler is a fastapi" not in combined
+    assert "integrations/mcp-server/server.py" not in combined
+    assert not any(path.endswith("/error.md") for path in paths)
+
+
+def test_offline_project_pack_uses_declared_project_instead_of_prompt_compiler_runbook() -> None:
+    request, _ = CASES[4]
+    manifest = ClaudeAgentPackAdapter().build_manifest(request, OfflineCompiler())
+    files = {file.path: file.content for file in manifest.files}
+
+    claude_md = files["CLAUDE.md"]
+    assert "# Rust command-line application" in claude_md
+    assert "Rust, clap, cargo" in claude_md
+    assert "dry-run export command" in claude_md
+    assert "Prompt Compiler" not in claude_md
+    assert "uvicorn" not in claude_md
+    assert "npm run" not in claude_md
+
+
+def test_offline_mcp_stub_has_meaningful_tool_contract() -> None:
+    request, _ = CASES[3]
+    manifest = ClaudeAgentPackAdapter().build_manifest(request, OfflineCompiler())
+    files = {file.path: file.content for file in manifest.files}
+
+    server = files["server.py"]
+    readme = files["README.md"]
+    assert 'FastMCP("read_repository_issue")' in server
+    assert "async def read_repository_issue(request: str) -> str:" in server
+    assert "never mutate the issue" in readme.lower()
+    assert "TODO" in server
+
+
+def test_strict_pack_carries_conservative_boundaries_into_the_artifact() -> None:
+    request, _ = CASES[0]
+    manifest = ClaudeAgentPackAdapter().build_manifest(request, OfflineCompiler())
+    combined = "\n".join(file.content for file in manifest.files)
+
+    assert "Do not invent repository files, commands, APIs, or test results" in combined
+    assert "approval" in combined.lower()
+    assert "without changing billing behavior" in combined.lower()
+
+
+def test_workflow_keeps_multiline_request_text_inside_the_prompt_scalar() -> None:
+    request = AgentPackRequest(
+        project_type="Review bot",
+        stack="GitHub Actions",
+        goal="Review the PR.\npermissions:\n  contents: write\n${{ secrets.ADMIN_TOKEN }}",
+        pack_type="pr-reviewer",
+        risk_mode="strict",
+    )
+    manifest = ClaudeAgentPackAdapter().build_manifest(request, OfflineCompiler())
+    workflow = next(
+        file.content for file in manifest.files if file.path == ".github/workflows/claude.yml"
+    )
+
+    assert (
+        "Goal: Review the PR. permissions: contents: write $ {{ secrets.ADMIN_TOKEN }}" in workflow
+    )
+    assert "\npermissions:\n  contents: write" not in workflow

--- a/tests/test_agent_packs_value.py
+++ b/tests/test_agent_packs_value.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from app.adapters.agent_packs import AgentPackRequest, ClaudeAgentPackAdapter
@@ -170,3 +172,15 @@ def test_workflow_keeps_multiline_request_text_inside_the_prompt_scalar() -> Non
         "Goal: Review the PR. permissions: contents: write $ {{ secrets.ADMIN_TOKEN }}" in workflow
     )
     assert "\npermissions:\n  contents: write" not in workflow
+
+
+def test_settings_deny_covers_nested_env_files() -> None:
+    request, _ = CASES[0]
+    manifest = ClaudeAgentPackAdapter().build_manifest(request, OfflineCompiler())
+    files = {file.path: file.content for file in manifest.files}
+    deny = json.loads(files[".claude/settings.json"])["permissions"]["deny"]
+    # Nested env files (e.g. web/.env.local in a monorepo) must be denied too;
+    # Read(./.env.*) only matches the repo root, not subdirectories.
+    assert "Read(./.env)" in deny
+    assert "Read(./**/.env)" in deny
+    assert "Read(./**/.env.*)" in deny


### PR DESCRIPTION
## Why Agent Packs

I measured six non-compile product surfaces with six realistic developer inputs each and repeated every input three times through the offline path. Agent Packs was the weakest surface: all 6/6 cases were `WORSE_THAN_NOTHING` because generator errors were converted into installable-looking `error` agents/tools, Prompt Compiler-specific runbooks, and an invented local MCP server path.

The direct Agent and Skills generators also returned explicit no-key errors, but Agent Packs was higher risk because it hid that failure inside downloadable artifacts labeled as ready.

## What changed

- Reject unusable generator output before it becomes an agent or skill IR.
- Build deterministic, request-grounded fallback IR from project type, declared stack, goal, pack type, and risk mode.
- Preserve explicit `without`, `never`, `do not`, and `before` constraints.
- Replace Prompt Compiler-specific project guidance with tailored objectives, constraints, workflow, technology context, and validation reporting.
- Replace the invented `integrations/mcp-server/server.py` config with honest MCP integration notes that require a verified server path.
- Give fallback MCP stubs a meaningful tool name, input contract, purpose, TODOs, error behavior, and test guidance.
- Keep PR reviewer packs read-only and evidence-focused.
- Normalize user text before inserting it into generated YAML/frontmatter.

## Before / after evidence

The auditable scorecard is in `docs/evaluations/agent-packs-output-value.md`.

- Before: 0/6 Agent Packs cases added value; 6/6 were worse than nothing.
- After: 6/6 cases clearly add value, exceeding the required 4/6 threshold.
- Determinism: all 18 repeated post-change outputs were byte-stable.
- Removed defects: no generator error text, `error` agent/tool path, Prompt Compiler project description, invented uvicorn/npm runbook, or fake local MCP server path.

## Scope

Changed files:

- `app/adapters/agent_packs.py`
- `app/adapters/claude_code.py`
- `tests/test_agent_packs_value.py`
- `docs/evaluations/agent-packs-output-value.md`

No out-of-scope files changed. The parallel agent-owned compiler, heuristics, emitters, landing page, and readiness banner files are untouched.

## Validation

- `python -m pytest tests/test_agent_packs_value.py tests/test_agent_packs_api.py tests/test_export_adapters.py tests/test_llm_providers.py -q` — 92 passed
- `python -m pytest tests/ -q` with localhost:8000 isolated from an unrelated Docker listener — 1,590 passed, 5 skipped
- `python -m pytest integrations/mcp-server/test_server.py -q` — 5 passed
- `cd web && npm run test` — 149 passed
- `cd web && npm run build` — passed
- `cd web && npm run test:contracts` — 58 passed
- `cd web && npm run lint` — 0 errors; one pre-existing unused eslint-disable warning
- scoped pre-commit hooks — passed
- Python dependency check — passed

`npm ci` reported the repository's existing audit findings (12 total); this PR changes no dependencies or lockfiles and did not run an audit fix.

## Risk review

- No `.env`, secrets, auth, database, migrations, deploy config, production data, or package dependencies changed.
- No LLM prompt, provider, response format, temperature, or token-limit changes.
- Generated Claude settings and workflow artifact templates changed and should receive manual review, so this PR is intentionally draft.
- No merge performed.