### PR TITLE
fix(compiler): split on sentence boundaries, not every ; and .

### DIFF
--- a/app/compiler.py
+++ b/app/compiler.py
@@ -119,7 +119,11 @@ GENERIC_TASK = {"tr": "İsteği analiz et ve yanıtla.", "en": "Analyze the requ
 RECENCY_CONSTRAINT_TR = "Güncel bilgi gerektirir; cevap üretmeden önce web araştırması yap."
 RECENCY_CONSTRAINT_EN = "Requires up-to-date info; perform web research before answering."
 
-_SENTENCE_SPLIT_PATTERN = re.compile(r"[\n;.]+")
+# Split on line breaks and real sentence boundaries (.!? followed by
+# whitespace) only. The old pattern split on every ";" and ".", which
+# fragmented coherent requests ("…on Safari; works on Chrome" became two
+# tasks) and broke dotted tokens like "Node.js" / "v2.0".
+_SENTENCE_SPLIT_PATTERN = re.compile(r"\n+|(?<=[.!?])\s+")
 
 _ADVERSARIAL_PATTERNS = [
     r"ignore\s+(?:previous|all|the)\s+(?:instructions|rules|prompts?)",
@@ -141,7 +145,7 @@ def _is_adversarial(sentence: str) -> bool:
 
 def split_sentences(text: str) -> List[str]:
     parts = _SENTENCE_SPLIT_PATTERN.split(text)
-    return [p.strip() for p in parts if p.strip()]
+    return [cleaned for p in parts if (cleaned := p.strip().rstrip(".!?").strip())]
 
 
 def extract_goals_tasks(text: str, lang: str) -> Tuple[List[str], List[str]]:

--- a/tests/test_sentence_split.py
+++ b/tests/test_sentence_split.py
@@ -1,0 +1,44 @@
+"""Sentence splitting must not mangle coherent requests.
+
+Regression for the input-mangling defect: the splitter used `[\\n;.]+`, so it
+broke a single coherent request on every semicolon and every period — turning
+'…does nothing on Safari; works on Chrome.' into two fragments, and splitting
+dotted tokens like 'Node.js' / 'v2.0'. It should split on newlines and real
+sentence boundaries (.!? followed by whitespace) only.
+"""
+
+from app.compiler import split_sentences, extract_goals_tasks
+
+
+def test_semicolon_does_not_split():
+    parts = split_sentences("export button does nothing on Safari; works on Chrome")
+    assert len(parts) == 1
+    assert "works on Chrome" in parts[0]
+
+
+def test_dotted_tokens_stay_intact():
+    parts = split_sentences("Deploy the Node.js app version v2.0 to production")
+    assert len(parts) == 1
+    joined = " ".join(parts)
+    assert "Node.js" in joined
+    assert "v2.0" in joined
+
+
+def test_real_sentences_still_split():
+    parts = split_sentences("Set up the database. Then seed it with test data.")
+    assert len(parts) == 2
+
+
+def test_newlines_still_split():
+    assert len(split_sentences("First task\nSecond task")) == 2
+
+
+def test_safari_issue_does_not_fragment():
+    goals, tasks = extract_goals_tasks(
+        'Turn this GitHub issue into a safe implementation brief: '
+        '"export button does nothing on Safari; works on Chrome."',
+        "en",
+    )
+    # the coherent request must not split off a bare "works on Chrome" task
+    assert not any(g.strip().lower().startswith("works on chrome") for g in goals)
+    assert not any(t.strip().lower().startswith("works on chrome") for t in tasks)

--- a/tests/test_sentence_split.py
+++ b/tests/test_sentence_split.py
@@ -35,7 +35,7 @@ def test_newlines_still_split():
 
 def test_safari_issue_does_not_fragment():
     goals, tasks = extract_goals_tasks(
-        'Turn this GitHub issue into a safe implementation brief: '
+        "Turn this GitHub issue into a safe implementation brief: "
         '"export button does nothing on Safari; works on Chrome."',
         "en",
     )


### PR DESCRIPTION
## What & why

PR 2 of the "make compile genuinely valuable" core-heuristic work. A value benchmark found offline compile **mangles** coherent requests: `split_sentences` used `[\n;.]+`, splitting on every semicolon and every period.

- `'…export button does nothing on Safari; works on Chrome.'` → fragmented into two goals/tasks (a bare `"works on Chrome"` task).
- Dotted tokens like `Node.js` and `v2.0` were torn apart.

## Change (`app/compiler.py`)
Split on **newlines and real sentence boundaries** (`.!?` followed by whitespace) only:
```
_SENTENCE_SPLIT_PATTERN = re.compile(r"\n+|(?<=[.!?])\s+")
```
- Semicolons no longer split a clause into separate tasks.
- Dotted/versioned tokens (`Node.js`, `v2.0`) stay intact (period not followed by whitespace).
- Genuine multi-sentence input still splits; trailing `.!?` is trimmed from fragments.

## Evidence (before → after)
| Input | Before | After |
|---|---|---|
| `…on Safari; works on Chrome.` | 2 goals (incl. bare `works on Chrome`) | **1 coherent goal/task** |
| `Deploy the Node.js app version v2.0` | `Node` / `js` / `v2` / `0` split | **`Node.js`, `v2.0` intact** |

(Goals still equal Tasks — that verbatim echo is the next stage's job, decomposition; this PR only stops the mangling.)

## Verification
- New `tests/test_sentence_split.py` — 5 cases (semicolon, dotted tokens, real-sentence split, newlines, Safari non-fragmentation).
- Full suite: 1584 passed. The one failure (`test_validate_summary_and_api_schemas`) is a pre-existing **network-dependent** test that fails identically on `main` (HTTP 404).
- `ruff` clean.

## Scope / safety
Provider-agnostic parsing only. No LLM prompt / temperature / response-format changes.

Part of the core "make compile actually beat the raw prompt" roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)