### PR TITLE
fix(heuristics): detect modern software requests, match on word boundaries

### DIFF
--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -59,8 +59,35 @@ DOMAIN_PATTERNS: Dict[str, List[str]] = {
         r"kubernetes",
         r"python",
         r"javascript",
+        r"typescript",
         r"refactor",
         r"microservices",
+        # Modern frameworks / runtimes
+        r"react",
+        r"vue",
+        r"angular",
+        r"svelte",
+        r"next.js",
+        r"node.js",
+        r"nodejs",
+        r"django",
+        r"flask",
+        r"fastapi",
+        r"rails",
+        r"tailwind",
+        r"graphql",
+        r"rust",
+        r"golang",
+        # Product/build phrasing that implies a software task
+        r"dashboard",
+        r"frontend",
+        r"backend",
+        r"full-stack",
+        r"fullstack",
+        r"webhook",
+        r"web app",
+        r"webapp",
+        r"stripe",
     ],
     "cloud": [r"aws", r"azure", r"gcp", r"cloudformation", r"terraform", r"serverless"],
     # Newer domains for coverage
@@ -1013,13 +1040,24 @@ def detect_language(text: str) -> str:
     return "en"
 
 
+# Leading-word-boundary matchers for domain keywords. Substring matching
+# misclassified words like "rapid" (contains "api") or "trustworthy" (contains
+# "rust") as software. A leading boundary keeps tech names and their inflections
+# ("react" -> "reactjs", "rust" not matched inside "trust") while ignoring
+# mid-word coincidences. re.escape keeps multi-word ("web app") and dotted
+# ("next.js") keywords literal.
+_DOMAIN_PATTERNS_COMPILED: Dict[str, List[Tuple[str, "re.Pattern[str]"]]] = {
+    domain: [(p, re.compile(r"\b" + re.escape(p), re.IGNORECASE)) for p in pats]
+    for domain, pats in DOMAIN_PATTERNS.items()
+}
+
+
 def detect_domain(text: str) -> Tuple[str, List[str]]:
-    lower = text.lower()
     evidence: List[str] = []
-    for domain, pats in DOMAIN_PATTERNS.items():
-        for p in pats:
-            if p in lower:
-                evidence.append(f"{domain}:{p}")
+    for domain, pats in _DOMAIN_PATTERNS_COMPILED.items():
+        for raw, pattern in pats:
+            if pattern.search(text):
+                evidence.append(f"{domain}:{raw}")
     if not evidence:
         return "general", []
     # Choose the domain with most evidence counts

--- a/tests/test_domain_coverage.py
+++ b/tests/test_domain_coverage.py
@@ -1,0 +1,36 @@
+"""Domain detection must recognise modern product/tech requests as software.
+
+Regression for the classification gap: product-phrased technical requests like
+"Build me a dashboard that shows my Stripe revenue" or "My React app re-renders"
+fell through to the "general" domain, so no developer persona/role was applied.
+The keyword set was missing modern frameworks/products, and substring matching
+mislabelled words like "rapid" (contains "api") as software.
+"""
+
+from app.heuristics import detect_domain
+
+
+def test_dashboard_stripe_request_is_software():
+    domain, _ = detect_domain("Build me a dashboard that shows my Stripe revenue")
+    assert domain == "software"
+
+
+def test_react_app_request_is_software():
+    domain, _ = detect_domain("My React app re-renders too much, help me fix the performance")
+    assert domain == "software"
+
+
+def test_nextjs_typescript_request_is_software():
+    domain, _ = detect_domain("Create a Next.js frontend with TypeScript and Tailwind")
+    assert domain == "software"
+
+
+def test_existing_python_request_still_software():
+    domain, _ = detect_domain("Write a Python function to parse nginx logs")
+    assert domain == "software"
+
+
+def test_word_boundary_avoids_rapid_api_false_positive():
+    # "rapid" contains "api" but is not a software request
+    domain, _ = detect_domain("We need rapid iteration on our marketing copy")
+    assert domain != "software"


### PR DESCRIPTION
## What & why

PR 3 of the "make compile genuinely valuable" core-heuristic work. The value benchmark found product-phrased technical requests fell through to the **`general`** domain, so no developer context was applied to the output:
- `Build me a dashboard that shows my Stripe revenue` → general
- `My React app re-renders too much` → general

`DOMAIN_PATTERNS["software"]` only had `api, microservice, docker, kubernetes, python, javascript, refactor`.

## Change (`app/heuristics/__init__.py`)
- **Add modern software keywords:** react, vue, angular, svelte, next.js, node.js, typescript, django, flask, fastapi, rails, tailwind, graphql, rust, golang, dashboard, frontend, backend, webhook, web app, stripe, …
- **Switch `detect_domain` to leading-word-boundary matching** (like the risk-flags fix). This also kills substring misclassifications: `rapid` no longer matches `api`, `trust` no longer matches `rust`.

## Evidence (before → after)
| Input | Before | After |
|---|---|---|
| `Build me a dashboard that shows my Stripe revenue` | general | **software** |
| `My React app re-renders too much…` | general | **software** |
| `Create a Next.js frontend with TypeScript` | general | **software** |
| `We need rapid iteration on our marketing copy` | software (via `api`∈`rapid`) | **not software** |

(Persona/role for software requests is still generic in some cases — that's the next PR, which ties the developer role + detected language to the now-correct domain.)

## Verification
- New `tests/test_domain_coverage.py` — 5 cases (modern requests → software, rapid false-positive killed).
- `tests/test_domain_confidence.py` — 7/7.
- Full suite: 1584 passed. The one failure (`test_validate_summary_and_api_schemas`) is a pre-existing **network-dependent** test that fails identically on `main` (HTTP 404).
- `ruff` clean.

## Scope / safety
Provider-agnostic heuristic only. No LLM prompt / temperature / response-format changes.

Part of the core "make compile actually beat the raw prompt" roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)