### PR TITLE
fix(heuristics): give software requests the right developer role

### DIFF
--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -155,7 +155,10 @@ TEACHING_KEYWORDS = [
     r"ders",
     r"öğrenmek istiyorum",
 ]
-_TEACHING_RE = re.compile("|".join(TEACHING_KEYWORDS))
+# Leading word boundary: "ders" (TR for lesson) must not match inside
+# "re-nders", "guide" must not match mid-word, etc. Substring matching here
+# flagged "My React app re-renders" as a teaching request -> teacher persona.
+_TEACHING_RE = re.compile("|".join(r"\b" + re.escape(k) for k in TEACHING_KEYWORDS))
 
 # Bolt Optimization: Pre-compile regexes for fast evaluation
 
@@ -222,6 +225,13 @@ PERSONA_KEYWORDS = {
         r"rust",
         r"deno",
         r"node",
+        # Frontend frameworks (bounded so "react" does not match "reaction")
+        r"\breact\b",
+        r"\bvue\b",
+        r"\bangular\b",
+        r"\bsvelte\b",
+        r"\bnextjs\b",
+        r"\bnext\.js\b",
         r"kod",
         r"örnek kod",
         r"birlikte kodla",

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -61,6 +61,17 @@ _GENERIC_ROLES = {
     DEFAULT_ROLE_DEV_TR,
 }
 
+# Map a detected programming language (analysis.sub_domain) to an expert role
+# label. Used to set the role from the reliably-detected language instead of the
+# implied-persona keyword tiebreaker (which gave "Expert JavaScript Developer"
+# for a Python request).
+_LANGUAGE_ROLE = {
+    "python": "Python Developer",
+    "javascript": "JavaScript Developer",
+    "rust": "Rust Developer",
+    "go": "Go Developer",
+}
+
 
 # ==============================================================================
 # DOMAIN RULES DICTIONARY
@@ -739,6 +750,13 @@ class DomainHandler(BaseHandler):
         role_is_generic = not ir_v2.role or ir_v2.role in _GENERIC_ROLES
         if persona_is_generic and role_is_generic:
             implied_persona, confidence = self.detect_implied_persona(original_text)
+            # Prefer the reliably detected programming language over the implied-
+            # persona keyword tiebreaker, which let "function " pick JavaScript for
+            # a Python request.
+            if analysis.detected_domain == "coding" and analysis.sub_domain:
+                lang_role = _LANGUAGE_ROLE.get(analysis.sub_domain)
+                if lang_role:
+                    implied_persona = lang_role
             if implied_persona:
                 ir_v2.persona = "expert"
                 ir_v2.role = f"Expert {implied_persona}"
@@ -756,6 +774,17 @@ class DomainHandler(BaseHandler):
                         category="persona_inference",
                     )
                 )
+            elif analysis.detected_domain == "coding":
+                # A coding request with no language or keyword signal (e.g.
+                # "build me a dashboard") still deserves a developer rather than a
+                # generic assistant.
+                ir_v2.persona = "developer"
+                ir_v2.role = DEFAULT_ROLE_DEV_EN
+                ir_v2.metadata["implied_persona"] = {
+                    "persona": "developer",
+                    "confidence": 0.5,
+                    "reason": "coding_domain",
+                }
 
         # Store analysis metadata
         ir_v2.metadata["domain_analysis"] = {
@@ -860,6 +889,9 @@ class DomainHandler(BaseHandler):
 
     def _detect_domain(self, text_lower: str, hint: str) -> str:
         """Detect the primary domain of the text."""
+        # The upstream IR domain uses "software"; this analyzer calls it "coding".
+        if hint == "software":
+            hint = "coding"
         # Trust the hint if it's valid
         if hint and hint in DOMAIN_RULES:
             return hint

--- a/tests/test_persona_role_language.py
+++ b/tests/test_persona_role_language.py
@@ -1,0 +1,39 @@
+"""Persona/role must fit the request: right language, no teaching false-positive.
+
+Regressions found by the value benchmark:
+- "Write a Python function..." produced role "Expert JavaScript Developer"
+  (the implied-persona tiebreaker let "function " beat the language).
+- "My React app re-renders too much..." produced persona "teacher" because the
+  teaching matcher found "ders" inside "re-nders" (substring match).
+- "Build me a dashboard..." stayed persona "assistant" with no developer context.
+"""
+
+from app.compiler import compile_text_v2
+from app.heuristics import detect_teaching_intent
+
+
+def test_python_request_gets_python_role_not_javascript():
+    ir = compile_text_v2(
+        "Write a Python function to parse nginx logs and detect brute-force login attempts"
+    )
+    assert "python" in ir.role.lower()
+    assert "javascript" not in ir.role.lower()
+
+
+def test_renders_does_not_trigger_teaching_intent():
+    assert detect_teaching_intent("My React app re-renders too much") is False
+
+
+def test_real_teaching_intent_still_detected():
+    assert detect_teaching_intent("teach me recursion with a tutorial") is True
+
+
+def test_react_performance_is_not_teacher():
+    ir = compile_text_v2("My React app re-renders too much, help me fix the performance")
+    assert ir.persona != "teacher"
+    assert ir.persona in {"developer", "expert"}
+
+
+def test_dashboard_request_gets_developer_persona():
+    ir = compile_text_v2("Build me a dashboard that shows my Stripe revenue")
+    assert ir.persona in {"developer", "expert"}


### PR DESCRIPTION
## What & why

PR 4 of the "make compile genuinely valuable" core-heuristic work. The value benchmark found persona/role frequently misfit the request — and a wrong expert role is worse than none, because it steers the model off-target:

- `Write a Python function…` → role **"Expert JavaScript Developer"** (the implied-persona tiebreaker let `"function "` beat the detected language).
- `My React app re-renders too much…` → persona **"teacher"** — the teaching matcher found `"ders"` (TR: lesson) inside `"re-nders"`.
- `Build me a dashboard…` → persona **"assistant"**, no developer context.

## Changes
- **Teaching keywords match on a word boundary** (`app/heuristics/__init__.py`) — `"ders"` no longer hits `"renders"`; real teaching requests still detected.
- **Role from the detected language** (`domain_expert.py`) — the DomainHandler sets the role from `analysis.sub_domain` (reliably detected by `_detect_language`) via a `_LANGUAGE_ROLE` map, instead of the buggy tiebreaker.
- **Coding-domain fallback** — a coding request with no language signal upgrades from a generic assistant to a developer; the upstream `"software"` domain hint now maps to this analyzer's `"coding"`.
- **Bounded framework keywords** — `react/vue/angular/svelte/next.js` added to the developer persona signals (with `\b` so `"react"` ≠ `"reaction"`).

## Evidence (before → after)
| Input | Before | After |
|---|---|---|
| `Write a Python function…` | role **Expert JavaScript Developer** | **Expert Python Developer** |
| `My React app re-renders…` | persona **teacher** | **expert** (JavaScript — React is JS) |
| `Build me a dashboard…` | persona **assistant** | **developer** |

## Verification
- New `tests/test_persona_role_language.py` — 5 cases.
- Regression: `test_persona.py`, `test_developer_persona.py`, `test_domain_confidence.py`, `test_intent_coverage_v2.py` all green.
- Full suite: **1614 passed**. The one failure (`test_validate_summary_and_api_schemas`) is a pre-existing **network-dependent** test that fails identically on `main` (HTTP 404).
- `ruff check` + `ruff format --check` clean.

## Scope / safety
Provider-agnostic heuristic only. No LLM prompt / temperature / response-format changes.

Part of the core "make compile actually beat the raw prompt" roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)