### PR TITLE
fix(policy): escalate destructive operations to high risk

### DIFF
--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -790,6 +790,82 @@ def detect_risk_flags(text: str) -> list[str]:
     return flags
 
 
+# Destructive, hard-to-reverse operations. The risk model under-rated these
+# ("wipe the production database" was only medium). A destructive operation is
+# either an unambiguous phrase (rm -rf, drop table, git reset --hard) or a
+# destructive verb paired with a sensitive target (wipe + database). Requiring a
+# target keeps ordinary actions ("delete a temp file", "drop a dependency") low.
+# Unambiguous, command-shaped destructive operations (always high risk).
+_DESTRUCTIVE_ALWAYS = [
+    # rm with both recursive and force flags, in any order (-rf, -fr, -fR, ...)
+    re.compile(r"\brm\s+-(?=[a-z]*r)(?=[a-z]*f)[a-z]+", re.IGNORECASE),
+    re.compile(r"\bdelete\s+from\s+\w+", re.IGNORECASE),  # SQL mass delete
+    re.compile(r"\bterraform\s+destroy\b", re.IGNORECASE),
+    re.compile(r"\bgit\s+reset\s+--hard\b", re.IGNORECASE),
+    re.compile(r"\bgit\s+clean\s+-[a-z]*f", re.IGNORECASE),
+    re.compile(r"\bformat\s+(?:the\s+)?(?:disk|drive|volume)\b", re.IGNORECASE),
+    re.compile(r"\bformat\s+[a-z]:", re.IGNORECASE),
+    re.compile(r"\bfactory\s+reset\b", re.IGNORECASE),
+]
+
+# Benign phrases that reuse destructive verbs/targets but are not destructive
+# ("drop the database connection pool", "truncate the cell text to 40 chars").
+_DESTRUCTIVE_BENIGN = re.compile(
+    r"connection\s+pool|\bcell\s+text\b|to\s+\d+\s+char|truncate[^.]*\b(?:string|text|label|characters)\b",
+    re.IGNORECASE,
+)
+_DESTRUCTIVE_VERBS = [
+    re.compile(r"\b" + v, re.IGNORECASE)
+    for v in (
+        r"wipe",
+        r"truncate",
+        r"destroy",
+        r"obliterate",
+        r"purge",
+        r"nuke",
+        r"delete",
+        r"drop",
+        r"erase",
+        r"shred",
+    )
+]
+_DESTRUCTIVE_TARGETS = [
+    re.compile(r"\b" + t, re.IGNORECASE)
+    for t in (
+        r"database",
+        r"\bdb\b",
+        r"production",
+        r"\bprod\b",
+        r"table",
+        r"schema",
+        r"volume",
+        r"disk",
+        r"cluster",
+        r"\bdata\b",
+        r"records",
+        r"backup",
+        r"everything",
+        r"all data",
+        r"bucket",
+        r"namespace",
+        r"account",
+        r"users",
+        r"collection",
+    )
+]
+
+
+def detect_destructive_operation(text: str) -> bool:
+    """True if the request describes a destructive, hard-to-reverse operation."""
+    if any(pattern.search(text) for pattern in _DESTRUCTIVE_ALWAYS):
+        return True
+    if _DESTRUCTIVE_BENIGN.search(text):
+        return False
+    has_verb = any(pattern.search(text) for pattern in _DESTRUCTIVE_VERBS)
+    has_target = any(pattern.search(text) for pattern in _DESTRUCTIVE_TARGETS)
+    return has_verb and has_target
+
+
 def extract_entities(text: str) -> list[str]:
     # Simple heuristic: capitalized tokens & tech patterns
     entities: list[str] = []

--- a/app/heuristics/handlers/policy.py
+++ b/app/heuristics/handlers/policy.py
@@ -3,7 +3,7 @@ import re
 from .base import BaseHandler
 from app.models import IR
 from app.models_v2 import IRv2
-from app.heuristics import _contains_any_keyword
+from app.heuristics import _contains_any_keyword, detect_destructive_operation
 
 
 class PolicyHandler(BaseHandler):
@@ -31,6 +31,7 @@ class PolicyHandler(BaseHandler):
         "terminal",
         "system",
         "workspace",
+        "database",
     )
 
     _DOMAIN_TOOL_RULES: dict[str, dict[str, list[str]]] = {
@@ -101,6 +102,7 @@ class PolicyHandler(BaseHandler):
         # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
         file_or_system_request = has_path or _contains_any_keyword(text, self._FILE_KEYWORDS)
         debug_request = bool(md.get("code_request")) or bool(persona_flags.get("live_debug"))
+        destructive = detect_destructive_operation(original_text)
         educational_request = self._is_educational_request(text)
         benign_educational_risk = (
             educational_request
@@ -123,6 +125,8 @@ class PolicyHandler(BaseHandler):
             policy_reasons.append("debug_request")
         if file_or_system_request:
             policy_reasons.append("file_or_system_request")
+        if destructive:
+            policy_reasons.append("destructive_operation")
         for flag in pii_flags:
             policy_reasons.append(f"pii_detected:{flag}")
 
@@ -133,6 +137,11 @@ class PolicyHandler(BaseHandler):
             policy.execution_mode = "advice_only"
             if "security" not in policy.risk_domains:
                 policy.risk_domains.append("security")
+        elif destructive:
+            # Hard-to-reverse operations (wipe/drop/truncate a database, rm -rf)
+            # are high risk regardless of domain count.
+            policy.risk_level = "high"
+            policy.execution_mode = "human_approval_required"
         elif benign_educational_risk:
             policy.risk_level = "low"
             policy.execution_mode = "auto_ok"
@@ -144,6 +153,12 @@ class PolicyHandler(BaseHandler):
             policy.execution_mode = "human_approval_required"
         else:
             policy.execution_mode = "auto_ok"
+
+        if destructive:
+            policy.sanitization_rules = self._unique(
+                policy.sanitization_rules + ["backup_before_destructive", "dry_run_required"]
+            )
+            policy.forbidden_tools = self._unique(policy.forbidden_tools + ["production_write"])
 
         # Domain-specific tool control
         for domain in risk_flags:

--- a/tests/test_destructive_risk.py
+++ b/tests/test_destructive_risk.py
@@ -1,0 +1,81 @@
+"""Destructive operations must escalate to high risk; ordinary ones must not.
+
+Regression for the inverted risk model: "Deploy to production and wipe the old
+database" was only rated medium (the same level as a routine task), while safe
+requests were over-flagged. Genuinely destructive, irreversible operations
+(wipe/drop/truncate a database, rm -rf, etc.) should be high risk with a
+backup/dry-run recommendation — without flagging every "delete".
+"""
+
+from app.compiler import compile_text_v2
+from app.heuristics import detect_destructive_operation
+
+
+# --- Must escalate to HIGH ---------------------------------------------------
+
+
+def test_wipe_production_database_is_high():
+    ir = compile_text_v2("Deploy my app to production and wipe the old database")
+    assert ir.policy.risk_level == "high"
+    assert "destructive_operation" in ir.metadata.get("policy_reasons", [])
+    assert "backup_before_destructive" in ir.policy.sanitization_rules
+
+
+def test_drop_table_is_destructive():
+    assert detect_destructive_operation("Drop the production users table") is True
+
+
+def test_rm_rf_is_destructive():
+    assert detect_destructive_operation("Just rm -rf the data directory to clean up") is True
+
+
+def test_truncate_table_is_destructive():
+    assert detect_destructive_operation("truncate the users table before reseeding") is True
+
+
+def test_sql_delete_from_is_destructive():
+    assert detect_destructive_operation("Run DELETE FROM users where 1=1") is True
+
+
+def test_terraform_destroy_is_destructive():
+    assert detect_destructive_operation("Run terraform destroy on the prod workspace") is True
+
+
+def test_rm_rf_flag_order_agnostic():
+    assert detect_destructive_operation("just rm -fr /var/www to clean up") is True
+
+
+def test_factory_reset_is_destructive():
+    assert detect_destructive_operation("factory reset the device before returning it") is True
+
+
+def test_git_clean_force_is_destructive():
+    assert detect_destructive_operation("run git clean -fdx to wipe untracked files") is True
+
+
+# --- Must NOT over-escalate ---------------------------------------------------
+
+
+def test_plain_deploy_is_not_destructive():
+    assert detect_destructive_operation("Deploy my app to production") is False
+
+
+def test_deleting_a_temp_file_is_not_destructive():
+    assert detect_destructive_operation("Delete the temporary file in the build folder") is False
+
+
+def test_dropping_a_dependency_is_not_destructive():
+    assert detect_destructive_operation("Drop the unused npm dependency from package.json") is False
+
+
+def test_drop_database_connection_pool_is_not_destructive():
+    assert detect_destructive_operation("Drop the database connection pool when idle") is False
+
+
+def test_truncate_table_cell_text_is_not_destructive():
+    assert detect_destructive_operation("Truncate the table cell text to 40 characters") is False
+
+
+def test_plain_deploy_stays_medium_not_high():
+    ir = compile_text_v2("Deploy my app to production")
+    assert ir.policy.risk_level != "high"


### PR DESCRIPTION
## What & why

PR 5 of the "make compile genuinely valuable" core-heuristic work. The value benchmark found the risk model **inverted** — soft on the truly dangerous, harsh on the safe:
- `Deploy my app to production and wipe the old database` → only **medium** (same as a routine task), no "backup first".

## Change
- New `detect_destructive_operation` (`app/heuristics/__init__.py`): flags an unambiguous command (`rm -rf`/`-fr`, `DELETE FROM`, `terraform destroy`, `git reset --hard`, `git clean -f`, `format C:`, `factory reset`) **or** a destructive verb (wipe/drop/truncate/destroy/purge/nuke/delete/erase/shred) paired with a sensitive target (database, production, table, bucket, namespace, account, …). Benign reuses (`drop the database connection pool`, `truncate the cell text to 40 chars`) are excluded.
- `PolicyHandler` (`policy.py`) escalates destructive ops to **high** + `human_approval_required`, adds `backup_before_destructive` + `dry_run_required` sanitization and forbids `production_write`. `database` added to file keywords.

## Evidence (before → after)
| Input | Before | After |
|---|---|---|
| `…production and wipe the old database` | **medium** | **high** + backup/dry-run |
| `Deploy my app to production` | medium | medium (unchanged — no over-escalation) |
| `DELETE FROM users` / `terraform destroy` / `rm -fr …` | not flagged | **destructive → high** |

## Verification
- New `tests/test_destructive_risk.py` — 15 cases (catastrophic ops escalate; ordinary deletes/deploys don't).
- **Calibration was stress-tested adversarially** (an over-trigger lens + an under-trigger lens running the real detector); the misses it surfaced (`DELETE FROM`, `terraform destroy`, flag-order `rm -fr`, `factory reset`, `git clean -f`, `shred`) are now covered, and the two real over-triggers are excluded.
- Full suite: **1629 passed**. The one failure (`test_validate_summary_and_api_schemas`) is a pre-existing **network-dependent** test that fails identically on `main` (HTTP 404).
- `ruff check` + `ruff format --check` clean.

## Scope / safety
Provider-agnostic heuristic only. No LLM prompt / temperature / response-format changes.

Part of the core "make compile actually beat the raw prompt" roadmap (PR 6 — real decomposition — is the remaining value jump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)