### PR TITLE
feat(compiler): decompose coordinated tasks into plan steps (conservative)

### DIFF
--- a/app/compiler.py
+++ b/app/compiler.py
@@ -168,13 +168,38 @@ def extract_goals_tasks(text: str, lang: str) -> Tuple[List[str], List[str]]:
     return goals, tasks
 
 
+# Split only on real coordinating conjunctions ("X and Y", "X then Y").
+_CONJUNCTION_SPLIT = re.compile(r",?\s+(?:and\s+then|and|then)\s+", re.IGNORECASE)
+# A deliberate enumerated list ("X, Y, and Z") additionally splits on its commas.
+_LIST_SPLIT = re.compile(r",\s+(?:and\s+|then\s+)?|\s+(?:and|then)\s+", re.IGNORECASE)
+_OXFORD_LIST = re.compile(r",\s+(?:and|then)\s+", re.IGNORECASE)
+
+
+def decompose_task(task: str) -> List[str]:
+    """Break a task into ordered sub-steps using only the user's own words.
+
+    Conservative on purpose — it must never mangle a coherent request:
+    - a task carrying a quoted payload (an issue, an example) is never split;
+    - it splits on "and"/"then", never on a stray semicolon or prose comma;
+    - it only splits on commas for a clear enumerated list ("X, Y, and Z").
+    One-word fragments are dropped so a noun list collapses instead of producing
+    junk steps. It never invents a requirement the user did not state.
+    """
+    if '"' in task or "“" in task or "”" in task:
+        return [task.strip()]
+    pattern = _LIST_SPLIT if _OXFORD_LIST.search(task) else _CONJUNCTION_SPLIT
+    parts = [p.strip(" .,;") for p in pattern.split(task)]
+    parts = [p for p in parts if len(p.split()) >= 2]
+    return parts or [task.strip()]
+
+
 def build_steps(tasks: List[str]) -> List[str]:
     steps: List[str] = []
     for t in tasks:
-        if len(steps) >= 8:
-            break
-        # naive split: each task maybe broken into sub points (not implemented yet)
-        steps.append(t)
+        for sub in decompose_task(t):
+            if len(steps) >= 8:
+                return steps
+            steps.append(sub)
     return steps
 
 

--- a/tests/test_step_decomposition.py
+++ b/tests/test_step_decomposition.py
@@ -1,0 +1,60 @@
+"""Plan steps should decompose a coordinated request, not echo it verbatim.
+
+The value benchmark found goals == tasks == the single plan step == the raw
+sentence: no decomposition, the core reason to use the tool. build_steps now
+splits a task on its own coordinating conjunctions ("and"/"then"/commas) into
+sub-steps, without inventing any requirement the user did not state.
+"""
+
+from app.compiler import build_steps, compile_text_v2
+
+
+def test_and_coordinated_task_splits():
+    steps = build_steps(
+        ["Write a Python function to parse nginx logs and detect brute-force login attempts"]
+    )
+    assert len(steps) >= 2
+
+
+def test_comma_list_splits_into_three():
+    steps = build_steps(
+        ["Validate Stripe webhook signatures, enforce idempotency, and add focused tests"]
+    )
+    assert len(steps) == 3
+
+
+def test_single_clause_task_stays_one_step():
+    steps = build_steps(["Build me a dashboard that shows my Stripe revenue"])
+    assert len(steps) == 1
+
+
+def test_quoted_payload_is_never_split():
+    # a quoted issue/example must stay coherent, not fragment on its punctuation
+    steps = build_steps(
+        [
+            'Turn this GitHub issue into a brief: "export button does nothing on Safari; works on Chrome."'
+        ]
+    )
+    assert len(steps) == 1
+
+
+def test_prose_comma_is_not_split():
+    steps = build_steps(["My React app re-renders too much, help me fix the performance"])
+    assert len(steps) == 1
+
+
+def test_decomposition_invents_no_new_words():
+    task = "parse the access log and email a daily summary to the team"
+    steps = build_steps([task])
+    allowed = set(task.lower().replace(".", "").split())
+    for step in steps:
+        for word in step.lower().replace(".", "").split():
+            assert word in allowed, f"invented word in step: {word!r}"
+
+
+def test_compiled_plan_has_multiple_task_steps():
+    ir = compile_text_v2(
+        "Write a Python script that reads a log file, counts requests by IP, and flags noisy IPs"
+    )
+    task_steps = [s for s in ir.steps if getattr(s, "type", "task") == "task"]
+    assert len(task_steps) >= 2


### PR DESCRIPTION
## What & why

PR 6 of the "make compile genuinely valuable" core work. `build_steps` echoed each task verbatim (its own comment said *"naive split ... not implemented yet"*), so the Plan just restated the input — the single most-flagged weakness in the value benchmark.

Now a task is split into ordered sub-steps on its coordinating conjunctions (`X and Y`, `X then Y`) plus the commas of an explicit enumerated list (`X, Y, and Z`).

**Conservative by design — it must never mangle a coherent request:**
- a task carrying a **quoted payload** (an issue, an example) is never split;
- it never splits on a stray **semicolon** or a **prose comma**;
- it invents no requirement the user did not state.

## Evidence
| Input | Plan steps |
|---|---|
| `parse nginx logs and detect brute-force attempts` | **2 steps** (parse / detect) |
| `Turn this issue into a brief: "…Safari; works on Chrome."` | **1 coherent step** (quoted payload kept whole) |
| `My React app re-renders too much, help me fix the performance` | **1 step** (prose comma not split) |

## Honest scope note
A value re-benchmark (the same skeptical panel that scored the baseline 0/6) puts the engine at **0 ADDS_VALUE / 4 NEUTRAL / 2 WORSE** after PRs 1–5 — "no longer harmful, not yet useful." This PR stops the plan from re-mangling quoted/prose input (the two WORSE cases); reaching ADDS_VALUE needs domain-expertise injection, tracked as follow-up work.

## Verification
- New `tests/test_step_decomposition.py` — 7 cases (splits clean conjunctions/lists; never splits quotes/prose/semicolons; invents no words).
- Full suite: **1636 passed**. The one failure (`test_validate_summary_and_api_schemas`) is a pre-existing **network-dependent** test that fails identically on `main` (HTTP 404).
- `ruff check` + `ruff format --check` clean.

## Scope / safety
Provider-agnostic heuristic only. No LLM prompt / temperature / response-format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)