### PR TITLE
refactor: code quality improvements for new feature surfaces

### DIFF
--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -20,8 +20,16 @@ from api.shared import (
     safety_refusal_prompt_fields,
 )
 from app.compile_export import render_compile_export
-from app.compiler import HEURISTIC_VERSION, HEURISTIC2_VERSION
-from app.compiler import compile_text, compile_text_v2, generate_trace, optimize_ir
+from app.compiler import (
+    HEURISTIC_VERSION,
+    HEURISTIC2_VERSION,
+    compile_text,
+    compile_text_v2,
+    generate_trace,
+    merge_policy_from_critique,
+    optimize_ir,
+)
+from app.heuristics.handlers.safety import SafetyHandler
 from app.emitters import (
     emit_expanded_prompt,
     emit_expanded_prompt_v2,
@@ -40,6 +48,7 @@ from app.optimizer.language_costs import (
     detect_language,
     estimate_prompt_cost,
 )
+from app.optimizer.critic import CriticAgent
 from app.optimizer.postprocess import strip_wrapper_labels
 from app.readiness.analyzer import analyze_readiness
 from app.readiness.language_guard import output_language_mismatch
@@ -153,6 +162,20 @@ def _safe_worker_text(worker_res, field_name: str) -> str:
     if not isinstance(value, str):
         return ""
     return value if field_name == "plan" or not is_meta_leaked(value) else ""
+
+
+def _serialize_readiness(text: str, ir2: IRv2 | None) -> tuple[dict, str]:
+    report = analyze_readiness(text, ir2)
+    return report.model_dump(), report_to_markdown(report)
+
+
+def _export_prompt_fields(compiled: CompileResponse) -> tuple[str, str, str]:
+    """Prefer v2 prompt fields so export matches CLI and web tab content."""
+    return (
+        compiled.system_prompt_v2 or compiled.system_prompt,
+        compiled.user_prompt_v2 or compiled.user_prompt,
+        compiled.plan_v2 or compiled.plan,
+    )
 
 
 def _warning_for_fast_fallback(reason: str) -> DiagnosticItem:
@@ -292,7 +315,7 @@ def _fast_compile_payload(
         or emit_expanded_prompt_v2(ir2, diagnostics=req.diagnostics)
     )
     ir_dump = ir2.model_dump()
-    readiness_report = analyze_readiness(req.text, ir2)
+    readiness, readiness_markdown = _serialize_readiness(req.text, ir2)
 
     return (
         {
@@ -312,8 +335,8 @@ def _fast_compile_payload(
             "heuristic2_version": "v2-fast",
             "trace": [],
             "critique": None,
-            "readiness": readiness_report.model_dump(),
-            "readiness_markdown": report_to_markdown(readiness_report),
+            "readiness": readiness,
+            "readiness_markdown": readiness_markdown,
         },
         used_fallback,
     )
@@ -440,8 +463,6 @@ def _compile_response(req: CompileRequest, request: Request) -> CompileResponse:
     critique_result = None
     if sys_v2:
         try:
-            from app.optimizer.critic import CriticAgent
-
             critic = CriticAgent()
             context_str = ""
             if ir2 and ir2.metadata.get("context_snippets"):
@@ -460,8 +481,6 @@ def _compile_response(req: CompileRequest, request: Request) -> CompileResponse:
 
             # Merge critique verdict into policy (#700)
             if ir2:
-                from app.compiler import merge_policy_from_critique
-
                 merge_policy_from_critique(ir2, critique_result)
 
         except Exception:
@@ -471,9 +490,7 @@ def _compile_response(req: CompileRequest, request: Request) -> CompileResponse:
                 extra={"request_id": rid},
             )
 
-    readiness_report = analyze_readiness(req.text, ir2)
-    readiness = readiness_report.model_dump()
-    readiness_markdown = report_to_markdown(readiness_report)
+    readiness, readiness_markdown = _serialize_readiness(req.text, ir2)
     elapsed = int((time.time() - t0) * 1000)
 
     # Block compilation ONLY when the safety scan flags the input as unsafe
@@ -547,11 +564,12 @@ def compile_export_endpoint(
     _: None = Depends(rate_limit_by_ip),
 ):
     compiled = _compile_response(req, request)
+    system_prompt, user_prompt, plan = _export_prompt_fields(compiled)
     return CompileExportResponse(
         markdown=render_compile_export(
-            system_prompt=compiled.system_prompt,
-            user_prompt=compiled.user_prompt,
-            plan=compiled.plan,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            plan=plan,
             readiness_markdown=compiled.readiness_markdown,
         ),
         json_payload=compiled.model_dump(mode="json"),
@@ -618,8 +636,6 @@ def validate_endpoint(
                 extra={"text_length": len(req.text)},
             )
             report = _build_offline_quality_report(req)
-
-        from app.heuristics.handlers.safety import SafetyHandler
 
         safety = SafetyHandler()
         pii = safety._scan_pii(req.text)

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -1255,4 +1255,3 @@ class DomainHandler(BaseHandler):
                 analysis.suggestions.append(check_rules["suggestion"])
 
         return analysis
-

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -8,8 +8,9 @@ Provides domain-specific heuristics and best-practice enforcement:
 """
 
 from __future__ import annotations
-import re
 import ast
+import hashlib
+import re
 import textwrap
 from typing import List, Dict, Optional, Tuple
 from dataclasses import dataclass, field
@@ -796,8 +797,6 @@ class DomainHandler(BaseHandler):
 
     def _hash_id(self, text: str) -> str:
         """Generate a short hash ID."""
-        import hashlib
-
         return hashlib.sha1(text.encode()).hexdigest()[:10]
 
     def analyze_domain(self, text: str, domain_hint: str = "") -> DomainAnalysis:
@@ -1257,22 +1256,3 @@ class DomainHandler(BaseHandler):
 
         return analysis
 
-
-# ==============================================================================
-# CONVENIENCE FUNCTIONS
-# ==============================================================================
-
-
-def analyze_domain(text: str, domain_hint: str = "") -> DomainAnalysis:
-    """
-    Convenience function to analyze domain-specific aspects of a prompt.
-
-    Args:
-        text: The prompt text to analyze.
-        domain_hint: Optional domain hint.
-
-    Returns:
-        DomainAnalysis with suggestions and diagnostics.
-    """
-    handler = DomainHandler()
-    return handler.analyze_domain(text, domain_hint)

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -92,7 +92,9 @@ def test_compile_fast_success(test_key):
         assert "processing_ms" in data
         assert "readiness" in data
         assert data["readiness"]["verdict"] in {"ready", "clarify", "risky", "noise"}
-        assert isinstance(data.get("readiness_markdown"), str) and data["readiness_markdown"].strip()
+        assert (
+            isinstance(data.get("readiness_markdown"), str) and data["readiness_markdown"].strip()
+        )
 
 
 def test_compile_fast_trivial_input_forces_instruction_prompt(test_key):

--- a/tests/test_auth_fast_path.py
+++ b/tests/test_auth_fast_path.py
@@ -90,6 +90,9 @@ def test_compile_fast_success(test_key):
         data = resp.json()
         assert data["heuristic_version"] == "v2-fast"
         assert "processing_ms" in data
+        assert "readiness" in data
+        assert data["readiness"]["verdict"] in {"ready", "clarify", "risky", "noise"}
+        assert isinstance(data.get("readiness_markdown"), str) and data["readiness_markdown"].strip()
 
 
 def test_compile_fast_trivial_input_forces_instruction_prompt(test_key):

--- a/tests/test_critique_verdict_enforcement.py
+++ b/tests/test_critique_verdict_enforcement.py
@@ -72,7 +72,7 @@ def test_compile_endpoint_blocks_unsafe_injection_input(client):
     mock_worker_result.optimized_content = "Test optimized content"
 
     # Use patch to mock both the compiler and the CriticAgent
-    with patch("app.optimizer.critic.CriticAgent", mock_critic_class), patch(
+    with patch("api.routes.compile.CriticAgent", mock_critic_class), patch(
         "api.routes.compile._get_compiler"
     ) as mock_get_compiler:
         mock_compiler = MagicMock()
@@ -170,7 +170,7 @@ def test_compile_endpoint_enforces_reject_verdict_without_critical_issue(client)
     mock_worker_result.optimized_content = "Write a hello world program in Python"
 
     # Use patch to mock both the compiler and the CriticAgent
-    with patch("app.optimizer.critic.CriticAgent", mock_critic_class), patch(
+    with patch("api.routes.compile.CriticAgent", mock_critic_class), patch(
         "api.routes.compile._get_compiler"
     ) as mock_get_compiler:
         mock_compiler = MagicMock()
@@ -254,7 +254,7 @@ def test_compile_endpoint_allows_accept_verdict(client):
     )
 
     # Use patch to mock both the compiler and the CriticAgent
-    with patch("app.optimizer.critic.CriticAgent", mock_critic_class), patch(
+    with patch("api.routes.compile.CriticAgent", mock_critic_class), patch(
         "api.routes.compile._get_compiler"
     ) as mock_get_compiler:
         mock_compiler = MagicMock()

--- a/tests/test_readiness_export.py
+++ b/tests/test_readiness_export.py
@@ -85,9 +85,8 @@ def test_compile_export_markdown_contains_all_sections():
 def test_compile_export_markdown_embeds_real_prompt_content():
     compiled = _compile()
     md = _export()["markdown"]
-    # The export must embed the actual compiled system prompt, not an empty
-    # placeholder section (anti-gaming).
-    sys_prompt = compiled["system_prompt"]
+    # Export prefers v2 prompt fields (same as web tabs and CLI compile-export).
+    sys_prompt = compiled.get("system_prompt_v2") or compiled["system_prompt"]
     assert sys_prompt[:30] in md
 
 

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -4,31 +4,17 @@ import { useState, useCallback } from "react";
 import { WifiOff } from "lucide-react";
 import ContextManager from "../components/ContextManager";
 import CopyButton from "../components/CopyButton";
+import ReadinessBanner from "../components/ReadinessBanner";
 import { describeRequestError } from "@/config";
 import { compilePrompt } from "../../lib/api/promptc";
 import type { CompileMode, CompileResponse } from "../../lib/api/types";
+import { getCompileTabContent } from "../../lib/compileTabContent";
 
 import InfoButton from "../components/InfoButton";
 
 type OfflineOutputTab = "system" | "user" | "plan" | "expanded" | "json";
 
 const OFFLINE_MODE: CompileMode = "conservative";
-
-function getOfflineTabContent(result: CompileResponse, activeTab: OfflineOutputTab): string {
-    if (activeTab === "system") {
-        return result.system_prompt_v2 || result.system_prompt || "";
-    }
-
-    if (activeTab === "user") {
-        return result.user_prompt_v2 || result.user_prompt || "";
-    }
-
-    if (activeTab === "plan") {
-        return result.plan_v2 || result.plan || "";
-    }
-
-    return result.expanded_prompt_v2 || result.expanded_prompt || "";
-}
 
 export default function OfflinePage() {
     const [prompt, setPrompt] = useState("");
@@ -207,6 +193,7 @@ export default function OfflinePage() {
                     <div className="relative flex min-h-[360px] w-full flex-col bg-black/30 md:min-h-0 md:w-[65%]">
                         {result ? (
                             <>
+                                {result.readiness && <ReadinessBanner report={result.readiness} />}
                                 <div role="tablist" aria-label="Output views" className="flex gap-1 overflow-x-auto scroll-smooth border-b border-white/5 px-4 pt-4 pb-1" style={{ maskImage: "linear-gradient(to right, black, black calc(100% - 24px), transparent)" }}>
                                     {(["system", "user", "plan", "expanded", "json"] as const).map((tab) => (
                                         <button
@@ -241,10 +228,10 @@ export default function OfflinePage() {
                                                 aria-label="Compiled prompt output"
                                                 className="w-full h-full bg-transparent p-6 font-mono text-sm text-zinc-300 resize-none focus:outline-none leading-relaxed selection:bg-orange-500/30"
                                                 readOnly
-                                                value={getOfflineTabContent(result, activeTab)}
+                                                value={getCompileTabContent(result, activeTab)}
                                             />
                                             <CopyButton
-                                                text={getOfflineTabContent(result, activeTab)}
+                                                text={getCompileTabContent(result, activeTab)}
                                                 className="absolute bottom-6 right-6"
                                                 variant="gray"
                                             />

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -14,7 +14,7 @@ import { useCompiler } from "./hooks/useCompiler";
 import { useContextManager } from "./hooks/useContextManager";
 
 import { describeRequestError } from "../config";
-import type { CompileMode, CompileResponse, ReadinessVerdict } from "../lib/api/types";
+import type { CompileMode, ReadinessVerdict } from "../lib/api/types";
 import { getCompileTabContent } from "../lib/compileTabContent";
 
 type OutputTab = "intent" | "system" | "user" | "plan" | "expanded" | "json" | "quality";

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,6 +15,7 @@ import { useContextManager } from "./hooks/useContextManager";
 
 import { describeRequestError } from "../config";
 import type { CompileMode, CompileResponse, ReadinessVerdict } from "../lib/api/types";
+import { getCompileTabContent } from "../lib/compileTabContent";
 
 type OutputTab = "intent" | "system" | "user" | "plan" | "expanded" | "json" | "quality";
 
@@ -24,22 +25,6 @@ const READINESS_LEGEND: { verdict: ReadinessVerdict; label: string }[] = [
   { verdict: "risky", label: "Risky" },
   { verdict: "noise", label: "Not a task" },
 ];
-
-function getTabContent(result: CompileResponse, activeTab: OutputTab): string {
-  if (activeTab === "system") {
-    return result.system_prompt_v2 || result.system_prompt;
-  }
-
-  if (activeTab === "user") {
-    return result.user_prompt_v2 || result.user_prompt;
-  }
-
-  if (activeTab === "plan") {
-    return result.plan_v2 || result.plan;
-  }
-
-  return result.expanded_prompt_v2 || result.expanded_prompt;
-}
 
 function TabButton({
   tabKey,
@@ -462,11 +447,11 @@ export default function Home() {
                           aria-label="Compiled prompt output"
                           className="w-full h-full overflow-y-auto bg-transparent p-6 pb-24 font-mono text-sm text-zinc-300 resize-none focus:outline-none leading-relaxed selection:bg-blue-500/30"
                           readOnly
-                          value={getTabContent(result, tab)}
+                          value={getCompileTabContent(result, tab)}
                         />
 
                         <CopyButton
-                          text={getTabContent(result, tab)}
+                          text={getCompileTabContent(result, tab)}
                           className="absolute bottom-6 right-6"
                         />
                       </>

--- a/web/lib/compileTabContent.test.ts
+++ b/web/lib/compileTabContent.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getCompileTabContent } from "./compileTabContent";
+import type { CompileResponse } from "./api/types";
+
+function makeResult(overrides: Partial<CompileResponse> = {}): CompileResponse {
+  return {
+    ir: {},
+    system_prompt: "v1-system",
+    user_prompt: "v1-user",
+    plan: "v1-plan",
+    expanded_prompt: "v1-expanded",
+    system_prompt_v2: "v2-system",
+    user_prompt_v2: "v2-user",
+    plan_v2: "v2-plan",
+    expanded_prompt_v2: "v2-expanded",
+    processing_ms: 1,
+    request_id: "req_test",
+    heuristic_version: "v1",
+    ...overrides,
+  };
+}
+
+describe("getCompileTabContent", () => {
+  it("prefers v2 fields for each tab", () => {
+    const result = makeResult();
+    expect(getCompileTabContent(result, "system")).toBe("v2-system");
+    expect(getCompileTabContent(result, "user")).toBe("v2-user");
+    expect(getCompileTabContent(result, "plan")).toBe("v2-plan");
+    expect(getCompileTabContent(result, "expanded")).toBe("v2-expanded");
+  });
+
+  it("falls back to v1 when v2 is missing", () => {
+    const result = makeResult({
+      system_prompt_v2: null,
+      user_prompt_v2: undefined,
+      plan_v2: "",
+      expanded_prompt_v2: null,
+    });
+    expect(getCompileTabContent(result, "system")).toBe("v1-system");
+    expect(getCompileTabContent(result, "user")).toBe("v1-user");
+    expect(getCompileTabContent(result, "plan")).toBe("v1-plan");
+    expect(getCompileTabContent(result, "expanded")).toBe("v1-expanded");
+  });
+});

--- a/web/lib/compileTabContent.ts
+++ b/web/lib/compileTabContent.ts
@@ -1,0 +1,23 @@
+import type { CompileResponse } from "./api/types";
+
+export type CompileOutputTab = "system" | "user" | "plan" | "expanded";
+
+/** Prefer v2 prompt fields when present — matches API/CLI export behavior. */
+export function getCompileTabContent(
+  result: CompileResponse,
+  activeTab: CompileOutputTab,
+): string {
+  if (activeTab === "system") {
+    return result.system_prompt_v2 || result.system_prompt || "";
+  }
+
+  if (activeTab === "user") {
+    return result.user_prompt_v2 || result.user_prompt || "";
+  }
+
+  if (activeTab === "plan") {
+    return result.plan_v2 || result.plan || "";
+  }
+
+  return result.expanded_prompt_v2 || result.expanded_prompt || "";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Targeted code quality improvements across recently shipped features (domain expertise compile, readiness export, offline compile UI, compile export API).

## What changed

### Backend
- **`domain_expert.py`**: Removed unused module-level `analyze_domain()` helper; hoisted `hashlib` import to module top (no-inline-imports rule).
- **`api/routes/compile.py`**: Hoisted `CriticAgent`, `merge_policy_from_critique`, and `SafetyHandler` imports; extracted `_serialize_readiness()` to dedupe fast-path and full compile logic; added `_export_prompt_fields()` so `/compile/export` prefers v2 prompt fields — matching CLI `compile-export` and web tab content.

### Frontend
- **`web/lib/compileTabContent.ts`**: Shared helper for v2-first tab content selection (replaces duplicated logic in main and offline pages).
- **`web/app/offline/page.tsx`**: Shows `ReadinessBanner` when readiness data is present (parity with main compiler page).

### Tests
- Fast compile path now asserts `readiness` + `readiness_markdown` are returned.
- Export content test updated to expect v2 prompt fields in markdown.
- New unit tests for `getCompileTabContent`.

## Product impact

- **Export consistency**: Downloaded `.md` exports now match what users see in the UI tabs and CLI output.
- **Offline UX**: Offline mode users get the same readiness traffic-light feedback as the main compiler.
- **Maintainability**: Less duplicated readiness/tab logic; fewer inline imports.

## Risk

Low — behavior-preserving except export now correctly prefers v2 fields when available (intentional bugfix). All focused tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1be4-3828-7936-a4e8-55e7f0ccd561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1be4-3828-7936-a4e8-55e7f0ccd561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

