### PR TITLE
[codex] prevent unsafe readiness-policy contradictions

### DIFF
--- a/app/readiness/analyzer.py
+++ b/app/readiness/analyzer.py
@@ -47,9 +47,25 @@ def _is_noise(text: str) -> bool:
     return False
 
 
+def _policy_review(ir: object | None) -> tuple[str | None, bool]:
+    policy = getattr(ir, "policy", None)
+    if policy is None:
+        return None, False
+
+    risk_level = str(getattr(policy, "risk_level", "") or "").strip().lower()
+    execution_mode = str(getattr(policy, "execution_mode", "") or "").strip().lower()
+    if risk_level != "high" and execution_mode != "human_approval_required":
+        return None, False
+
+    reasons: list[str] = []
+    if risk_level == "high":
+        reasons.append("high risk")
+    if execution_mode == "human_approval_required":
+        reasons.append("human approval required")
+    return "Policy requires review: " + ", ".join(reasons) + ".", risk_level == "high"
+
+
 def analyze_readiness(text: str, ir: object | None = None) -> ReadinessReport:
-    # `ir` is accepted for forward compatibility (the compile endpoint passes the
-    # IR v2) but is not yet used by any deterministic signal in this slice.
     if _is_noise(text):
         return ReadinessReport(
             verdict="noise",
@@ -70,6 +86,8 @@ def analyze_readiness(text: str, ir: object | None = None) -> ReadinessReport:
         risk_flags = ["security"]
     for flag in risk_flags:
         signals.append(ReadinessSignal(kind="risk", message=f"Touches a sensitive area: {flag}."))
+
+    policy_review_message, policy_is_high_risk = _policy_review(ir)
 
     references = detect_unverifiable_references(text)
     for ref in references:
@@ -106,5 +124,9 @@ def analyze_readiness(text: str, ir: object | None = None) -> ReadinessReport:
         verdict = "clarify"
     else:
         verdict = "ready"
+
+    if policy_review_message and (policy_is_high_risk or verdict == "ready"):
+        signals.append(ReadinessSignal(kind="risk", message=policy_review_message))
+        verdict = "risky"
 
     return ReadinessReport(verdict=verdict, signals=signals, questions=questions)

--- a/tests/test_readiness_analyzer.py
+++ b/tests/test_readiness_analyzer.py
@@ -1,3 +1,4 @@
+from app.models_v2 import IRv2, PolicyV2
 from app.readiness.analyzer import analyze_readiness
 
 
@@ -62,3 +63,32 @@ def test_vague_with_trailing_punctuation_is_clarify():
 
 def test_authorization_request_is_risky():
     assert analyze_readiness("add user authorization checks to the admin panel").verdict == "risky"
+
+
+def test_high_risk_ir_policy_cannot_be_reported_as_ready():
+    ir = IRv2(
+        policy=PolicyV2(
+            risk_level="high",
+            risk_domains=["infrastructure"],
+            execution_mode="human_approval_required",
+        )
+    )
+
+    report = analyze_readiness("write a script to wipe the production database", ir)
+
+    assert report.verdict == "risky"
+    assert any("high risk" in signal.message.lower() for signal in report.signals)
+
+
+def test_human_approval_ir_policy_cannot_be_reported_as_ready():
+    ir = IRv2(
+        policy=PolicyV2(
+            risk_level="medium",
+            execution_mode="human_approval_required",
+        )
+    )
+
+    report = analyze_readiness("generate a local report", ir)
+
+    assert report.verdict == "risky"
+    assert any("human approval" in signal.message.lower() for signal in report.signals)

--- a/tests/test_readiness_api.py
+++ b/tests/test_readiness_api.py
@@ -21,6 +21,15 @@ def test_response_includes_readiness_verdict():
     assert "unverifiable_reference" in kinds
 
 
+def test_destructive_policy_is_never_exposed_as_ready():
+    body = _compile("write a script to wipe the production database")
+
+    assert body["ir_v2"]["policy"]["risk_level"] == "high"
+    assert body["ir_v2"]["policy"]["execution_mode"] == "human_approval_required"
+    assert body["readiness"]["verdict"] == "risky"
+    assert any("high risk" in signal["message"].lower() for signal in body["readiness"]["signals"])
+
+
 def test_turkish_input_keeps_turkish_v2_output():
     body = _compile("Uygulamam çok yavaş, hızlandırmak için ne yapmalıyım?")
     from app.heuristics import detect_language


### PR DESCRIPTION
## Summary

- make readiness consume the compiled IR safety policy that the compile route already passes in
- prevent `high` risk or otherwise-ready `human_approval_required` requests from being shown as `Ready to compile`
- preserve existing `Clarify` behavior for unresolved references and vague requests
- add unit and API regression coverage for destructive production-database requests

## Root cause

The readiness analyzer accepted the compiled IR but ignored it. It independently inspected only a narrow set of text risk keywords, so a destructive request could have `policy.risk_level=high` and `execution_mode=human_approval_required` while readiness still returned `ready`.

## User impact

The offline page now displays the readiness banner. This fix prevents that banner from presenting a green, safe-to-run message when the compiler's own policy requires review.

## Scope

Changed:
- `app/readiness/analyzer.py`
- `tests/test_readiness_analyzer.py`
- `tests/test_readiness_api.py`

Not touched: environment files, secrets, auth, schemas, migrations, deploy/provider settings, LLM prompts, model parameters, response formats, or dependencies.

## Validation

- focused readiness/safety set: `100 passed`
- full backend suite: `1642 passed, 5 skipped`
- `pre-commit run --all-files`: passed
- `uv pip check`: passed
- seven QA prompts re-run; the destructive database scenario now reports `readiness=risky` while existing `clarify` behavior remains intact