### PR TITLE
fix(heuristics): stop off-domain bleed on infra tasks; correct front-end download classification (S1/S5)

### DIFF
--- a/app/compiler.py
+++ b/app/compiler.py
@@ -569,7 +569,8 @@ def compile_text(text: str) -> IR:
             output_format = "table"
     if variant_count > 1:
         add_constraint(f"Generate {variant_count} distinct variants", "variants")
-    if risk_flags:
+    professional_advice_domains = {"financial", "health", "legal"}
+    if professional_advice_domains.intersection(risk_flags):
         if lang == "tr":
             add_constraint(
                 "Riskli alan: profesyonel tavsiye yerine genel bilgi ver (finans/tıp/hukuk)",

--- a/app/emitters.py
+++ b/app/emitters.py
@@ -4,6 +4,7 @@ import itertools
 import os
 from .models import IR
 from .models_v2 import IRv2, ConstraintV2, StepV2
+from .heuristics import detect_frontend_download_feature
 
 
 def emit_system_prompt(ir: IR) -> str:
@@ -64,6 +65,11 @@ _FOLLOWUP_SETS = {
         "Which browser and version is affected, and does it work in others?",
         "What are the exact reproduction steps and any console or network errors?",
         "What is the expected behavior versus what actually happens?",
+    ],
+    "browser_feature": [
+        "Which file format, filename, and data should the download include?",
+        "Should the file be generated in the browser or returned by a server endpoint?",
+        "Which browsers and accessibility states must the download control support?",
     ],
     "payment": [
         "Are API keys and secrets kept server-side only (never exposed in the browser)?",
@@ -129,10 +135,7 @@ def _scenario_considerations(ir) -> list[str]:
     for attr in ("goals", "tasks"):
         parts.extend(getattr(ir, attr, None) or [])
     text = " ".join(parts).lower()
-    # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
-    if _contains_any_marker(
-        text, ("safari", "chrome", "firefox", "browser")
-    ) and _contains_any_marker(text, ("download", "export", "save file", "save the file")):
+    if detect_frontend_download_feature(text):
         return _SCENARIO_CONSIDERATIONS["browser_download"]
     # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
     if "log" in text and _contains_any_marker(
@@ -176,6 +179,8 @@ def _relevant_followups(ir) -> list[str]:
         ),
     ):
         return _FOLLOWUP_SETS["perf"]
+    if detect_frontend_download_feature(text):
+        return _FOLLOWUP_SETS["browser_feature"]
     # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
     if _contains_any_marker(
         text, ("browser", "safari", "chrome", "firefox", "css", "render", "button")

--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -462,6 +462,26 @@ def _contains_any_keyword(text: str, keywords: list[str]) -> bool:
     return False
 
 
+_FRONTEND_DOWNLOAD_ACTION_RE = re.compile(r"\b(?:download|export)\b", re.IGNORECASE)
+_FRONTEND_FEATURE_ADD_RE = re.compile(
+    r"\b(?:add|allow|build|create|enable|give|implement|let)\b",
+    re.IGNORECASE,
+)
+_FRONTEND_DOWNLOAD_SURFACE_RE = re.compile(
+    r"\b(?:button|web\s*app|dashboard|browser|frontend|page|users?)\b",
+    re.IGNORECASE,
+)
+
+
+def detect_frontend_download_feature(text: str) -> bool:
+    """Detect user-facing browser download/export feature requests."""
+    return bool(
+        _FRONTEND_DOWNLOAD_ACTION_RE.search(text)
+        and _FRONTEND_FEATURE_ADD_RE.search(text)
+        and _FRONTEND_DOWNLOAD_SURFACE_RE.search(text)
+    )
+
+
 def detect_creative_intent(text: str) -> bool:
     return _contains_any_keyword(text, CREATIVE_INTENT_KEYWORDS)
 
@@ -1162,8 +1182,12 @@ def detect_domain(text: str) -> Tuple[str, List[str]]:
         for raw, pattern in pats:
             if pattern.search(text):
                 evidence.append(f"{domain}:{raw}")
+    if detect_frontend_download_feature(text):
+        evidence.append("software:frontend_download_feature")
     if not evidence:
         return "general", []
+    if any(ev == "software:frontend_download_feature" for ev in evidence):
+        return "software", evidence
     # Choose the domain with most evidence counts
     counts: Dict[str, int] = {}
     for ev in evidence:

--- a/app/heuristics/handlers/domain_expert.py
+++ b/app/heuristics/handlers/domain_expert.py
@@ -260,7 +260,6 @@ DOMAIN_RULES: Dict[str, Dict] = {
             "script",
             "prose",
             "creative",
-            "write",
             "protagonist",
             "antagonist",
             "setting",
@@ -713,6 +712,8 @@ class DomainHandler(BaseHandler):
         """
         original_text = (ir_v1.metadata or {}).get("original_text", "")
         detected_domain = ir_v2.domain.lower() if ir_v2.domain else "general"
+        if "infrastructure" in ir_v2.policy.risk_domains:
+            detected_domain = "infrastructure"
 
         # Perform domain analysis
         analysis = self.analyze_domain(original_text, detected_domain)
@@ -891,6 +892,8 @@ class DomainHandler(BaseHandler):
         # The upstream IR domain uses "software"; this analyzer calls it "coding".
         if hint == "software":
             hint = "coding"
+        if hint == "infrastructure":
+            return hint
         # Trust the hint if it's valid
         if hint and hint in DOMAIN_RULES:
             return hint

--- a/app/heuristics/handlers/policy.py
+++ b/app/heuristics/handlers/policy.py
@@ -3,7 +3,11 @@ import re
 from .base import BaseHandler
 from app.models import IR
 from app.models_v2 import IRv2
-from app.heuristics import _contains_any_keyword, detect_destructive_operation
+from app.heuristics import (
+    _contains_any_keyword,
+    detect_destructive_operation,
+    detect_frontend_download_feature,
+)
 
 
 class PolicyHandler(BaseHandler):
@@ -20,18 +24,34 @@ class PolicyHandler(BaseHandler):
 
     _FILE_KEYWORDS = (
         "file",
+        "files",
+        "filesystem",
         "path",
+        "paths",
         "directory",
+        "directories",
         "folder",
+        "folders",
         "repo",
+        "repos",
         "repository",
+        "repositories",
         "log",
         "logs",
         "shell",
+        "shells",
         "terminal",
+        "terminals",
         "system",
+        "systems",
         "workspace",
+        "workspaces",
         "database",
+        "databases",
+    )
+    _FILE_KEYWORD_PATTERN = re.compile(
+        r"\b(?:" + "|".join(re.escape(keyword) for keyword in _FILE_KEYWORDS) + r")\b",
+        re.IGNORECASE,
     )
 
     _DOMAIN_TOOL_RULES: dict[str, dict[str, list[str]]] = {
@@ -99,8 +119,10 @@ class PolicyHandler(BaseHandler):
         risk_score = len(set(risk_flags))
 
         has_path = self._has_explicit_path(original_text)
-        # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
-        file_or_system_request = has_path or _contains_any_keyword(text, self._FILE_KEYWORDS)
+        frontend_download_feature = detect_frontend_download_feature(original_text)
+        file_or_system_request = has_path or (
+            bool(self._FILE_KEYWORD_PATTERN.search(text)) and not frontend_download_feature
+        )
         debug_request = bool(md.get("code_request")) or bool(persona_flags.get("live_debug"))
         destructive = detect_destructive_operation(original_text)
         educational_request = self._is_educational_request(text)

--- a/tests/test_qa_report_gate.py
+++ b/tests/test_qa_report_gate.py
@@ -1,0 +1,136 @@
+"""Acceptance gate for the two high-severity July 1 browser QA findings."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.compiler import compile_text_v2
+from app.emitters import emit_expanded_prompt_v2, emit_plan_v2
+
+OFFDOMAIN_BANNED = [
+    "stakes early",
+    "character motivations",
+    "immersion",
+    "narrative",
+    "protagonist",
+    "plot",
+    "provide general information, not professional advice",
+    "not legal advice",
+    "consult a professional",
+]
+BROWSER_DL_MARKERS = [
+    "blob",
+    "object url",
+    "user gesture",
+    "user-gesture",
+    "content-disposition",
+]
+DEBUG_FOLLOWUP_MARKERS = [
+    "reproduction steps",
+    "which browser and version",
+    "expected behavior versus what actually happens",
+    "expected behaviour versus",
+]
+INFRA_DESTRUCTIVE = [
+    "Write a script to wipe the production database",
+    "Drop all tables in the production database",
+    "Delete everything in the production database",
+]
+FRONTEND_ADD = [
+    "Add a button to download the report as a PDF in my web app",
+    "Add a CSV export button to my dashboard",
+    "Let users download their data as a JSON file",
+]
+
+
+def _compile_twice(prompt: str):
+    first_ir = compile_text_v2(prompt, offline_only=True)
+    first_expanded = emit_expanded_prompt_v2(first_ir)
+    second_ir = compile_text_v2(prompt, offline_only=True)
+    second_expanded = emit_expanded_prompt_v2(second_ir)
+
+    assert first_expanded == second_expanded
+    assert first_ir.model_dump() == second_ir.model_dump()
+    return first_ir, first_expanded.lower()
+
+
+@pytest.mark.parametrize("prompt", INFRA_DESTRUCTIVE)
+def test_gate_1_infrastructure_output_has_no_off_domain_advice(prompt):
+    _, expanded = _compile_twice(prompt)
+
+    assert not [marker for marker in OFFDOMAIN_BANNED if marker in expanded]
+
+
+@pytest.mark.parametrize("prompt", INFRA_DESTRUCTIVE)
+def test_gate_1_safety_stays_high_and_actionable(prompt):
+    ir, expanded = _compile_twice(prompt)
+
+    assert ir.policy.risk_level == "high"
+    assert ir.policy.execution_mode == "human_approval_required"
+    assert any(marker in expanded for marker in ("backup", "dry run", "rollback"))
+
+
+@pytest.mark.parametrize("prompt", FRONTEND_ADD)
+def test_gate_2_frontend_download_features_are_low_risk(prompt):
+    ir, _ = _compile_twice(prompt)
+
+    assert ir.policy.risk_level == "low"
+    assert ir.policy.execution_mode == "auto_ok"
+
+
+@pytest.mark.parametrize("prompt", FRONTEND_ADD)
+def test_gate_2_frontend_download_features_include_browser_gotchas(prompt):
+    _, expanded = _compile_twice(prompt)
+
+    assert any(marker in expanded for marker in BROWSER_DL_MARKERS)
+
+
+@pytest.mark.parametrize("prompt", FRONTEND_ADD)
+def test_gate_2_frontend_feature_followups_are_not_debugging_questions(prompt):
+    _, expanded = _compile_twice(prompt)
+
+    assert not [marker for marker in DEBUG_FOLLOWUP_MARKERS if marker in expanded]
+
+
+def test_gate_2_existing_download_bug_keeps_debugging_followups():
+    _, expanded = _compile_twice("The download button is broken in Safari; help me fix it")
+
+    assert any(marker in expanded for marker in DEBUG_FOLLOWUP_MARKERS)
+
+
+def test_gate_3_nginx_security_considerations_still_fire():
+    _, expanded = _compile_twice(
+        "Analyze my nginx logs to find failed login / brute-force attempts"
+    )
+
+    markers = ("401", "403", "sliding window", "false positive")
+    assert sum(marker in expanded for marker in markers) >= 2
+
+
+def test_gate_3_stripe_considerations_still_fire():
+    _, expanded = _compile_twice("Integrate Stripe checkout into my Next.js app")
+
+    assert "test" in expanded and "live" in expanded
+    assert "gross" in expanded or "net" in expanded
+
+
+def test_gate_3_react_performance_considerations_still_fire():
+    _, expanded = _compile_twice("My React table is slow and re-renders too much, help me fix it")
+
+    assert any(marker in expanded for marker in ("memo", "re-render", "rerender", "virtualiz"))
+
+
+def test_gate_3_greeting_stays_low_risk_and_minimal():
+    ir, expanded = _compile_twice("hi")
+
+    assert ir.policy.risk_level == "low"
+    assert ir.policy.execution_mode == "auto_ok"
+    assert "optional considerations" not in expanded
+    assert "follow-up questions" not in expanded
+    assert "project plan" not in expanded
+
+
+def test_gate_3_ambiguous_request_keeps_clarify_step():
+    ir, _ = _compile_twice("make it better")
+
+    assert "[clarify]" in emit_plan_v2(ir).lower()


### PR DESCRIPTION
## Summary

Fixes both high-severity findings from the July 1 browser QA report using the deterministic offline path:

- destructive infrastructure requests no longer receive creative-writing or professional-advice guidance
- user-facing download/export feature requests stay low-risk, receive concrete browser download gotchas, and ask feature-design questions instead of debugging questions
- preserves the existing nginx, Stripe, React performance, greeting, and ambiguity behavior

## Root cause

1. The legacy compiler added a professional-advice constraint for every risk domain, including infrastructure.
2. Domain suggestions could infer creative writing from the generic word `write`, even after policy had identified an infrastructure task.
3. File/system policy matching used substring checks, so `report` matched `repo`; genuine browser download features were treated like filesystem access.
4. Browser considerations required an explicit browser name, while every `button` was routed to bug-reproduction follow-ups.

## Implementation

- restrict professional-advice constraints to financial, health, and legal domains
- make infrastructure policy context authoritative for domain suggestions and remove `write` as a standalone creative-writing signal
- add a shared feature-add detector for user-facing download/export requests
- use word-bounded file/system matching while preserving explicit filesystem and plural keyword coverage
- reuse the feature detector for policy, software-domain evidence, browser gotchas, and feature-specific follow-ups
- add `tests/test_qa_report_gate.py` with two-run determinism checks and all required regression scenarios

## Validation

- `pytest tests/test_qa_report_gate.py -q`: **21 passed**
- focused heuristics/policy/regression set: **134 passed**
- `pytest tests/ -q`: **1663 passed, 5 skipped**
- `ruff check .`: passed
- Ruff format check on all six changed files: passed
- `pre-commit run --all-files`: passed
- `uv pip check`: passed

## Boundaries untouched

- `app/readiness/` and readiness-policy integration
- `.env` files and secrets
- auth and database schemas/migrations
- deploy/provider configuration
- LLM prompts, temperature, response format, model parameters
- dependencies and lockfiles
- frontend, CLI, integrations, and production data