### PR TITLE
fix(heuristics): add word boundaries to live-debug keywords

### DIFF
--- a/app/heuristics/__init__.py
+++ b/app/heuristics/__init__.py
@@ -704,7 +704,11 @@ LIVE_DEBUG_KEYWORDS = [
     r"istisna",
 ]
 
-_JOINED_LIVE_DEBUG = re.compile("|".join(LIVE_DEBUG_KEYWORDS))
+# Word boundaries prevent substring false positives: "logs?" must not match
+# inside "login"/"blog"/"catalog", "mre" inside unrelated tokens, etc. The
+# keywords intentionally contain regex (e.g. "logs?"), so we wrap with \b rather
+# than re.escape. Mirrors the fix already applied to _TEACHING_RE above.
+_JOINED_LIVE_DEBUG = re.compile("|".join(rf"\b{keyword}\b" for keyword in LIVE_DEBUG_KEYWORDS))
 
 
 def detect_live_debug(text: str) -> bool:

--- a/tests/test_detect_live_debug.py
+++ b/tests/test_detect_live_debug.py
@@ -11,3 +11,20 @@ def test_detect_live_debug_false_cases():
     assert detect_live_debug("How do I write a Python function?") is False
     assert detect_live_debug("Explain quantum physics") is False
     assert detect_live_debug("") is False
+
+
+def test_detect_live_debug_ignores_substring_false_positives():
+    # Keywords like "logs?" must not substring-match unrelated words such as
+    # "login", "blog", "catalog", or "dialog" (regression for the missing
+    # word boundaries in _JOINED_LIVE_DEBUG).
+    assert detect_live_debug("Implement secure login sessions") is False
+    assert detect_live_debug("write a blog post") is False
+    assert detect_live_debug("browse the catalog") is False
+    assert detect_live_debug("open the dialog box") is False
+
+
+def test_detect_live_debug_matches_log_and_debug_keywords():
+    # Genuine log/debug cues must still be detected once word boundaries are added.
+    assert detect_live_debug("check the error log") is True
+    assert detect_live_debug("attach the logs") is True
+    assert detect_live_debug("help me debug this stack trace") is True


### PR DESCRIPTION
## Problem
`_JOINED_LIVE_DEBUG` in `app/heuristics/__init__.py` joined `LIVE_DEBUG_KEYWORDS` with `re.compile("|".join(...))` and **no word boundaries**. Patterns like `logs?` therefore substring-matched unrelated words — `login`, `blog`, `catalog`, `dialog`.

This made `detect_live_debug()` return `True` for benign prompts (e.g. "Implement secure login sessions"), which cascaded:

`detect_live_debug` → `detect_troubleshooting_intent` / `live_debug` flag → `ContentHandler` + `LiveDebugHandler` add spurious `troubleshooting`/`debug` intents → `PolicyHandler` sets `debug_request=True` → escalates policy to `risk_level=medium` with `execution_mode=human_approval_required`.

The result: harmless requests were misclassified as live-debug and forced into human approval.

## Fix
Wrap each keyword with `\b…\b`. This mirrors the fix already applied to `_TEACHING_RE` (same file, ~line 169, with a comment documenting the identical substring bug). We wrap with `\b` rather than reusing that helper's `re.escape`, because these keywords intentionally contain regex (e.g. the `?` in `logs?`), which `re.escape` would neutralize.

## Tests
Added regression tests in `tests/test_detect_live_debug.py`:
- **Must be `False`:** "Implement secure login sessions", "write a blog post", "browse the catalog", "open the dialog box"
- **Must stay `True`:** "check the error log", "attach the logs", "help me debug this stack trace"

## Verification
- Full backend suite: **1692 passed, 5 skipped**. The one unrelated failure (`test_cli_new_features.py::test_validate_summary_and_api_schemas`) is an environmental flake — its opportunistic branch assumes port 8000 is the Compiler API, but a local Docker process on 8000 returns 404. Not caused by this change.
- `ruff check .` → clean.

## Scope
Two files, no out-of-scope changes:
- `app/heuristics/__init__.py` (+5/-1)
- `tests/test_detect_live_debug.py` (+17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)