### PR TITLE
feat(compiler): adaptive exploration modes per plan step (entropy scheduling)

### DIFF
--- a/app/_schemas/ir_v2.schema.json
+++ b/app/_schemas/ir_v2.schema.json
@@ -192,6 +192,40 @@
           },
           "text": {
             "type": "string"
+          },
+          "scheduling": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "enum": [
+                  "explore",
+                  "decide",
+                  "execute",
+                  "verify"
+                ]
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "confidence": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "additionalProperties": true
           }
         },
         "additionalProperties": false

--- a/app/compiler.py
+++ b/app/compiler.py
@@ -51,6 +51,7 @@ from .heuristics.handlers.policy import PolicyHandler
 from .heuristics.handlers.format_enforcer import FormatEnforcerHandler
 from .heuristics.handlers.paradox_resolver import ParadoxResolverHandler
 from .heuristics.handlers.deduplicator import DeduplicatorHandler
+from .heuristics.handlers.exploration import ExplorationHandler
 from .heuristics.handlers.schema_sanitizer import SchemaSanitizerHandler
 
 logger = logging.getLogger(__name__)
@@ -305,6 +306,7 @@ def compile_text_v2(
         FormatEnforcerHandler(),
         ParadoxResolverHandler(),
         DeduplicatorHandler(),
+        ExplorationHandler(),  # last: needs final intents + policy
     ]
 
     for handler in handlers:

--- a/app/emitters.py
+++ b/app/emitters.py
@@ -141,6 +141,122 @@ _SCENARIO_CONSIDERATIONS = {
 }
 
 
+# Exploration-mode scheduling (see heuristics/handlers/exploration.py).
+# Rendering reads only scheduling.mode; reason/confidence are for future
+# consumers (agent packs, analytics, benchmarking). Behavioral text only —
+# no sampling parameters, no jargon.
+_PLAN_MODE_RATIONALE = {
+    "explore": (
+        "Rationale: the cause is not yet established; list plausible explanations "
+        "and test them against evidence before committing to a fix"
+    ),
+    "decide": (
+        "Rationale: converge on one option by impact, effort, and risk; "
+        "do not keep exploring once a choice is justified"
+    ),
+    "verify": (
+        "Rationale: high-impact change; confirm edge cases and regressions "
+        "instead of assuming success"
+    ),
+}
+
+_PLAN_PSEUDO_STEP_TEXT = {
+    "decide": "Choose one likely cause or approach to pursue before making changes.",
+    "verify": "Re-check the result against the original request before treating it as done.",
+}
+
+_MODE_DIRECTIVES = {
+    "en": {
+        "explore": (
+            "Start by listing the plausible causes or approaches and check them against "
+            "the evidence; do not commit to changes while the cause is still unknown."
+        ),
+        "decide": (
+            "Pick one option based on impact, effort, and risk, and state briefly why it "
+            "wins; stop exploring once a choice is justified."
+        ),
+        "execute": (
+            "Carry out the chosen work exactly as scoped; do not add requirements, "
+            "dependencies, or scope beyond what was asked."
+        ),
+        "verify": (
+            "Before finishing, re-check the result against the original request, including "
+            "edge cases and possible regressions; do not treat unverified output as done."
+        ),
+    },
+    "tr": {
+        "explore": (
+            "Önce olası nedenleri veya yaklaşımları listele ve kanıtlarla karşılaştır; "
+            "neden belirsizken değişiklik yapmaya başlama."
+        ),
+        "decide": (
+            "Etki, maliyet ve riske göre tek bir seçenek belirle ve nedenini kısaca "
+            "açıkla; karar verildikten sonra keşfe geri dönme."
+        ),
+        "execute": (
+            "Seçilen işi tam olarak istenen kapsamda uygula; istenmeyen gereksinim, "
+            "bağımlılık veya kapsam ekleme."
+        ),
+        "verify": (
+            "Bitirmeden önce sonucu özgün istekle karşılaştır; uç durumları ve olası "
+            "gerilemeleri kontrol etmeden işi bitmiş sayma."
+        ),
+    },
+    "es": {
+        "explore": (
+            "Primero enumera las causas o enfoques plausibles y contrástalos con la "
+            "evidencia; no hagas cambios mientras la causa siga siendo desconocida."
+        ),
+        "decide": (
+            "Elige una opción según impacto, esfuerzo y riesgo, y explica brevemente por "
+            "qué; deja de explorar una vez justificada la elección."
+        ),
+        "execute": (
+            "Ejecuta el trabajo elegido exactamente según lo acordado; no añadas "
+            "requisitos, dependencias ni alcance extra."
+        ),
+        "verify": (
+            "Antes de terminar, contrasta el resultado con la solicitud original, "
+            "incluidos casos límite y posibles regresiones; no des por terminado un "
+            "resultado sin verificar."
+        ),
+    },
+}
+
+_MODE_LABELS = {
+    "en": {"explore": "Explore", "decide": "Decide", "execute": "Execute", "verify": "Verify"},
+    "tr": {"explore": "Keşfet", "decide": "Karar ver", "execute": "Uygula", "verify": "Doğrula"},
+    "es": {"explore": "Explorar", "decide": "Decidir", "execute": "Ejecutar", "verify": "Verificar"},
+}
+
+
+def _step_mode(step) -> str | None:
+    """Scheduling mode of a step, tolerating objects without the attribute."""
+    return getattr(getattr(step, "scheduling", None), "mode", None)
+
+
+def _scheduled_modes(ir) -> list[str]:
+    """Modes to surface in the Working approach section, in fixed order.
+
+    Empty for an untouched compile (suppression rule): the section renders only
+    when explore/decide/verify was actually scheduled — a lone execute tag or a
+    silent profile must not create a section.
+    """
+    modes: set[str] = set()
+    for step in getattr(ir, "steps", None) or []:
+        mode = _step_mode(step)
+        if mode:
+            modes.add(mode)
+    profile = (getattr(ir, "metadata", None) or {}).get("uncertainty_profile") or {}
+    profile_modes = profile.get("modes") or {}
+    for name in ("explore", "decide", "verify"):
+        if (profile_modes.get(name) or {}).get("scheduled"):
+            modes.add(name)
+    if not modes & {"explore", "decide", "verify"}:
+        return []
+    return [m for m in ("explore", "decide", "execute", "verify") if m in modes]
+
+
 def _contains_any_marker(text: str, markers: tuple[str, ...]) -> bool:
     """Fast-path helper to bypass any() generator overhead."""
     for marker in markers:
@@ -835,14 +951,33 @@ def emit_plan_v2(ir: IRv2) -> str:
             f"{step_number}. [policy] Pause for human approval before executing or relying on tools.\n"
             f"   {rationale}"
         )
+    profile_modes = ((ir.metadata or {}).get("uncertainty_profile") or {}).get("modes") or {}
+    decide_pending = bool((profile_modes.get("decide") or {}).get("scheduled"))
+    verify_scheduled = bool((profile_modes.get("verify") or {}).get("scheduled"))
     steps = ir.steps if ir.steps else [StepV2(type="task", text=t) for t in ir.tasks]
-    for i, step in enumerate(steps, start=1):
+    for step in steps:
         step_number = len(out) + 1
-        rationale = (
-            "Rationale: complete the user's stated task without adding unstated requirements"
-        )
         kind = step.type if hasattr(step, "type") else "task"
-        out.append(f"{step_number}. [{kind}] {step.text}\n   {rationale}")
+        mode = _step_mode(step)
+        if mode in _PLAN_MODE_RATIONALE:
+            # explore/verify tags; execute and untagged render identically below
+            out.append(f"{step_number}. [{kind}] ({mode}) {step.text}\n   {_PLAN_MODE_RATIONALE[mode]}")
+        else:
+            rationale = (
+                "Rationale: complete the user's stated task without adding unstated requirements"
+            )
+            out.append(f"{step_number}. [{kind}] {step.text}\n   {rationale}")
+        if mode == "explore" and decide_pending:
+            decide_pending = False  # one convergence point per plan
+            out.append(
+                f"{len(out) + 1}. [decide] {_PLAN_PSEUDO_STEP_TEXT['decide']}\n"
+                f"   {_PLAN_MODE_RATIONALE['decide']}"
+            )
+    if verify_scheduled and out:
+        out.append(
+            f"{len(out) + 1}. [verify] {_PLAN_PSEUDO_STEP_TEXT['verify']}\n"
+            f"   {_PLAN_MODE_RATIONALE['verify']}"
+        )
     return (
         "\n".join(out)
         if out
@@ -1008,6 +1143,21 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
         )
         for q in clarify_all[:5]:
             prompt.append(f"- {q}")
+
+    # Working approach: latitude directives for the scheduled exploration modes.
+    # Suppressed entirely when the scheduler did not engage (anti-boilerplate).
+    scheduled_modes = _scheduled_modes(ir)
+    if scheduled_modes:
+        header_wa = (
+            "Çalışma yaklaşımı"
+            if lang == "tr"
+            else ("Enfoque de trabajo" if lang == "es" else "Working approach")
+        )
+        directives = _MODE_DIRECTIVES.get(lang) or _MODE_DIRECTIVES["en"]
+        labels = _MODE_LABELS.get(lang) or _MODE_LABELS["en"]
+        prompt.extend(["", header_wa + ":"])
+        for mode in scheduled_modes:
+            prompt.append(f"- {labels[mode]}: {directives[mode]}")
 
     # Follow-up Questions (same approach as v1)
     followups: List[str] = []

--- a/app/emitters.py
+++ b/app/emitters.py
@@ -226,7 +226,12 @@ _MODE_DIRECTIVES = {
 _MODE_LABELS = {
     "en": {"explore": "Explore", "decide": "Decide", "execute": "Execute", "verify": "Verify"},
     "tr": {"explore": "Keşfet", "decide": "Karar ver", "execute": "Uygula", "verify": "Doğrula"},
-    "es": {"explore": "Explorar", "decide": "Decidir", "execute": "Ejecutar", "verify": "Verificar"},
+    "es": {
+        "explore": "Explorar",
+        "decide": "Decidir",
+        "execute": "Ejecutar",
+        "verify": "Verificar",
+    },
 }
 
 
@@ -961,7 +966,9 @@ def emit_plan_v2(ir: IRv2) -> str:
         mode = _step_mode(step)
         if mode in _PLAN_MODE_RATIONALE:
             # explore/verify tags; execute and untagged render identically below
-            out.append(f"{step_number}. [{kind}] ({mode}) {step.text}\n   {_PLAN_MODE_RATIONALE[mode]}")
+            out.append(
+                f"{step_number}. [{kind}] ({mode}) {step.text}\n   {_PLAN_MODE_RATIONALE[mode]}"
+            )
         else:
             rationale = (
                 "Rationale: complete the user's stated task without adding unstated requirements"

--- a/app/heuristics/handlers/exploration.py
+++ b/app/heuristics/handlers/exploration.py
@@ -1,0 +1,185 @@
+"""
+Exploration Handler: adaptive exploration-mode scheduling.
+
+Turns signals the compiler has already measured (problem cues in the user's
+own words, diagnostic intents, ambiguity, complexity, risk/policy) into an
+explicit per-step latitude budget: explore / decide / execute / verify.
+
+Design rules:
+- Silent for clear, trivial requests: every ``step.scheduling`` stays None and
+  emitted text is byte-identical to a build without this handler. Only the
+  ``uncertainty_profile`` metadata is written (always, for analytics).
+- Deterministic: pure function of IR signals; reads no environment.
+- Conservative: never invents steps — decide/verify are recorded in the
+  profile and rendered as pseudo-steps, mirroring the [clarify]/[policy]
+  precedent; ``ir.steps`` stays faithful to the user's words.
+
+Runs LAST in the chain so it sees final intents and final policy.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.heuristics.handlers.base import BaseHandler
+from app.models import IR
+from app.models_v2 import IRv2, StepScheduling
+
+# Problem stated in the user's own words. Mandatory for explore: diagnostic
+# intents alone over-trigger (LIVE_DEBUG_KEYWORDS matches "log" inside
+# "login"/"blog"), and bare asks ("fix a typo") are not diagnoses.
+# Deliberately excluded: bare "error", "fails"/"failed" — they fire on
+# "add error handling" and "find failed login attempts" style requests.
+_PROBLEM_CUES = (
+    "broken",
+    "crash",
+    "crashes",
+    "crashing",
+    "crashed",
+    "bug",
+    "traceback",
+    "stack trace",
+    "exception",
+    "not working",
+    "doesn't work",
+    "does not work",
+    "stopped working",
+    "error message",
+    "an error",
+    "this error",
+    "throws",
+    "regression",
+    "why is",
+)
+_DIAGNOSTIC_ASKS = (
+    "fix",
+    "debug",
+    "diagnose",
+    "troubleshoot",
+    "investigate",
+    "find out",
+    "figure out",
+    "resolve",
+    "root cause",
+    "help",
+)
+
+_MAX_SCORE = 7  # 2 (explore) + 1 (ambiguity) + 2 (complexity) + 1 (risk) + 1 (verify)
+
+
+def _compile_patterns(markers: tuple[str, ...]) -> tuple[re.Pattern[str], ...]:
+    return tuple(re.compile(r"\b" + re.escape(marker) + r"\b") for marker in markers)
+
+
+_CUE_PATTERNS = _compile_patterns(_PROBLEM_CUES)
+_ASK_PATTERNS = _compile_patterns(_DIAGNOSTIC_ASKS)
+
+
+def _first_match(
+    patterns: tuple[re.Pattern[str], ...], markers: tuple[str, ...], text: str
+) -> str | None:
+    for pattern, marker in zip(patterns, markers):
+        if pattern.search(text):
+            return marker
+    return None
+
+
+class ExplorationHandler(BaseHandler):
+    """Assign exploration modes to steps and write the uncertainty profile."""
+
+    def handle(self, ir_v2: IRv2, ir_v1: IR) -> None:
+        md = ir_v2.metadata or {}
+        text = str(md.get("original_text") or "").lower()
+        intents = set(ir_v2.intents or [])
+        ambiguous = md.get("ambiguous_terms") or []
+        complexity = str(md.get("complexity") or "").lower()
+        code_request = bool(md.get("code_request"))
+        policy_reasons = md.get("policy_reasons") or []
+        policy = ir_v2.policy
+
+        signals: list[str] = []
+
+        # R1 — explore: problem cue AND (diagnostic ask OR diagnostic intent).
+        cue = _first_match(_CUE_PATTERNS, _PROBLEM_CUES, text)
+        ask = _first_match(_ASK_PATTERNS, _DIAGNOSTIC_ASKS, text)
+        diagnostic_intents = sorted({"troubleshooting", "debug"} & intents)
+        explore = bool(cue and (ask or diagnostic_intents) and ir_v2.steps)
+        if cue:
+            signals.append(f"problem_cue:{cue}")
+        if ask:
+            signals.append(f"diagnostic_ask:{ask}")
+        signals.extend(f"intent:{intent}" for intent in diagnostic_intents)
+
+        # R2 — decide: convergence pseudo-step after a multi-step exploration.
+        decide = explore and len(ir_v2.steps) >= 2
+
+        # R3 — verify: destructive, or high-risk approval-gated concrete change.
+        destructive = "destructive_operation" in policy_reasons
+        concrete = code_request or "code" in intents
+        high_risk_change = (
+            not destructive
+            and policy.risk_level == "high"
+            and policy.execution_mode == "human_approval_required"
+            and concrete
+        )
+        verify = destructive or high_risk_change
+
+        # Informational score; modes are gated by the rules above, never by it.
+        score = 0
+        if explore:
+            score += 2
+        if ambiguous:
+            score += 1
+            signals.append(f"ambiguous_terms:{len(ambiguous)}")
+        if complexity in ("medium", "high"):
+            score += 1 if complexity == "medium" else 2
+            signals.append(f"complexity:{complexity}")
+        if policy.risk_level == "high":
+            score += 1
+            signals.append("risk:high")
+        if verify:
+            score += 1
+            signals.append("destructive_operation" if destructive else "high_risk_change")
+
+        level = "low" if score == 0 else "elevated" if score <= 2 else "high"
+        confidence = round(score / _MAX_SCORE, 2)
+
+        # R4 — execute backfill: only once another mode engaged; otherwise the
+        # scheduler stays silent and every step keeps scheduling=None.
+        if explore or verify:
+            for index, step in enumerate(ir_v2.steps):
+                if index == 0 and explore:
+                    step.scheduling = StepScheduling(
+                        mode="explore",
+                        reason="diagnostic_request",
+                        confidence=confidence,
+                    )
+                elif step.scheduling is None:
+                    step.scheduling = StepScheduling(
+                        mode="execute",
+                        reason="scoped_execution",
+                        confidence=confidence,
+                    )
+
+        verify_reason = None
+        if destructive:
+            verify_reason = "destructive_operation"
+        elif high_risk_change:
+            verify_reason = "high_risk_change"
+
+        ir_v2.metadata["uncertainty_profile"] = {
+            "level": level,
+            "score": score,
+            "signals": signals,
+            "modes": {
+                "explore": {
+                    "scheduled": explore,
+                    "reason": "diagnostic_request" if explore else None,
+                },
+                "decide": {
+                    "scheduled": decide,
+                    "reason": "convergence_after_exploration" if decide else None,
+                },
+                "verify": {"scheduled": verify, "reason": verify_reason},
+            },
+        }

--- a/app/ir_contract.py
+++ b/app/ir_contract.py
@@ -36,6 +36,14 @@ IR_INTENTS: Final = (
     "summarize",
 )
 IR_STEP_TYPES: Final = ("task", "teach", "research", "compare", "plan")
+IR_STEP_MODES: Final = ("explore", "decide", "execute", "verify")
+IR_SCHEDULING_REASONS: Final = (
+    "diagnostic_request",  # explore: problem cue + diagnostic ask/intent
+    "convergence_after_exploration",  # decide pseudo-step after an explore step
+    "scoped_execution",  # execute backfill once another mode engaged
+    "destructive_operation",  # verify via policy_reasons
+    "high_risk_change",  # verify via high risk + approval + concrete change
+)
 IR_CONSTRAINT_PRIORITIES: Final = (10, 20, 30, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100)
 IR_RISK_LEVELS: Final = ("low", "medium", "high")
 IR_DATA_SENSITIVITY_LEVELS: Final = ("public", "internal", "confidential", "restricted")

--- a/app/models_v2.py
+++ b/app/models_v2.py
@@ -28,11 +28,27 @@ class ConstraintV2(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+class StepScheduling(BaseModel):
+    """Exploration-mode scheduling attached to a step by the compiler.
+
+    Structured (not a bare mode string) so future consumers — agent packs,
+    analytics, benchmarking, adaptive routing — can add fields without
+    another IR/schema redesign. Rendering only reads ``mode``.
+    """
+
+    mode: str  # one of ir_contract.IR_STEP_MODES
+    reason: Optional[str] = None  # one of ir_contract.IR_SCHEDULING_REASONS
+    confidence: Optional[float] = None  # normalized scheduler score (0..1)
+
+    model_config = ConfigDict(extra="allow")
+
+
 class StepV2(BaseModel):
     """Flexible step model."""
 
     type: str = "task"
     text: str
+    scheduling: Optional[StepScheduling] = None  # None = scheduler did not engage
 
     model_config = ConfigDict(extra="ignore")
 

--- a/schema/ir_v2.schema.json
+++ b/schema/ir_v2.schema.json
@@ -192,6 +192,40 @@
           },
           "text": {
             "type": "string"
+          },
+          "scheduling": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "enum": [
+                  "explore",
+                  "decide",
+                  "execute",
+                  "verify"
+                ]
+              },
+              "reason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "confidence": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "additionalProperties": true
           }
         },
         "additionalProperties": false

--- a/tests/heuristics/test_exploration_handler.py
+++ b/tests/heuristics/test_exploration_handler.py
@@ -299,18 +299,14 @@ class TestPipelineIntegration:
         assert all(step.scheduling is None for step in ir.steps)
 
     def test_destructive_prompt_keeps_policy_and_gains_verify(self):
-        ir = compile_text_v2(
-            "Write a script to wipe the production database", offline_only=True
-        )
+        ir = compile_text_v2("Write a script to wipe the production database", offline_only=True)
 
         assert ir.policy.risk_level == "high"
         assert ir.policy.execution_mode == "human_approval_required"
         assert ir.metadata["uncertainty_profile"]["modes"]["verify"]["scheduled"] is True
 
     def test_scheduling_round_trips_through_model_dump(self):
-        ir = compile_text_v2(
-            "Find out why the build is broken and then fix it", offline_only=True
-        )
+        ir = compile_text_v2("Find out why the build is broken and then fix it", offline_only=True)
         restored = IRv2.model_validate(ir.model_dump())
 
         assert [s.scheduling for s in restored.steps] == [s.scheduling for s in ir.steps]

--- a/tests/heuristics/test_exploration_handler.py
+++ b/tests/heuristics/test_exploration_handler.py
@@ -1,0 +1,333 @@
+"""ExplorationHandler: adaptive exploration-mode scheduling (R1-R4).
+
+The handler derives a per-step latitude budget from signals the compiler has
+already measured (problem cues in the user's own words, diagnostic intents,
+ambiguity, complexity, risk/policy). It must be deterministic and must stay
+silent (all ``scheduling`` = None) for clear, trivial requests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.compiler import compile_text_v2
+from app.heuristics.handlers.exploration import ExplorationHandler
+from app.ir_contract import IR_SCHEDULING_REASONS, IR_STEP_MODES
+from app.models_v2 import IRv2, PolicyV2, StepV2
+
+
+@pytest.fixture
+def handler():
+    return ExplorationHandler()
+
+
+def _ir2(
+    text: str = "",
+    steps: int = 1,
+    intents: list[str] | None = None,
+    policy: PolicyV2 | None = None,
+    policy_reasons: list[str] | None = None,
+    ambiguous: list[str] | None = None,
+    complexity: str = "low",
+    code_request: bool = False,
+) -> IRv2:
+    """Build a minimal IRv2 the way the pipeline leaves it before the handler runs."""
+    return IRv2(
+        intents=list(intents or []),
+        steps=[StepV2(type="task", text=f"step {i + 1}") for i in range(steps)],
+        policy=policy or PolicyV2(),
+        metadata={
+            "original_text": text,
+            "ambiguous_terms": list(ambiguous or []),
+            "complexity": complexity,
+            "code_request": code_request,
+            "policy_reasons": list(policy_reasons or []),
+        },
+    )
+
+
+def _profile(ir: IRv2) -> dict:
+    return ir.metadata["uncertainty_profile"]
+
+
+# --------------------------------------------------------------------------
+# R1 — explore
+# --------------------------------------------------------------------------
+
+
+class TestR1Explore:
+    def test_cue_plus_ask_schedules_explore_on_first_step(self, handler):
+        ir = _ir2("The download button is broken in Safari; help me fix it", steps=1)
+        handler.handle(ir, None)
+
+        sched = ir.steps[0].scheduling
+        assert sched is not None
+        assert sched.mode == "explore"
+        assert sched.reason == "diagnostic_request"
+        assert sched.confidence is not None and 0.0 <= sched.confidence <= 1.0
+
+    def test_cue_plus_debug_intent_without_ask_schedules_explore(self, handler):
+        ir = _ir2("My app crashes on startup with a stack trace", intents=["debug"])
+        handler.handle(ir, None)
+
+        assert ir.steps[0].scheduling is not None
+        assert ir.steps[0].scheduling.mode == "explore"
+
+    def test_polluted_intents_without_problem_cue_do_not_trigger(self, handler):
+        # "Implement secure login sessions" gains troubleshooting/debug intents
+        # today via the 'logs?' keyword bug; the mandatory problem cue must
+        # keep explore off. Regression anchor.
+        ir = _ir2(
+            "Implement secure login sessions",
+            intents=["code", "ambiguous", "troubleshooting", "debug"],
+        )
+        handler.handle(ir, None)
+
+        assert all(step.scheduling is None for step in ir.steps)
+
+    def test_diagnostic_ask_without_problem_cue_does_not_trigger(self, handler):
+        ir = _ir2("fix a typo in the README")
+        handler.handle(ir, None)
+
+        assert all(step.scheduling is None for step in ir.steps)
+
+    def test_problem_cue_without_ask_or_intent_does_not_trigger(self, handler):
+        ir = _ir2("The build is broken again")
+        handler.handle(ir, None)
+
+        assert all(step.scheduling is None for step in ir.steps)
+
+    def test_cue_must_match_on_word_boundary(self, handler):
+        # "debugging" contains "bug"; without a standalone cue no explore.
+        ir = _ir2("Write a tutorial about debugging techniques, help me structure it")
+        handler.handle(ir, None)
+
+        assert all(step.scheduling is None for step in ir.steps)
+
+
+# --------------------------------------------------------------------------
+# R2 — decide (pseudo-step, recorded in the profile)
+# --------------------------------------------------------------------------
+
+
+class TestR2Decide:
+    def test_multi_step_diagnostic_schedules_decide(self, handler):
+        ir = _ir2("Find out why the build is broken and then fix it", steps=2)
+        handler.handle(ir, None)
+
+        decide = _profile(ir)["modes"]["decide"]
+        assert decide["scheduled"] is True
+        assert decide["reason"] == "convergence_after_exploration"
+
+    def test_single_step_diagnostic_does_not_schedule_decide(self, handler):
+        ir = _ir2("The download button is broken in Safari; help me fix it", steps=1)
+        handler.handle(ir, None)
+
+        assert _profile(ir)["modes"]["decide"]["scheduled"] is False
+
+    def test_decide_never_fires_without_explore(self, handler):
+        ir = _ir2("Summarize this article in five bullets", steps=3)
+        handler.handle(ir, None)
+
+        assert _profile(ir)["modes"]["decide"]["scheduled"] is False
+
+
+# --------------------------------------------------------------------------
+# R3 — verify
+# --------------------------------------------------------------------------
+
+
+class TestR3Verify:
+    def test_destructive_operation_schedules_verify(self, handler):
+        ir = _ir2(
+            "Write a script to wipe the production database",
+            policy=PolicyV2(risk_level="high", execution_mode="human_approval_required"),
+            policy_reasons=["destructive_operation"],
+            code_request=True,
+        )
+        handler.handle(ir, None)
+
+        verify = _profile(ir)["modes"]["verify"]
+        assert verify["scheduled"] is True
+        assert verify["reason"] == "destructive_operation"
+
+    def test_high_risk_concrete_change_schedules_verify(self, handler):
+        ir = _ir2(
+            "Rotate the auth tokens for every tenant",
+            policy=PolicyV2(risk_level="high", execution_mode="human_approval_required"),
+            policy_reasons=["high_risk_domain:security"],
+            code_request=True,
+        )
+        handler.handle(ir, None)
+
+        verify = _profile(ir)["modes"]["verify"]
+        assert verify["scheduled"] is True
+        assert verify["reason"] == "high_risk_change"
+
+    def test_high_risk_advice_only_prompt_stays_verify_free(self, handler):
+        ir = _ir2(
+            "Review this contract for risky clauses",
+            policy=PolicyV2(risk_level="high", execution_mode="human_approval_required"),
+            policy_reasons=["high_risk_domain:legal"],
+            code_request=False,
+        )
+        handler.handle(ir, None)
+
+        assert _profile(ir)["modes"]["verify"]["scheduled"] is False
+
+
+# --------------------------------------------------------------------------
+# R4 — execute backfill + silence guarantee
+# --------------------------------------------------------------------------
+
+
+class TestR4Backfill:
+    def test_backfill_tags_remaining_steps_as_execute(self, handler):
+        ir = _ir2("Find out why the build is broken and then fix it", steps=3)
+        handler.handle(ir, None)
+
+        assert ir.steps[0].scheduling.mode == "explore"
+        for step in ir.steps[1:]:
+            assert step.scheduling is not None
+            assert step.scheduling.mode == "execute"
+            assert step.scheduling.reason == "scoped_execution"
+
+    def test_no_rule_fired_means_all_scheduling_none(self, handler):
+        ir = _ir2("Summarize this article in five bullets", steps=3)
+        handler.handle(ir, None)
+
+        assert all(step.scheduling is None for step in ir.steps)
+
+    def test_verify_alone_backfills_execute(self, handler):
+        ir = _ir2(
+            "Write a script to wipe the production database",
+            steps=2,
+            policy=PolicyV2(risk_level="high", execution_mode="human_approval_required"),
+            policy_reasons=["destructive_operation"],
+            code_request=True,
+        )
+        handler.handle(ir, None)
+
+        for step in ir.steps:
+            assert step.scheduling is not None
+            assert step.scheduling.mode == "execute"
+
+
+# --------------------------------------------------------------------------
+# Uncertainty profile
+# --------------------------------------------------------------------------
+
+
+class TestUncertaintyProfile:
+    def test_profile_always_written_even_when_silent(self, handler):
+        ir = _ir2("Summarize this article in five bullets")
+        handler.handle(ir, None)
+
+        profile = _profile(ir)
+        assert profile["level"] in ("low", "elevated", "high")
+        assert isinstance(profile["score"], int)
+        assert isinstance(profile["signals"], list)
+        assert set(profile["modes"]) == {"explore", "decide", "verify"}
+
+    def test_confidence_is_normalized_score(self, handler):
+        ir = _ir2(
+            "Find out why the build is broken and then fix it",
+            steps=2,
+            ambiguous=["better"],
+            complexity="high",
+        )
+        handler.handle(ir, None)
+
+        profile = _profile(ir)
+        expected = round(profile["score"] / 7, 2)
+        tagged = [s.scheduling for s in ir.steps if s.scheduling is not None]
+        assert tagged, "expected scheduled steps"
+        assert all(s.confidence == expected for s in tagged)
+
+    def test_reasons_come_from_the_contract_enum(self, handler):
+        ir = _ir2(
+            "Find out why the build is broken and then fix it",
+            steps=2,
+            policy=PolicyV2(risk_level="high", execution_mode="human_approval_required"),
+            policy_reasons=["destructive_operation"],
+            code_request=True,
+        )
+        handler.handle(ir, None)
+
+        for step in ir.steps:
+            if step.scheduling is not None:
+                assert step.scheduling.mode in IR_STEP_MODES
+                assert step.scheduling.reason in IR_SCHEDULING_REASONS
+        for entry in _profile(ir)["modes"].values():
+            if entry["scheduled"]:
+                assert entry["reason"] in IR_SCHEDULING_REASONS
+
+    def test_handler_is_deterministic(self, handler):
+        def run():
+            ir = _ir2("Find out why the build is broken and then fix it", steps=2)
+            handler.handle(ir, None)
+            return ir.model_dump()
+
+        assert run() == run()
+
+
+# --------------------------------------------------------------------------
+# End-to-end spot checks through the real pipeline
+# --------------------------------------------------------------------------
+
+
+class TestPipelineIntegration:
+    def test_diagnostic_prompt_gets_explore_first(self):
+        ir = compile_text_v2(
+            "The download button is broken in Safari; help me fix it",
+            offline_only=True,
+        )
+
+        assert ir.steps, "expected steps"
+        assert ir.steps[0].scheduling is not None
+        assert ir.steps[0].scheduling.mode == "explore"
+
+    def test_trivial_prompt_stays_unscheduled(self):
+        ir = compile_text_v2("fix a typo in the README", offline_only=True)
+
+        assert all(step.scheduling is None for step in ir.steps)
+        assert ir.metadata["uncertainty_profile"]["modes"]["explore"]["scheduled"] is False
+
+    def test_login_prompt_regression_anchor(self):
+        ir = compile_text_v2("Implement secure login sessions", offline_only=True)
+
+        assert all(step.scheduling is None for step in ir.steps)
+
+    def test_destructive_prompt_keeps_policy_and_gains_verify(self):
+        ir = compile_text_v2(
+            "Write a script to wipe the production database", offline_only=True
+        )
+
+        assert ir.policy.risk_level == "high"
+        assert ir.policy.execution_mode == "human_approval_required"
+        assert ir.metadata["uncertainty_profile"]["modes"]["verify"]["scheduled"] is True
+
+    def test_scheduling_round_trips_through_model_dump(self):
+        ir = compile_text_v2(
+            "Find out why the build is broken and then fix it", offline_only=True
+        )
+        restored = IRv2.model_validate(ir.model_dump())
+
+        assert [s.scheduling for s in restored.steps] == [s.scheduling for s in ir.steps]
+
+    def test_scheduling_preserves_unknown_future_fields(self):
+        restored = IRv2.model_validate(
+            {
+                "steps": [
+                    {
+                        "type": "task",
+                        "text": "step",
+                        "scheduling": {"mode": "explore", "route_hint": "scout-pack"},
+                    }
+                ]
+            }
+        )
+
+        dumped = restored.steps[0].scheduling.model_dump()
+        assert dumped["mode"] == "explore"
+        assert dumped["route_hint"] == "scout-pack"

--- a/tests/test_emitters_scheduling.py
+++ b/tests/test_emitters_scheduling.py
@@ -1,0 +1,155 @@
+"""Rendering of exploration-mode scheduling in emit_plan_v2 / emit_expanded_prompt_v2.
+
+Hard rule under test: when the scheduler did not engage (all scheduling None,
+no profile mode scheduled) the rendered output is byte-identical to a build
+without the scheduler — no tags, no pseudo-steps, no "Working approach" section.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.emitters import emit_expanded_prompt_v2, emit_plan_v2
+from app.models_v2 import IRv2, PolicyV2, StepScheduling, StepV2
+
+
+def _profile(explore: bool = False, decide: bool = False, verify: bool = False) -> dict:
+    verify_reason = "destructive_operation" if verify else None
+    return {
+        "level": "elevated" if (explore or verify) else "low",
+        "score": 2 if explore else 0,
+        "signals": [],
+        "modes": {
+            "explore": {
+                "scheduled": explore,
+                "reason": "diagnostic_request" if explore else None,
+            },
+            "decide": {
+                "scheduled": decide,
+                "reason": "convergence_after_exploration" if decide else None,
+            },
+            "verify": {"scheduled": verify, "reason": verify_reason},
+        },
+    }
+
+
+def _sched(mode: str) -> StepScheduling:
+    reasons = {
+        "explore": "diagnostic_request",
+        "execute": "scoped_execution",
+    }
+    return StepScheduling(mode=mode, reason=reasons.get(mode), confidence=0.29)
+
+
+class TestPlanModeRendering:
+    def test_explore_step_renders_mode_tag_and_rationale(self) -> None:
+        ir = IRv2(
+            steps=[StepV2(type="task", text="Find the cause", scheduling=_sched("explore"))],
+            metadata={"uncertainty_profile": _profile(explore=True)},
+        )
+
+        plan = emit_plan_v2(ir)
+
+        assert "1. [task] (explore) Find the cause" in plan
+        assert "cause is not yet established" in plan
+
+    def test_execute_tagged_step_renders_identically_to_untagged(self) -> None:
+        untagged = IRv2(steps=[StepV2(type="task", text="Do the thing")])
+        tagged = IRv2(
+            steps=[StepV2(type="task", text="Do the thing", scheduling=_sched("execute"))]
+        )
+
+        assert emit_plan_v2(tagged) == emit_plan_v2(untagged)
+
+    def test_decide_pseudo_step_follows_the_explore_step(self) -> None:
+        ir = IRv2(
+            steps=[
+                StepV2(type="task", text="Find the cause", scheduling=_sched("explore")),
+                StepV2(type="task", text="Apply the fix", scheduling=_sched("execute")),
+            ],
+            metadata={"uncertainty_profile": _profile(explore=True, decide=True)},
+        )
+
+        plan = emit_plan_v2(ir)
+
+        assert "1. [task] (explore) Find the cause" in plan
+        assert (
+            "2. [decide] Choose one likely cause or approach to pursue before making changes."
+            in plan
+        )
+        assert "3. [task] Apply the fix" in plan
+
+    def test_verify_pseudo_step_appends_after_policy_and_steps(self) -> None:
+        ir = IRv2(
+            policy=PolicyV2(risk_level="high", execution_mode="human_approval_required"),
+            steps=[StepV2(type="task", text="Wipe the database", scheduling=_sched("execute"))],
+            metadata={"uncertainty_profile": _profile(verify=True)},
+        )
+
+        plan = emit_plan_v2(ir)
+
+        assert plan.startswith("1. [policy]")
+        assert "2. [task] Wipe the database" in plan
+        assert (
+            "3. [verify] Re-check the result against the original request before treating it as done."
+            in plan
+        )
+
+    def test_steps_without_scheduling_attribute_are_tolerated(self) -> None:
+        ir = SimpleNamespace(
+            metadata={},
+            policy=SimpleNamespace(execution_mode="advice_only", risk_level="low"),
+            steps=[SimpleNamespace(type="task", text="Do the thing")],
+            tasks=[],
+        )
+
+        plan = emit_plan_v2(ir)
+
+        assert "1. [task] Do the thing" in plan
+
+
+class TestWorkingApproachSection:
+    _LONG_TEXT = "The download button is broken in Safari; help me fix it"
+
+    def test_section_renders_scheduled_modes_only(self) -> None:
+        ir = IRv2(
+            steps=[
+                StepV2(type="task", text="Find the cause", scheduling=_sched("explore")),
+                StepV2(type="task", text="Apply the fix", scheduling=_sched("execute")),
+            ],
+            metadata={
+                "original_text": self._LONG_TEXT,
+                "uncertainty_profile": _profile(explore=True, decide=True),
+            },
+        )
+
+        ep = emit_expanded_prompt_v2(ir, diagnostics=False)
+
+        assert "Working approach:" in ep
+        assert "- Explore:" in ep
+        assert "- Decide:" in ep
+        assert "- Execute:" in ep
+        assert "- Verify:" not in ep
+
+    def test_section_suppressed_when_scheduler_silent(self) -> None:
+        ir = IRv2(
+            steps=[StepV2(type="task", text="Summarize the article")],
+            metadata={
+                "original_text": "Summarize this article in five clear bullets",
+                "uncertainty_profile": _profile(),
+            },
+        )
+
+        ep = emit_expanded_prompt_v2(ir, diagnostics=False)
+
+        assert "Working approach" not in ep
+
+    def test_section_absent_when_profile_missing_entirely(self) -> None:
+        ir = IRv2(
+            steps=[StepV2(type="task", text="Summarize the article")],
+            metadata={"original_text": "Summarize this article in five clear bullets"},
+        )
+
+        ep = emit_expanded_prompt_v2(ir, diagnostics=False)
+
+        assert "Working approach" not in ep

--- a/tests/test_exploration_gate.py
+++ b/tests/test_exploration_gate.py
@@ -1,0 +1,123 @@
+"""Acceptance gate for exploration-mode scheduling.
+
+The scheduler must add real scheduling on diagnostic/destructive work and must
+stay completely silent — no tags, no pseudo-steps, no Working approach section —
+on clear or trivial requests (anti-boilerplate / ADDS_VALUE rule).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.compiler import compile_text_v2
+from app.emitters import emit_expanded_prompt_v2, emit_plan_v2
+
+BOILERPLATE_BANNED = [
+    "working approach",
+    "çalışma yaklaşımı",
+    "(explore)",
+    "[decide]",
+    "[verify]",
+    "entropy",
+]
+OFFDOMAIN_BANNED = [
+    "stakes early",
+    "character motivations",
+    "narrative",
+    "protagonist",
+    "not legal advice",
+    "consult a professional",
+]
+TRIVIAL_OR_CLEAR = [
+    "fix a typo in the README",
+    "hi",
+    "Summarize this article in 5 bullets",
+    "Add a CSV export button to my dashboard",
+]
+
+DIAGNOSTIC = "The download button is broken in Safari; help me fix it"
+MULTI_STEP_DIAGNOSTIC = "Find out why the build is broken and then fix it"
+LOGIN_REGRESSION_ANCHOR = "Implement secure login sessions"
+DESTRUCTIVE = "Write a script to wipe the production database"
+
+
+def _compile_twice(prompt: str):
+    """Compile twice and assert full determinism (dump, plan, expanded)."""
+    first_ir = compile_text_v2(prompt, offline_only=True)
+    first_plan = emit_plan_v2(first_ir)
+    first_expanded = emit_expanded_prompt_v2(first_ir)
+    second_ir = compile_text_v2(prompt, offline_only=True)
+
+    assert first_plan == emit_plan_v2(second_ir)
+    assert first_expanded == emit_expanded_prompt_v2(second_ir)
+    assert first_ir.model_dump() == second_ir.model_dump()
+    return first_ir, first_plan.lower(), first_expanded.lower()
+
+
+@pytest.mark.parametrize("prompt", TRIVIAL_OR_CLEAR)
+def test_gate_trivial_or_clear_requests_gain_no_scheduling_text(prompt):
+    ir, plan, expanded = _compile_twice(prompt)
+
+    assert all(step.scheduling is None for step in ir.steps)
+    hits = [m for m in BOILERPLATE_BANNED if m in plan or m in expanded]
+    assert not hits, f"scheduler leaked boilerplate on a clear request: {hits}"
+
+
+def test_gate_pure_ambiguity_keeps_clarify_and_stays_unscheduled():
+    ir, plan, expanded = _compile_twice("make it better")
+
+    assert "[clarify]" in plan
+    assert all(step.scheduling is None for step in ir.steps)
+    assert not [m for m in BOILERPLATE_BANNED if m in plan or m in expanded]
+
+
+def test_gate_login_prompt_regression_anchor_stays_silent():
+    # Intents are polluted today ('logs?' matches inside 'login'); the
+    # mandatory problem cue must keep the scheduler out of auth feature work.
+    ir, plan, expanded = _compile_twice(LOGIN_REGRESSION_ANCHOR)
+
+    assert all(step.scheduling is None for step in ir.steps)
+    assert not [m for m in BOILERPLATE_BANNED if m in plan or m in expanded]
+
+
+def test_gate_diagnostic_request_schedules_explore_and_working_approach():
+    ir, plan, expanded = _compile_twice(DIAGNOSTIC)
+
+    assert ir.steps and ir.steps[0].scheduling is not None
+    assert ir.steps[0].scheduling.mode == "explore"
+    assert "(explore)" in plan
+    assert "working approach:" in expanded
+    assert "- explore:" in expanded
+
+
+def test_gate_multi_step_diagnostic_orders_explore_before_decide():
+    ir, plan, _ = _compile_twice(MULTI_STEP_DIAGNOSTIC)
+
+    assert "(explore)" in plan
+    assert "[decide]" in plan
+    assert plan.index("(explore)") < plan.index("[decide]")
+    assert ir.metadata["uncertainty_profile"]["modes"]["decide"]["scheduled"] is True
+
+
+def test_gate_destructive_request_keeps_policy_and_appends_verify():
+    ir, plan, expanded = _compile_twice(DESTRUCTIVE)
+
+    # Existing safety behavior must be untouched...
+    assert ir.policy.risk_level == "high"
+    assert ir.policy.execution_mode == "human_approval_required"
+    assert "[policy]" in plan
+    # ...with a verification step scheduled at the end of the plan.
+    assert "[verify]" in plan
+    assert plan.index("[policy]") < plan.index("[verify]")
+    assert not [m for m in OFFDOMAIN_BANNED if m in expanded]
+
+
+def test_gate_scheduling_survives_serialization_deterministically():
+    ir, _, _ = _compile_twice(MULTI_STEP_DIAGNOSTIC)
+    dump = ir.model_dump()
+
+    scheduled = [s for s in dump["steps"] if s["scheduling"] is not None]
+    assert scheduled, "expected scheduled steps in the serialized IR"
+    for step in scheduled:
+        assert step["scheduling"]["mode"] in ("explore", "decide", "execute", "verify")
+        assert 0.0 <= step["scheduling"]["confidence"] <= 1.0

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -13,6 +13,7 @@ from app.ir_contract import (
     IR_OUTPUT_FORMATS,
     IR_PERSONAS,
     IR_RISK_LEVELS,
+    IR_STEP_MODES,
     IR_STEP_TYPES,
 )
 from app.resources import get_ir_schema_text
@@ -158,3 +159,29 @@ def test_shared_ir_priority_contract_covers_declared_heuristic_priorities():
     declared = _collect_declared_constraint_priorities()
 
     assert declared <= set(IR_CONSTRAINT_PRIORITIES)
+
+
+def test_v2_schema_scheduling_mode_enum_matches_contract():
+    scheduling = schema_v2["properties"]["steps"]["items"]["properties"]["scheduling"]
+
+    assert set(scheduling["properties"]["mode"]["enum"]) == set(IR_STEP_MODES)
+
+
+def test_v2_schema_accepts_scheduled_and_unscheduled_compiles():
+    # Scheduled steps (verify + execute backfill) and null scheduling both validate.
+    scheduled = compile_text_v2("Write a script to wipe the production database", offline_only=True)
+    validate(instance=scheduled.model_dump(), schema=schema_v2)
+
+    silent = compile_text_v2("Summarize recent stock market trends", offline_only=True)
+    assert all(step.scheduling is None for step in silent.steps)
+    validate(instance=silent.model_dump(), schema=schema_v2)
+
+
+def test_v2_schema_scheduling_tolerates_future_fields():
+    ir = compile_text_v2("Find out why the build is broken and then fix it", offline_only=True)
+    dump = ir.model_dump()
+    scheduled = [s for s in dump["steps"] if s["scheduling"]]
+
+    assert scheduled, "expected scheduled steps"
+    scheduled[0]["scheduling"]["route_hint"] = "scout-pack"
+    validate(instance=dump, schema=schema_v2)


### PR DESCRIPTION
## What

Turns the compiler into an explicit uncertainty scheduler: signals it already measures (problem cues in the user's own words, diagnostic intents, ambiguity, complexity, risk/policy) now assign each plan step a latitude budget — `explore` / `decide` / `execute` / `verify` — instead of only driving questions and policy.

- **Diagnostic requests** ("X is broken; help me fix it") get an explore-first plan step, a `[decide]` convergence pseudo-step on multi-step plans, and a `Working approach` section in the expanded prompt (EN/TR/ES).
- **Destructive / high-risk approval-gated changes** keep their existing policy gates untouched and gain a trailing `[verify]` pseudo-step.
- **Clear or trivial requests are byte-identical to today's output.** The scheduler stays silent (all `scheduling: null`), locked by a dedicated gate suite.

## Design notes

- `StepV2.scheduling` is a structured object (`mode` + deterministic `reason` enum + normalized `confidence`) with `additionalProperties: true`, so agent packs / analytics / adaptive routing can add fields without another IR/schema redesign. Rendering reads only `mode`.
- New `ExplorationHandler` runs last in the chain (needs final intents + policy). Deterministic, offline-only, provider-agnostic — no LLM prompt/param changes.
- `decide`/`verify` are render-time pseudo-steps mirroring the `[clarify]`/`[policy]` precedent; `ir.steps` stays faithful to the user's words.
- Known intent pollution (`LIVE_DEBUG_KEYWORDS` `logs?` matches inside "login") is contained via a mandatory problem cue and pinned with a regression anchor test (`Implement secure login sessions` stays unscheduled). Fixing the keyword itself is a separate follow-up.

## Tests

- `tests/heuristics/test_exploration_handler.py` — per-rule units (R1–R4) + pipeline spot checks (22 tests)
- `tests/test_emitters_scheduling.py` — tag rendering, pseudo-step ordering/numbering, suppression, byte-identical execute/untagged rendering (8 tests)
- `tests/test_exploration_gate.py` — anti-boilerplate gate: trivial prompts gain zero scheduling text; determinism via double-compile dump equality (10 tests)
- `tests/test_schema_validation.py` — mode enum ↔ contract alignment, live-dump validation, future-field tolerance (+3 tests)

## Verification

- Focused targets + existing QA gate (`test_qa_report_gate.py`): green
- Full suite: 1748 passed, 5 skipped, 1 failure in `test_cli_new_features.py::test_validate_summary_and_api_schemas` — pre-existing environment flake (the test opportunistically queries `127.0.0.1:8000` when the port is open; a local Docker service on :8000 returns 404). Unrelated to this change.
- `ruff check app/ tests/`: clean

## Out of scope

Frontend mode badges, agent-pack phase mapping, benchmark cases, and the `LIVE_DEBUG_KEYWORDS` word-boundary fix — tracked as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)