### PR TITLE
test: add heuristics handler and pr_safety path_rules coverage

### DIFF
--- a/tests/heuristics/test_constraints_handler.py
+++ b/tests/heuristics/test_constraints_handler.py
@@ -1,0 +1,320 @@
+import pytest
+
+from app.heuristics.handlers.constraints import ConstraintHandler
+from app.heuristics.logic_analyzer import (
+    LogicAnalysisResult,
+    NegativeConstraint,
+    DependencyRule,
+    MissingInfo,
+    IOMapping,
+)
+from app.models import IR
+from app.models_v2 import IRv2
+
+
+@pytest.fixture
+def handler():
+    return ConstraintHandler()
+
+
+def _ir(text: str = "", **metadata) -> IR:
+    md = {"original_text": text}
+    md.update(metadata)
+    return IR(
+        language="en",
+        persona="assistant",
+        role="AI Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        tools=[],
+        output_format="markdown",
+        length_hint="medium",
+        metadata=md,
+    )
+
+
+# --------------------------------------------------------------------------
+# detect_negations
+# --------------------------------------------------------------------------
+
+
+def test_detect_negations_no_matches_returns_empty(handler):
+    analysis = LogicAnalysisResult(negations=[])
+    result = handler.detect_negations(analysis)
+    assert result == []
+
+
+def test_detect_negations_creates_restriction_constraint(handler):
+    neg = NegativeConstraint(
+        original_text="Do not use classes.",
+        stripped_text="use classes.",
+        negation_word="do not",
+        anti_pattern="Instead: use classes.",
+    )
+    analysis = LogicAnalysisResult(negations=[neg])
+
+    result = handler.detect_negations(analysis)
+
+    assert len(result) == 1
+    c = result[0]
+    assert c.text == "❌ RESTRICTION: Do not use classes."
+    assert c.origin == "restriction"
+    assert c.priority == 85
+    assert c.rationale == "Anti-pattern: Instead: use classes."
+    # id is a deterministic hash of the original text
+    assert c.id == handler._mk_id(neg.original_text)
+
+
+def test_detect_negations_multiple_matches_preserve_order(handler):
+    neg1 = NegativeConstraint("Never use eval.", "use eval.", "never", "Always consider: use eval.")
+    neg2 = NegativeConstraint("Avoid globals.", "globals.", "avoid", "Prefer: globals.")
+    analysis = LogicAnalysisResult(negations=[neg1, neg2])
+
+    result = handler.detect_negations(analysis)
+
+    assert len(result) == 2
+    assert result[0].text == "❌ RESTRICTION: Never use eval."
+    assert result[1].text == "❌ RESTRICTION: Avoid globals."
+    # Different source text should yield different ids.
+    assert result[0].id != result[1].id
+
+
+# --------------------------------------------------------------------------
+# detect_dependencies
+# --------------------------------------------------------------------------
+
+
+def test_detect_dependencies_no_matches_returns_empty(handler):
+    analysis = LogicAnalysisResult(dependencies=[])
+    assert handler.detect_dependencies(analysis) == []
+
+
+@pytest.mark.parametrize(
+    "dep_type,expected_label",
+    [
+        ("because", "Reason"),
+        ("so_that", "Purpose"),
+        ("in_order_to", "Goal"),
+        ("if_then", "Condition"),
+        ("result", "Result"),
+        ("unknown_type", "Reason"),  # falls back to default label
+    ],
+)
+def test_detect_dependencies_reason_label_mapping(handler, dep_type, expected_label):
+    dep = DependencyRule(
+        action="refactor the module",
+        reason="it improves readability",
+        full_text="refactor the module because it improves readability",
+        dependency_type=dep_type,
+    )
+    analysis = LogicAnalysisResult(dependencies=[dep])
+
+    result = handler.detect_dependencies(analysis)
+
+    assert len(result) == 1
+    c = result[0]
+    assert c.text == "\U0001f4cb RULE: refactor the module"
+    assert c.rationale == f"{expected_label}: it improves readability"
+    assert c.origin == "dependency"
+    assert c.priority == 75
+    assert c.id == handler._mk_id(dep.full_text)
+
+
+def test_detect_dependencies_multiple_preserve_order(handler):
+    dep1 = DependencyRule("do X", "reason one", "full text one", "because")
+    dep2 = DependencyRule("do Y", "reason two", "full text two", "so_that")
+    analysis = LogicAnalysisResult(dependencies=[dep1, dep2])
+
+    result = handler.detect_dependencies(analysis)
+
+    assert [c.rationale for c in result] == ["Reason: reason one", "Purpose: reason two"]
+
+
+# --------------------------------------------------------------------------
+# _extract_io_constraints
+# --------------------------------------------------------------------------
+
+
+def test_extract_io_constraints_no_mappings_returns_empty(handler):
+    analysis = LogicAnalysisResult(io_mappings=[])
+    assert handler._extract_io_constraints(analysis) == []
+
+
+def test_extract_io_constraints_skips_low_confidence(handler):
+    io = IOMapping(input_type="text", process_action="process", output_format="json", confidence=0.2)
+    analysis = LogicAnalysisResult(io_mappings=[io])
+
+    assert handler._extract_io_constraints(analysis) == []
+
+
+def test_extract_io_constraints_includes_at_or_above_threshold(handler):
+    io = IOMapping(input_type="csv", process_action="analyze", output_format="table", confidence=0.3)
+    analysis = LogicAnalysisResult(io_mappings=[io])
+
+    result = handler._extract_io_constraints(analysis)
+
+    assert len(result) == 1
+    c = result[0]
+    assert c.text == "\U0001f504 FLOW: Input(csv) → Process(analyze) → Output(table)"
+    assert c.origin == "io_flow"
+    assert c.priority == 50
+    assert c.rationale == "Confidence: 30%"
+
+
+def test_extract_io_constraints_multiple_mappings_get_unique_ids(handler):
+    io1 = IOMapping(input_type="json", process_action="parse", output_format="text", confidence=0.9)
+    io2 = IOMapping(input_type="json", process_action="parse", output_format="text", confidence=0.9)
+    analysis = LogicAnalysisResult(io_mappings=[io1, io2])
+
+    result = handler._extract_io_constraints(analysis)
+
+    assert len(result) == 2
+    assert result[0].id != result[1].id
+
+
+# --------------------------------------------------------------------------
+# _extract_diagnostics
+# --------------------------------------------------------------------------
+
+
+def test_extract_diagnostics_no_missing_info_returns_empty(handler):
+    analysis = LogicAnalysisResult(missing_info=[])
+    assert handler._extract_diagnostics(analysis) == []
+
+
+def test_extract_diagnostics_maps_severity_and_builds_suggestion(handler):
+    missing = MissingInfo(
+        entity="database",
+        context="...the database is...",
+        placeholder="[MISSING: Database Schema]",
+        severity="error",
+    )
+    analysis = LogicAnalysisResult(missing_info=[missing])
+
+    result = handler._extract_diagnostics(analysis)
+
+    assert len(result) == 1
+    d = result[0]
+    assert d.severity == "error"
+    assert d.message == "Missing: database"
+    assert d.suggestion == "Please provide Database Schema"
+    assert d.category == "missing_info"
+
+
+def test_extract_diagnostics_unknown_severity_defaults_to_warning(handler):
+    missing = MissingInfo(
+        entity="thing", context="ctx", placeholder="[MISSING: thing]", severity="totally_unknown"
+    )
+    analysis = LogicAnalysisResult(missing_info=[missing])
+
+    result = handler._extract_diagnostics(analysis)
+
+    assert result[0].severity == "warning"
+
+
+def test_extract_diagnostics_adds_summary_when_more_than_three(handler):
+    missing_items = [
+        MissingInfo(entity=f"entity{i}", context="ctx", placeholder=f"[MISSING: entity{i}]")
+        for i in range(4)
+    ]
+    analysis = LogicAnalysisResult(missing_info=missing_items)
+
+    result = handler._extract_diagnostics(analysis)
+
+    # 4 individual diagnostics + 1 summary diagnostic
+    assert len(result) == 5
+    summary = result[-1]
+    assert summary.category == "completeness"
+    assert "4 total" in summary.message
+
+
+def test_extract_diagnostics_no_summary_when_three_or_fewer(handler):
+    missing_items = [
+        MissingInfo(entity=f"entity{i}", context="ctx", placeholder=f"[MISSING: entity{i}]")
+        for i in range(3)
+    ]
+    analysis = LogicAnalysisResult(missing_info=missing_items)
+
+    result = handler._extract_diagnostics(analysis)
+
+    assert len(result) == 3
+    assert all(d.category == "missing_info" for d in result)
+
+
+# --------------------------------------------------------------------------
+# handle() integration - exercises the above via a realistic prompt
+# --------------------------------------------------------------------------
+
+
+def test_handle_integrates_negations_dependencies_and_diagnostics(handler):
+    text = (
+        "Do not use global variables. "
+        "Refactor the module because it improves readability. "
+        "Please analyze the database and return a json report."
+    )
+    ir_v1 = _ir(text)
+    ir_v2 = IRv2()
+
+    handler.handle(ir_v2, ir_v1)
+
+    origins = {c.origin for c in ir_v2.constraints}
+    assert "restriction" in origins
+    assert "dependency" in origins
+    assert "logic_analysis" in ir_v2.metadata
+    assert ir_v2.metadata["logic_analysis"]["negation_count"] >= 1
+    assert ir_v2.metadata["logic_analysis"]["dependency_count"] >= 1
+
+
+def test_handle_without_original_text_only_converts_v1_constraints(handler):
+    ir_v1 = IR(
+        language="en",
+        persona="assistant",
+        role="AI Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        tools=[],
+        output_format="markdown",
+        length_hint="medium",
+        constraints=["Be concise"],
+        metadata={},
+    )
+    ir_v2 = IRv2()
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert len(ir_v2.constraints) == 1
+    assert ir_v2.constraints[0].text == "Be concise"
+    assert "logic_analysis" not in ir_v2.metadata
+
+
+def test_handle_deduplicates_constraints_by_id(handler):
+    # IR's own field validator already dedupes ir_v1.constraints by lowercase
+    # text, so to exercise ConstraintHandler's own id-based dedup we build the
+    # IR via model_construct() to bypass that validator and force a genuine
+    # duplicate through to handle().
+    ir_v1 = IR.model_construct(
+        language="en",
+        persona="assistant",
+        role="AI Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        inputs={},
+        constraints=["Be concise", "Be concise"],
+        style=[],
+        tone=[],
+        output_format="markdown",
+        length_hint="medium",
+        steps=[],
+        examples=[],
+        banned=[],
+        tools=[],
+        metadata={},
+    )
+    ir_v2 = IRv2()
+
+    handler.handle(ir_v2, ir_v1)
+
+    assert len(ir_v2.constraints) == 1

--- a/tests/heuristics/test_constraints_handler.py
+++ b/tests/heuristics/test_constraints_handler.py
@@ -142,14 +142,18 @@ def test_extract_io_constraints_no_mappings_returns_empty(handler):
 
 
 def test_extract_io_constraints_skips_low_confidence(handler):
-    io = IOMapping(input_type="text", process_action="process", output_format="json", confidence=0.2)
+    io = IOMapping(
+        input_type="text", process_action="process", output_format="json", confidence=0.2
+    )
     analysis = LogicAnalysisResult(io_mappings=[io])
 
     assert handler._extract_io_constraints(analysis) == []
 
 
 def test_extract_io_constraints_includes_at_or_above_threshold(handler):
-    io = IOMapping(input_type="csv", process_action="analyze", output_format="table", confidence=0.3)
+    io = IOMapping(
+        input_type="csv", process_action="analyze", output_format="table", confidence=0.3
+    )
     analysis = LogicAnalysisResult(io_mappings=[io])
 
     result = handler._extract_io_constraints(analysis)

--- a/tests/heuristics/test_content_handler.py
+++ b/tests/heuristics/test_content_handler.py
@@ -1,0 +1,186 @@
+import pytest
+
+from app.heuristics.handlers.content import ContentHandler
+from app.models import IR
+from app.models_v2 import IRv2
+
+
+@pytest.fixture
+def handler():
+    return ContentHandler()
+
+
+def _ir(metadata=None, tools=None) -> IR:
+    return IR(
+        language="en",
+        persona="assistant",
+        role="AI Assistant",
+        domain="general",
+        goals=[],
+        tasks=[],
+        tools=tools or [],
+        output_format="markdown",
+        length_hint="medium",
+        metadata=metadata or {},
+    )
+
+
+def _run(handler, metadata=None, tools=None):
+    ir_v1 = _ir(metadata=metadata, tools=tools)
+    ir_v2 = IRv2()
+    handler.handle(ir_v2, ir_v1)
+    return ir_v2
+
+
+# --------------------------------------------------------------------------
+# Metadata-flag-driven intents
+# --------------------------------------------------------------------------
+
+
+def test_summary_flag_adds_summary_intent(handler):
+    ir_v2 = _run(handler, metadata={"summary": "true"})
+    assert "summary" in ir_v2.intents
+
+
+def test_summary_flag_string_false_does_not_add_summary(handler):
+    ir_v2 = _run(handler, metadata={"summary": "false"})
+    assert "summary" not in ir_v2.intents
+
+
+def test_comparison_items_adds_compare_intent(handler):
+    ir_v2 = _run(handler, metadata={"comparison_items": ["A", "B"]})
+    assert "compare" in ir_v2.intents
+
+
+def test_empty_comparison_items_does_not_add_compare(handler):
+    ir_v2 = _run(handler, metadata={"comparison_items": []})
+    assert "compare" not in ir_v2.intents
+
+
+def test_variant_count_greater_than_one_adds_variants_intent(handler):
+    ir_v2 = _run(handler, metadata={"variant_count": 3})
+    assert "variants" in ir_v2.intents
+
+
+def test_variant_count_of_one_does_not_add_variants(handler):
+    ir_v2 = _run(handler, metadata={"variant_count": 1})
+    assert "variants" not in ir_v2.intents
+
+
+def test_variant_count_missing_defaults_to_one_no_variants(handler):
+    ir_v2 = _run(handler, metadata={})
+    assert "variants" not in ir_v2.intents
+
+
+def test_code_request_adds_code_intent(handler):
+    ir_v2 = _run(handler, metadata={"code_request": True})
+    assert "code" in ir_v2.intents
+
+
+def test_no_code_request_key_no_code_intent(handler):
+    ir_v2 = _run(handler, metadata={})
+    assert "code" not in ir_v2.intents
+
+
+def test_ambiguous_terms_adds_ambiguous_intent(handler):
+    ir_v2 = _run(handler, metadata={"ambiguous_terms": ["it"]})
+    assert "ambiguous" in ir_v2.intents
+
+
+def test_web_tool_adds_recency_intent(handler):
+    ir_v2 = _run(handler, metadata={}, tools=["web"])
+    assert "recency" in ir_v2.intents
+
+
+def test_no_web_tool_no_recency_intent(handler):
+    ir_v2 = _run(handler, metadata={}, tools=["code_interpreter"])
+    assert "recency" not in ir_v2.intents
+
+
+# --------------------------------------------------------------------------
+# original_text-driven intents (regex/keyword detectors)
+# --------------------------------------------------------------------------
+
+
+def test_creative_intent_detected(handler):
+    ir_v2 = _run(handler, metadata={"original_text": "Write a short story about a dragon."})
+    assert "creative" in ir_v2.intents
+
+
+def test_explanation_intent_detected(handler):
+    ir_v2 = _run(handler, metadata={"original_text": "Can you explain how does this algorithm work?"})
+    assert "explanation" in ir_v2.intents
+
+
+def test_proposal_intent_detected(handler):
+    ir_v2 = _run(handler, metadata={"original_text": "Write a proposal for the new marketing plan."})
+    assert "proposal" in ir_v2.intents
+
+
+def test_review_intent_detected(handler):
+    ir_v2 = _run(handler, metadata={"original_text": "Please review my essay for grammar mistakes."})
+    assert "review" in ir_v2.intents
+
+
+def test_preparation_intent_detected(handler):
+    ir_v2 = _run(handler, metadata={"original_text": "Prepare me for my upcoming interview prep."})
+    assert "preparation" in ir_v2.intents
+
+
+def test_troubleshooting_intent_detected_via_keyword(handler):
+    ir_v2 = _run(handler, metadata={"original_text": "Help me troubleshoot this failing build."})
+    assert "troubleshooting" in ir_v2.intents
+
+
+def test_troubleshooting_intent_detected_via_live_debug(handler):
+    # detect_troubleshooting_intent also triggers off detect_live_debug();
+    # a stack trace / traceback is one of the TROUBLESHOOTING_INTENT_KEYWORDS
+    ir_v2 = _run(handler, metadata={"original_text": "Here is the traceback I'm seeing, please help."})
+    assert "troubleshooting" in ir_v2.intents
+
+
+def test_no_original_text_skips_regex_intents(handler):
+    ir_v2 = _run(handler, metadata={})
+    for intent in (
+        "creative",
+        "explanation",
+        "proposal",
+        "review",
+        "preparation",
+        "troubleshooting",
+    ):
+        assert intent not in ir_v2.intents
+
+
+def test_plain_text_with_no_keywords_adds_no_intents(handler):
+    ir_v2 = _run(handler, metadata={"original_text": "The weather is nice today."})
+    assert ir_v2.intents == []
+
+
+# --------------------------------------------------------------------------
+# Combined / multiple intents at once
+# --------------------------------------------------------------------------
+
+
+def test_multiple_intents_all_appended_in_order(handler):
+    ir_v2 = _run(
+        handler,
+        metadata={
+            "summary": "true",
+            "comparison_items": ["A", "B"],
+            "variant_count": 2,
+            "code_request": True,
+            "original_text": "Explain how does recursion work, then review my code.",
+        },
+        tools=["web"],
+    )
+
+    assert ir_v2.intents == [
+        "summary",
+        "compare",
+        "variants",
+        "code",
+        "recency",
+        "explanation",
+        "review",
+    ]

--- a/tests/heuristics/test_content_handler.py
+++ b/tests/heuristics/test_content_handler.py
@@ -108,17 +108,23 @@ def test_creative_intent_detected(handler):
 
 
 def test_explanation_intent_detected(handler):
-    ir_v2 = _run(handler, metadata={"original_text": "Can you explain how does this algorithm work?"})
+    ir_v2 = _run(
+        handler, metadata={"original_text": "Can you explain how does this algorithm work?"}
+    )
     assert "explanation" in ir_v2.intents
 
 
 def test_proposal_intent_detected(handler):
-    ir_v2 = _run(handler, metadata={"original_text": "Write a proposal for the new marketing plan."})
+    ir_v2 = _run(
+        handler, metadata={"original_text": "Write a proposal for the new marketing plan."}
+    )
     assert "proposal" in ir_v2.intents
 
 
 def test_review_intent_detected(handler):
-    ir_v2 = _run(handler, metadata={"original_text": "Please review my essay for grammar mistakes."})
+    ir_v2 = _run(
+        handler, metadata={"original_text": "Please review my essay for grammar mistakes."}
+    )
     assert "review" in ir_v2.intents
 
 
@@ -135,7 +141,9 @@ def test_troubleshooting_intent_detected_via_keyword(handler):
 def test_troubleshooting_intent_detected_via_live_debug(handler):
     # detect_troubleshooting_intent also triggers off detect_live_debug();
     # a stack trace / traceback is one of the TROUBLESHOOTING_INTENT_KEYWORDS
-    ir_v2 = _run(handler, metadata={"original_text": "Here is the traceback I'm seeing, please help."})
+    ir_v2 = _run(
+        handler, metadata={"original_text": "Here is the traceback I'm seeing, please help."}
+    )
     assert "troubleshooting" in ir_v2.intents
 
 

--- a/tests/heuristics/test_context_suggestions_handler.py
+++ b/tests/heuristics/test_context_suggestions_handler.py
@@ -1,0 +1,128 @@
+import pytest
+
+from app.heuristics.handlers.context_suggestions import ContextSuggestionHandler
+
+
+@pytest.fixture
+def handler():
+    return ContextSuggestionHandler()
+
+
+# --------------------------------------------------------------------------
+# Exact filename matching
+# --------------------------------------------------------------------------
+
+
+def test_exact_filename_match(handler):
+    text = "Take a look at auth.py and fix the bug."
+    suggestions = handler._find_suggestions(text, ["app/services/auth.py"])
+
+    assert len(suggestions) == 1
+    assert suggestions[0]["path"] == "app/services/auth.py"
+    assert suggestions[0]["name"] == "auth.py"
+    assert suggestions[0]["reason"] == "Mentioned 'auth.py'"
+
+
+def test_no_match_returns_empty_list(handler):
+    text = "Please write a poem about the ocean."
+    suggestions = handler._find_suggestions(text, ["app/services/auth.py"])
+    assert suggestions == []
+
+
+# --------------------------------------------------------------------------
+# Stem matching via word-boundary regex
+# --------------------------------------------------------------------------
+
+
+def test_stem_match_as_distinct_word(handler):
+    text = "Please fix the auth logic in the backend."
+    suggestions = handler._find_suggestions(text, ["app/services/auth.py"])
+
+    assert len(suggestions) == 1
+    assert suggestions[0]["path"] == "app/services/auth.py"
+    assert suggestions[0]["reason"] == "Topic 'auth' detected"
+
+
+def test_stem_match_requires_word_boundary_not_substring(handler):
+    # "authentication" contains "auth" as a substring but not as a distinct
+    # word, so a stem of "auth" should not match it.
+    text = "We need better authentication in this service."
+    suggestions = handler._find_suggestions(text, ["app/services/auth.py"])
+    assert suggestions == []
+
+
+def test_short_stem_is_skipped_to_avoid_noise(handler):
+    # Stems shorter than 3 chars (e.g. "db" from db.py) are skipped entirely,
+    # even when the filename is mentioned verbatim in the text — the length
+    # guard runs before the exact-filename check.
+    text = "Please update db.py now."
+    suggestions = handler._find_suggestions(text, ["app/db.py"])
+    assert suggestions == []
+
+
+# --------------------------------------------------------------------------
+# Dedup
+# --------------------------------------------------------------------------
+
+
+def test_same_path_not_suggested_twice(handler):
+    # Filename and stem both appear in text, but the same path must only be
+    # suggested once (exact filename match takes priority via `continue`).
+    text = "Look at auth.py — the auth module needs work."
+    suggestions = handler._find_suggestions(text, ["app/services/auth.py"])
+
+    assert len(suggestions) == 1
+    assert suggestions[0]["reason"] == "Mentioned 'auth.py'"
+
+
+def test_duplicate_paths_in_input_deduped(handler):
+    text = "Check auth.py carefully."
+    suggestions = handler._find_suggestions(
+        text, ["app/services/auth.py", "app/services/auth.py"]
+    )
+    assert len(suggestions) == 1
+
+
+# --------------------------------------------------------------------------
+# Cap at 5
+# --------------------------------------------------------------------------
+
+
+def test_suggestions_capped_at_five(handler):
+    text = "Please review auth.py, billing.py, users.py, orders.py, payments.py, and reports.py."
+    file_paths = [
+        "app/auth.py",
+        "app/billing.py",
+        "app/users.py",
+        "app/orders.py",
+        "app/payments.py",
+        "app/reports.py",
+    ]
+
+    suggestions = handler._find_suggestions(text, file_paths)
+
+    assert len(suggestions) == 5
+    # The cap simply truncates the accumulation order — first five files
+    # that matched, in the order they were scanned.
+    assert [s["path"] for s in suggestions] == file_paths[:5]
+
+
+def test_fewer_than_five_matches_returns_all(handler):
+    text = "Please review auth.py and billing.py."
+    file_paths = ["app/auth.py", "app/billing.py", "app/unrelated.py"]
+
+    suggestions = handler._find_suggestions(text, file_paths)
+
+    assert len(suggestions) == 2
+    assert {s["path"] for s in suggestions} == {"app/auth.py", "app/billing.py"}
+
+
+# --------------------------------------------------------------------------
+# Case-insensitivity (text is lowercased before matching)
+# --------------------------------------------------------------------------
+
+
+def test_matching_is_case_insensitive(handler):
+    text = "Please check Auth.PY for issues."
+    suggestions = handler._find_suggestions(text, ["app/services/auth.py"])
+    assert len(suggestions) == 1

--- a/tests/heuristics/test_context_suggestions_handler.py
+++ b/tests/heuristics/test_context_suggestions_handler.py
@@ -77,9 +77,7 @@ def test_same_path_not_suggested_twice(handler):
 
 def test_duplicate_paths_in_input_deduped(handler):
     text = "Check auth.py carefully."
-    suggestions = handler._find_suggestions(
-        text, ["app/services/auth.py", "app/services/auth.py"]
-    )
+    suggestions = handler._find_suggestions(text, ["app/services/auth.py", "app/services/auth.py"])
     assert len(suggestions) == 1
 
 

--- a/tests/test_pr_safety_path_rules.py
+++ b/tests/test_pr_safety_path_rules.py
@@ -214,9 +214,7 @@ def test_detect_risky_areas_finds_auth_and_api_hits_for_same_path():
 
 def test_detect_risky_areas_secrets():
     hits = detect_risky_areas([".env.example"])
-    assert hits == [
-        ("secrets", ".env.example", "Touches secret or environment configuration")
-    ]
+    assert hits == [("secrets", ".env.example", "Touches secret or environment configuration")]
 
 
 def test_detect_risky_areas_migrations():

--- a/tests/test_pr_safety_path_rules.py
+++ b/tests/test_pr_safety_path_rules.py
@@ -1,0 +1,312 @@
+from app.pr_safety.path_rules import (
+    normalize_path,
+    is_test_file,
+    is_doc_file,
+    is_config_file,
+    is_source_file,
+    group_changed_files,
+    detect_risky_areas,
+    extract_scope_terms,
+    path_reflects_scope_term,
+)
+
+
+# --------------------------------------------------------------------------
+# normalize_path
+# --------------------------------------------------------------------------
+
+
+def test_normalize_path_strips_whitespace_and_converts_backslashes():
+    assert normalize_path("  a\\b\\c.py  ") == "a/b/c.py"
+
+
+def test_normalize_path_leaves_forward_slash_path_unchanged():
+    assert normalize_path("app/compiler.py") == "app/compiler.py"
+
+
+def test_normalize_path_empty_string():
+    assert normalize_path("   ") == ""
+
+
+# --------------------------------------------------------------------------
+# is_test_file
+# --------------------------------------------------------------------------
+
+
+def test_is_test_file_top_level_tests_dir():
+    assert is_test_file("tests/test_foo.py") is True
+
+
+def test_is_test_file_test_prefix_py():
+    assert is_test_file("test_foo.py") is True
+
+
+def test_is_test_file_test_suffix_py():
+    assert is_test_file("foo_test.py") is True
+
+
+def test_is_test_file_nested_dunder_tests_dir():
+    assert is_test_file("web/app/components/__tests__/ReadinessBanner.spec.tsx") is True
+
+
+def test_is_test_file_dot_test_ts():
+    assert is_test_file("src/foo.test.ts") is True
+
+
+def test_is_test_file_regular_source_is_not_a_test():
+    assert is_test_file("app/foo.py") is False
+
+
+def test_is_test_file_normalizes_backslashes():
+    assert is_test_file("tests\\test_foo.py") is True
+
+
+# --------------------------------------------------------------------------
+# is_doc_file
+# --------------------------------------------------------------------------
+
+
+def test_is_doc_file_docs_directory():
+    assert is_doc_file("docs/README.md") is True
+
+
+def test_is_doc_file_readme_at_root():
+    assert is_doc_file("README.md") is True
+
+
+def test_is_doc_file_changelog_at_root():
+    assert is_doc_file("CHANGELOG.md") is True
+
+
+def test_is_doc_file_txt_extension():
+    assert is_doc_file("notes.txt") is True
+
+
+def test_is_doc_file_rst_extension():
+    assert is_doc_file("docs/api.rst") is True
+
+
+def test_is_doc_file_source_file_is_not_doc():
+    assert is_doc_file("app/compiler.py") is False
+
+
+def test_is_doc_file_no_extension_not_matched_by_pattern():
+    assert is_doc_file("app/Makefile") is False
+
+
+# --------------------------------------------------------------------------
+# is_config_file
+# --------------------------------------------------------------------------
+
+
+def test_is_config_file_yaml_extension():
+    assert is_config_file("app/config.yaml") is True
+
+
+def test_is_config_file_config_directory():
+    assert is_config_file("config/settings.json") is True
+
+
+def test_is_config_file_json_at_root():
+    assert is_config_file("package.json") is True
+
+
+def test_is_config_file_toml_extension():
+    assert is_config_file("pyproject.toml") is True
+
+
+def test_is_config_file_source_file_is_not_config():
+    assert is_config_file("app/compiler.py") is False
+
+
+# --------------------------------------------------------------------------
+# is_source_file
+# --------------------------------------------------------------------------
+
+
+def test_is_source_file_python_module():
+    assert is_source_file("app/compiler.py") is True
+
+
+def test_is_source_file_excludes_test_files():
+    assert is_source_file("tests/test_foo.py") is False
+
+
+def test_is_source_file_excludes_doc_files():
+    assert is_source_file("docs/README.md") is False
+
+
+def test_is_source_file_excludes_config_files():
+    assert is_source_file("app/config.yaml") is False
+
+
+def test_is_source_file_excludes_unknown_extensions():
+    assert is_source_file("image.png") is False
+
+
+def test_is_source_file_typescript():
+    assert is_source_file("web/app/page.tsx") is True
+
+
+# --------------------------------------------------------------------------
+# group_changed_files
+# --------------------------------------------------------------------------
+
+
+def test_group_changed_files_buckets_by_category():
+    paths = [
+        "app/compiler.py",
+        "tests/test_compiler.py",
+        "docs/architecture.md",
+        "config/settings.yaml",
+        ".github/workflows/ci.yml",
+        "api/routes/auth.py",
+        ".env.example",
+        "image.png",
+    ]
+
+    groups = group_changed_files(paths)
+
+    assert groups == {
+        "source": ["app/compiler.py"],
+        "tests": ["tests/test_compiler.py"],
+        "docs": ["docs/architecture.md"],
+        "config": ["config/settings.yaml"],
+        "ci": [".github/workflows/ci.yml"],
+        "auth": ["api/routes/auth.py"],
+        "secrets": [".env.example"],
+        "other": ["image.png"],
+    }
+
+
+def test_group_changed_files_omits_empty_groups():
+    groups = group_changed_files(["app/compiler.py"])
+    assert set(groups.keys()) == {"source"}
+
+
+def test_group_changed_files_deduplicates_and_normalizes_input():
+    groups = group_changed_files(["app\\compiler.py", "app/compiler.py"])
+    assert groups == {"source": ["app/compiler.py"]}
+
+
+def test_group_changed_files_empty_input_returns_empty_dict():
+    assert group_changed_files([]) == {}
+
+
+def test_group_changed_files_a_path_only_belongs_to_one_group():
+    # auth.py under api/routes matches both the "auth" GROUP_RULES pattern
+    # and could be considered source; GROUP_RULES is checked first and wins.
+    groups = group_changed_files(["api/routes/auth.py"])
+    assert groups == {"auth": ["api/routes/auth.py"]}
+
+
+# --------------------------------------------------------------------------
+# detect_risky_areas
+# --------------------------------------------------------------------------
+
+
+def test_detect_risky_areas_finds_auth_and_api_hits_for_same_path():
+    hits = detect_risky_areas(["api/routes/auth.py"])
+    categories = {h[0] for h in hits}
+    assert categories == {"auth", "api"}
+    assert all(h[1] == "api/routes/auth.py" for h in hits)
+
+
+def test_detect_risky_areas_secrets():
+    hits = detect_risky_areas([".env.example"])
+    assert hits == [
+        ("secrets", ".env.example", "Touches secret or environment configuration")
+    ]
+
+
+def test_detect_risky_areas_migrations():
+    hits = detect_risky_areas(["app/models/migrations/0001.py"])
+    assert hits == [
+        (
+            "migrations",
+            "app/models/migrations/0001.py",
+            "Touches database migration files",
+        )
+    ]
+
+
+def test_detect_risky_areas_no_hits_for_plain_source_file():
+    assert detect_risky_areas(["app/emitters.py"]) == []
+
+
+def test_detect_risky_areas_deduplicates_same_category_and_path():
+    # "*auth*" would otherwise match multiple times if patterns overlapped;
+    # verify duplicate input paths don't produce duplicate hits.
+    hits = detect_risky_areas(["api/routes/auth.py", "api/routes/auth.py"])
+    auth_hits = [h for h in hits if h[0] == "auth"]
+    assert len(auth_hits) == 1
+
+
+def test_detect_risky_areas_ci_workflow():
+    hits = detect_risky_areas([".github/workflows/ci.yml"])
+    assert ("ci", ".github/workflows/ci.yml", "Touches CI/CD workflow configuration") in hits
+
+
+# --------------------------------------------------------------------------
+# extract_scope_terms
+# --------------------------------------------------------------------------
+
+
+def test_extract_scope_terms_from_title_and_description():
+    terms = extract_scope_terms(
+        "feat: add login flow",
+        "Add session-based login endpoints for the API.",
+    )
+
+    assert terms == [
+        "login",
+        "flow",
+        "session-based",
+        "endpoints",
+        "api",
+        "session",
+        "endpoint",
+    ]
+
+
+def test_extract_scope_terms_drops_stop_words_and_short_tokens():
+    terms = extract_scope_terms("fix: update the docs", "Make this change for readability.")
+    for stop in ("fix", "update", "the", "make", "this", "for"):
+        assert stop not in terms
+
+
+def test_extract_scope_terms_dedupes_repeated_tokens():
+    terms = extract_scope_terms("auth auth auth", "")
+    assert terms.count("auth") == 1
+
+
+def test_extract_scope_terms_empty_input_returns_empty_list():
+    assert extract_scope_terms("", "") == []
+
+
+# --------------------------------------------------------------------------
+# path_reflects_scope_term
+# --------------------------------------------------------------------------
+
+
+def test_path_reflects_scope_term_direct_substring_match():
+    assert path_reflects_scope_term("api/routes/auth.py", "auth") is True
+
+
+def test_path_reflects_scope_term_no_match():
+    assert path_reflects_scope_term("docs/CONTRIBUTING.md", "login") is False
+
+
+def test_path_reflects_scope_term_matches_via_underscored_stem():
+    # "session manager" isn't a literal substring of the path (underscore vs
+    # space), but the stem-normalization step (underscores/hyphens -> spaces)
+    # should still surface the match.
+    assert path_reflects_scope_term("app/session_manager.py", "session manager") is True
+
+
+def test_path_reflects_scope_term_matches_via_hyphenated_stem():
+    assert path_reflects_scope_term("app/user-auth-flow.py", "auth flow") is True
+
+
+def test_path_reflects_scope_term_case_insensitive():
+    assert path_reflects_scope_term("API/Routes/Auth.py", "auth") is True


### PR DESCRIPTION
## Summary

Closes a set of test gaps identified in a prior audit: several pure-logic modules in the heuristics handler layer and `app/pr_safety/path_rules.py` had zero or near-zero direct test coverage despite non-trivial branching logic. No source files were modified — this PR only adds new test files.

Gaps closed:

- `app/heuristics/handlers/constraints.py` (`ConstraintHandler.detect_negations`, `.detect_dependencies`, `._extract_io_constraints`, `._extract_diagnostics`) had zero references in `tests/`.
- `app/heuristics/handlers/content.py` (`ContentHandler.handle`, the 10-branch intent-flag mapping) had zero references in `tests/`.
- `app/heuristics/handlers/context_suggestions.py` (`ContextSuggestionHandler._find_suggestions`) had zero references in `tests/`.
- `app/pr_safety/path_rules.py` — only `top_level_directories` was directly imported in `tests/test_pr_safety.py`; `normalize_path`, `is_test_file`, `is_doc_file`, `is_config_file`, `is_source_file`, `group_changed_files`, `detect_risky_areas`, `extract_scope_terms`, and `path_reflects_scope_term` were untested.

## New files

- `tests/heuristics/test_constraints_handler.py` — negation/dependency/IO-flow/diagnostic extraction, priority mapping, id-based dedup (via `handle()`), and no-original-text fallback.
- `tests/heuristics/test_content_handler.py` — all ~10 intent branches (summary, compare, variants, code, ambiguous, recency, creative, explanation, proposal, review, preparation, troubleshooting incl. the live-debug path), plus negative/empty cases and a combined multi-intent ordering check.
- `tests/heuristics/test_context_suggestions_handler.py` — exact filename match, stem word-boundary matching (including the "authentication" false-positive guard), short-stem skip, path/reason dedup, and the cap-at-5 truncation.
- `tests/test_pr_safety_path_rules.py` — `normalize_path`, `is_test_file`, `is_doc_file`, `is_config_file`, `is_source_file`, `group_changed_files`, `detect_risky_areas`, `extract_scope_terms`, `path_reflects_scope_term`, with realistic paths and edge cases.

## Test plan

- [x] `python -m pytest tests/heuristics/test_constraints_handler.py tests/heuristics/test_content_handler.py tests/heuristics/test_context_suggestions_handler.py tests/test_pr_safety_path_rules.py -v` — 103 passed
- [x] `python -m pytest tests/ -q` — 1840 passed, 7 skipped (pre-existing skips, unrelated to this change)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_018AFirMWyaRESFgaQnZqM78)_