### PR TITLE
fix(web): move copy aria-live to status region in ExportPanel

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -23,6 +23,12 @@ describe("Agent ExportPanel", () => {
         files: [],
       }),
     });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
   });
 
   test("exposes pressed state for the selected target and output mode", async () => {
@@ -76,5 +82,28 @@ describe("Agent ExportPanel", () => {
     await waitFor(() => expect(apiFetch).toHaveBeenCalled());
     const [, options] = apiFetch.mock.calls.at(-1);
     expect(JSON.parse(options.body).format).toBe("claude-agent-sdk-ts");
+  });
+
+  test("announces copy success via sr-only live region, not the copy button", async () => {
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    const copyButton = screen.getByRole("button", { name: "Copy code" });
+    expect(copyButton.getAttribute("aria-live")).toBeNull();
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("print('hello')");
+    });
+
+    const liveRegion = copyButton.querySelector(".sr-only");
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.getAttribute("aria-live")).toBe("polite");
+    expect(liveRegion).toHaveTextContent("Copied to clipboard");
+    expect(copyButton.getAttribute("aria-label")).toBe("Copied to clipboard");
   });
 });

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -309,10 +309,11 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                   type="button"
                   onClick={handleCopy}
                   className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
-                  aria-label="Copy code"
-                  aria-live="polite"
+                  aria-label={copied ? "Copied to clipboard" : "Copy code"}
                 >
-                  <span className="sr-only">{copied ? "Copied to clipboard" : ""}</span>
+                  <span className="sr-only" aria-live="polite">
+                    {copied ? "Copied to clipboard" : ""}
+                  </span>
                   {copied ? "Copied!" : "Copy"}
                 </button>
               </div>

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -23,6 +23,12 @@ describe("Skill ExportPanel", () => {
         files: [],
       }),
     });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
   });
 
   test("exposes pressed state for the selected target and output mode", async () => {
@@ -64,5 +70,28 @@ describe("Skill ExportPanel", () => {
     await waitFor(() => expect(apiFetch).toHaveBeenCalled());
     const [, options] = apiFetch.mock.calls.at(-1);
     expect(JSON.parse(options.body).format).toBe("claude-mcp-tool-stub");
+  });
+
+  test("announces copy success via sr-only live region, not the copy button", async () => {
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    const copyButton = screen.getByRole("button", { name: "Copy code" });
+    expect(copyButton.getAttribute("aria-live")).toBeNull();
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('{"name":"tool"}');
+    });
+
+    const liveRegion = copyButton.querySelector(".sr-only");
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion?.getAttribute("aria-live")).toBe("polite");
+    expect(liveRegion).toHaveTextContent("Copied to clipboard");
+    expect(copyButton.getAttribute("aria-label")).toBe("Copied to clipboard");
   });
 });

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -281,10 +281,11 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                   type="button"
                   onClick={handleCopy}
                   className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
-                  aria-label="Copy code"
-                  aria-live="polite"
+                  aria-label={copied ? "Copied to clipboard" : "Copy code"}
                 >
-                  <span className="sr-only">{copied ? "Copied to clipboard" : ""}</span>
+                  <span className="sr-only" aria-live="polite">
+                    {copied ? "Copied to clipboard" : ""}
+                  </span>
                   {copied ? "Copied!" : "Copy"}
                 </button>
               </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `aria-live` from the copy button to the `sr-only` status span in agent and skill generator ExportPanel components
- Toggle copy button `aria-label` so screen readers announce success after copy
- Add focused component tests that mock clipboard and assert post-copy live region behavior

## Category
UX

## Risk
Low — markup-only accessibility fix; copy behavior and visual feedback unchanged

## Test plan
- [x] `cd web && npm run test -- app/agent-generator/components/ExportPanel.test.tsx app/skills-generator/components/ExportPanel.test.tsx`
- [x] `cd web && npm run lint`
- [ ] CI Smoke + PR Tests green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

