### PR TITLE
fix(web): improve Conservative toggle focus ring and screen reader semantics

### DIFF
--- a/web/app/__tests__/page-conservative-toggle.test.tsx
+++ b/web/app/__tests__/page-conservative-toggle.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+describe("Conservative mode toggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({
+      indexStats: null,
+    });
+  });
+
+  it("renders as a switch with conservative mode on by default", () => {
+    render(<Home />);
+
+    const toggle = screen.getByRole("switch", { name: "Conservative mode ON" });
+
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("toggles conservative mode off and on when clicked", () => {
+    render(<Home />);
+
+    const toggle = screen.getByRole("switch", { name: "Conservative mode ON" });
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(toggle.getAttribute("aria-label")).toBe("Conservative mode OFF");
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(toggle.getAttribute("aria-label")).toBe("Conservative mode ON");
+  });
+
+  it("receives keyboard focus", () => {
+    render(<Home />);
+
+    const toggle = screen.getByRole("switch", { name: "Conservative mode ON" });
+    toggle.focus();
+
+    expect(document.activeElement).toBe(toggle);
+  });
+});

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -239,13 +239,14 @@ export default function Home() {
               aria-checked={conservativeMode}
               aria-label={conservativeMode ? "Conservative mode ON" : "Conservative mode OFF"}
               title={conservativeMode ? "Conservative mode ON" : "Conservative mode OFF"}
-              className={`group inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 ${
+              className={`group inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
                 conservativeMode
                   ? "border-cyan-400/40 bg-cyan-400/10 text-cyan-100 shadow-lg shadow-cyan-900/20"
                   : "border-zinc-700 bg-zinc-900/70 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200"
               }`}
             >
               <span
+                aria-hidden="true"
                 className={`h-2.5 w-2.5 rounded-full transition-all ${
                   conservativeMode ? "bg-emerald-400 shadow-[0_0_10px_rgba(74,222,128,0.7)]" : "bg-zinc-500"
                 }`}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add focus ring offset to the main compiler Conservative toggle so keyboard focus is visible on the dark header
- Mark the decorative status dot as `aria-hidden` so screen readers rely on `aria-checked` and the label
- Add focused Vitest coverage for switch role, default state, toggle, and focus

## Category
UX

## Risk
Low — CSS and aria attribute polish plus additive tests; no compiler or API behavior change

## Test plan
- [x] `cd web && npm run test -- __tests__/page-conservative-toggle.test.tsx`
- [x] `cd web && npm run lint`
- [ ] CI Smoke + PR Tests green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

