### PR TITLE
chore(api): add return type hints to meta health routes

### DIFF
--- a/api/routes/meta.py
+++ b/api/routes/meta.py
@@ -6,10 +6,10 @@ router = APIRouter(tags=["meta"])
 
 
 @router.get("/health")
-async def health():
+async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
 @router.get("/")
-async def root():
+async def root() -> dict[str, str]:
     return {"message": "Prompt Compiler API is running"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add explicit `-> dict[str, str]` return type hints to `/health` and `/` handlers in `api/routes/meta.py`

## Category
Code quality

## Risk
Low — annotation-only change; no runtime or API contract change

## Test plan
- [x] `python -m pytest tests/test_operational_hardening.py -q`
- [x] `python -m ruff check api/routes/meta.py`
- [ ] CI Smoke + PR Tests green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

