### PR TITLE
perf(heuristics): add negation fast-path guard to LogicAnalyzer

### DIFF
--- a/app/heuristics/logic_analyzer.py
+++ b/app/heuristics/logic_analyzer.py
@@ -120,6 +120,11 @@ _DEPENDENCY_FAST_PATH_RE = re.compile(
     re.IGNORECASE,
 )
 
+_NEGATION_FAST_PATH_RE = re.compile(
+    r"\b(?:never|absolutely\s+not|under\s+no\s+circumstances|do\s+not|don't|dont|doesn't|does\s+not|should\s+not|shouldn't|shouldnt|must\s+not|mustn't|mustnt|cannot|can't|can\s+not|avoid|refrain\s+from|stay\s+away\s+from|exclude|omit|skip|bypass|ignore|without|except|unless|none\s+of|forbidden|prohibited|disallowed|banned|\bno\s+\w+)\b",
+    re.IGNORECASE,
+)
+
 # Missing information reference patterns
 MISSING_REFERENCE_PATTERNS = [
     # Database/data references
@@ -274,6 +279,9 @@ class LogicAnalyzer:
         seen = set()
 
         for sentence in sentences:
+            if not _NEGATION_FAST_PATH_RE.search(sentence):
+                continue
+
             for pattern, neg_type in self._negation_re:
                 match = pattern.search(sentence)
                 if match:
@@ -457,8 +465,9 @@ class LogicAnalyzer:
         # Detect "the [noun]" patterns without prior definition
         for match in _UNDEFINED_ENTITY_PATTERN.finditer(text):
             entity = match.group(1)
-            key = f"Entity:{entity.lower()}"
-            if key not in seen and entity.lower() not in (
+            entity_lower = entity.lower()
+            key = f"Entity:{entity_lower}"
+            if key not in seen and entity_lower not in (
                 "user",
                 "system",
                 "output",

--- a/tests/test_logic_analyzer.py
+++ b/tests/test_logic_analyzer.py
@@ -40,6 +40,14 @@ def test_detect_dependencies_skips_sentences_without_dependency_keywords():
     assert dependencies == []
 
 
+def test_detect_negations_skips_sentences_without_negation_keywords():
+    analyzer = LogicAnalyzer()
+
+    negations = analyzer.detect_negations("Cache the API response for later reuse.")
+
+    assert negations == []
+
+
 def test_analyze_method_and_convenience_function():
     # Test analyze_prompt_logic convenience function and analyze method
     result = analyze_prompt_logic("Do not use JOIN because it is slow.")


### PR DESCRIPTION
## What
Skip the per-sentence negation pattern loop in `LogicAnalyzer.detect_negations` when a sentence contains no negation trigger word.

## Why it's safe
`_NEGATION_FAST_PATH_RE` is a **complete superset** of every trigger word in `NEGATION_PATTERNS`, so a non-matching sentence provably cannot match any real negation pattern — no detections are dropped.

## Scope note
The original version also added `missing-info` and `io` fast-path guards. Those were **dropped**: their trigger vocabularies (`the`, `with`, `data`, `should`, `list`, `format`, …) are so common that real prompts almost always match, giving a near-zero skip rate while paying an extra regex pass and introducing a hand-maintained duplicate vocabulary (silent-regression risk). Only the negation guard — where trigger words are genuinely sparse — is kept.

Mirrors the existing `_DEPENDENCY_FAST_PATH_RE` convention already in this file.