### PR TITLE
perf(emitters): dedupe goals/tasks lower() in expanded prompt path

### DIFF
--- a/app/emitters.py
+++ b/app/emitters.py
@@ -270,18 +270,25 @@ def _contains_any_marker(text: str, markers: tuple[str, ...]) -> bool:
     return False
 
 
-def _scenario_considerations(ir) -> list[str]:
-    """High-value, conservative gotchas for a recognized scenario (empty if none)."""
+def _ir_goals_tasks_lower(ir) -> str:
+    """Joined lowercase goals/tasks text for scenario/followup heuristics."""
     parts: list[str] = []
     for attr in ("goals", "tasks"):
         parts.extend(getattr(ir, attr, None) or [])
-    text = " ".join(parts).lower()
+    return " ".join(parts).lower()
+
+
+def _scenario_considerations(ir, *, text: str | None = None) -> list[str]:
+    """High-value, conservative gotchas for a recognized scenario (empty if none)."""
+    if text is None:
+        text = _ir_goals_tasks_lower(ir)
+    padded = f" {text} "
     if detect_frontend_download_feature(text):
         return _SCENARIO_CONSIDERATIONS["browser_download"]
     # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
     is_log_source = (
         _contains_any_marker(text, ("log file", "log files", "logs", "logfile", "logfiles"))
-        or " log " in f" {text} "
+        or " log " in padded
     )
     if is_log_source and _contains_any_marker(
         text, ("brute", "attack", "intrusion", "abuse", "bruteforce", "failed")
@@ -295,9 +302,12 @@ def _scenario_considerations(ir) -> list[str]:
         text, ("re-render", "rerender", "render", "slow", "perf", "memo")
     ):
         return _SCENARIO_CONSIDERATIONS["react_perf"]
-    has_orm = (
-        "orm" in [w.strip(".,;:!?()") for w in text.split()] or "-orm" in text or "orm-" in text
-    )
+    has_orm = "-orm" in text or "orm-" in text
+    if not has_orm:
+        for w in text.split():
+            if w.strip(".,;:!?()") == "orm":
+                has_orm = True
+                break
     if (
         _contains_any_marker(text, ("sql", "postgres", "mysql", "sqlite", "n+1"))
         or has_orm
@@ -317,7 +327,7 @@ def _scenario_considerations(ir) -> list[str]:
         return _SCENARIO_CONSIDERATIONS["auth_login"]
     if _contains_any_marker(
         text, ("timezone", "utc", "daylight saving", "datetime")
-    ) or _contains_any_marker(f" {text} ", (" dst ", " tz ")):
+    ) or _contains_any_marker(padded, (" dst ", " tz ")):
         return _SCENARIO_CONSIDERATIONS["datetime_tz"]
     if _contains_any_marker(
         text, ("frontend", "ui", "vue", "angular", "framework")
@@ -339,12 +349,10 @@ def _scenario_considerations(ir) -> list[str]:
     return []
 
 
-def _relevant_followups(ir) -> list[str]:
+def _relevant_followups(ir, *, text: str | None = None) -> list[str]:
     """Pick decisive follow-up questions from the detected domain/intents/text."""
-    parts: list[str] = []
-    for attr in ("goals", "tasks"):
-        parts.extend(getattr(ir, attr, None) or [])
-    text = " ".join(parts).lower()
+    if text is None:
+        text = _ir_goals_tasks_lower(ir)
     intents = set(getattr(ir, "intents", None) or [])
     domain = (getattr(ir, "domain", "") or "").lower()
     # Bolt Optimization: Replace any() generator expression with fast-path loop to avoid overhead
@@ -1072,7 +1080,8 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
             + ": "
             + ", ".join(ir.tone)
         )
-    scenario_considerations = _scenario_considerations(ir)
+    goals_tasks_text = _ir_goals_tasks_lower(ir)
+    scenario_considerations = _scenario_considerations(ir, text=goals_tasks_text)
     if scenario_considerations:
         ctx_lines.append(
             (
@@ -1181,7 +1190,7 @@ def emit_expanded_prompt_v2(ir: IRv2, diagnostics: bool = False) -> str:
         ]
         header_fu = "Preguntas de seguimiento"
     else:
-        followups = _relevant_followups(ir)
+        followups = _relevant_followups(ir, text=goals_tasks_text)
         header_fu = "Follow-up Questions"
     if followups:
         prompt.extend(["", header_fu + ":"])

--- a/tests/test_emitters_utils.py
+++ b/tests/test_emitters_utils.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from app.emitters import (
     _clean_domain_suggestion_text,
     _contains_any_marker,
+    _ir_goals_tasks_lower,
     _is_trivial_input,
     _minimal_greeting_prompt,
     _relevant_followups,
@@ -250,6 +251,26 @@ class TestScenarioConsiderations:
         assert "devtools" in considerations[0].lower()
         assert "virtualization" in considerations[1].lower()
 
+    def test_text_param_matches_standalone(self) -> None:
+        cases = [
+            SimpleNamespace(
+                goals=["Add a button so users can download CSV exports from the dashboard"],
+                tasks=[],
+            ),
+            SimpleNamespace(
+                goals=["Write a database query to list all active projects"],
+                tasks=[],
+            ),
+            SimpleNamespace(
+                goals=["Optimize frontend search rendering performance and latency"],
+                tasks=[],
+            ),
+        ]
+        for ir in cases:
+            standalone = _scenario_considerations(ir)
+            shared = _scenario_considerations(ir, text=_ir_goals_tasks_lower(ir))
+            assert shared == standalone
+
 
 class TestRelevantFollowups:
     """Choose the most useful follow-up question set for the prompt context."""
@@ -320,3 +341,29 @@ class TestRelevantFollowups:
             followups = _relevant_followups(ir)
             assert len(followups) == 3
             assert "Is there a tested backup" in followups[0]
+
+    def test_text_param_matches_standalone(self) -> None:
+        cases = [
+            SimpleNamespace(
+                goals=["My React button re-renders constantly and the page feels slow"],
+                tasks=[],
+                intents=[],
+                domain="software",
+            ),
+            SimpleNamespace(
+                goals=["This Chrome button renders in the wrong place after click"],
+                tasks=[],
+                intents=[],
+                domain="software",
+            ),
+            SimpleNamespace(
+                goals=["Set up docker script"],
+                tasks=[],
+                intents=[],
+                domain="software",
+            ),
+        ]
+        for ir in cases:
+            standalone = _relevant_followups(ir)
+            shared = _relevant_followups(ir, text=_ir_goals_tasks_lower(ir))
+            assert shared == standalone


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extract `_ir_goals_tasks_lower` so goals/tasks text is joined and lowercased once per expanded prompt
- Pass shared `text=` into `_scenario_considerations` and `_relevant_followups` from `emit_expanded_prompt_v2`
- Cache padded text in scenario considerations and use early-exit ORM keyword scan

## Category
Performance

## Risk
Low — refactor of string preparation only; classification output unchanged with tests proving parity

## Test plan
- [x] `python -m pytest tests/test_emitters_utils.py tests/test_expanded_prompt.py -q`
- [ ] CI Smoke + PR Tests green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

