### PR TITLE
fix(web): add aria-label to header retry button

### DIFF
--- a/web/app/__tests__/page-error-state.test.tsx
+++ b/web/app/__tests__/page-error-state.test.tsx
@@ -44,7 +44,10 @@ describe("Prompt Compiler home", () => {
       screen.getByText("Could not reach the backend. Check the API URL or make sure the server is running."),
     ).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Retry compile" }));
+    const headerRetry = screen.getByText("Retry");
+    expect(headerRetry).toHaveAttribute("aria-label", "Retry compile");
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Retry compile" })[0]);
 
     expect(retryMock).toHaveBeenCalledTimes(1);
   });

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -270,6 +270,7 @@ export default function Home() {
               {!!lastError && !loading && (
                 <button
                   type="button"
+                  aria-label="Retry compile"
                   onClick={() => void retry()}
                   className="text-xs font-medium text-red-300 bg-red-500/10 border border-red-500/20 px-3 py-1.5 rounded-lg hover:bg-red-500/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/50"
                 >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `aria-label="Retry compile"` to the header Retry button so screen readers get a clear action name matching the output panel
- Extend error-state test to assert the accessible name when the header retry is visible

## Category
UX (free pick)

## Risk
Low — aria attribute and test-only update; visible label and retry behavior unchanged

## Test plan
- [x] `cd web && npm run test -- __tests__/page-error-state.test.tsx`
- [x] `cd web && npm run lint`
- [ ] CI Smoke + PR Tests green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb5a02f-7a10-4b6a-a23d-303f2d972c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

