### PR TITLE
feat(web): typewriter animation parity for "try an example" across generators

### DIFF
--- a/docs/superpowers/plans/2026-07-03-typewriter-animation-parity.md
+++ b/docs/superpowers/plans/2026-07-03-typewriter-animation-parity.md
@@ -1,0 +1,542 @@
+# Typewriter Animation Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the main compile page's typewriter "or try an example" effect into a shared hook and apply it to the 6 single-field generator surfaces.
+
+**Architecture:** One reusable hook (`useTypewriterFill`) encapsulates the interval-based typing, `prefers-reduced-motion` bailout, focus, and cleanup. The main page is refactored to consume it (single source of truth); each sibling surface swaps its instant `setX(...)` example handler for `fillExample(...)` and cancels an in-flight run on manual edit / clear.
+
+**Tech Stack:** Next.js (App Router), React, TypeScript, Tailwind, Vitest + @testing-library/react (happy-dom).
+
+---
+
+## File Structure
+
+- **New:** `web/app/hooks/useTypewriterFill.ts` — the shared hook (only logic unit).
+- **New:** `web/app/hooks/useTypewriterFill.test.tsx` — hook unit tests (all logic coverage).
+- **New:** `web/app/__tests__/page-example-fill.test.tsx` — regression test that the main-page refactor preserves example fill.
+- **Modified (wiring only):** `web/app/page.tsx`, `web/app/agent-generator/page.tsx`, `web/app/skills-generator/page.tsx`, `web/app/benchmark/page.tsx`, `web/app/optimizer/page.tsx`, `web/app/agent-packs/page.tsx`, `web/app/offline/page.tsx`.
+
+**Testing strategy:** The hook holds 100% of the logic and is unit-tested for both paths (reduced-motion instant + animated typing + cancel + cleanup). The main-page refactor gets a dedicated regression test. The 6 surface changes are mechanical wiring; they are verified by TypeScript compile (`npm run build`) and the full `npm run test` suite staying green, plus a final manual smoke — this tests at the right unit instead of scaffolding six heavy full-page render tests for a one-line swap.
+
+---
+
+### Task 1: Create the `useTypewriterFill` hook
+
+**Files:**
+- Create: `web/app/hooks/useTypewriterFill.ts`
+- Test: `web/app/hooks/useTypewriterFill.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `web/app/hooks/useTypewriterFill.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { useTypewriterFill } from "./useTypewriterFill";
+
+function Harness({ text }: { text: string }) {
+  const [val, setVal] = useState("");
+  const { fillExample } = useTypewriterFill(setVal, { id: "harness-input" });
+  return (
+    <>
+      <textarea id="harness-input" aria-label="harness" value={val} readOnly />
+      <button onClick={() => fillExample(text)}>fill</button>
+    </>
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  // reset any matchMedia stub
+  // @ts-expect-error test cleanup
+  delete window.matchMedia;
+});
+
+describe("useTypewriterFill", () => {
+  it("fills instantly when prefers-reduced-motion is set", () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    render(<Harness text="hello world" />);
+
+    fireEvent.click(screen.getByText("fill"));
+
+    expect((screen.getByLabelText("harness") as HTMLTextAreaElement).value).toBe("hello world");
+  });
+
+  it("types the full text over the interval when motion is allowed", () => {
+    vi.useFakeTimers();
+    // no matchMedia -> guard is false -> animate
+    render(<Harness text="abcdefghij" />);
+
+    fireEvent.click(screen.getByText("fill"));
+    // mid-run it is not yet complete
+    vi.advanceTimersByTime(16);
+    const mid = (screen.getByLabelText("harness") as HTMLTextAreaElement).value;
+    expect(mid.length).toBeGreaterThanOrEqual(0);
+    expect(mid.length).toBeLessThan("abcdefghij".length);
+
+    vi.runAllTimers();
+    expect((screen.getByLabelText("harness") as HTMLTextAreaElement).value).toBe("abcdefghij");
+  });
+
+  it("focuses the target element", () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    render(<Harness text="x" />);
+
+    fireEvent.click(screen.getByText("fill"));
+
+    expect(document.activeElement).toBe(screen.getByLabelText("harness"));
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run app/hooks/useTypewriterFill.test.tsx`
+Expected: FAIL — module `./useTypewriterFill` not found.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `web/app/hooks/useTypewriterFill.ts`:
+
+```ts
+import { useEffect, useRef } from "react";
+
+type FocusTarget = { id?: string; selector?: string };
+
+/**
+ * Shared "type an example in" effect. Mirrors the original page.tsx behavior:
+ * ~0.65s total, length-independent, honors prefers-reduced-motion, cancellable.
+ */
+export function useTypewriterFill(
+  setter: (value: string) => void,
+  focusTarget?: FocusTarget,
+) {
+  const intervalRef = useRef<number | null>(null);
+
+  const stop = () => {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  useEffect(() => stop, []);
+
+  const focus = () => {
+    if (!focusTarget) return;
+    const el = focusTarget.id
+      ? document.getElementById(focusTarget.id)
+      : focusTarget.selector
+        ? document.querySelector<HTMLElement>(focusTarget.selector)
+        : null;
+    el?.focus();
+  };
+
+  const fillExample = (text: string) => {
+    stop();
+    focus();
+    const prefersReduced =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReduced) {
+      setter(text);
+      return;
+    }
+    setter("");
+    const stepChars = Math.max(1, Math.ceil(text.length / 40)); // ~0.65s total, length-independent
+    let i = 0;
+    intervalRef.current = window.setInterval(() => {
+      i = Math.min(text.length, i + stepChars);
+      setter(text.slice(0, i));
+      if (i >= text.length) stop();
+    }, 16);
+  };
+
+  return { fillExample, stop };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run app/hooks/useTypewriterFill.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/hooks/useTypewriterFill.ts web/app/hooks/useTypewriterFill.test.tsx
+git commit -m "feat(web): add shared useTypewriterFill hook for example autofill"
+```
+
+---
+
+### Task 2: Refactor main `page.tsx` to consume the hook
+
+**Files:**
+- Modify: `web/app/page.tsx` (imports; remove lines ~165–196; add hook call)
+- Test: `web/app/__tests__/page-example-fill.test.tsx`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Create `web/app/__tests__/page-example-fill.test.tsx` (mock scaffold mirrors `page-conservative-toggle.test.tsx`):
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({ useCompiler: () => useCompilerMock() }));
+vi.mock("../hooks/useContextManager", () => ({ useContextManager: () => useContextManagerMock() }));
+vi.mock("../components/ContextManager", () => ({ default: () => <div data-testid="context-manager" /> }));
+vi.mock("../components/OutputSkeleton", () => ({ default: () => <div data-testid="output-skeleton" /> }));
+
+describe("main page example fill", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    useCompilerMock.mockReturnValue({
+      loading: false, result: null, status: "Ready", lastError: null,
+      securityFindings: [], redactedText: "",
+      runCompile: vi.fn(), retry: vi.fn(), resolveSecurityDecision: vi.fn(), cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({ indexStats: null });
+  });
+
+  it("fills the prompt textarea from the example button", () => {
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("button", { name: /or try an example/i }));
+
+    const textarea = screen.getByLabelText("Describe what you want compiled") as HTMLTextAreaElement;
+    expect(textarea.value.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it passes against current code (baseline green)**
+
+Run: `cd web && npx vitest run app/__tests__/page-example-fill.test.tsx`
+Expected: PASS (proves the test is valid before refactor). If the example button role/name differs, adjust the query to `screen.getByText(/or try an example/i)`.
+
+- [ ] **Step 3: Refactor page.tsx**
+
+1. Change the React import (drop now-unused `useRef`):
+   - From: `import { useEffect, useId, useRef, useState } from "react";`
+   - To:   `import { useEffect, useId, useState } from "react";`
+2. Add the hook import near the other imports:
+   - `import { useTypewriterFill } from "./hooks/useTypewriterFill";`
+3. Delete the inline block (current lines ~165–196: the `// Typewriter entrance...` comment, `typewriterRef`, `stopTypewriter`, `useEffect(() => stopTypewriter, [])`, and the whole `fillExample` function).
+4. In its place add:
+
+```tsx
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setPrompt, {
+    selector: 'textarea[aria-label="Describe what you want compiled"]',
+  });
+```
+
+   (Aliasing `stop` to `stopTypewriter` keeps the existing `onChange` at line ~299 and Clear at line ~312 unchanged.)
+
+- [ ] **Step 4: Run the regression test + full suite**
+
+Run: `cd web && npx vitest run app/__tests__/page-example-fill.test.tsx && npm run test`
+Expected: PASS; whole suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/page.tsx web/app/__tests__/page-example-fill.test.tsx
+git commit -m "refactor(web): main page uses shared useTypewriterFill hook"
+```
+
+---
+
+### Task 3: Wire `agent-generator`
+
+**Files:** Modify `web/app/agent-generator/page.tsx`
+
+- [ ] **Step 1: Add the hook import** (top of file, with other imports):
+
+```tsx
+import { useTypewriterFill } from "../hooks/useTypewriterFill";
+```
+
+- [ ] **Step 2: Call the hook** inside the component (near the `const [description, setDescription] = useState("")` declarations):
+
+```tsx
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setDescription, { id: "agent-description" });
+```
+
+- [ ] **Step 3: Replace the example button handler** (current lines ~454–461):
+
+Replace:
+```tsx
+                        onClick={() => {
+                          setDescription("A customer support agent that answers questions about billing, handles refunds, and escalates complex issues to a human.");
+                          setTimeout(() => {
+                            const textarea = document.getElementById('agent-description');
+                            if (textarea) textarea.focus();
+                          }, 0);
+                        }}
+```
+With:
+```tsx
+                        onClick={() => fillExample("A customer support agent that answers questions about billing, handles refunds, and escalates complex issues to a human.")}
+```
+
+- [ ] **Step 4: Cancel on manual edit and clear.**
+
+Textarea onChange (line ~260):
+- From: `onChange={(e) => setDescription(e.target.value)}`
+- To:   `onChange={(e) => { stopTypewriter(); setDescription(e.target.value); }}`
+
+Clear button (line ~275):
+- From: `onClick={() => setDescription("")}`
+- To:   `onClick={() => { stopTypewriter(); setDescription(""); }}`
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd web && npm run test`
+Expected: whole suite green.
+```bash
+git add web/app/agent-generator/page.tsx
+git commit -m "feat(web): animate agent-generator example fill"
+```
+
+---
+
+### Task 4: Wire `skills-generator`
+
+**Files:** Modify `web/app/skills-generator/page.tsx`
+
+- [ ] **Step 1: Add import** `import { useTypewriterFill } from "../hooks/useTypewriterFill";`
+- [ ] **Step 2: Call the hook** (near `const [description, setDescription] = useState("")`):
+
+```tsx
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setDescription, { id: "skill-description" });
+```
+
+- [ ] **Step 3: Replace the example handler** (current lines ~427–434):
+
+Replace the `onClick={() => { setDescription("A skill that ..."); setTimeout(...) }}` block with:
+```tsx
+                        onClick={() => fillExample("A skill that takes a URL, fetches the page content, extracts the main article text, and returns a 3-bullet summary.")}
+```
+
+- [ ] **Step 4: Cancel on manual edit.** Textarea onChange (line ~254):
+- From: `onChange={(e) => setDescription(e.target.value)}`
+- To:   `onChange={(e) => { stopTypewriter(); setDescription(e.target.value); }}`
+
+(If this surface has a Clear-field button, wire `stopTypewriter()` into it the same way.)
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd web && npm run test`
+```bash
+git add web/app/skills-generator/page.tsx
+git commit -m "feat(web): animate skills-generator example fill"
+```
+
+---
+
+### Task 5: Wire `benchmark`
+
+**Files:** Modify `web/app/benchmark/page.tsx`
+
+- [ ] **Step 1: Add import** `import { useTypewriterFill } from "../hooks/useTypewriterFill";`
+- [ ] **Step 2: Call the hook** (near `const [prompt, setPrompt] = useState(...)`):
+
+```tsx
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setPrompt, { id: "benchmark-prompt" });
+```
+
+- [ ] **Step 3: Replace the example handler** (current lines ~525–531) with:
+```tsx
+                          onClick={() => fillExample("Write a Python script to scrape data from a Wikipedia page and extract all the tables.")}
+```
+
+- [ ] **Step 4: Cancel on manual edit.** Textarea onChange (lines ~355–358):
+- From:
+```tsx
+                onChange={(event) => {
+                  setPrompt(event.target.value);
+                  window.localStorage.setItem("promptc_benchmark_prompt", event.target.value);
+                }}
+```
+- To:
+```tsx
+                onChange={(event) => {
+                  stopTypewriter();
+                  setPrompt(event.target.value);
+                  window.localStorage.setItem("promptc_benchmark_prompt", event.target.value);
+                }}
+```
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd web && npm run test`
+```bash
+git add web/app/benchmark/page.tsx
+git commit -m "feat(web): animate benchmark example fill"
+```
+
+---
+
+### Task 6: Wire `optimizer`
+
+**Files:** Modify `web/app/optimizer/page.tsx` (textarea already has `id="original-prompt"`; the example button currently does not focus at all — the hook adds focus).
+
+- [ ] **Step 1: Add import** `import { useTypewriterFill } from "../hooks/useTypewriterFill";`
+- [ ] **Step 2: Call the hook** (near `const [input, setInput] = useState(...)`):
+
+```tsx
+    const { fillExample, stop: stopTypewriter } = useTypewriterFill(setInput, { id: "original-prompt" });
+```
+
+- [ ] **Step 3: Replace the example handler** (current lines ~497–499) with:
+```tsx
+                                        onClick={() => fillExample("You are a helpful assistant. Provide a detailed, step-by-step summary of the provided text, ensuring that no important information is left out, and format the output as a bulleted list with clear headings for each section.")}
+```
+
+- [ ] **Step 4: Cancel on manual edit.** Textarea onChange (lines ~410–413):
+- From:
+```tsx
+                            onChange={(e) => {
+                                setInput(e.target.value);
+                                window.localStorage.setItem("promptc_optimizer_prompt", e.target.value);
+                            }}
+```
+- To:
+```tsx
+                            onChange={(e) => {
+                                stopTypewriter();
+                                setInput(e.target.value);
+                                window.localStorage.setItem("promptc_optimizer_prompt", e.target.value);
+                            }}
+```
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd web && npm run test`
+```bash
+git add web/app/optimizer/page.tsx
+git commit -m "feat(web): animate optimizer example fill"
+```
+
+---
+
+### Task 7: Wire `agent-packs`
+
+**Files:** Modify `web/app/agent-packs/page.tsx` (setter writes a nested field via `handleFieldChange('goal', …)`).
+
+- [ ] **Step 1: Add import** `import { useTypewriterFill } from "../hooks/useTypewriterFill";`
+- [ ] **Step 2: Call the hook** (after `handleFieldChange` is defined, ~line 119):
+
+```tsx
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(
+    (v) => handleFieldChange("goal", v),
+    { id: "agent-pack-goal" },
+  );
+```
+
+- [ ] **Step 3: Replace the example handler** (current lines ~582–589) with:
+```tsx
+                        onClick={() => fillExample("Review PRs for prompt leakage, unsafe settings, and missing regression tests.")}
+```
+
+- [ ] **Step 4: Cancel on manual edit and clear.**
+
+Textarea onChange (line ~338):
+- From: `onChange={(event) => handleFieldChange("goal", event.target.value)}`
+- To:   `onChange={(event) => { stopTypewriter(); handleFieldChange("goal", event.target.value); }}`
+
+Clear button (line ~346):
+- From: `onClick={() => handleFieldChange("goal", "")}`
+- To:   `onClick={() => { stopTypewriter(); handleFieldChange("goal", ""); }}`
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd web && npm run test`
+```bash
+git add web/app/agent-packs/page.tsx
+git commit -m "feat(web): animate agent-packs example fill"
+```
+
+---
+
+### Task 8: Wire `offline` (two example buttons, one hook)
+
+**Files:** Modify `web/app/offline/page.tsx`
+
+- [ ] **Step 1: Add import** `import { useTypewriterFill } from "../hooks/useTypewriterFill";`
+- [ ] **Step 2: Call the hook once** (near `const [prompt, setPrompt] = useState("")`):
+
+```tsx
+    const { fillExample, stop: stopTypewriter } = useTypewriterFill(setPrompt, { id: "offline-prompt" });
+```
+
+- [ ] **Step 3: Replace BOTH example handlers.**
+
+First button (current lines ~174–181):
+```tsx
+                                        onClick={() => fillExample("Create a Python script that monitors a local log directory for new .log files, parses them for ERROR level messages, and outputs a summary report.")}
+```
+Second button (current lines ~276–286): keep its own example text — replace its `onClick={() => { setPrompt("..."); setTimeout(...) }}` with:
+```tsx
+                                            onClick={() => fillExample("Summarize the key points of this meeting transcript.")}
+```
+
+- [ ] **Step 4: Cancel on manual edit.** Textarea onChange (line ~123):
+- From: `onChange={(e) => setPrompt(e.target.value)}`
+- To:   `onChange={(e) => { stopTypewriter(); setPrompt(e.target.value); }}`
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `cd web && npm run test`
+```bash
+git add web/app/offline/page.tsx
+git commit -m "feat(web): animate offline example fill"
+```
+
+---
+
+### Task 9: Full verification
+
+- [ ] **Step 1: Full web test suite**
+
+Run: `cd web && npm run test`
+Expected: all files/tests pass.
+
+- [ ] **Step 2: Type-check / build**
+
+Run: `cd web && npm run build`
+Expected: build succeeds (no TS errors).
+
+- [ ] **Step 3: Manual smoke (optional but recommended)**
+
+Run the dev server, open each surface, click "or try an example", confirm the text types in (and that manual typing mid-animation cancels it). Also toggle OS "reduce motion" and confirm instant fill.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Shared hook `useTypewriterFill` → Task 1. ✅
+- Applied to the 6 surfaces (agent-generator, skills-generator, benchmark, optimizer, agent-packs, offline) → Tasks 3–8. ✅
+- Main `page.tsx` refactored to consume the hook → Task 2. ✅
+- Behavior parity (~0.65s, length-independent, reduced-motion, cancel on edit/clear) → hook impl + per-surface onChange/Clear wiring. ✅
+- `pr-safety` excluded → not in any task. ✅
+- Testing (reduced-motion + timer paths) → Task 1 hook tests; Task 2 regression test. ✅
+
+**Placeholder scan:** Each surface task shows exact before/after code and exact example strings. The only conditional note ("if this surface has a Clear button") applies to skills-generator, where none was found in the mapped region; onChange cancellation (the primary guard) is exact. No TODO/TBD.
+
+**Type consistency:** Hook returns `{ fillExample, stop }` everywhere; surfaces alias `stop` as `stopTypewriter` to match the reference naming used in onChange/Clear handlers. `focusTarget` uses `{ id }` for surfaces and `{ selector }` for the main page. Consistent across all tasks.

--- a/docs/superpowers/specs/2026-07-03-typewriter-animation-parity-design.md
+++ b/docs/superpowers/specs/2026-07-03-typewriter-animation-parity-design.md
@@ -1,0 +1,86 @@
+# Typewriter Animation Parity — Design
+
+- **Date:** 2026-07-03
+- **Status:** Approved (design), pending spec review → implementation plan
+- **Scope:** Frontend only (`web/`)
+
+## Goal
+
+The "or try an example" affordance types its example prompt in character-by-character
+(typewriter effect) **only** on the main compile surface (`web/app/page.tsx`). Every other
+generator surface fills the field **instantly**. Bring the animation to the sibling surfaces
+by extracting the existing logic into one reusable hook and wiring it in.
+
+## Current State (confirmed by code map)
+
+- Reference implementation lives in `web/app/page.tsx` (lines ~165–196): a `typewriterRef`
+  (`useRef<number|null>`), a `stopTypewriter()` (clearInterval + null the ref), a
+  `prefers-reduced-motion` bailout (set full text instantly), `stepChars = Math.max(1, Math.ceil(text.length / 40))`,
+  a 16ms `setInterval` advancing `setPrompt(text.slice(0, i))`, unmount cleanup via
+  `useEffect(() => stopTypewriter, [])`, and defensive cancellation on textarea `onChange`
+  (line ~299) and Clear (line ~312). No framer-motion; plain `setInterval` + React state.
+- Surfaces **missing** the animation (fill instantly today):
+  | Surface | File | State setter | Focus target |
+  |---|---|---|---|
+  | agent-generator | `web/app/agent-generator/page.tsx` | `setDescription` | id `agent-description` |
+  | skills-generator | `web/app/skills-generator/page.tsx` | `setDescription` | id `skill-description` |
+  | benchmark | `web/app/benchmark/page.tsx` | `setPrompt` | id `benchmark-prompt` |
+  | optimizer | `web/app/optimizer/page.tsx` | `setInput` | none today (add one) |
+  | agent-packs | `web/app/agent-packs/page.tsx` | `handleFieldChange('goal', …)` | id `agent-pack-goal` |
+  | offline | `web/app/offline/page.tsx` | `setPrompt` (2 buttons) | id `offline-prompt` |
+- **Out of scope:** `web/app/pr-safety/page.tsx` — its `loadExample()` fills four fields
+  from an `EXAMPLE` constant (title/description/changedFiles/commitsBehind) and uses
+  different button copy; it does not fit the single-field typewriter pattern.
+
+## Design
+
+### New hook — `web/app/hooks/useTypewriterFill.ts`
+
+Encapsulates the reference logic so there is exactly one implementation.
+
+```ts
+// Conceptual signature — final types decided in the plan.
+function useTypewriterFill(
+  setter: (value: string) => void,
+  focusTarget?: { id?: string; selector?: string },
+): { fillExample: (text: string) => void; stop: () => void };
+```
+
+Behavior (identical to today's main surface):
+- Cancels any in-flight run, then focuses the target (`getElementById(id)` or `querySelector(selector)`).
+- If `prefers-reduced-motion: reduce` → set full text instantly and return.
+- Otherwise clear the field, then `setInterval(16ms)` advancing by `stepChars = max(1, ceil(len/40))`
+  so total runtime is ~0.65s and length-independent; stop when complete.
+- Interval id held in a ref; cleared on unmount.
+
+### Wiring per surface
+
+- Replace each "or try an example" `onClick` instant `setX(...)` with `fillExample(...)`.
+- Wire `stop()` into each surface's textarea `onChange` and Clear handler so manual typing
+  cancels an in-flight animation (mirroring main).
+- **Refactor `web/app/page.tsx` to consume the hook too**, removing the duplicated inline
+  logic (improve the code we're touching; single source of truth).
+- Special cases:
+  - **agent-packs:** setter is `(v) => handleFieldChange('goal', v)`; each tick feeds the sliced string.
+  - **optimizer:** add a focus target (give the textarea an `id`, e.g. `optimizer-input`) for parity.
+  - **offline:** both example buttons use the same hook instance (setter `setPrompt`, id `offline-prompt`).
+
+## Testing
+
+- Per surface: a click test asserting the field ends up with the full example text.
+- `prefers-reduced-motion` path (instant fill) — mock `matchMedia` to `matches: true`.
+- Timer path — `vi.useFakeTimers()` + advance to assert intermediate/typed state, or assert
+  final state after running all timers.
+- Keep existing tests green (main surface behavior unchanged after refactor).
+
+## Non-Goals
+
+- No new animation library (no framer-motion).
+- No change to `pr-safety`.
+- No change to example prompt copy.
+
+## Files
+
+- **New:** `web/app/hooks/useTypewriterFill.ts` (+ test).
+- **Modified:** `web/app/page.tsx` (refactor to hook), and the 6 sibling surfaces listed above
+  (+ their tests).

--- a/web/app/__tests__/page-example-fill.test.tsx
+++ b/web/app/__tests__/page-example-fill.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({ useCompiler: () => useCompilerMock() }));
+vi.mock("../hooks/useContextManager", () => ({ useContextManager: () => useContextManagerMock() }));
+vi.mock("../components/ContextManager", () => ({ default: () => <div data-testid="context-manager" /> }));
+vi.mock("../components/OutputSkeleton", () => ({ default: () => <div data-testid="output-skeleton" /> }));
+
+describe("main page example fill", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({ indexStats: null });
+  });
+
+  it("fills the prompt textarea from the example button", () => {
+    render(<Home />);
+
+    fireEvent.click(screen.getByText(/or try an example/i));
+
+    const textarea = screen.getByLabelText("Describe what you want compiled") as HTMLTextAreaElement;
+    expect(textarea.value.length).toBeGreaterThan(0);
+  });
+});

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -3,6 +3,7 @@
 import { toast } from "sonner";
 
 import { useRef, useState } from "react";
+import { useTypewriterFill } from "../hooks/useTypewriterFill";
 import ReactMarkdown from "react-markdown";
 import { Bot } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
@@ -63,6 +64,7 @@ export default function AgentGenerator() {
   const [history, setHistory] = useState<{ label: string; result: AgentGenerationView }[]>([]);
   const [copied, setCopied] = useState(false);
 
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setDescription, { id: "agent-description" });
   const isGeneratingRef = useRef(false);
   const isValidRepoUrl = isSupportedGitHubRepoRootUrl(repoUrl);
 
@@ -257,7 +259,7 @@ export default function AgentGenerator() {
                 className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'I need an agent that reviews React code for performance bottlenecks' or 'A creative writer for sci-fi stories'"
                 value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={(e) => { stopTypewriter(); setDescription(e.target.value); }}
                 onKeyDown={(e) => {
                   if (e.repeat) return;
                   if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
@@ -272,7 +274,7 @@ export default function AgentGenerator() {
             {description && (
               <button
                 type="button"
-                onClick={() => setDescription("")}
+                onClick={() => { stopTypewriter(); setDescription(""); }}
                 className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green-500/50"
                 title="Clear input"
                 aria-label="Clear input"
@@ -451,13 +453,7 @@ export default function AgentGenerator() {
                     {!description.trim() && (
                       <button
                         type="button"
-                        onClick={() => {
-                          setDescription("A customer support agent that answers questions about billing, handles refunds, and escalates complex issues to a human.");
-                          setTimeout(() => {
-                            const textarea = document.getElementById('agent-description');
-                            if (textarea) textarea.focus();
-                          }, 0);
-                        }}
+                        onClick={() => fillExample("A customer support agent that answers questions about billing, handles refunds, and escalates complex issues to a human.")}
                         className={`text-xs ${multiAgent ? 'text-purple-400/80 hover:text-purple-300 focus-visible:ring-purple-500' : 'text-green-400/80 hover:text-green-300 focus-visible:ring-green-500'} transition-colors focus-visible:outline-none focus-visible:ring-1 rounded px-2 py-1`}
                       >
                         or try an example

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -3,6 +3,7 @@
 import { toast } from "sonner";
 
 import { useMemo, useState } from "react";
+import { useTypewriterFill } from "../hooks/useTypewriterFill";
 import { Bot, Copy, Download, FileCode2, FolderArchive, Loader2, ShieldCheck, Sparkles, X } from "lucide-react";
 
 import { apiFetch, apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
@@ -119,6 +120,11 @@ export default function AgentPacksPage() {
   const handleFieldChange = <K extends keyof AgentPackRequest>(key: K, value: AgentPackRequest[K]) => {
     setRequest((prev) => ({ ...prev, [key]: value }));
   };
+
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(
+    (v) => handleFieldChange("goal", v),
+    { id: "agent-pack-goal" },
+  );
 
   const handleGenerate = async () => {
     if (!request.goal.trim()) return;
@@ -335,7 +341,7 @@ export default function AgentPacksPage() {
                 id="agent-pack-goal"
                 aria-label="Agent Pack Goal"
                 value={request.goal}
-                onChange={(event) => handleFieldChange("goal", event.target.value)}
+                onChange={(event) => { stopTypewriter(); handleFieldChange("goal", event.target.value); }}
                 className="min-h-36 rounded-2xl border border-white/10 bg-black/20 p-4 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
                 placeholder="e.g. Review PRs for prompt leakage, unsafe settings, and missing regression tests."
               />
@@ -343,7 +349,7 @@ export default function AgentPacksPage() {
             {request.goal && (
               <button
                 type="button"
-                onClick={() => handleFieldChange("goal", "")}
+                onClick={() => { stopTypewriter(); handleFieldChange("goal", ""); }}
                 className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500/50"
                 title="Clear input"
                 aria-label="Clear input"
@@ -579,13 +585,7 @@ export default function AgentPacksPage() {
                     {!request.goal.trim() && (
                       <button
                         type="button"
-                        onClick={() => {
-                          handleFieldChange("goal", "Review PRs for prompt leakage, unsafe settings, and missing regression tests.");
-                          setTimeout(() => {
-                            const textarea = document.getElementById('agent-pack-goal');
-                            if (textarea) textarea.focus();
-                          }, 0);
-                        }}
+                        onClick={() => fillExample("Review PRs for prompt leakage, unsafe settings, and missing regression tests.")}
                         className="text-xs text-cyan-400/80 hover:text-cyan-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded px-2 py-1"
                       >
                         or try an example

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { useTypewriterFill } from "../hooks/useTypewriterFill";
 import {
   Legend,
   PolarAngleAxis,
@@ -129,6 +130,7 @@ export default function BenchmarkPage() {
     if (typeof window === "undefined") return "";
     return window.localStorage.getItem("promptc_benchmark_prompt") || "";
   });
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setPrompt, { id: "benchmark-prompt" });
   const [loading, setLoading] = useState(false);
   const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkPayload | null>(null);
   const [resultIsMock, setResultIsMock] = useState(false);
@@ -353,6 +355,7 @@ export default function BenchmarkPage() {
                 placeholder={"Enter a prompt to benchmark...\n\ne.g. 'Write a Python script to scrape data'"}
                 value={prompt}
                 onChange={(event) => {
+                  stopTypewriter();
                   setPrompt(event.target.value);
                   window.localStorage.setItem("promptc_benchmark_prompt", event.target.value);
                 }}
@@ -522,13 +525,7 @@ export default function BenchmarkPage() {
                       {!prompt.trim() && (
                         <button
                           type="button"
-                          onClick={() => {
-                            setPrompt("Write a Python script to scrape data from a Wikipedia page and extract all the tables.");
-                            setTimeout(() => {
-                              const textarea = document.getElementById('benchmark-prompt');
-                              if (textarea) textarea.focus();
-                            }, 0);
-                          }}
+                          onClick={() => fillExample("Write a Python script to scrape data from a Wikipedia page and extract all the tables.")}
                           className="text-xs text-amber-400/80 hover:text-amber-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-500 rounded px-2 py-1"
                         >
                           or try an example

--- a/web/app/hooks/useTypewriterFill.test.tsx
+++ b/web/app/hooks/useTypewriterFill.test.tsx
@@ -1,0 +1,61 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { useTypewriterFill } from "./useTypewriterFill";
+
+function Harness({ text }: { text: string }) {
+  const [val, setVal] = useState("");
+  const { fillExample } = useTypewriterFill(setVal, { id: "harness-input" });
+  return (
+    <>
+      <textarea id="harness-input" aria-label="harness" value={val} readOnly />
+      <button onClick={() => fillExample(text)}>fill</button>
+    </>
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  // @ts-expect-error test cleanup of the matchMedia stub
+  delete window.matchMedia;
+});
+
+describe("useTypewriterFill", () => {
+  it("fills instantly when prefers-reduced-motion is set", () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    render(<Harness text="hello world" />);
+
+    fireEvent.click(screen.getByText("fill"));
+
+    expect((screen.getByLabelText("harness") as HTMLTextAreaElement).value).toBe("hello world");
+  });
+
+  it("types the full text over the interval when motion is allowed", () => {
+    vi.useFakeTimers();
+    // no matchMedia -> guard is false -> animate
+    render(<Harness text="abcdefghij" />);
+
+    fireEvent.click(screen.getByText("fill"));
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    const mid = (screen.getByLabelText("harness") as HTMLTextAreaElement).value;
+    expect(mid.length).toBeLessThan("abcdefghij".length);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect((screen.getByLabelText("harness") as HTMLTextAreaElement).value).toBe("abcdefghij");
+  });
+
+  it("focuses the target element", () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia;
+    render(<Harness text="x" />);
+
+    fireEvent.click(screen.getByText("fill"));
+
+    expect(document.activeElement).toBe(screen.getByLabelText("harness"));
+  });
+});

--- a/web/app/hooks/useTypewriterFill.ts
+++ b/web/app/hooks/useTypewriterFill.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from "react";
+
+type FocusTarget = { id?: string; selector?: string };
+
+/**
+ * Shared "type an example in" effect. Mirrors the original page.tsx behavior:
+ * ~0.65s total, length-independent, honors prefers-reduced-motion, cancellable.
+ */
+export function useTypewriterFill(
+  setter: (value: string) => void,
+  focusTarget?: FocusTarget,
+) {
+  const intervalRef = useRef<number | null>(null);
+
+  const stop = () => {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  useEffect(() => stop, []);
+
+  const focus = () => {
+    if (!focusTarget) return;
+    const el = focusTarget.id
+      ? document.getElementById(focusTarget.id)
+      : focusTarget.selector
+        ? document.querySelector<HTMLElement>(focusTarget.selector)
+        : null;
+    el?.focus();
+  };
+
+  const fillExample = (text: string) => {
+    stop();
+    focus();
+    const prefersReduced =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReduced) {
+      setter(text);
+      return;
+    }
+    setter("");
+    const stepChars = Math.max(1, Math.ceil(text.length / 40)); // ~0.65s total, length-independent
+    let i = 0;
+    intervalRef.current = window.setInterval(() => {
+      i = Math.min(text.length, i + stepChars);
+      setter(text.slice(0, i));
+      if (i >= text.length) stop();
+    }, 16);
+  };
+
+  return { fillExample, stop };
+}

--- a/web/app/offline/page.tsx
+++ b/web/app/offline/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTypewriterFill } from "../hooks/useTypewriterFill";
 import { WifiOff } from "lucide-react";
 import ContextManager from "../components/ContextManager";
 import CopyButton from "../components/CopyButton";
@@ -18,6 +19,7 @@ const OFFLINE_MODE: CompileMode = "conservative";
 
 export default function OfflinePage() {
     const [prompt, setPrompt] = useState("");
+    const { fillExample, stop: stopTypewriter } = useTypewriterFill(setPrompt, { id: "offline-prompt" });
     const [loading, setLoading] = useState(false);
     const [result, setResult] = useState<CompileResponse | null>(null);
     const [activeTab, setActiveTab] = useState<OfflineOutputTab>("system");
@@ -120,7 +122,7 @@ export default function OfflinePage() {
                                 className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-500/50 sm:min-h-44 md:min-h-0"
                                 placeholder="Enter prompt (offline heuristics active)..."
                                 value={prompt}
-                                onChange={(e) => setPrompt(e.target.value)}
+                                onChange={(e) => { stopTypewriter(); setPrompt(e.target.value); }}
                                 onKeyDown={(e) => {
                                     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
                                         e.preventDefault();
@@ -171,13 +173,7 @@ export default function OfflinePage() {
                                 {!prompt.trim() && (
                                     <button
                                         type="button"
-                                        onClick={() => {
-                                            setPrompt("Create a Python script that monitors a local log directory for new .log files, parses them for ERROR level messages, and outputs a summary report.");
-                                            setTimeout(() => {
-                                                const textarea = document.getElementById('offline-prompt');
-                                                if (textarea) textarea.focus();
-                                            }, 0);
-                                        }}
+                                        onClick={() => fillExample("Create a Python script that monitors a local log directory for new .log files, parses them for ERROR level messages, and outputs a summary report.")}
                                         className="text-xs text-zinc-400/80 hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded px-2 py-1 mx-auto"
                                     >
                                         or try an example
@@ -273,13 +269,7 @@ export default function OfflinePage() {
                                     {!prompt.trim() && (
                                         <button
                                             type="button"
-                                            onClick={() => {
-                                                setPrompt("Summarize the key points of this meeting transcript.");
-                                                setTimeout(() => {
-                                                    const textarea = document.getElementById('offline-prompt');
-                                                    if (textarea) textarea.focus();
-                                                }, 0);
-                                            }}
+                                            onClick={() => fillExample("Summarize the key points of this meeting transcript.")}
                                             className="mt-3 text-xs text-zinc-400/80 hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded px-2 py-1 mx-auto block"
                                         >
                                             or try an example

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTypewriterFill } from "../hooks/useTypewriterFill";
 import { useRouter } from "next/navigation";
 import { Sparkles } from "lucide-react";
 import { apiJson } from "@/config";
@@ -189,6 +190,7 @@ export default function OptimizerPage() {
         if (typeof window === "undefined") return "";
         return window.localStorage.getItem("promptc_optimizer_prompt") || "";
     });
+    const { fillExample, stop: stopTypewriter } = useTypewriterFill(setInput, { id: "original-prompt" });
     const [result, setResult] = useState<OptimizeResponse | null>(null);
     const [loading, setLoading] = useState(false);
     const [maxTokens, setMaxTokens] = useState<number>(1000);
@@ -409,6 +411,7 @@ export default function OptimizerPage() {
                             aria-label="Original Prompt"
                             value={input}
                             onChange={(e) => {
+                                stopTypewriter();
                                 setInput(e.target.value);
                                 window.localStorage.setItem("promptc_optimizer_prompt", e.target.value);
                             }}
@@ -494,9 +497,7 @@ export default function OptimizerPage() {
                                 {!input.trim() && (
                                     <button
                                         type="button"
-                                        onClick={() => {
-                                            setInput("You are a helpful assistant. Provide a detailed, step-by-step summary of the provided text, ensuring that no important information is left out, and format the output as a bulleted list with clear headings for each section.");
-                                        }}
+                                        onClick={() => fillExample("You are a helpful assistant. Provide a detailed, step-by-step summary of the provided text, ensuring that no important information is left out, and format the output as a bulleted list with clear headings for each section.")}
                                         className="text-xs text-emerald-400/80 hover:text-emerald-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-emerald-500 rounded px-2 py-1"
                                     >
                                         or try an example

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
+import { useTypewriterFill } from "./hooks/useTypewriterFill";
 import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
@@ -163,37 +164,9 @@ export default function Home() {
   };
 
   // Typewriter entrance when an example prompt is inserted.
-  const typewriterRef = useRef<number | null>(null);
-  const stopTypewriter = () => {
-    if (typewriterRef.current !== null) {
-      window.clearInterval(typewriterRef.current);
-      typewriterRef.current = null;
-    }
-  };
-  useEffect(() => stopTypewriter, []);
-
-  const fillExample = (text: string) => {
-    stopTypewriter();
-    document
-      .querySelector<HTMLTextAreaElement>('textarea[aria-label="Describe what you want compiled"]')
-      ?.focus();
-    const prefersReduced =
-      typeof window !== "undefined" &&
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (prefersReduced) {
-      setPrompt(text);
-      return;
-    }
-    setPrompt("");
-    const stepChars = Math.max(1, Math.ceil(text.length / 40)); // ~0.65s total, length-independent
-    let i = 0;
-    typewriterRef.current = window.setInterval(() => {
-      i = Math.min(text.length, i + stepChars);
-      setPrompt(text.slice(0, i));
-      if (i >= text.length) stopTypewriter();
-    }, 16);
-  };
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setPrompt, {
+    selector: 'textarea[aria-label="Describe what you want compiled"]',
+  });
 
   return (
     <main className="relative flex min-h-screen flex-col items-center justify-start overflow-x-hidden p-3 py-4 sm:p-4 md:h-screen md:justify-center md:overflow-hidden md:p-8">

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -3,6 +3,7 @@
 import { toast } from "sonner";
 
 import { useRef, useState } from "react";
+import { useTypewriterFill } from "../hooks/useTypewriterFill";
 import ReactMarkdown from "react-markdown";
 import { Zap } from "lucide-react";
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
@@ -57,6 +58,7 @@ export default function SkillsGenerator() {
   const [history, setHistory] = useState<{ label: string; result: SkillGenerationView }[]>([]);
   const [copied, setCopied] = useState(false);
 
+  const { fillExample, stop: stopTypewriter } = useTypewriterFill(setDescription, { id: "skill-description" });
   const isGeneratingRef = useRef(false);
   const isValidRepoUrl = isSupportedGitHubRepoRootUrl(repoUrl);
 
@@ -251,7 +253,7 @@ export default function SkillsGenerator() {
                 className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'A skill that parses JSON and validates schemas' or 'Fetch and summarize web pages'"
                 value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={(e) => { stopTypewriter(); setDescription(e.target.value); }}
                 onKeyDown={(e) => {
                   if (e.repeat) return;
                   if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
@@ -266,7 +268,7 @@ export default function SkillsGenerator() {
             {description && (
               <button
                 type="button"
-                onClick={() => setDescription("")}
+                onClick={() => { stopTypewriter(); setDescription(""); }}
                 className="absolute top-2 right-2 text-xs text-zinc-500 hover:text-zinc-300 bg-black/40 hover:bg-black/60 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-yellow-500/50"
                 title="Clear input"
                 aria-label="Clear input"
@@ -424,13 +426,7 @@ export default function SkillsGenerator() {
                     {!description.trim() && (
                       <button
                         type="button"
-                        onClick={() => {
-                          setDescription("A skill that takes a URL, fetches the page content, extracts the main article text, and returns a 3-bullet summary.");
-                          setTimeout(() => {
-                            const textarea = document.getElementById('skill-description');
-                            if (textarea) textarea.focus();
-                          }, 0);
-                        }}
+                        onClick={() => fillExample("A skill that takes a URL, fetches the page content, extracts the main article text, and returns a 3-bullet summary.")}
                         className="text-xs text-yellow-400/80 hover:text-yellow-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-yellow-500 rounded px-2 py-1"
                       >
                         or try an example


### PR DESCRIPTION
## What
The typewriter "or try an example" effect previously existed **only** on the main compile page. This extracts it into a shared hook and applies it to every single-field generator surface.

- **New** \`web/app/hooks/useTypewriterFill.ts\` — one implementation of the effect (interval-based typing, \`prefers-reduced-motion\` bailout, focus, unmount cleanup, cancellable).
- **Refactor** \`web/app/page.tsx\` to consume the hook (removes the duplicated inline logic).
- **Applied to 6 surfaces:** agent-generator, skills-generator, benchmark, optimizer, agent-packs, offline (both example buttons). Each now types the example in and cancels an in-flight run on manual edit / clear.

Out of scope: \`pr-safety\` (multi-field example loader — doesn't fit the single-field pattern).

## Why
Consistent, polished autofill across all generators; single source of truth instead of one-off copies.

## Testing
- Hook unit tests: reduced-motion instant fill, animated typing over the interval, focus (3/3).
- Main-page regression test for example fill.
- Full web suite: **30 files / 161 tests pass**.
- \`npm run build\` (typecheck) passes.

## Notes
- No new dependencies (plain \`setInterval\` + React state).
- Honors \`prefers-reduced-motion\` on every surface (instant fill).
- Design + plan docs included under \`docs/superpowers/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)