### PR TITLE
feat(agent-packs): B2 web delivery polish — client-side zip, file tree, interactive checklist

### DIFF
--- a/docs/superpowers/plans/2026-07-04-agent-packs-b2-web-delivery.md
+++ b/docs/superpowers/plans/2026-07-04-agent-packs-b2-web-delivery.md
@@ -1,0 +1,1398 @@
+# Agent Packs B2 — Web Delivery Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish the Agent Packs web delivery UX — client-side pack zip from the in-state manifest, an interactive install checklist, a real file tree with per-file download, removal of the dead provider card, and reduced beta hedging.
+
+**Architecture:** All changes live in `web/app/agent-packs/**`. New pure helpers (`lib/packZip.ts`, `lib/fileTree.ts`) and one new component (`components/FileTree.tsx`) are built and unit-tested in isolation first, then wired into `page.tsx`. The whole-pack `.zip` is assembled in the browser from the manifest already in React state using `fflate` (no second server round-trip). Backend, API, and MCP are untouched.
+
+**Tech Stack:** Next.js 16 (App Router, client component), React 19, TypeScript, Tailwind v4, lucide-react icons, Vitest + Testing Library (happy-dom), `fflate` (new dependency, approved).
+
+**Spec:** `docs/superpowers/specs/2026-07-04-agent-packs-b2-web-delivery-design.md`
+
+**Branch:** `feat/agent-packs-web-b2` (already created off `main`; the spec is already committed on it).
+
+---
+
+## File Structure
+
+**New files:**
+- `web/app/agent-packs/lib/packZip.ts` — pure: build a `.zip` (bytes + Blob) from `AgentPackFile[]`.
+- `web/app/agent-packs/lib/packZip.test.ts` — unit tests (round-trip, empty).
+- `web/app/agent-packs/lib/fileTree.ts` — pure: build a nested folder/file tree from `AgentPackFile[]`.
+- `web/app/agent-packs/lib/fileTree.test.ts` — unit tests (nesting, ordering).
+- `web/app/agent-packs/components/FileTree.tsx` — collapsible tree UI + per-file download button.
+- `web/app/agent-packs/components/FileTree.test.tsx` — component tests (a11y names, select, download).
+- `web/app/agent-packs/components/InstallChecklist.test.tsx` — component tests for the interactive checklist.
+
+**Modified files:**
+- `web/package.json` — add `fflate`.
+- `web/app/agent-packs/page.tsx` — client-side download, tree replaces tabs, checklist state, dead card removed, hedging reduced, dead imports removed.
+- `web/app/agent-packs/components/InstallChecklist.tsx` — interactive checkboxes + progress.
+- `web/app/agent-packs/providerRegistry.ts` — trim `badge`/`summary` wording.
+- `web/app/agent-packs/page.test.tsx` — update the tests that assumed tabs/server-download/beta box.
+
+**Unchanged (intentionally):** `installChecklist.ts`, `installChecklist.test.ts`, `claude/download/route.ts`, `proxy-routes.test.ts`, `types.ts`, all backend/API/MCP.
+
+**Command notes:** all commands run from `web/`. Single test file: `npm run test -- <path-relative-to-web>`. Full suite: `npm run test`. Build: `npm run build`.
+
+---
+
+## Task 1: Add the `fflate` dependency
+
+**Files:**
+- Modify: `web/package.json` (and `web/package-lock.json` via install)
+
+- [ ] **Step 1: Install fflate**
+
+Run:
+```bash
+cd web && npm install fflate@^0.8.2
+```
+Expected: `package.json` gains `"fflate": "^0.8.2"` under `dependencies`; lockfile updates; no errors.
+
+- [ ] **Step 2: Verify it resolves**
+
+Run:
+```bash
+cd web && node -e "const {zipSync,strToU8,unzipSync,strFromU8}=require('fflate'); const z=zipSync({'a.txt':strToU8('hi')}); console.log(strFromU8(unzipSync(z)['a.txt']))"
+```
+Expected: prints `hi`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .. && git add web/package.json web/package-lock.json
+git commit -m "chore(web): add fflate for client-side pack zipping
+
+Approved dependency addition (normally a hard boundary) to build the
+Agent Packs download client-side from the in-state manifest.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `lib/packZip.ts` — build the pack zip in the browser
+
+**Files:**
+- Create: `web/app/agent-packs/lib/packZip.ts`
+- Test: `web/app/agent-packs/lib/packZip.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/app/agent-packs/lib/packZip.test.ts`:
+```ts
+import { describe, expect, test } from "vitest";
+import { unzipSync, strFromU8 } from "fflate";
+
+import { zipPackBytes, buildPackZip } from "./packZip";
+import type { AgentPackFile } from "../types";
+
+const files: AgentPackFile[] = [
+  { path: "CLAUDE.md", content: "# Memory\n", kind: "claude_md" },
+  { path: ".claude/agents/pr-reviewer.md", content: "review agent", kind: "agents" },
+];
+
+describe("packZip", () => {
+  test("round-trips every file path and content", () => {
+    const unzipped = unzipSync(zipPackBytes(files));
+    expect(Object.keys(unzipped).sort()).toEqual(
+      [".claude/agents/pr-reviewer.md", "CLAUDE.md"].sort(),
+    );
+    expect(strFromU8(unzipped["CLAUDE.md"])).toBe("# Memory\n");
+    expect(strFromU8(unzipped[".claude/agents/pr-reviewer.md"])).toBe("review agent");
+  });
+
+  test("buildPackZip returns an application/zip Blob", () => {
+    expect(buildPackZip(files).type).toBe("application/zip");
+  });
+
+  test("empty file list produces a valid empty zip", () => {
+    expect(Object.keys(unzipSync(zipPackBytes([])))).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npm run test -- app/agent-packs/lib/packZip.test.ts`
+Expected: FAIL — cannot resolve `./packZip` / `zipPackBytes is not a function`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `web/app/agent-packs/lib/packZip.ts`:
+```ts
+import { zipSync, strToU8 } from "fflate";
+
+import type { AgentPackFile } from "../types";
+
+/** Zip the given files into raw bytes (in-memory, synchronous). */
+export function zipPackBytes(files: AgentPackFile[]): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const file of files) {
+    entries[file.path] = strToU8(file.content);
+  }
+  return zipSync(entries);
+}
+
+/** Build a downloadable application/zip Blob from the given files. */
+export function buildPackZip(files: AgentPackFile[]): Blob {
+  return new Blob([zipPackBytes(files)], { type: "application/zip" });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npm run test -- app/agent-packs/lib/packZip.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/agent-packs/lib/packZip.ts web/app/agent-packs/lib/packZip.test.ts
+git commit -m "feat(agent-packs): client-side pack zip helper (packZip)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `lib/fileTree.ts` — build a nested file tree
+
+**Files:**
+- Create: `web/app/agent-packs/lib/fileTree.ts`
+- Test: `web/app/agent-packs/lib/fileTree.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/app/agent-packs/lib/fileTree.test.ts`:
+```ts
+import { describe, expect, test } from "vitest";
+
+import { buildFileTree, type FileTreeFolderNode } from "./fileTree";
+import type { AgentPackFile } from "../types";
+
+const mk = (path: string): AgentPackFile => ({ path, content: path, kind: "files" });
+
+describe("buildFileTree", () => {
+  test("a single top-level file becomes one file node", () => {
+    const tree = buildFileTree([mk("CLAUDE.md")]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ type: "file", name: "CLAUDE.md", path: "CLAUDE.md" });
+  });
+
+  test("nested paths build folder nodes with the right segments and paths", () => {
+    const tree = buildFileTree([mk(".claude/agents/pr-reviewer.md")]);
+    expect(tree).toHaveLength(1);
+    const claude = tree[0] as FileTreeFolderNode;
+    expect(claude).toMatchObject({ type: "folder", name: ".claude", path: ".claude" });
+    const agents = claude.children[0] as FileTreeFolderNode;
+    expect(agents).toMatchObject({ type: "folder", name: "agents", path: ".claude/agents" });
+    expect(agents.children[0]).toMatchObject({
+      type: "file",
+      name: "pr-reviewer.md",
+      path: ".claude/agents/pr-reviewer.md",
+    });
+  });
+
+  test("folders sort before files, alphabetically within a level", () => {
+    const tree = buildFileTree([mk("README.md"), mk(".claude/settings.json"), mk("AGENTS.md")]);
+    expect(tree.map((n) => n.name)).toEqual([".claude", "AGENTS.md", "README.md"]);
+    expect(tree[0].type).toBe("folder");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npm run test -- app/agent-packs/lib/fileTree.test.ts`
+Expected: FAIL — cannot resolve `./fileTree`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `web/app/agent-packs/lib/fileTree.ts`:
+```ts
+import type { AgentPackFile } from "../types";
+
+export interface FileTreeFileNode {
+  type: "file";
+  name: string;
+  path: string;
+  file: AgentPackFile;
+}
+
+export interface FileTreeFolderNode {
+  type: "folder";
+  name: string;
+  path: string;
+  children: FileTreeNode[];
+}
+
+export type FileTreeNode = FileTreeFileNode | FileTreeFolderNode;
+
+export function buildFileTree(files: AgentPackFile[]): FileTreeNode[] {
+  const root: FileTreeFolderNode = { type: "folder", name: "", path: "", children: [] };
+
+  for (const file of files) {
+    const segments = file.path.split("/");
+    let cursor = root;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const segment = segments[i];
+      const folderPath = segments.slice(0, i + 1).join("/");
+      let next = cursor.children.find(
+        (child): child is FileTreeFolderNode =>
+          child.type === "folder" && child.name === segment,
+      );
+      if (!next) {
+        next = { type: "folder", name: segment, path: folderPath, children: [] };
+        cursor.children.push(next);
+      }
+      cursor = next;
+    }
+    const name = segments[segments.length - 1];
+    cursor.children.push({ type: "file", name, path: file.path, file });
+  }
+
+  sortTree(root.children);
+  return root.children;
+}
+
+function sortTree(nodes: FileTreeNode[]): void {
+  nodes.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "folder" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  for (const node of nodes) {
+    if (node.type === "folder") sortTree(node.children);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npm run test -- app/agent-packs/lib/fileTree.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/agent-packs/lib/fileTree.ts web/app/agent-packs/lib/fileTree.test.ts
+git commit -m "feat(agent-packs): pure file-tree builder from manifest paths
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `components/FileTree.tsx` — tree UI + per-file download
+
+**Files:**
+- Create: `web/app/agent-packs/components/FileTree.tsx`
+- Test: `web/app/agent-packs/components/FileTree.test.tsx`
+
+Folders default to **expanded** so every node is visible in small packs.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/app/agent-packs/components/FileTree.test.tsx`:
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import FileTree from "./FileTree";
+import type { AgentPackFile } from "../types";
+
+const files: AgentPackFile[] = [
+  { path: "CLAUDE.md", content: "# Memory", kind: "claude_md" },
+  { path: ".claude/agents/pr-reviewer.md", content: "agent", kind: "agents" },
+];
+
+describe("FileTree", () => {
+  test("renders file rows by basename and folder rows by segment", () => {
+    render(
+      <FileTree files={files} selectedPath={null} onSelect={() => {}} onDownloadFile={() => {}} />,
+    );
+    expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: ".claude" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "agents" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "pr-reviewer.md" })).toBeTruthy();
+  });
+
+  test("selecting a file calls onSelect with its full path", () => {
+    const onSelect = vi.fn();
+    render(
+      <FileTree files={files} selectedPath={null} onSelect={onSelect} onDownloadFile={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "pr-reviewer.md" }));
+    expect(onSelect).toHaveBeenCalledWith(".claude/agents/pr-reviewer.md");
+  });
+
+  test("per-file download button is named by basename and passes the file", () => {
+    const onDownloadFile = vi.fn();
+    render(
+      <FileTree files={files} selectedPath={null} onSelect={() => {}} onDownloadFile={onDownloadFile} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Download pr-reviewer.md" }));
+    expect(onDownloadFile).toHaveBeenCalledWith(files[1]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npm run test -- app/agent-packs/components/FileTree.test.tsx`
+Expected: FAIL — cannot resolve `./FileTree`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `web/app/agent-packs/components/FileTree.tsx`:
+```tsx
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Download, FileText, Folder } from "lucide-react";
+
+import type { AgentPackFile } from "../types";
+import { buildFileTree, type FileTreeNode } from "../lib/fileTree";
+
+interface FileTreeProps {
+  files: AgentPackFile[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onDownloadFile: (file: AgentPackFile) => void;
+}
+
+export default function FileTree({ files, selectedPath, onSelect, onDownloadFile }: FileTreeProps) {
+  const nodes = buildFileTree(files);
+  return (
+    <ul className="space-y-0.5">
+      {nodes.map((node) => (
+        <FileTreeItem
+          key={node.path}
+          node={node}
+          depth={0}
+          selectedPath={selectedPath}
+          onSelect={onSelect}
+          onDownloadFile={onDownloadFile}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface FileTreeItemProps {
+  node: FileTreeNode;
+  depth: number;
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onDownloadFile: (file: AgentPackFile) => void;
+}
+
+function FileTreeItem({ node, depth, selectedPath, onSelect, onDownloadFile }: FileTreeItemProps) {
+  const [expanded, setExpanded] = useState(true);
+  const indent = { paddingLeft: `${depth * 12 + 8}px` };
+
+  if (node.type === "folder") {
+    return (
+      <li>
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+          style={indent}
+          className="flex w-full items-center gap-1.5 rounded-lg px-2 py-1 text-left text-xs text-zinc-300 transition hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500"
+        >
+          {expanded ? (
+            <ChevronDown size={13} aria-hidden="true" />
+          ) : (
+            <ChevronRight size={13} aria-hidden="true" />
+          )}
+          <Folder size={13} className="text-cyan-300/70" aria-hidden="true" />
+          <span className="font-mono">{node.name}</span>
+        </button>
+        {expanded && (
+          <ul className="space-y-0.5">
+            {node.children.map((child) => (
+              <FileTreeItem
+                key={child.path}
+                node={child}
+                depth={depth + 1}
+                selectedPath={selectedPath}
+                onSelect={onSelect}
+                onDownloadFile={onDownloadFile}
+              />
+            ))}
+          </ul>
+        )}
+      </li>
+    );
+  }
+
+  const active = node.path === selectedPath;
+  return (
+    <li className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onSelect(node.path)}
+        style={indent}
+        className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2 py-1 text-left text-xs transition focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 ${
+          active
+            ? "bg-cyan-500/10 text-cyan-100"
+            : "text-zinc-400 hover:bg-white/[0.05] hover:text-zinc-200"
+        }`}
+      >
+        <FileText size={13} aria-hidden="true" />
+        <span className="truncate font-mono">{node.name}</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onDownloadFile(node.file)}
+        aria-label={`Download ${node.name}`}
+        title={`Download ${node.name}`}
+        className="shrink-0 rounded-lg p-1 text-zinc-500 transition hover:bg-white/[0.05] hover:text-cyan-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500"
+      >
+        <Download size={13} aria-hidden="true" />
+      </button>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npm run test -- app/agent-packs/components/FileTree.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/agent-packs/components/FileTree.tsx web/app/agent-packs/components/FileTree.test.tsx
+git commit -m "feat(agent-packs): collapsible file tree with per-file download
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `page.tsx` — build the download client-side from the manifest
+
+Rewrite `handleDownload` to build the zip from `manifest.files` (no server call), remove the dead `apiFetch` import and `getDownloadFilename` helper, and update the download tests.
+
+**Files:**
+- Modify: `web/app/agent-packs/page.tsx`
+- Modify: `web/app/agent-packs/page.test.tsx`
+
+- [ ] **Step 1: Update the download tests first (they should fail against current code)**
+
+In `web/app/agent-packs/page.test.tsx`:
+
+(a) Remove `apiFetch` from the hoisted mock. Change the top mock block:
+```tsx
+const { apiJson, apiFetch } = vi.hoisted(() => ({
+  apiJson: vi.fn(),
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("@/config", () => ({
+  apiJson,
+  apiFetch,
+  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+  describeRequestError: (error: unknown) =>
+    error instanceof Error && error.message === "Failed to fetch"
+      ? "The service is temporarily unavailable or still waking up. Please retry in a few seconds."
+      : error instanceof Error
+        ? error.message
+        : "Connection failed.",
+}));
+```
+to:
+```tsx
+const { apiJson } = vi.hoisted(() => ({
+  apiJson: vi.fn(),
+}));
+
+vi.mock("@/config", () => ({
+  apiJson,
+  buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
+  describeRequestError: (error: unknown) =>
+    error instanceof Error && error.message === "Failed to fetch"
+      ? "The service is temporarily unavailable or still waking up. Please retry in a few seconds."
+      : error instanceof Error
+        ? error.message
+        : "Connection failed.",
+}));
+```
+
+(b) In `beforeEach`, delete the `apiFetch.mockReset();` line and the whole `apiFetch.mockResolvedValue(new Response("zip-bytes", {...}));` block (keep the `apiJson` setup, the `navigator.clipboard` stub, and the `URL` stub).
+
+(c) Replace the test `"downloads the generated pack through the Claude download route"` (the whole `test(...)` block) with:
+```tsx
+  test("downloads a zip built from the in-state manifest", async () => {
+    const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
+      }
+      return element;
+    });
+
+    render(<AgentPacksPage />);
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "Create a full project pack." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+
+    await screen.findByText("Pack Preview");
+    fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
+
+    // Built client-side: a blob URL is created and the anchor is clicked, no server call.
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("saas-pr-reviewer-claude.zip");
+    expect(await screen.findByText("Downloaded")).toBeTruthy();
+    await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview"));
+  });
+
+  test("falls back to agent-pack.zip when the manifest has no download_name", async () => {
+    apiJson.mockResolvedValueOnce({
+      provider: "claude",
+      pack_type: "pr-reviewer",
+      download_name: "",
+      preview_order: ["claude_md"],
+      files: [{ path: "CLAUDE.md", content: "x", kind: "claude_md" }],
+    });
+    const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
+      }
+      return element;
+    });
+
+    render(<AgentPacksPage />);
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+
+    await screen.findByText("Pack Preview");
+    fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
+
+    expect(anchors[anchors.length - 1].download).toBe("agent-pack.zip");
+  });
+```
+
+(d) Replace BOTH the `"shows a visible error and does not start a download when the pack response is empty"` test and the `"shows a visible error and resets the button when download fails"` test with a single guard test:
+```tsx
+  test("does not download when the manifest has no files", async () => {
+    apiJson.mockResolvedValueOnce({
+      provider: "claude",
+      pack_type: "pr-reviewer",
+      download_name: "empty",
+      preview_order: [],
+      files: [],
+    });
+    const clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+      }
+      return element;
+    });
+
+    render(<AgentPacksPage />);
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+
+    await screen.findByText("Pack Preview");
+    fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
+
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run the download tests to verify they fail**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx -t "download"`
+Expected: FAIL (current code still calls `apiFetch` / server route; new assertions don't hold).
+
+- [ ] **Step 3: Rewrite `handleDownload` and remove dead code in `page.tsx`**
+
+(a) Change the config import (line 8) from:
+```tsx
+import { apiFetch, apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
+```
+to:
+```tsx
+import { apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
+```
+
+(b) Add the packZip import near the other local imports (after the `providerRegistry` import):
+```tsx
+import { buildPackZip } from "./lib/packZip";
+```
+
+(c) Delete the `getDownloadFilename` helper entirely:
+```tsx
+function getDownloadFilename(response: Response, fallback: string): string {
+  const disposition = response.headers.get("content-disposition") || "";
+  const match = disposition.match(/filename=\"?([^"]+)\"?/i);
+  return match?.[1] || fallback;
+}
+```
+
+(d) Replace the entire `handleDownload` function with:
+```tsx
+  const handleDownload = () => {
+    if (!manifest || manifest.files.length === 0) return;
+
+    setDownloading(true);
+    setError(null);
+    try {
+      const blob = buildPackZip(manifest.files);
+      const href = URL.createObjectURL(blob);
+      const filename = `${manifest.download_name || "agent-pack"}.zip`;
+      const anchor = document.createElement("a");
+      anchor.href = href;
+      anchor.download = filename;
+      anchor.rel = "noopener";
+      anchor.style.display = "none";
+      // The anchor must be in the document for the synthetic click to trigger a
+      // download in Firefox, and the object URL must outlive the click — revoking
+      // it synchronously cancels the download in Chromium-based browsers.
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      setTimeout(() => URL.revokeObjectURL(href), 0);
+      setDownloaded(true);
+    } catch (err: unknown) {
+      showError(err);
+      setError(describeRequestError(err, { fallback: "Failed to download agent pack." }));
+    } finally {
+      setDownloading(false);
+    }
+  };
+```
+
+- [ ] **Step 4: Run the download tests to verify they pass**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx -t "download"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole page test file (nothing else regressed yet)**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx`
+Expected: PASS (tabs, beta, checklist tests still green — those areas are untouched in this task).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/app/agent-packs/page.tsx web/app/agent-packs/page.test.tsx
+git commit -m "feat(agent-packs): build pack download client-side from the manifest
+
+Download now zips the in-state manifest in the browser (fflate) instead of
+re-POSTing to /agent-packs/claude/download. Guarantees the download equals
+the preview and drops a redundant server round-trip. The server endpoint and
+its proxy route are kept for non-UI clients.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `page.tsx` — replace group tabs/select with the file tree
+
+**Files:**
+- Modify: `web/app/agent-packs/page.tsx`
+- Modify: `web/app/agent-packs/page.test.tsx`
+
+- [ ] **Step 1: Update the preview-navigation tests first**
+
+In `web/app/agent-packs/page.test.tsx`, in the test `"submits the selected pack type and renders grouped preview output"`, replace the two assertions:
+```tsx
+    expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "agents" })).toBeTruthy();
+```
+with tree assertions (a top-level file, plus a folder that proves nesting):
+```tsx
+    expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: ".claude" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "agents" })).toBeTruthy();
+```
+(The `"closing the preview…"` test's `{ name: "CLAUDE.md" }` assertions still hold — a file row is a button named by basename — so leave that test as is.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx -t "grouped preview output"`
+Expected: FAIL — `.claude` folder button does not exist yet (current UI renders kind tabs, not a tree).
+
+- [ ] **Step 3: Wire the tree into `page.tsx`**
+
+(a) Add the FileTree import (after the packZip import):
+```tsx
+import FileTree from "./components/FileTree";
+```
+
+(b) Remove the `AgentPackFileKind` type from the type import (it is only used by `PREVIEW_LABELS`/`activeKind`, both deleted). The import becomes:
+```tsx
+import type {
+  AgentPackFile,
+  AgentPackManifest,
+  AgentPackRequest,
+  AgentPackRiskMode,
+  AgentPackType,
+} from "./types";
+```
+
+(c) Delete the `PREVIEW_LABELS` constant:
+```tsx
+const PREVIEW_LABELS: Record<AgentPackFileKind, string> = {
+  claude_md: "CLAUDE.md",
+  settings: "settings.json",
+  agents: "agents",
+  workflow: "workflow",
+  mcp: "mcp",
+  readme: "README",
+  files: "files",
+};
+```
+
+(d) Remove the `activeKind` state and replace the `previewGroups`/`activeGroup`/`currentFile` derivations. Delete:
+```tsx
+  const [activeKind, setActiveKind] = useState<AgentPackFileKind | null>(null);
+```
+Delete:
+```tsx
+  const previewGroups = useMemo(() => {
+    if (!manifest) return [];
+    return manifest.preview_order
+      .map((kind) => ({
+        kind,
+        label: PREVIEW_LABELS[kind] ?? kind,
+        files: manifest.files.filter((file) => file.kind === kind),
+      }))
+      .filter((group) => group.files.length > 0);
+  }, [manifest]);
+
+  const activeGroup = previewGroups.find((group) => group.kind === activeKind) ?? previewGroups[0] ?? null;
+  const currentFile =
+    activeGroup?.files.find((file) => file.path === selectedPath) ??
+    activeGroup?.files[0] ??
+    null;
+```
+Replace with:
+```tsx
+  const currentFile = useMemo(() => {
+    if (!manifest) return null;
+    return manifest.files.find((file) => file.path === selectedPath) ?? manifest.files[0] ?? null;
+  }, [manifest, selectedPath]);
+```
+
+(e) In `handleGenerate`, remove the `setActiveKind(...)` calls. Change the reset lines from:
+```tsx
+    setManifest(null);
+    setActiveKind(null);
+    setSelectedPath(null);
+    setDownloaded(false);
+```
+to:
+```tsx
+    setManifest(null);
+    setSelectedPath(null);
+    setDownloaded(false);
+```
+and change the success lines from:
+```tsx
+      setManifest(data);
+      setActiveKind(data.preview_order[0] ?? null);
+      setSelectedPath(data.files[0]?.path ?? null);
+```
+to:
+```tsx
+      setManifest(data);
+      setSelectedPath(data.files[0]?.path ?? null);
+```
+
+(f) In `handleClosePreview`, remove `setActiveKind(null);`:
+```tsx
+  const handleClosePreview = () => {
+    setManifest(null);
+    setSelectedPath(null);
+    setCopiedState(null);
+    setDownloaded(false);
+  };
+```
+
+(g) Add the per-file download handler (next to `handleDownload`):
+```tsx
+  const handleDownloadFile = (file: AgentPackFile) => {
+    const blob = new Blob([file.content], { type: "text/plain" });
+    const href = URL.createObjectURL(blob);
+    const basename = file.path.split("/").pop() || "file";
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.download = basename;
+    anchor.rel = "noopener";
+    anchor.style.display = "none";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(href), 0);
+  };
+```
+
+(h) Replace the tabs + `<select>` JSX block. Delete this whole block:
+```tsx
+                <div className="flex flex-wrap gap-2 border-b border-white/5 px-4 py-3 sm:px-6">
+                  {previewGroups.map((group) => (
+                    <button
+                      key={group.kind}
+                      type="button"
+                      onClick={() => {
+                        setActiveKind(group.kind);
+                        setSelectedPath(group.files[0]?.path ?? null);
+                      }}
+                      className={`rounded-full border px-3 py-1.5 text-[11px] font-mono uppercase tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 ${
+                        activeGroup?.kind === group.kind
+                          ? "border-cyan-400/40 bg-cyan-500/10 text-cyan-100"
+                          : "border-transparent bg-white/[0.03] text-zinc-500 hover:bg-white/[0.07] hover:text-zinc-300"
+                      }`}
+                    >
+                      {group.label}
+                    </button>
+                  ))}
+                </div>
+
+                {activeGroup && activeGroup.files.length > 1 && (
+                  <div className="px-4 pt-4 sm:px-6">
+                    <label htmlFor="agent-pack-file-select" className="sr-only">
+                      Preview file
+                    </label>
+                    <select
+                      id="agent-pack-file-select"
+                      value={currentFile?.path ?? activeGroup.files[0].path}
+                      onChange={(event) => setSelectedPath(event.target.value)}
+                      className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
+                    >
+                      {activeGroup.files.map((file) => (
+                        <option key={file.path} value={file.path}>
+                          {file.path}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+```
+and replace it with the file tree:
+```tsx
+                <div className="border-b border-white/5 px-4 py-3 sm:px-6">
+                  <div className="mb-2 text-[11px] font-mono uppercase tracking-[0.2em] text-zinc-500">
+                    Files
+                  </div>
+                  <FileTree
+                    files={manifest.files}
+                    selectedPath={currentFile?.path ?? null}
+                    onSelect={setSelectedPath}
+                    onDownloadFile={handleDownloadFile}
+                  />
+                </div>
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx`
+Expected: PASS (grouped-preview + closing-preview tests now resolve to tree nodes; download tests from Task 5 still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/agent-packs/page.tsx web/app/agent-packs/page.test.tsx
+git commit -m "feat(agent-packs): replace kind tabs with a real file tree
+
+The preview now shows files in their repo paths as a collapsible tree with
+per-file download, replacing the group-by-kind tabs and the file <select>.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Interactive install checklist
+
+Make `InstallChecklist.tsx` render `reviewFirst`/`validationSteps` items as checkboxes with a progress bar, `nextAction` as text, and skip `generatedFiles`. Wire checked-state into `page.tsx`.
+
+**Files:**
+- Modify: `web/app/agent-packs/components/InstallChecklist.tsx`
+- Modify: `web/app/agent-packs/page.tsx`
+- Create: `web/app/agent-packs/components/InstallChecklist.test.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `web/app/agent-packs/components/InstallChecklist.test.tsx`:
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, test } from "vitest";
+
+import InstallChecklist from "./InstallChecklist";
+import { buildInstallChecklist } from "../installChecklist";
+import type { AgentPackManifest } from "../types";
+
+const manifest: AgentPackManifest = {
+  provider: "claude",
+  pack_type: "project-pack",
+  download_name: "x",
+  preview_order: ["claude_md", "settings", "workflow"],
+  files: [
+    { path: "CLAUDE.md", content: "#", kind: "claude_md" },
+    { path: ".claude/settings.json", content: "{}", kind: "settings" },
+    { path: ".github/workflows/claude.yml", content: "y", kind: "workflow" },
+  ],
+};
+
+function Harness() {
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+  const sections = buildInstallChecklist(manifest);
+  return (
+    <InstallChecklist
+      sections={sections}
+      checkedIds={checkedIds}
+      onToggle={(id) =>
+        setCheckedIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+          return next;
+        })
+      }
+    />
+  );
+}
+
+describe("InstallChecklist", () => {
+  test("renders review/validation items as labelled checkboxes and updates progress", () => {
+    render(<Harness />);
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+    expect(screen.getByText(`0/${checkboxes.length} done`)).toBeTruthy();
+
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByText(`1/${checkboxes.length} done`)).toBeTruthy();
+  });
+
+  test("does not render the generatedFiles section", () => {
+    render(<Harness />);
+    expect(screen.queryByText(/Add CLAUDE\.md to the matching path/i)).toBeNull();
+  });
+
+  test("keeps an accessible checklist heading", () => {
+    render(<Harness />);
+    expect(screen.getByRole("heading", { name: "Install & review checklist" })).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd web && npm run test -- app/agent-packs/components/InstallChecklist.test.tsx`
+Expected: FAIL — current `InstallChecklist` has no checkboxes and different props.
+
+- [ ] **Step 3: Rewrite `InstallChecklist.tsx`**
+
+Replace the entire contents of `web/app/agent-packs/components/InstallChecklist.tsx` with:
+```tsx
+import { CheckCircle2 } from "lucide-react";
+
+import type { InstallChecklistSection } from "../installChecklist";
+
+interface InstallChecklistProps {
+  sections: InstallChecklistSection[];
+  checkedIds: Set<string>;
+  onToggle: (id: string) => void;
+  downloaded?: boolean;
+}
+
+const CHECKBOX_SECTION_IDS = new Set(["reviewFirst", "validationSteps"]);
+
+export default function InstallChecklist({
+  sections,
+  checkedIds,
+  onToggle,
+  downloaded = false,
+}: InstallChecklistProps) {
+  const titleId = "agent-pack-install-checklist-title";
+  const rendered = sections.filter((section) => section.id !== "generatedFiles");
+
+  const checkboxIds = rendered
+    .filter((section) => CHECKBOX_SECTION_IDS.has(section.id))
+    .flatMap((section) => section.items.map((_, index) => `${section.id}-${index}`));
+  const total = checkboxIds.length;
+  const done = checkboxIds.filter((id) => checkedIds.has(id)).length;
+  const complete = total > 0 && done === total;
+
+  return (
+    <section aria-labelledby={titleId} className="border-b border-white/5 px-4 py-4 sm:px-6">
+      <div className="rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h3 id={titleId} className="text-sm font-semibold text-cyan-100">
+              Install &amp; review checklist
+            </h3>
+            <p className="mt-1 text-xs leading-relaxed text-cyan-100/70">
+              Generated files are a starting point — review before committing.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {complete ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                <CheckCircle2 size={12} aria-hidden="true" />
+                All steps complete
+              </span>
+            ) : null}
+            {downloaded ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                <CheckCircle2 size={12} aria-hidden="true" />
+                Downloaded
+              </span>
+            ) : null}
+          </div>
+        </div>
+
+        {total > 0 ? (
+          <div className="mb-3">
+            <div className="mb-1 flex items-center justify-between text-[11px] text-cyan-100/70">
+              <span>Progress</span>
+              <span aria-live="polite">{`${done}/${total} done`}</span>
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-cyan-400 transition-all"
+                style={{ width: `${(done / total) * 100}%` }}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {rendered.map((section) => (
+            <div key={section.id} className="rounded-xl border border-white/8 bg-black/20 p-3">
+              <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-400">
+                {section.title}
+              </h4>
+              {CHECKBOX_SECTION_IDS.has(section.id) ? (
+                <ul className="space-y-2 text-xs leading-relaxed text-zinc-300">
+                  {section.items.map((item, index) => {
+                    const id = `${section.id}-${index}`;
+                    return (
+                      <li key={id}>
+                        <label className="flex cursor-pointer gap-2">
+                          <input
+                            type="checkbox"
+                            checked={checkedIds.has(id)}
+                            onChange={() => onToggle(id)}
+                            className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-cyan-400"
+                          />
+                          <span>{item}</span>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <ul className="space-y-2 text-xs leading-relaxed text-zinc-300">
+                  {section.items.map((item) => (
+                    <li key={`${section.id}-${item}`} className="flex gap-2">
+                      <span
+                        className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400/80"
+                        aria-hidden="true"
+                      />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the component test to verify it passes**
+
+Run: `cd web && npm run test -- app/agent-packs/components/InstallChecklist.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire checked-state into `page.tsx`**
+
+(a) Add the state near the other `useState` hooks (after `downloaded`):
+```tsx
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+```
+
+(b) Add a toggle handler (next to the other handlers):
+```tsx
+  const toggleChecklistItem = (id: string) => {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+```
+
+(c) Reset it on generate and on close. In `handleGenerate`, add to the reset block:
+```tsx
+    setManifest(null);
+    setSelectedPath(null);
+    setDownloaded(false);
+    setCheckedIds(new Set());
+```
+In `handleClosePreview`, add:
+```tsx
+  const handleClosePreview = () => {
+    setManifest(null);
+    setSelectedPath(null);
+    setCopiedState(null);
+    setDownloaded(false);
+    setCheckedIds(new Set());
+  };
+```
+
+(d) Update the `<InstallChecklist ... />` render to pass the new props:
+```tsx
+                <InstallChecklist
+                  sections={installChecklist}
+                  checkedIds={checkedIds}
+                  onToggle={toggleChecklistItem}
+                  downloaded={downloaded}
+                />
+```
+
+- [ ] **Step 6: Replace the closing-preview page test to also cover checklist reset**
+
+In `web/app/agent-packs/page.test.tsx`, replace the entire `"closing the preview clears the generated pack and its labels"` test block with:
+```tsx
+  test("closing the preview clears the pack, checklist, and checked state", async () => {
+    render(<AgentPacksPage />);
+
+    fireEvent.change(screen.getByLabelText("What should Claude do?"), {
+      target: { value: "Create a full project pack." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+
+    expect(await screen.findByText("Pack Preview")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+
+    // Tick a checklist item.
+    const firstCheckbox = screen.getAllByRole("checkbox")[0];
+    fireEvent.click(firstCheckbox);
+    const totalBefore = screen.getAllByRole("checkbox").length;
+    expect(screen.getByText(`1/${totalBefore} done`)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /close pack preview/i }));
+
+    // The preview, checklist, and file tree are gone; the empty state returns.
+    await waitFor(() => expect(screen.queryByText("Pack Preview")).toBeNull());
+    expect(screen.queryByRole("heading", { name: "Install & review checklist" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "CLAUDE.md" })).toBeNull();
+    expect(screen.getByText("Single-click pack generation")).toBeTruthy();
+
+    // Regenerating starts the checklist progress from zero.
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+    await screen.findByText("Pack Preview");
+    const totalAfter = screen.getAllByRole("checkbox").length;
+    expect(screen.getByText(`0/${totalAfter} done`)).toBeTruthy();
+  });
+```
+
+- [ ] **Step 7: Run the page tests to verify they pass**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/app/agent-packs/components/InstallChecklist.tsx web/app/agent-packs/components/InstallChecklist.test.tsx web/app/agent-packs/page.tsx web/app/agent-packs/page.test.tsx
+git commit -m "feat(agent-packs): interactive install checklist with progress
+
+Review/validation steps are now tickable checkboxes with a progress bar;
+state is in-session and resets on generate/close. The file list moves to the
+tree, so the checklist no longer duplicates it.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Remove the dead provider card and dial back beta hedging
+
+**Files:**
+- Modify: `web/app/agent-packs/page.tsx`
+- Modify: `web/app/agent-packs/providerRegistry.ts`
+- Modify: `web/app/agent-packs/page.test.tsx`
+
+- [ ] **Step 1: Tighten the beta messaging test first**
+
+In `web/app/agent-packs/page.test.tsx`, replace the `"surfaces beta messaging"` test with:
+```tsx
+  test("surfaces a single, calm beta caveat", () => {
+    render(<AgentPacksPage />);
+
+    expect(screen.getAllByText("Beta")).toHaveLength(1);
+    expect(screen.queryByText("Experimental Feature")).toBeNull();
+    expect(screen.queryByText("API Key (Optional)")).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx -t "single, calm beta caveat"`
+Expected: FAIL — currently multiple "Beta" nodes and an "Experimental Feature" box exist.
+
+- [ ] **Step 3: Trim `providerRegistry.ts`**
+
+In `web/app/agent-packs/providerRegistry.ts`, change:
+```tsx
+    badge: "Beta Preview",
+    summary: "Generate repo-ready Claude assets from one short brief, then review them before production use.",
+```
+to:
+```tsx
+    badge: "",
+    summary: "Generate repo-ready Claude assets from one short brief.",
+```
+
+- [ ] **Step 4: Remove the dead card, the Experimental box, and the "beta-stage" heading in `page.tsx`**
+
+(a) Change the intro heading from:
+```tsx
+                  <h2 className="text-xl font-semibold text-white">Generate beta-stage agent assets for your repo</h2>
+```
+to:
+```tsx
+                  <h2 className="text-xl font-semibold text-white">Generate agent assets for your repo</h2>
+```
+
+(b) Delete the dead provider card button entirely:
+```tsx
+            <button
+              type="button"
+              className={`group flex items-center justify-between rounded-2xl border border-white/10 p-4 text-left transition-all hover:border-cyan-400/30 hover:bg-white/[0.05] ${manifest ? "bg-white/[0.05]" : "bg-white/[0.02]"}`}
+              aria-label="Claude provider card"
+            >
+              <div>
+                <div className="mb-1 text-sm font-semibold text-white">{provider.name}</div>
+                <div className="text-xs text-zinc-500">
+                  Beta preview. Good for fast bootstrapping, but you should still review prompts, permissions,
+                  workflows, and generated files before shipping.
+                </div>
+              </div>
+              <div className={`rounded-xl bg-gradient-to-br ${provider.accentClass} px-3 py-2 text-xs font-semibold text-white shadow-lg shadow-cyan-500/10`}>
+                Beta
+              </div>
+            </button>
+```
+
+(c) Delete the "Experimental Feature" amber box entirely:
+```tsx
+            <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm leading-relaxed text-amber-100/90">
+              <div className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-amber-200">Experimental Feature</div>
+              Agent Packs is in beta and gives you a starting point, not a finished install. After generation, follow the
+              install checklist on the right, review sensitive files, then commit only what you trust.
+            </div>
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx -t "single, calm beta caveat"`
+Expected: PASS (only the header `Beta` pill remains).
+
+- [ ] **Step 6: Run the whole page test file**
+
+Run: `cd web && npm run test -- app/agent-packs/page.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/app/agent-packs/page.tsx web/app/agent-packs/providerRegistry.ts web/app/agent-packs/page.test.tsx
+git commit -m "refactor(agent-packs): remove dead provider card, dial back beta hedging
+
+Delete the no-op Claude provider card and the Experimental Feature box; keep a
+single honest Beta badge in the header plus one review caveat in the checklist.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Full verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full web test suite**
+
+Run: `cd web && npm run test`
+Expected: PASS — all agent-packs suites (packZip, fileTree, FileTree, InstallChecklist, page, installChecklist, proxy-routes) plus the rest of the web tests green.
+
+- [ ] **Step 2: Type/lint via build**
+
+Run: `cd web && npm run build`
+Expected: SUCCESS — Next.js compiles with no type errors (this catches any leftover unused import such as `apiFetch`, `AgentPackFileKind`, `getDownloadFilename`, `useMemo` usage).
+
+- [ ] **Step 3: Lint (optional but recommended)**
+
+Run: `cd web && npm run lint`
+Expected: no errors (unused-variable rules would flag dead imports if any remain).
+
+- [ ] **Step 4: Stop for review — do NOT open a PR automatically**
+
+Per project rules, never push/PR/merge without Mehmet's explicit approval. Report: changed files, out-of-scope changes (the `fflate` dependency, pre-approved), test/build results, and the boundary note (dependency added). Then ask whether to open the PR.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Client-side download from in-state manifest → Task 2 (helper) + Task 5 (wiring). ✅
+- Interactive checklist (checkboxes + progress, in-session, reset on generate/close, nextAction as text, skip generatedFiles) → Task 7. ✅
+- File tree + per-file download → Task 3 (builder) + Task 4 (component) + Task 6 (wiring). ✅
+- Remove dead provider card → Task 8. ✅
+- Dial back beta hedging (single header badge, `toHaveLength(1)`, provider wording, remove Experimental box + "beta-stage" heading) → Task 8. ✅
+- Keep `/download` route + `proxy-routes.test.ts` untouched → confirmed (no task modifies them). ✅
+- `installChecklist.ts`/`installChecklist.test.ts` untouched → confirmed (Task 7 only touches the component + page). ✅
+- `fflate` dependency (approved) → Task 1. ✅
+- Empty-manifest guard + test → Task 5 Step 1(d) + Task 2 empty-zip test. ✅
+- Download filename + fallback tests → Task 5 Step 1(c). ✅
+- FileTree a11y contract (basename file rows, segment folder rows, `Download <basename>`) → Task 4. ✅
+- Checklist a11y (labelled checkboxes via `<label>`, `role="checkbox"` by name) → Task 7 test. ✅
+- Gate (`npm run test` + `npm run build`) → Task 9. ✅
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N" — every code step shows complete code. ✅
+
+**3. Type/name consistency:**
+- `buildPackZip`/`zipPackBytes` (Task 2) used in Task 5. ✅
+- `buildFileTree`, `FileTreeFolderNode`, `FileTreeNode` (Task 3) used in Task 4. ✅
+- `FileTree` props `files`/`selectedPath`/`onSelect`/`onDownloadFile` (Task 4) match the render in Task 6. ✅
+- `InstallChecklist` props `sections`/`checkedIds`/`onToggle`/`downloaded` (Task 7 component) match the render + `Harness` in Task 7. ✅
+- `CHECKBOX_SECTION_IDS = {reviewFirst, validationSteps}` and id scheme `${section.id}-${index}` consistent between component and tests. ✅
+- `handleDownloadFile`, `toggleChecklistItem`, `checkedIds` names consistent across Task 6/7 page edits. ✅

--- a/docs/superpowers/specs/2026-07-04-agent-packs-b2-web-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-04-agent-packs-b2-web-delivery-design.md
@@ -1,0 +1,276 @@
+# Agent Packs B2 — Web Delivery Polish (Design)
+
+- **Date:** 2026-07-04
+- **Status:** Approved (design), pending spec review
+- **Branch:** `feat/agent-packs-web-b2` (off `main`, independent of B1 / PR #933)
+- **Surface:** `web/app/agent-packs/**` only — backend, API, and MCP untouched.
+
+## Problem
+
+The Agent Packs web surface generates repo-ready assets but its delivery UX is weak in
+five concrete ways:
+
+1. **Download re-generates on the server.** Clicking "Download Pack" POSTs the request a
+   second time to `/agent-packs/claude/download`, re-running generation. Generation is
+   deterministic today (heuristic, not LLM), so this is not a correctness bug, but it is a
+   wasted round-trip, hits a separate rate limit, and gives no hard guarantee that the
+   bytes downloaded equal the bytes previewed.
+2. **Static install checklist.** `InstallChecklist.tsx` renders plain bullets. Users can't
+   track which install/review steps they've completed.
+3. **No file tree, no per-file download.** Preview navigation is a flat set of
+   group-by-kind tabs plus a `<select>`. There is no view of files in their real repo
+   paths, and no way to grab a single file.
+4. **Dead provider card.** `page.tsx` renders a `<button aria-label="Claude provider
+   card">` with no `onClick` — it does nothing. There is only one provider (Claude).
+5. **Over-hedged copy.** "Beta", "Beta Preview", "Experimental Feature", "beta-stage",
+   "beta output", "beta preview" appear repeatedly, reading as fear-marketing rather than
+   an honest single caveat.
+
+## Goals / Non-goals
+
+**Goals:** fix all five above on the existing web surface, keep the product honest (one
+calm caveat, not zero), and keep the change independently mergeable.
+
+**Non-goals:** No backend/API/MCP changes. No B3 work (dead IR fields, `CLAUDE.md`
+smart-merge, CLI/GitHub vehicles). No persistence of checklist state across reloads. No
+new provider. No redesign of the generation form (project type / stack / goal / pack type
+/ risk mode stay as-is). No full ARIA `role="tree"` keyboard navigation (see §3).
+
+## Approved decisions
+
+- **Whole-pack download is built client-side from the in-state manifest**, using the
+  `fflate` library. Mehmet explicitly approved adding this one dependency this session
+  (dependencies are normally a hard boundary). `fflate` is ~8KB, zero-dependency,
+  tree-shakeable, actively maintained; its synchronous `zipSync` + `strToU8` (and
+  `unzipSync` for tests) fit a small-text-file zip. The PR description will call out the
+  added dependency explicitly.
+- **Branch off `main`** as an independent PR. B2 does not need B1's backend.
+- **Checklist state is in-session only** (resets on generate and on close). No localStorage.
+
+## Design
+
+All new logic goes in small, pure, independently testable units. `page.tsx` shrinks as
+tab/select navigation is replaced by the tree.
+
+### 1. Client-side pack zip — `lib/packZip.ts`
+
+- `buildPackZip(files: AgentPackFile[]): Blob` — maps each file to
+  `{ [file.path]: strToU8(file.content) }` and returns `new Blob([zipSync(entries)], {
+  type: "application/zip" })`. `buildPackZip([])` returns a valid **empty** zip Blob
+  (`zipSync({})` is well-defined); the UI guard below prevents ever downloading one.
+- `handleDownload` in `page.tsx`:
+  - No longer calls `apiFetch("/agent-packs/claude/download", …)`. It is fully client-side.
+  - **Guard:** early-returns if `!manifest || manifest.files.length === 0` (defensive;
+    the Download Pack button only renders when a manifest exists, and real manifests always
+    have ≥1 file, so this is unreachable in normal UI flow — no user-facing error, just a
+    no-op).
+  - Builds the Blob via `buildPackZip(manifest.files)`, then reuses the existing
+    anchor-download flow (append anchor → click → remove → `revokeObjectURL` on next tick).
+  - Filename = `${manifest.download_name || "agent-pack"}.zip`.
+    (`AgentPackManifest.download_name` already exists in `types.ts` — no type change.)
+  - Wrapped in try/catch; on failure sets the visible error and clears the busy state.
+  - On success sets `downloaded = true` (drives the "Downloaded" checklist state). It does
+    **not** reset checked checklist items.
+- Remove now-dead code from `page.tsx`: the `apiFetch` import and the `getDownloadFilename`
+  helper (both only served the server download; after this change `page.tsx` uses only
+  `apiJson`).
+- **The server `/agent-packs/claude/download` endpoint and the Next.js proxy route
+  (`web/app/agent-packs/claude/download/route.ts`) are kept.** They remain valid and
+  tested (`proxy-routes.test.ts` imports the route handler directly and is unaffected) and
+  may serve non-UI clients (direct API, future CLI). The UI simply stops depending on them.
+
+### 2. Interactive install checklist
+
+- `installChecklist.ts` (the generator) is **unchanged** — it still returns the four
+  sections (`generatedFiles`, `reviewFirst`, `validationSteps`, `nextAction`) as
+  `{ id, title, items: string[] }`, and its section titles ("Review before use",
+  "Suggested validation", etc.) are unchanged. Its unit tests stay green. It intentionally
+  keeps emitting a `generatedFiles` section that the component no longer renders; a future
+  cleanup that removes it must also update `installChecklist.test.ts:44-53`.
+- `InstallChecklist.tsx` becomes interactive:
+  - **Rendered sections and checkbox rule (explicit):**
+    - `generatedFiles` — **not rendered** (the file tree in §3 lists the files; rendering
+      them again would duplicate).
+    - `reviewFirst` — rendered; each item is a **checkbox**.
+    - `validationSteps` — rendered; each item is a **checkbox**.
+    - `nextAction` — rendered as **plain guidance text** (not a checkbox): it is a single
+      advisory sentence and its copy changes with `downloaded`, which would make checkbox
+      ids unstable.
+  - **Checkbox items = `reviewFirst.items ∪ validationSteps.items`.** Each item's id is
+    `${section.id}-${index}`. These ids are stable for a given generated manifest:
+    neither `reviewFirst` nor `validationSteps` depends on `downloaded`, and the file set
+    is fixed until a regenerate (which resets state). Only `nextAction` is
+    `downloaded`-dependent, and it is excluded from checkboxes.
+  - **Progress:** `total` = number of rendered checkbox items (reviewFirst + validationSteps
+    only). Show `${checked}/${total} done` with a thin progress bar; at
+    `checked === total` show a subtle "All steps complete" state. The existing "Downloaded"
+    badge stays.
+  - **State:** checked ids live in `page.tsx` as `Set<string>`, passed down with a toggle
+    handler. Reset (cleared to empty) on **generate** and on **close** — the same resets
+    that already clear `manifest`, `downloaded`, `activeKind`, etc. **Not** reset on
+    download.
+  - **Accessibility contract (testable):** each checkbox is a real `<input
+    type="checkbox">` with an associated `<label>` whose text is the item string, so
+    `getByRole("checkbox", { name: <item text> })` resolves. The section keeps its
+    `aria-labelledby` heading (`getByRole("group")` present).
+
+### 3. File tree + per-file download
+
+- `lib/fileTree.ts` — pure: `buildFileTree(files: AgentPackFile[]): TreeNode[]` splits each
+  `file.path` on `/` into nested folder/file nodes. Folders sort before files;
+  alphabetical within a level. Each file node carries a reference to its `AgentPackFile`.
+- `components/FileTree.tsx` — renders collapsible folders and selectable file rows.
+  - **a11y contract (testable, no full ARIA tree):** each **file row** is a `<button>` with
+    accessible name = the file's **basename** (e.g. `CLAUDE.md`, `pr-reviewer.md`); each
+    **folder row** is a `<button aria-expanded>` with accessible name = the folder
+    **segment** (e.g. `.claude`, `agents`); each file row also has a separate download
+    `<button>` with accessible name `Download {basename}`. Nested `<ul>`/`<li>`. Full ARIA
+    `role="tree"` arrow-key navigation is out of scope for B2 (documented non-goal).
+  - Selecting a file row sets `selectedPath`; the preview `<pre>` pane renders that file.
+  - Each file row's download button downloads **that single file**:
+    `new Blob([file.content])`, filename = **basename** of `file.path` (paths flatten —
+    `.claude/agents/pr-reviewer.md` downloads as `pr-reviewer.md`), same anchor flow. No
+    zip for a single file.
+  - Replaces the group-by-kind tab bar (`previewGroups`, `PREVIEW_LABELS`) and the
+    `<select>` file picker. Those and their derived state are removed from `page.tsx`.
+- **Preview pane data flow (changes, though its markup is the same):** `currentFile` is
+  recomputed independently of the removed group state as
+  `manifest.files.find(f => f.path === selectedPath) ?? manifest.files[0] ?? null`. The
+  `<pre>` still renders `currentFile?.content`.
+- **Copy controls:** `handleCopyCurrent` is repointed to the new `currentFile` (the
+  tree-selected file). `handleCopyAll`, `handleDownload` (whole zip), and Close are
+  otherwise unchanged in behavior. So the header keeps Copy / Copy All / Download Pack /
+  Close — Copy now copies the tree-selected file.
+
+### 4. Remove the dead provider card
+
+- Delete the no-op `<button aria-label="Claude provider card">` block in `page.tsx`.
+- `providerRegistry.ts` stays (still supplies name, cta label, accent/glow/button
+  classes used across the header and buttons). Only the redundant card UI is removed and
+  the wording is trimmed (see §5).
+
+### 5. Dial back beta / experimental hedging
+
+- Reduce many hedges to **exactly one** honest caveat:
+  - Keep a single small **"Beta"** badge in the header (`page.tsx:233-235`), text node
+    exactly `Beta`. This is the only "Beta" occurrence on the page after this change.
+  - Keep one concise review caveat inside the checklist intro copy ("Generated files are a
+    starting point — review before committing."). The generator's section titles (e.g.
+    "Review before use") are unchanged.
+  - Remove: the "Experimental Feature" amber box, the "beta-stage agent assets" heading
+    text (→ e.g. "Generate agent assets for your repo"), and the dead card's "Beta
+    preview…" copy (the card is deleted anyway).
+  - `providerRegistry.ts` exact target strings: `badge: ""` (so the header chip renders
+    just `Claude`, not `Claude Beta Preview`) and
+    `summary: "Generate repo-ready Claude assets from one short brief."`
+- This is "dial back" (memo: *azalt*), not "erase" — one responsible caveat remains.
+
+## File-level impact
+
+**New:**
+- `web/app/agent-packs/lib/packZip.ts`
+- `web/app/agent-packs/lib/fileTree.ts`
+- `web/app/agent-packs/components/FileTree.tsx`
+- Tests: `lib/packZip.test.ts`, `lib/fileTree.test.ts`, `components/FileTree.test.tsx`
+  (all **required**, not optional).
+
+**Changed:**
+- `web/app/agent-packs/page.tsx` — client-side download; tree replaces tabs/select;
+  `currentFile` recomputed from `selectedPath`; checklist checked-state `Set`; dead card
+  removed; hedging reduced; dead `apiFetch` import + `getDownloadFilename` removed.
+- `web/app/agent-packs/components/InstallChecklist.tsx` — interactive checkboxes +
+  progress; renders reviewFirst/validationSteps as checkboxes, nextAction as text, skips
+  generatedFiles.
+- `web/app/agent-packs/providerRegistry.ts` — `badge`/`summary` wording trimmed (shape
+  unchanged).
+- `web/package.json` — add `fflate` dependency (approved).
+- `web/app/agent-packs/page.test.tsx` — see test impact below.
+
+**Unchanged (intentionally):**
+- `web/app/agent-packs/installChecklist.ts` and `installChecklist.test.ts`.
+- `web/app/agent-packs/claude/download/route.ts` and `web/app/proxy-routes.test.ts`.
+- `web/app/agent-packs/types.ts` (existing types suffice; `download_name` already present).
+- All backend, API, and MCP code.
+
+## Testing
+
+**New unit/component tests:**
+- `packZip.test.ts` — (a) build a zip from a multi-file manifest, `unzipSync` it, assert
+  every path and its exact content round-trips; (b) `buildPackZip([])` returns a valid
+  (empty) zip Blob without throwing. Deterministic, no network.
+- `fileTree.test.ts` — single top-level file; nested paths
+  (`.claude/agents/pr-reviewer.md`); folder-before-file ordering; alphabetical sort within
+  a level.
+- `FileTree.test.tsx` — folder/file rows render with the a11y names from §3; clicking a
+  file row selects it (content shows); clicking a file's download button downloads a
+  single-file Blob with `anchor.download === "<basename>"` (e.g. `pr-reviewer.md` for a
+  nested path) and does **not** build a zip.
+- `InstallChecklist` component test — reviewFirst/validationSteps items render as
+  `role="checkbox"` (verifying label association); ticking a checkbox increments progress;
+  `nextAction` renders as text (no checkbox); the group has its `aria-labelledby` heading.
+
+**`page.test.tsx` updates (existing tests that assume old behavior):**
+- Remove the now-orphaned `apiFetch` mock plumbing: the `vi.hoisted`/`vi.mock` `apiFetch`
+  entry (lines 6-9, 11-21) and the `beforeEach` `apiFetch.mockResolvedValue(new
+  Response("zip-bytes"...))` (lines 30, 42-50). After B2, `page.tsx` never calls
+  `apiFetch`.
+- **"surfaces beta messaging"** (lines 68-74) — drop `getByText("Experimental Feature")`;
+  tighten the Beta assertion to `expect(screen.getAllByText("Beta")).toHaveLength(1)` so it
+  actually enforces the "exactly one caveat" decision (a `>0` assertion would not). Keep
+  the `queryByText("API Key (Optional)")` null assertion.
+- **"submits the selected pack type and renders grouped preview output"** (lines 76-95) —
+  replace the tab-button assertions `getByRole("button", { name: "CLAUDE.md" })` and
+  `{ name: "agents" }` (lines 93-94) with file-tree assertions per the §3 contract (a
+  `CLAUDE.md` file-row button; an `agents` folder button). The `getByText("Review before
+  use")` assertion (line 92) still passes (section title unchanged).
+- **"renders pack-specific checklist guidance for project-pack output"** (lines 97-120) —
+  expected to **stay green**: its assertions `/Merge \.claude\/settings\.json carefully/`
+  (line 118) and `/GitHub workflow YAML permissions/` (line 119) come from the
+  `validationSteps` section, which is still rendered (now as checkbox labels). Verified
+  against `installChecklist.ts` (validationSteps builder). Listed here so an implementer
+  confirms rather than accidentally breaks it.
+- **"downloads the generated pack through the Claude download route"** (lines 122-163) —
+  rewrite: after clicking Download Pack, assert **no** `apiFetch` call, that
+  `URL.createObjectURL` was called once, that the created anchor's
+  `download === "saas-pr-reviewer-claude.zip"` (from the fixture `download_name`), that the
+  anchor was clicked, and that the "Downloaded" state appears.
+- **New download fallback case** — with an `apiJson` manifest that omits `download_name`,
+  assert the anchor `download === "agent-pack.zip"`.
+- **"…empty…" (lines 165-211) and "…download fails…" (lines 213-240)** — the server-driven
+  failure modes no longer exist. Replace with a **files:[] guard test**: render with an
+  `apiJson` manifest whose `files: []`, click Download Pack, assert `URL.createObjectURL`
+  was **not** called and the anchor was **not** clicked (no-op guard). Remove the obsolete
+  "empty server blob" / 500-response assertions.
+- **"closing the preview clears the generated pack and its labels"** (lines 269-287) —
+  update the stale tab assertions (`{ name: "CLAUDE.md" }`, lines 278, 285) to the file-tree
+  equivalent; additionally tick a checkbox, click Close, regenerate, and assert progress
+  reads `0/${total}` with no boxes checked (covers the reset-on-close branch, distinct from
+  reset-on-generate).
+- Assert that clicking **Download** does **not** reset already-checked checkboxes (only
+  flips "Downloaded").
+
+**Unaffected:** `installChecklist.test.ts` (generator untouched); `proxy-routes.test.ts`
+(tests the retained route handler directly, never imports `page.tsx`).
+
+**Gate before PR:** `cd web && npm run test` and `cd web && npm run build` both green.
+
+## Risks & mitigations
+
+- **Added dependency (`fflate`).** Normally a hard boundary; explicitly approved this
+  session. Mitigate by pinning it and calling it out in the PR body.
+- **Test churn in `page.test.tsx`.** Several tests assert on the old tabs/server-download.
+  Rewrites are scoped and enumerated above; the pure generator's tests are deliberately
+  untouched to limit blast radius.
+- **Checkbox id stability.** Guaranteed by excluding the only `downloaded`-dependent
+  section (`nextAction`) from checkboxes and resetting the checked `Set` on every
+  regenerate/close.
+
+## Out of scope / follow-ups
+
+- Removing the now-UI-unused `/download` endpoint + Next.js proxy route (only if confirmed
+  dead). **Note:** that follow-up must also delete the three parametrized download cases in
+  `proxy-routes.test.ts` (approx. lines 125-130, 205-208, 369-373), or they will fail.
+- B3: render dead IR fields (hooks → settings, `mcp_servers` → `.mcp.json`), `CLAUDE.md`
+  smart-merge, CLI + GitHub-PR vehicles.
+- Persisting checklist progress across reloads.
+- Full ARIA `role="tree"` keyboard navigation for the file tree.

--- a/web/app/agent-packs/components/FileTree.test.tsx
+++ b/web/app/agent-packs/components/FileTree.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import FileTree from "./FileTree";
+import type { AgentPackFile } from "../types";
+
+const files: AgentPackFile[] = [
+  { path: "CLAUDE.md", content: "# Memory", kind: "claude_md" },
+  { path: ".claude/agents/pr-reviewer.md", content: "agent", kind: "agents" },
+];
+
+describe("FileTree", () => {
+  test("renders file rows by basename and folder rows by segment", () => {
+    render(
+      <FileTree files={files} selectedPath={null} onSelect={() => {}} onDownloadFile={() => {}} />,
+    );
+    expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: ".claude" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "agents" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "pr-reviewer.md" })).toBeTruthy();
+  });
+
+  test("selecting a file calls onSelect with its full path", () => {
+    const onSelect = vi.fn();
+    render(
+      <FileTree files={files} selectedPath={null} onSelect={onSelect} onDownloadFile={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "pr-reviewer.md" }));
+    expect(onSelect).toHaveBeenCalledWith(".claude/agents/pr-reviewer.md");
+  });
+
+  test("per-file download button is named by basename and passes the file", () => {
+    const onDownloadFile = vi.fn();
+    render(
+      <FileTree files={files} selectedPath={null} onSelect={() => {}} onDownloadFile={onDownloadFile} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Download pr-reviewer.md" }));
+    expect(onDownloadFile).toHaveBeenCalledWith(files[1]);
+  });
+});

--- a/web/app/agent-packs/components/FileTree.tsx
+++ b/web/app/agent-packs/components/FileTree.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Download, FileText, Folder } from "lucide-react";
+
+import type { AgentPackFile } from "../types";
+import { buildFileTree, type FileTreeNode } from "../lib/fileTree";
+
+interface FileTreeProps {
+  files: AgentPackFile[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onDownloadFile: (file: AgentPackFile) => void;
+}
+
+export default function FileTree({ files, selectedPath, onSelect, onDownloadFile }: FileTreeProps) {
+  const nodes = buildFileTree(files);
+  return (
+    <ul className="space-y-0.5">
+      {nodes.map((node) => (
+        <FileTreeItem
+          key={node.path}
+          node={node}
+          depth={0}
+          selectedPath={selectedPath}
+          onSelect={onSelect}
+          onDownloadFile={onDownloadFile}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface FileTreeItemProps {
+  node: FileTreeNode;
+  depth: number;
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onDownloadFile: (file: AgentPackFile) => void;
+}
+
+function FileTreeItem({ node, depth, selectedPath, onSelect, onDownloadFile }: FileTreeItemProps) {
+  const [expanded, setExpanded] = useState(true);
+  const indent = { paddingLeft: `${depth * 12 + 8}px` };
+
+  if (node.type === "folder") {
+    return (
+      <li>
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+          style={indent}
+          className="flex w-full items-center gap-1.5 rounded-lg px-2 py-1 text-left text-xs text-zinc-300 transition hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500"
+        >
+          {expanded ? (
+            <ChevronDown size={13} aria-hidden="true" />
+          ) : (
+            <ChevronRight size={13} aria-hidden="true" />
+          )}
+          <Folder size={13} className="text-cyan-300/70" aria-hidden="true" />
+          <span className="font-mono">{node.name}</span>
+        </button>
+        {expanded && (
+          <ul className="space-y-0.5">
+            {node.children.map((child) => (
+              <FileTreeItem
+                key={child.path}
+                node={child}
+                depth={depth + 1}
+                selectedPath={selectedPath}
+                onSelect={onSelect}
+                onDownloadFile={onDownloadFile}
+              />
+            ))}
+          </ul>
+        )}
+      </li>
+    );
+  }
+
+  const active = node.path === selectedPath;
+  return (
+    <li className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onSelect(node.path)}
+        style={indent}
+        className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-lg px-2 py-1 text-left text-xs transition focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 ${
+          active
+            ? "bg-cyan-500/10 text-cyan-100"
+            : "text-zinc-400 hover:bg-white/[0.05] hover:text-zinc-200"
+        }`}
+      >
+        <FileText size={13} aria-hidden="true" />
+        <span className="truncate font-mono">{node.name}</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onDownloadFile(node.file)}
+        aria-label={`Download ${node.name}`}
+        title={`Download ${node.name}`}
+        className="shrink-0 rounded-lg p-1 text-zinc-500 transition hover:bg-white/[0.05] hover:text-cyan-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500"
+      >
+        <Download size={13} aria-hidden="true" />
+      </button>
+    </li>
+  );
+}

--- a/web/app/agent-packs/components/InstallChecklist.test.tsx
+++ b/web/app/agent-packs/components/InstallChecklist.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, test } from "vitest";
+
+import InstallChecklist from "./InstallChecklist";
+import { buildInstallChecklist } from "../installChecklist";
+import type { AgentPackManifest } from "../types";
+
+const manifest: AgentPackManifest = {
+  provider: "claude",
+  pack_type: "project-pack",
+  download_name: "x",
+  preview_order: ["claude_md", "settings", "workflow"],
+  files: [
+    { path: "CLAUDE.md", content: "#", kind: "claude_md" },
+    { path: ".claude/settings.json", content: "{}", kind: "settings" },
+    { path: ".github/workflows/claude.yml", content: "y", kind: "workflow" },
+  ],
+};
+
+function Harness() {
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+  const sections = buildInstallChecklist(manifest);
+  return (
+    <InstallChecklist
+      sections={sections}
+      checkedIds={checkedIds}
+      onToggle={(id) =>
+        setCheckedIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+          return next;
+        })
+      }
+    />
+  );
+}
+
+describe("InstallChecklist", () => {
+  test("renders review/validation items as labelled checkboxes and updates progress", () => {
+    render(<Harness />);
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+    expect(screen.getByText(`0/${checkboxes.length} done`)).toBeTruthy();
+
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByText(`1/${checkboxes.length} done`)).toBeTruthy();
+  });
+
+  test("does not render the generatedFiles section", () => {
+    render(<Harness />);
+    expect(screen.queryByText(/Add CLAUDE\.md to the matching path/i)).toBeNull();
+  });
+
+  test("keeps an accessible checklist heading", () => {
+    render(<Harness />);
+    expect(screen.getByRole("heading", { name: "Install & review checklist" })).toBeTruthy();
+  });
+});

--- a/web/app/agent-packs/components/InstallChecklist.tsx
+++ b/web/app/agent-packs/components/InstallChecklist.tsx
@@ -4,17 +4,31 @@ import type { InstallChecklistSection } from "../installChecklist";
 
 interface InstallChecklistProps {
   sections: InstallChecklistSection[];
+  checkedIds: Set<string>;
+  onToggle: (id: string) => void;
   downloaded?: boolean;
 }
 
-export default function InstallChecklist({ sections, downloaded = false }: InstallChecklistProps) {
+const CHECKBOX_SECTION_IDS = new Set(["reviewFirst", "validationSteps"]);
+
+export default function InstallChecklist({
+  sections,
+  checkedIds,
+  onToggle,
+  downloaded = false,
+}: InstallChecklistProps) {
   const titleId = "agent-pack-install-checklist-title";
+  const rendered = sections.filter((section) => section.id !== "generatedFiles");
+
+  const checkboxIds = rendered
+    .filter((section) => CHECKBOX_SECTION_IDS.has(section.id))
+    .flatMap((section) => section.items.map((_, index) => `${section.id}-${index}`));
+  const total = checkboxIds.length;
+  const done = checkboxIds.filter((id) => checkedIds.has(id)).length;
+  const complete = total > 0 && done === total;
 
   return (
-    <section
-      aria-labelledby={titleId}
-      className="border-b border-white/5 px-4 py-4 sm:px-6"
-    >
+    <section aria-labelledby={titleId} className="border-b border-white/5 px-4 py-4 sm:px-6">
       <div className="rounded-2xl border border-cyan-400/20 bg-cyan-500/5 p-4">
         <div className="mb-3 flex items-start justify-between gap-3">
           <div>
@@ -22,31 +36,78 @@ export default function InstallChecklist({ sections, downloaded = false }: Insta
               Install &amp; review checklist
             </h3>
             <p className="mt-1 text-xs leading-relaxed text-cyan-100/70">
-              Beta output is a starting point. Use this list to install files safely in your repo.
+              Generated files are a starting point — review before committing.
             </p>
           </div>
-          {downloaded ? (
-            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
-              <CheckCircle2 size={12} aria-hidden="true" />
-              Downloaded
-            </span>
-          ) : null}
+          <div className="flex items-center gap-2">
+            {complete ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                <CheckCircle2 size={12} aria-hidden="true" />
+                All steps complete
+              </span>
+            ) : null}
+            {downloaded ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                <CheckCircle2 size={12} aria-hidden="true" />
+                Downloaded
+              </span>
+            ) : null}
+          </div>
         </div>
 
+        {total > 0 ? (
+          <div className="mb-3">
+            <div className="mb-1 flex items-center justify-between text-[11px] text-cyan-100/70">
+              <span>Progress</span>
+              <span aria-live="polite">{`${done}/${total} done`}</span>
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-cyan-400 transition-all"
+                style={{ width: `${(done / total) * 100}%` }}
+              />
+            </div>
+          </div>
+        ) : null}
+
         <div className="grid gap-4 md:grid-cols-2">
-          {sections.map((section) => (
+          {rendered.map((section) => (
             <div key={section.id} className="rounded-xl border border-white/8 bg-black/20 p-3">
               <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-400">
                 {section.title}
               </h4>
-              <ul className="space-y-2 text-xs leading-relaxed text-zinc-300">
-                {section.items.map((item) => (
-                  <li key={`${section.id}-${item}`} className="flex gap-2">
-                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400/80" aria-hidden="true" />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
+              {CHECKBOX_SECTION_IDS.has(section.id) ? (
+                <ul className="space-y-2 text-xs leading-relaxed text-zinc-300">
+                  {section.items.map((item, index) => {
+                    const id = `${section.id}-${index}`;
+                    return (
+                      <li key={id}>
+                        <label className="flex cursor-pointer gap-2">
+                          <input
+                            type="checkbox"
+                            checked={checkedIds.has(id)}
+                            onChange={() => onToggle(id)}
+                            className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-cyan-400"
+                          />
+                          <span>{item}</span>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <ul className="space-y-2 text-xs leading-relaxed text-zinc-300">
+                  {section.items.map((item) => (
+                    <li key={`${section.id}-${item}`} className="flex gap-2">
+                      <span
+                        className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400/80"
+                        aria-hidden="true"
+                      />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           ))}
         </div>

--- a/web/app/agent-packs/lib/fileTree.test.ts
+++ b/web/app/agent-packs/lib/fileTree.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+import { buildFileTree, type FileTreeFolderNode } from "./fileTree";
+import type { AgentPackFile } from "../types";
+
+const mk = (path: string): AgentPackFile => ({ path, content: path, kind: "files" });
+
+describe("buildFileTree", () => {
+  test("a single top-level file becomes one file node", () => {
+    const tree = buildFileTree([mk("CLAUDE.md")]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ type: "file", name: "CLAUDE.md", path: "CLAUDE.md" });
+  });
+
+  test("nested paths build folder nodes with the right segments and paths", () => {
+    const tree = buildFileTree([mk(".claude/agents/pr-reviewer.md")]);
+    expect(tree).toHaveLength(1);
+    const claude = tree[0] as FileTreeFolderNode;
+    expect(claude).toMatchObject({ type: "folder", name: ".claude", path: ".claude" });
+    const agents = claude.children[0] as FileTreeFolderNode;
+    expect(agents).toMatchObject({ type: "folder", name: "agents", path: ".claude/agents" });
+    expect(agents.children[0]).toMatchObject({
+      type: "file",
+      name: "pr-reviewer.md",
+      path: ".claude/agents/pr-reviewer.md",
+    });
+  });
+
+  test("folders sort before files, alphabetically within a level", () => {
+    const tree = buildFileTree([mk("README.md"), mk(".claude/settings.json"), mk("AGENTS.md")]);
+    expect(tree.map((n) => n.name)).toEqual([".claude", "AGENTS.md", "README.md"]);
+    expect(tree[0].type).toBe("folder");
+  });
+});

--- a/web/app/agent-packs/lib/fileTree.ts
+++ b/web/app/agent-packs/lib/fileTree.ts
@@ -1,0 +1,54 @@
+import type { AgentPackFile } from "../types";
+
+export interface FileTreeFileNode {
+  type: "file";
+  name: string;
+  path: string;
+  file: AgentPackFile;
+}
+
+export interface FileTreeFolderNode {
+  type: "folder";
+  name: string;
+  path: string;
+  children: FileTreeNode[];
+}
+
+export type FileTreeNode = FileTreeFileNode | FileTreeFolderNode;
+
+export function buildFileTree(files: AgentPackFile[]): FileTreeNode[] {
+  const root: FileTreeFolderNode = { type: "folder", name: "", path: "", children: [] };
+
+  for (const file of files) {
+    const segments = file.path.split("/");
+    let cursor = root;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const segment = segments[i];
+      const folderPath = segments.slice(0, i + 1).join("/");
+      let next = cursor.children.find(
+        (child): child is FileTreeFolderNode =>
+          child.type === "folder" && child.name === segment,
+      );
+      if (!next) {
+        next = { type: "folder", name: segment, path: folderPath, children: [] };
+        cursor.children.push(next);
+      }
+      cursor = next;
+    }
+    const name = segments[segments.length - 1];
+    cursor.children.push({ type: "file", name, path: file.path, file });
+  }
+
+  sortTree(root.children);
+  return root.children;
+}
+
+function sortTree(nodes: FileTreeNode[]): void {
+  nodes.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "folder" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  for (const node of nodes) {
+    if (node.type === "folder") sortTree(node.children);
+  }
+}

--- a/web/app/agent-packs/lib/packZip.test.ts
+++ b/web/app/agent-packs/lib/packZip.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { unzipSync, strFromU8 } from "fflate";
+
+import { zipPackBytes, buildPackZip } from "./packZip";
+import type { AgentPackFile } from "../types";
+
+const files: AgentPackFile[] = [
+  { path: "CLAUDE.md", content: "# Memory\n", kind: "claude_md" },
+  { path: ".claude/agents/pr-reviewer.md", content: "review agent", kind: "agents" },
+];
+
+describe("packZip", () => {
+  test("round-trips every file path and content", () => {
+    const unzipped = unzipSync(zipPackBytes(files));
+    expect(Object.keys(unzipped).sort()).toEqual(
+      [".claude/agents/pr-reviewer.md", "CLAUDE.md"].sort(),
+    );
+    expect(strFromU8(unzipped["CLAUDE.md"])).toBe("# Memory\n");
+    expect(strFromU8(unzipped[".claude/agents/pr-reviewer.md"])).toBe("review agent");
+  });
+
+  test("buildPackZip returns an application/zip Blob", () => {
+    expect(buildPackZip(files).type).toBe("application/zip");
+  });
+
+  test("empty file list produces a valid empty zip", () => {
+    expect(Object.keys(unzipSync(zipPackBytes([])))).toEqual([]);
+  });
+});

--- a/web/app/agent-packs/lib/packZip.ts
+++ b/web/app/agent-packs/lib/packZip.ts
@@ -13,5 +13,10 @@ export function zipPackBytes(files: AgentPackFile[]): Uint8Array {
 
 /** Build a downloadable application/zip Blob from the given files. */
 export function buildPackZip(files: AgentPackFile[]): Blob {
-  return new Blob([zipPackBytes(files)], { type: "application/zip" });
+  const bytes = zipPackBytes(files);
+  // Copy into an ArrayBuffer-backed view so the bytes satisfy BlobPart
+  // (fflate types its output as Uint8Array<ArrayBufferLike>).
+  const buffer = new Uint8Array(bytes.length);
+  buffer.set(bytes);
+  return new Blob([buffer], { type: "application/zip" });
 }

--- a/web/app/agent-packs/lib/packZip.ts
+++ b/web/app/agent-packs/lib/packZip.ts
@@ -1,0 +1,17 @@
+import { zipSync, strToU8 } from "fflate";
+
+import type { AgentPackFile } from "../types";
+
+/** Zip the given files into raw bytes (in-memory, synchronous). */
+export function zipPackBytes(files: AgentPackFile[]): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const file of files) {
+    entries[file.path] = strToU8(file.content);
+  }
+  return zipSync(entries);
+}
+
+/** Build a downloadable application/zip Blob from the given files. */
+export function buildPackZip(files: AgentPackFile[]): Blob {
+  return new Blob([zipPackBytes(files)], { type: "application/zip" });
+}

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -53,11 +53,11 @@ describe("Agent Packs page", () => {
     vi.restoreAllMocks();
   });
 
-  test("surfaces beta messaging", () => {
+  test("surfaces a single, calm beta caveat", () => {
     render(<AgentPacksPage />);
 
-    expect(screen.getAllByText("Beta").length).toBeGreaterThan(0);
-    expect(screen.getByText("Experimental Feature")).toBeTruthy();
+    expect(screen.getAllByText("Beta")).toHaveLength(1);
+    expect(screen.queryByText("Experimental Feature")).toBeNull();
     expect(screen.queryByText("API Key (Optional)")).toBeNull();
   });
 

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -79,6 +79,7 @@ describe("Agent Packs page", () => {
     expect(screen.getByRole("heading", { name: "Install & review checklist" })).toBeTruthy();
     expect(screen.getByText("Review before use")).toBeTruthy();
     expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: ".claude" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "agents" })).toBeTruthy();
   });
 

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -228,7 +228,7 @@ describe("Agent Packs page", () => {
     expect(screen.getByText(/so the generated files match your setup/i)).toBeTruthy();
   });
 
-  test("closing the preview clears the generated pack and its labels", async () => {
+  test("closing the preview clears the pack, checklist, and checked state", async () => {
     render(<AgentPacksPage />);
 
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
@@ -239,12 +239,24 @@ describe("Agent Packs page", () => {
     expect(await screen.findByText("Pack Preview")).toBeTruthy();
     expect(screen.getByRole("button", { name: "CLAUDE.md" })).toBeTruthy();
 
+    // Tick a checklist item.
+    const firstCheckbox = screen.getAllByRole("checkbox")[0];
+    fireEvent.click(firstCheckbox);
+    const totalBefore = screen.getAllByRole("checkbox").length;
+    expect(screen.getByText(`1/${totalBefore} done`)).toBeTruthy();
+
     fireEvent.click(screen.getByRole("button", { name: /close pack preview/i }));
 
-    // The preview, checklist, and stale file-group labels are gone; the empty state returns.
+    // The preview, checklist, and file tree are gone; the empty state returns.
     await waitFor(() => expect(screen.queryByText("Pack Preview")).toBeNull());
     expect(screen.queryByRole("heading", { name: "Install & review checklist" })).toBeNull();
     expect(screen.queryByRole("button", { name: "CLAUDE.md" })).toBeNull();
     expect(screen.getByText("Single-click pack generation")).toBeTruthy();
+
+    // Regenerating starts the checklist progress from zero.
+    fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
+    await screen.findByText("Pack Preview");
+    const totalAfter = screen.getAllByRole("checkbox").length;
+    expect(screen.getByText(`0/${totalAfter} done`)).toBeTruthy();
   });
 });

--- a/web/app/agent-packs/page.test.tsx
+++ b/web/app/agent-packs/page.test.tsx
@@ -3,14 +3,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import AgentPacksPage from "./page";
 
-const { apiJson, apiFetch } = vi.hoisted(() => ({
+const { apiJson } = vi.hoisted(() => ({
   apiJson: vi.fn(),
-  apiFetch: vi.fn(),
 }));
 
 vi.mock("@/config", () => ({
   apiJson,
-  apiFetch,
   buildGeneratorApiHeaders: (headers: HeadersInit = {}) => headers,
   describeRequestError: (error: unknown) =>
     error instanceof Error && error.message === "Failed to fetch"
@@ -27,7 +25,6 @@ vi.mock("../lib/showError", () => ({
 describe("Agent Packs page", () => {
   beforeEach(() => {
     apiJson.mockReset();
-    apiFetch.mockReset();
     apiJson.mockResolvedValue({
       provider: "claude",
       pack_type: "pr-reviewer",
@@ -39,15 +36,6 @@ describe("Agent Packs page", () => {
         { path: ".github/workflows/claude.yml", content: "name: Claude", kind: "workflow" },
       ],
     });
-    apiFetch.mockResolvedValue(
-      new Response("zip-bytes", {
-        status: 200,
-        headers: {
-          "content-disposition": 'attachment; filename="saas-pr-reviewer-claude.zip"',
-          "content-type": "application/zip",
-        },
-      }),
-    );
     Object.defineProperty(globalThis.navigator, "clipboard", {
       configurable: true,
       value: {
@@ -119,22 +107,20 @@ describe("Agent Packs page", () => {
     expect(screen.getByText(/GitHub workflow YAML permissions/i)).toBeTruthy();
   });
 
-  test("downloads the generated pack through the Claude download route", async () => {
+  test("downloads a zip built from the in-state manifest", async () => {
     const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
     const originalCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
       const element = originalCreateElement(tagName);
       if (tagName.toLowerCase() === "a") {
-        Object.defineProperty(element, "click", {
-          configurable: true,
-          value: clickSpy,
-        });
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
       }
       return element;
     });
 
     render(<AgentPacksPage />);
-
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
       target: { value: "Create a full project pack." },
     });
@@ -143,100 +129,75 @@ describe("Agent Packs page", () => {
     await screen.findByText("Pack Preview");
     fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
 
-    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
-    const [path, options] = apiFetch.mock.calls[0];
-    expect(path).toBe("/agent-packs/claude/download");
-    expect(JSON.parse(options.body).goal).toBe("Create a full project pack.");
-    expect(clickSpy).toHaveBeenCalledTimes(1);
-    expect(await screen.findByText("Downloaded")).toBeTruthy();
-
-    // The blob URL is created for the download and cleaned up afterwards.
+    // Built client-side: a blob URL is created and the anchor is clicked, no server call.
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("saas-pr-reviewer-claude.zip");
+    expect(await screen.findByText("Downloaded")).toBeTruthy();
     await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview"));
-
-    // Button leaves the "Preparing..." state after a successful download.
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: /download pack/i }).textContent).toContain(
-        "Download Pack",
-      ),
-    );
   });
 
-  test("shows a visible error and does not start a download when the pack response is empty", async () => {
-    const originalCreateElement = document.createElement.bind(document);
+  test("falls back to agent-pack.zip when the manifest has no download_name", async () => {
+    apiJson.mockResolvedValueOnce({
+      provider: "claude",
+      pack_type: "pr-reviewer",
+      download_name: "",
+      preview_order: ["claude_md"],
+      files: [{ path: "CLAUDE.md", content: "x", kind: "claude_md" }],
+    });
     const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
       const element = originalCreateElement(tagName);
       if (tagName.toLowerCase() === "a") {
-        Object.defineProperty(element, "click", {
-          configurable: true,
-          value: clickSpy,
-        });
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
       }
       return element;
     });
 
     render(<AgentPacksPage />);
-
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
-      target: { value: "Create a full project pack." },
+      target: { value: "x" },
     });
     fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
 
     await screen.findByText("Pack Preview");
-
-    apiFetch.mockResolvedValueOnce(
-      new Response(new Blob([]), {
-        status: 200,
-        headers: {
-          "content-disposition": 'attachment; filename="saas-pr-reviewer-claude.zip"',
-          "content-type": "application/zip",
-        },
-      }),
-    );
-
     fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
 
-    expect(
-      await screen.findByText("The agent pack download was empty. Please try generating it again."),
-    ).toBeTruthy();
-    expect(clickSpy).not.toHaveBeenCalled();
-    expect(URL.createObjectURL).not.toHaveBeenCalled();
-
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: /download pack/i }).textContent).toContain(
-        "Download Pack",
-      ),
-    );
+    expect(anchors[anchors.length - 1].download).toBe("agent-pack.zip");
   });
 
-  test("shows a visible error and resets the button when download fails", async () => {
-    render(<AgentPacksPage />);
+  test("does not download when the manifest has no files", async () => {
+    apiJson.mockResolvedValueOnce({
+      provider: "claude",
+      pack_type: "pr-reviewer",
+      download_name: "empty",
+      preview_order: [],
+      files: [],
+    });
+    const clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+      }
+      return element;
+    });
 
+    render(<AgentPacksPage />);
     fireEvent.change(screen.getByLabelText("What should Claude do?"), {
-      target: { value: "Create a full project pack." },
+      target: { value: "x" },
     });
     fireEvent.click(screen.getAllByRole("button", { name: /generate claude pack/i })[0]);
 
     await screen.findByText("Pack Preview");
-
-    apiFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ detail: "Pack generation failed." }), {
-        status: 500,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-
     fireEvent.click(screen.getByRole("button", { name: /download pack/i }));
 
-    expect(await screen.findByText("Pack generation failed.")).toBeTruthy();
-
-    // No silent infinite loading state: the button returns to its idle label.
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: /download pack/i }).textContent).toContain(
-        "Download Pack",
-      ),
-    );
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
   });
 
   test("shows a normalized network error when generation fails to fetch", async () => {

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -73,6 +73,7 @@ export default function AgentPacksPage() {
   const [error, setError] = useState<string | null>(null);
   const [copiedState, setCopiedState] = useState<"single" | "all" | null>(null);
   const [downloaded, setDownloaded] = useState(false);
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
 
   const requestHeaders = useMemo(
     () => buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
@@ -93,6 +94,15 @@ export default function AgentPacksPage() {
     setRequest((prev) => ({ ...prev, [key]: value }));
   };
 
+  const toggleChecklistItem = (id: string) => {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
   const handleGenerate = async () => {
     if (!request.goal.trim()) return;
 
@@ -101,6 +111,7 @@ export default function AgentPacksPage() {
     setManifest(null);
     setSelectedPath(null);
     setDownloaded(false);
+    setCheckedIds(new Set());
 
     try {
       const data = await apiJson<AgentPackManifest>("/agent-packs/claude", {
@@ -139,6 +150,7 @@ export default function AgentPacksPage() {
     setSelectedPath(null);
     setCopiedState(null);
     setDownloaded(false);
+    setCheckedIds(new Set());
   };
 
   const handleDownloadFile = (file: AgentPackFile) => {
@@ -468,7 +480,12 @@ export default function AgentPacksPage() {
                   </div>
                 </div>
 
-                <InstallChecklist sections={installChecklist} downloaded={downloaded} />
+                <InstallChecklist
+                  sections={installChecklist}
+                  checkedIds={checkedIds}
+                  onToggle={toggleChecklistItem}
+                  downloaded={downloaded}
+                />
 
                 <div className="border-b border-white/5 px-4 py-3 sm:px-6">
                   <div className="mb-2 text-[11px] font-mono uppercase tracking-[0.2em] text-zinc-500">

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -8,13 +8,13 @@ import { Bot, Copy, Download, FileCode2, FolderArchive, Loader2, ShieldCheck, Sp
 import { apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
 import InfoButton from "../components/InfoButton";
 import { showError } from "../lib/showError";
+import FileTree from "./components/FileTree";
 import InstallChecklist from "./components/InstallChecklist";
 import { buildInstallChecklist } from "./installChecklist";
 import { buildPackZip } from "./lib/packZip";
 import { agentPackProviders } from "./providerRegistry";
 import type {
   AgentPackFile,
-  AgentPackFileKind,
   AgentPackManifest,
   AgentPackRequest,
   AgentPackRiskMode,
@@ -44,16 +44,6 @@ const PACK_OPTIONS: { id: AgentPackType; label: string; detail: string }[] = [
   },
 ];
 
-const PREVIEW_LABELS: Record<AgentPackFileKind, string> = {
-  claude_md: "CLAUDE.md",
-  settings: "settings.json",
-  agents: "agents",
-  workflow: "workflow",
-  mcp: "mcp",
-  readme: "README",
-  files: "files",
-};
-
 const RISK_OPTIONS: { id: AgentPackRiskMode; label: string; detail: string }[] = [
   { id: "balanced", label: "Balanced", detail: "Practical defaults with guardrails." },
   { id: "strict", label: "Strict", detail: "Tighter permissions and more defensive posture." },
@@ -77,7 +67,6 @@ export default function AgentPacksPage() {
   const provider = agentPackProviders[0];
   const [request, setRequest] = useState<AgentPackRequest>(DEFAULT_REQUEST);
   const [manifest, setManifest] = useState<AgentPackManifest | null>(null);
-  const [activeKind, setActiveKind] = useState<AgentPackFileKind | null>(null);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -90,22 +79,10 @@ export default function AgentPacksPage() {
     [],
   );
 
-  const previewGroups = useMemo(() => {
-    if (!manifest) return [];
-    return manifest.preview_order
-      .map((kind) => ({
-        kind,
-        label: PREVIEW_LABELS[kind] ?? kind,
-        files: manifest.files.filter((file) => file.kind === kind),
-      }))
-      .filter((group) => group.files.length > 0);
-  }, [manifest]);
-
-  const activeGroup = previewGroups.find((group) => group.kind === activeKind) ?? previewGroups[0] ?? null;
-  const currentFile =
-    activeGroup?.files.find((file) => file.path === selectedPath) ??
-    activeGroup?.files[0] ??
-    null;
+  const currentFile = useMemo(() => {
+    if (!manifest) return null;
+    return manifest.files.find((file) => file.path === selectedPath) ?? manifest.files[0] ?? null;
+  }, [manifest, selectedPath]);
 
   const installChecklist = useMemo(() => {
     if (!manifest) return [];
@@ -122,7 +99,6 @@ export default function AgentPacksPage() {
     setLoading(true);
     setError(null);
     setManifest(null);
-    setActiveKind(null);
     setSelectedPath(null);
     setDownloaded(false);
 
@@ -133,7 +109,6 @@ export default function AgentPacksPage() {
         body: JSON.stringify(request),
       });
       setManifest(data);
-      setActiveKind(data.preview_order[0] ?? null);
       setSelectedPath(data.files[0]?.path ?? null);
     } catch (err: unknown) {
       showError(err);
@@ -161,10 +136,24 @@ export default function AgentPacksPage() {
 
   const handleClosePreview = () => {
     setManifest(null);
-    setActiveKind(null);
     setSelectedPath(null);
     setCopiedState(null);
     setDownloaded(false);
+  };
+
+  const handleDownloadFile = (file: AgentPackFile) => {
+    const blob = new Blob([file.content], { type: "text/plain" });
+    const href = URL.createObjectURL(blob);
+    const basename = file.path.split("/").pop() || "file";
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.download = basename;
+    anchor.rel = "noopener";
+    anchor.style.display = "none";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(href), 0);
   };
 
   const handleDownload = () => {
@@ -481,45 +470,17 @@ export default function AgentPacksPage() {
 
                 <InstallChecklist sections={installChecklist} downloaded={downloaded} />
 
-                <div className="flex flex-wrap gap-2 border-b border-white/5 px-4 py-3 sm:px-6">
-                  {previewGroups.map((group) => (
-                    <button
-                      key={group.kind}
-                      type="button"
-                      onClick={() => {
-                        setActiveKind(group.kind);
-                        setSelectedPath(group.files[0]?.path ?? null);
-                      }}
-                      className={`rounded-full border px-3 py-1.5 text-[11px] font-mono uppercase tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 ${
-                        activeGroup?.kind === group.kind
-                          ? "border-cyan-400/40 bg-cyan-500/10 text-cyan-100"
-                          : "border-transparent bg-white/[0.03] text-zinc-500 hover:bg-white/[0.07] hover:text-zinc-300"
-                      }`}
-                    >
-                      {group.label}
-                    </button>
-                  ))}
-                </div>
-
-                {activeGroup && activeGroup.files.length > 1 && (
-                  <div className="px-4 pt-4 sm:px-6">
-                    <label htmlFor="agent-pack-file-select" className="sr-only">
-                      Preview file
-                    </label>
-                    <select
-                      id="agent-pack-file-select"
-                      value={currentFile?.path ?? activeGroup.files[0].path}
-                      onChange={(event) => setSelectedPath(event.target.value)}
-                      className="w-full rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
-                    >
-                      {activeGroup.files.map((file) => (
-                        <option key={file.path} value={file.path}>
-                          {file.path}
-                        </option>
-                      ))}
-                    </select>
+                <div className="border-b border-white/5 px-4 py-3 sm:px-6">
+                  <div className="mb-2 text-[11px] font-mono uppercase tracking-[0.2em] text-zinc-500">
+                    Files
                   </div>
-                )}
+                  <FileTree
+                    files={manifest.files}
+                    selectedPath={currentFile?.path ?? null}
+                    onSelect={setSelectedPath}
+                    onDownloadFile={handleDownloadFile}
+                  />
+                </div>
 
                 <div className="flex-1 overflow-hidden p-4 sm:p-6">
                   <div className="relative h-full overflow-hidden rounded-2xl border border-white/8 bg-black/35">

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -240,36 +240,13 @@ export default function AgentPacksPage() {
                   <div className="mb-1 text-[11px] font-mono uppercase tracking-[0.25em] text-cyan-300/80">
                     {provider.name}
                   </div>
-                  <h2 className="text-xl font-semibold text-white">Generate beta-stage agent assets for your repo</h2>
+                  <h2 className="text-xl font-semibold text-white">Generate agent assets for your repo</h2>
                 </div>
                 <div className={`h-12 w-12 rounded-2xl ${provider.glowClass} flex items-center justify-center`}>
                   <Bot size={22} className="text-cyan-200" aria-hidden="true" />
                 </div>
               </div>
               <p className="text-sm leading-relaxed text-zinc-400">{provider.summary}</p>
-            </div>
-
-            <button
-              type="button"
-              className={`group flex items-center justify-between rounded-2xl border border-white/10 p-4 text-left transition-all hover:border-cyan-400/30 hover:bg-white/[0.05] ${manifest ? "bg-white/[0.05]" : "bg-white/[0.02]"}`}
-              aria-label="Claude provider card"
-            >
-              <div>
-                <div className="mb-1 text-sm font-semibold text-white">{provider.name}</div>
-                <div className="text-xs text-zinc-500">
-                  Beta preview. Good for fast bootstrapping, but you should still review prompts, permissions,
-                  workflows, and generated files before shipping.
-                </div>
-              </div>
-              <div className={`rounded-xl bg-gradient-to-br ${provider.accentClass} px-3 py-2 text-xs font-semibold text-white shadow-lg shadow-cyan-500/10`}>
-                Beta
-              </div>
-            </button>
-
-            <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm leading-relaxed text-amber-100/90">
-              <div className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-amber-200">Experimental Feature</div>
-              Agent Packs is in beta and gives you a starting point, not a finished install. After generation, follow the
-              install checklist on the right, review sensitive files, then commit only what you trust.
             </div>
 
             <div className="grid gap-3 sm:grid-cols-2">

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -5,11 +5,12 @@ import { toast } from "sonner";
 import { useMemo, useState } from "react";
 import { Bot, Copy, Download, FileCode2, FolderArchive, Loader2, ShieldCheck, Sparkles, X } from "lucide-react";
 
-import { apiFetch, apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
+import { apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
 import InfoButton from "../components/InfoButton";
 import { showError } from "../lib/showError";
 import InstallChecklist from "./components/InstallChecklist";
 import { buildInstallChecklist } from "./installChecklist";
+import { buildPackZip } from "./lib/packZip";
 import { agentPackProviders } from "./providerRegistry";
 import type {
   AgentPackFile,
@@ -66,11 +67,6 @@ const DEFAULT_REQUEST: AgentPackRequest = {
   risk_mode: "balanced",
 };
 
-function getDownloadFilename(response: Response, fallback: string): string {
-  const disposition = response.headers.get("content-disposition") || "";
-  const match = disposition.match(/filename=\"?([^"]+)\"?/i);
-  return match?.[1] || fallback;
-}
 function bundleFiles(files: AgentPackFile[]): string {
   return files
     .map((file) => `# ${file.path}\n\n${file.content.trim()}`)
@@ -171,30 +167,15 @@ export default function AgentPacksPage() {
     setDownloaded(false);
   };
 
-  const handleDownload = async () => {
-    if (!request.goal.trim()) return;
+  const handleDownload = () => {
+    if (!manifest || manifest.files.length === 0) return;
 
     setDownloading(true);
     setError(null);
     try {
-      const response = await apiFetch("/agent-packs/claude/download", {
-        method: "POST",
-        headers: requestHeaders,
-        body: JSON.stringify(request),
-      });
-
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({ detail: response.statusText }));
-        throw new Error(payload.detail ?? "Download failed.");
-      }
-
-      const blob = await response.blob();
-      if (blob.size === 0) {
-        throw new Error("The agent pack download was empty. Please try generating it again.");
-      }
-
+      const blob = buildPackZip(manifest.files);
       const href = URL.createObjectURL(blob);
-      const filename = getDownloadFilename(response, `${manifest?.download_name || "agent-pack"}.zip`);
+      const filename = `${manifest.download_name || "agent-pack"}.zip`;
       const anchor = document.createElement("a");
       anchor.href = href;
       anchor.download = filename;

--- a/web/app/agent-packs/providerRegistry.ts
+++ b/web/app/agent-packs/providerRegistry.ts
@@ -4,8 +4,8 @@ export const agentPackProviders: AgentPackProviderConfig[] = [
   {
     id: "claude",
     name: "Claude",
-    badge: "Beta Preview",
-    summary: "Generate repo-ready Claude assets from one short brief, then review them before production use.",
+    badge: "",
+    summary: "Generate repo-ready Claude assets from one short brief.",
     ctaLabel: "Generate Claude Pack",
     accentClass: "from-sky-500 via-cyan-500 to-blue-600",
     glowClass: "bg-cyan-500/20",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@types/dompurify": "^3.2.0",
         "diff-match-patch": "^1.0.5",
         "dompurify": "^3.3.3",
+        "fflate": "^0.8.3",
         "lucide-react": "^0.575.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -56,77 +57,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.5.tgz",
-      "integrity": "sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.7"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
-      "integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.6.tgz",
-      "integrity": "sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
-      "integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -378,173 +308,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
-      }
-    },
-    "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -720,26 +483,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -3487,18 +3230,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "require-from-string": "^2.0.2"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3788,22 +3519,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -3945,22 +3660,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4031,15 +3730,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -4212,21 +3902,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4973,6 +4648,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5454,21 +5135,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@exodus/bytes": "^1.6.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -5892,15 +5558,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6106,61 +5763,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdom": {
-      "version": "29.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
-      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@asamuzakjp/dom-selector": "^7.0.3",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
-        "@exodus/bytes": "^1.15.0",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7",
-        "parse5": "^8.0.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.24.5",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
-      "integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -6779,15 +6381,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "optional": true,
-      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7663,21 +7256,6 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8084,18 +7662,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -8272,21 +7838,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -8812,15 +8363,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -8923,30 +8465,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tldts-core": "^7.0.28"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8958,36 +8476,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -9201,18 +8689,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -9891,62 +9367,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10100,27 +9520,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "@types/dompurify": "^3.2.0",
     "diff-match-patch": "^1.0.5",
     "dompurify": "^3.3.3",
+    "fflate": "^0.8.3",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       dompurify:
         specifier: ^3.3.3
         version: 3.4.2
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@19.2.3)
@@ -883,6 +886,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1569,6 +1573,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4100,7 +4107,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -4123,7 +4130,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4138,14 +4145,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4160,7 +4167,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4333,6 +4340,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- **Client-side download.** Build the pack `.zip` in the browser from the in-state manifest (`fflate`) instead of re-POSTing to `/agent-packs/claude/download`. The download now provably equals the preview and drops a redundant server round-trip.
- **Real file tree.** Replace the group-by-kind tabs + `<select>` with a collapsible file tree showing files at their repo paths, each downloadable on its own.
- **Interactive install checklist.** Review/validation steps are tickable checkboxes with an in-session progress bar (resets on generate/close).
- **Cleanup.** Remove the dead (no-op) Claude provider card and dial back the beta/experimental hedging to a single honest caveat.

## Notes / boundaries
- Adds one dependency, `fflate` (~8KB, tree-shakeable), for client-side zipping — pre-approved.
- `package-lock.json` also drops a stale, unused `jsdom` subtree that `npm install` pruned. The test env is `happy-dom`; `jsdom` is not a direct dependency and is referenced nowhere in code/config. Safe — all tests/build green.
- Backend, API, MCP, and the `/agent-packs/claude/download` endpoint + its Next.js proxy route are untouched (kept for non-UI clients).

## Test plan
- [x] `cd web && npm run test` — 169/169 web tests pass (26 in agent-packs, incl. new `packZip` / `fileTree` / `FileTree` / `InstallChecklist` suites)
- [x] `cd web && npm run build` — TypeScript passes
- [x] `cd web && npm run lint` — 0 errors
- [ ] Optional live smoke (backend :8080 + web :3000): generate a pack → browse the tree → download whole `.zip` and a single file → tick the checklist

Spec: `docs/superpowers/specs/2026-07-04-agent-packs-b2-web-delivery-design.md`
Plan: `docs/superpowers/plans/2026-07-04-agent-packs-b2-web-delivery.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)