### PR TITLE
feat(agent-packs): B3 slice-1 — render dead IR fields (.mcp.json + hooks example)

### DIFF
--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -6,6 +6,7 @@ import textwrap
 from typing import Any
 
 from .agent_ir import AgentExportIR
+from .mcp_servers import render_mcp_json, unregistered_servers
 from .skill_ir import SkillExportIR
 
 
@@ -109,6 +110,9 @@ def to_claude_project_pack(ir: AgentExportIR) -> list[dict[str, str]]:
         {"path": ".github/workflows/claude.yml", "content": _github_action_workflow(ir)},
         {"path": ".claude/mcp/README.md", "content": _mcp_integration_notes(ir)},
     ]
+    mcp_json = render_mcp_json(ir.mcp_servers)
+    if mcp_json is not None:
+        files.append({"path": ".mcp.json", "content": mcp_json})
     return files
 
 
@@ -153,6 +157,9 @@ def to_claude_pr_reviewer_pack(ir: AgentExportIR) -> list[dict[str, str]]:
         {"path": ".github/workflows/claude.yml", "content": _github_action_workflow(ir)},
         {"path": "README.md", "content": _pr_reviewer_readme(ir)},
     ]
+    mcp_json = render_mcp_json(ir.mcp_servers)
+    if mcp_json is not None:
+        files.append({"path": ".mcp.json", "content": mcp_json})
     return files
 
 
@@ -417,7 +424,7 @@ This pack gives Claude Code a dedicated `pr-reviewer` subagent and repository gu
 
 
 def _mcp_integration_notes(ir: AgentExportIR) -> str:
-    return textwrap.dedent(
+    notes = textwrap.dedent(
         f"""\
 # MCP integration notes for {ir.name}
 
@@ -431,6 +438,10 @@ Before adding an MCP server:
 4. Keep secrets in the host environment; do not write credentials into this pack.
 """
     )
+    extra = unregistered_servers(ir.mcp_servers)
+    if extra:
+        notes += f"\nDetected but not auto-configured (add manually): {', '.join(extra)}.\n"
+    return notes
 
 
 def _skill_params_markdown(ir: SkillExportIR) -> str:

--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -114,6 +114,9 @@ def to_claude_project_pack(ir: AgentExportIR) -> list[dict[str, str]]:
     mcp_json = render_mcp_json(ir.mcp_servers)
     if mcp_json is not None:
         files.append({"path": ".mcp.json", "content": mcp_json})
+    hooks_example = _hooks_example_json(ir)
+    if hooks_example is not None:
+        files.append({"path": ".claude/hooks.example.json", "content": hooks_example})
     return files
 
 
@@ -161,6 +164,9 @@ def to_claude_pr_reviewer_pack(ir: AgentExportIR) -> list[dict[str, str]]:
     mcp_json = render_mcp_json(ir.mcp_servers)
     if mcp_json is not None:
         files.append({"path": ".mcp.json", "content": mcp_json})
+    hooks_example = _hooks_example_json(ir)
+    if hooks_example is not None:
+        files.append({"path": ".claude/hooks.example.json", "content": hooks_example})
     return files
 
 

--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 import textwrap
 from typing import Any
 
@@ -269,6 +270,43 @@ def _project_claude_md(ir: AgentExportIR) -> str:
 - Suggested tools: {", ".join(ir.allowed_tools) or "Read, Glob, Grep"}
 """
     )
+
+
+def _select_post_edit_suggestions(ir: AgentExportIR) -> list[str]:
+    """Hook suggestions that describe a post-edit action (test/lint/frontend build)."""
+    return [
+        s
+        for s in ir.hook_suggestions
+        if "after" in s.lower() and ("edit" in s.lower() or "code" in s.lower())
+    ]
+
+
+def _hooks_example_json(ir: AgentExportIR) -> str | None:
+    """Render an example Claude Code hooks file from post-edit suggestions.
+
+    Returns None when there is nothing to render. This is an *example* file the
+    user adopts; it is never read live by Claude Code, so it does not nag on edits.
+    The suggestion text is passed through shlex.quote so the echo command is valid
+    shell for any content (no injection/expansion).
+    """
+    selected = _select_post_edit_suggestions(ir)
+    if not selected:
+        return None
+    post_tool_use = [
+        {
+            "matcher": "Edit|Write",
+            "hooks": [{"type": "command", "command": f"echo {shlex.quote(s)}"}],
+        }
+        for s in selected
+    ]
+    data = {
+        "//": (
+            'Example Claude Code hooks. Copy the "hooks" block into '
+            ".claude/settings.json and replace each echo with your real command."
+        ),
+        "hooks": {"PostToolUse": post_tool_use},
+    }
+    return json.dumps(data, indent=2)
 
 
 def _project_settings_json(ir: AgentExportIR) -> str:

--- a/app/adapters/mcp_servers.py
+++ b/app/adapters/mcp_servers.py
@@ -30,9 +30,7 @@ def render_mcp_json(server_names: list[str]) -> str | None:
     for deterministic output; unregistered names are ignored.
     """
     selected = {
-        name: config
-        for name, config in MCP_SERVER_REGISTRY.items()
-        if name in server_names
+        name: config for name, config in MCP_SERVER_REGISTRY.items() if name in server_names
     }
     if not selected:
         return None

--- a/app/adapters/mcp_servers.py
+++ b/app/adapters/mcp_servers.py
@@ -1,0 +1,44 @@
+"""Known MCP server config stubs for generated agent packs.
+
+Configs verified 2026-07-04 against https://code.claude.com/docs/en/mcp.
+The old @modelcontextprotocol/server-* npx packages are archived; the current
+GitHub/Slack/Notion/Sentry servers are remote HTTP. `figma` and `jira` are
+intentionally absent (no current config confirmed) and are surfaced in the
+pack README instead. Secrets are only ${ENV} placeholders or OAuth (no secret).
+"""
+
+from __future__ import annotations
+
+import json
+
+MCP_SERVER_REGISTRY: dict[str, dict] = {
+    "github": {
+        "type": "http",
+        "url": "https://api.githubcopilot.com/mcp/",
+        "headers": {"Authorization": "Bearer ${GITHUB_PAT}"},
+    },
+    "slack": {"type": "http", "url": "https://mcp.slack.com/mcp"},
+    "notion": {"type": "http", "url": "https://mcp.notion.com/mcp"},
+    "sentry": {"type": "http", "url": "https://mcp.sentry.dev/mcp"},
+}
+
+
+def render_mcp_json(server_names: list[str]) -> str | None:
+    """Render a .mcp.json for the registered servers among ``server_names``.
+
+    Returns None when none of the names are registered. Registry order is used
+    for deterministic output; unregistered names are ignored.
+    """
+    selected = {
+        name: config
+        for name, config in MCP_SERVER_REGISTRY.items()
+        if name in server_names
+    }
+    if not selected:
+        return None
+    return json.dumps({"mcpServers": selected}, indent=2)
+
+
+def unregistered_servers(server_names: list[str]) -> list[str]:
+    """Detected server names that have no verified registry config."""
+    return [name for name in server_names if name not in MCP_SERVER_REGISTRY]

--- a/docs/superpowers/plans/2026-07-04-agent-packs-b3-render-ir-fields.md
+++ b/docs/superpowers/plans/2026-07-04-agent-packs-b3-render-ir-fields.md
@@ -1,0 +1,575 @@
+# Agent Packs B3 (slice 1) — Render Dead IR Fields Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the two dead `AgentExportIR` fields — `hook_suggestions` and `mcp_servers` — into real pack files for the `project-pack` and `pr-reviewer` pack types.
+
+**Architecture:** Pure backend adapter work in `app/adapters/`. A new `mcp_servers.py` module holds a docs-verified registry and renders `.mcp.json`; `claude_code.py` gains two helpers that render an example hooks file, and both pack builders conditionally append the new files. `.claude/settings.json` is untouched.
+
+**Tech Stack:** Python 3, Pydantic (`AgentExportIR`), pytest. Files are built as Python objects then `json.dumps`-ed; shell-safety via `shlex.quote`.
+
+**Spec:** `docs/superpowers/specs/2026-07-04-agent-packs-b3-render-ir-fields-design.md`
+
+**Branch:** `feat/agent-packs-render-ir-b3` (already created off `main`; the spec is committed on it).
+
+---
+
+## File Structure
+
+**New files:**
+- `app/adapters/mcp_servers.py` — `MCP_SERVER_REGISTRY`, `render_mcp_json`, `unregistered_servers`.
+- `tests/test_mcp_servers.py` — unit tests for the registry/renderer.
+
+**Modified files:**
+- `app/adapters/claude_code.py` — add `import shlex`; add `_select_post_edit_suggestions` + `_hooks_example_json`; import from `mcp_servers`; append `.mcp.json` and `.claude/hooks.example.json` in `to_claude_project_pack` and `to_claude_pr_reviewer_pack`; append an unregistered-servers line in `_mcp_integration_notes`.
+- `tests/test_export_adapters.py` — extend imports; add pack-level tests.
+
+**Unchanged:** `claude_code.py :: _project_settings_json`, `app/adapters/agent_ir.py`, `app/adapters/agent_packs.py`, all web/API/MCP code.
+
+**Command notes:** all commands run from repo root. Single file: `python -m pytest tests/test_mcp_servers.py -q`. Single test: `python -m pytest "tests/test_export_adapters.py::test_name" -q`. Known pre-existing flake unrelated to this work: `test_validate_summary_and_api_schemas` fails locally and on `main` (it hits 127.0.0.1:8000) — ignore it.
+
+---
+
+## Task 1: `mcp_servers.py` — registry, renderer, unregistered helper
+
+**Files:**
+- Create: `app/adapters/mcp_servers.py`
+- Test: `tests/test_mcp_servers.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_mcp_servers.py`:
+```python
+from __future__ import annotations
+
+import json
+
+from app.adapters.mcp_servers import (
+    MCP_SERVER_REGISTRY,
+    render_mcp_json,
+    unregistered_servers,
+)
+
+
+def test_render_none_for_empty():
+    assert render_mcp_json([]) is None
+
+
+def test_render_none_for_unregistered_only():
+    assert render_mcp_json(["figma", "jira"]) is None
+
+
+def test_render_github_slack_secret_safe():
+    payload = json.loads(render_mcp_json(["github", "slack"]))
+    servers = payload["mcpServers"]
+    assert servers["github"]["type"] == "http"
+    assert servers["github"]["url"] == "https://api.githubcopilot.com/mcp/"
+    assert servers["slack"]["url"] == "https://mcp.slack.com/mcp"
+    # github's secret is an env placeholder, not a literal token
+    assert servers["github"]["headers"]["Authorization"].startswith("Bearer ${")
+    # slack (OAuth) carries no headers/env
+    assert "headers" not in servers["slack"]
+    assert "env" not in servers["slack"]
+    # No literal secret anywhere: every headers/env value is a ${...} expansion
+    for cfg in servers.values():
+        for section in ("headers", "env"):
+            for value in cfg.get(section, {}).values():
+                assert "${" in value
+
+
+def test_render_omits_unregistered():
+    payload = json.loads(render_mcp_json(["github", "figma"]))
+    assert "github" in payload["mcpServers"]
+    assert "figma" not in payload["mcpServers"]
+
+
+def test_registry_has_no_archived_npx_packages():
+    # Guard against re-introducing the archived @modelcontextprotocol/server-* stubs.
+    blob = json.dumps(MCP_SERVER_REGISTRY)
+    assert "@modelcontextprotocol/server-" not in blob
+
+
+def test_unregistered_servers():
+    assert unregistered_servers(["github", "figma", "jira"]) == ["figma", "jira"]
+    assert unregistered_servers(["github", "slack"]) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_mcp_servers.py -q`
+Expected: FAIL — `ModuleNotFoundError: app.adapters.mcp_servers`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `app/adapters/mcp_servers.py`:
+```python
+"""Known MCP server config stubs for generated agent packs.
+
+Configs verified 2026-07-04 against https://code.claude.com/docs/en/mcp.
+The old @modelcontextprotocol/server-* npx packages are archived; the current
+GitHub/Slack/Notion/Sentry servers are remote HTTP. `figma` and `jira` are
+intentionally absent (no current config confirmed) and are surfaced in the
+pack README instead. Secrets are only ${ENV} placeholders or OAuth (no secret).
+"""
+
+from __future__ import annotations
+
+import json
+
+MCP_SERVER_REGISTRY: dict[str, dict] = {
+    "github": {
+        "type": "http",
+        "url": "https://api.githubcopilot.com/mcp/",
+        "headers": {"Authorization": "Bearer ${GITHUB_PAT}"},
+    },
+    "slack": {"type": "http", "url": "https://mcp.slack.com/mcp"},
+    "notion": {"type": "http", "url": "https://mcp.notion.com/mcp"},
+    "sentry": {"type": "http", "url": "https://mcp.sentry.dev/mcp"},
+}
+
+
+def render_mcp_json(server_names: list[str]) -> str | None:
+    """Render a .mcp.json for the registered servers among ``server_names``.
+
+    Returns None when none of the names are registered. Registry order is used
+    for deterministic output; unregistered names are ignored.
+    """
+    selected = {
+        name: config
+        for name, config in MCP_SERVER_REGISTRY.items()
+        if name in server_names
+    }
+    if not selected:
+        return None
+    return json.dumps({"mcpServers": selected}, indent=2)
+
+
+def unregistered_servers(server_names: list[str]) -> list[str]:
+    """Detected server names that have no verified registry config."""
+    return [name for name in server_names if name not in MCP_SERVER_REGISTRY]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_mcp_servers.py -q`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/adapters/mcp_servers.py tests/test_mcp_servers.py
+git commit -m "feat(agent-packs): MCP server registry + .mcp.json renderer
+
+Docs-verified current remote-HTTP configs for github/slack/notion/sentry;
+figma/jira intentionally unregistered. Secrets are env placeholders or OAuth.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Emit `.mcp.json` from the pack builders + note unregistered servers
+
+**Files:**
+- Modify: `app/adapters/claude_code.py`
+- Modify: `tests/test_export_adapters.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_export_adapters.py`, extend the `from app.adapters.claude_code import (...)` block to also import `to_claude_pr_reviewer_pack`:
+```python
+from app.adapters.claude_code import (
+    to_agent_sdk_python,
+    to_agent_sdk_typescript,
+    to_claude_project_pack,
+    to_claude_pr_reviewer_pack,
+    to_claude_subagent,
+    to_claude_mcp_tool_stub,
+)
+```
+Then add these tests at the end of the file:
+```python
+def test_project_pack_emits_mcp_json_for_known_servers():
+    ir = AgentExportIR(name="X", mcp_servers=["github"])
+    pack = to_claude_project_pack(ir)
+    mcp_files = [f for f in pack if f["path"] == ".mcp.json"]
+    assert len(mcp_files) == 1
+    payload = json.loads(mcp_files[0]["content"])
+    assert payload["mcpServers"]["github"]["url"] == "https://api.githubcopilot.com/mcp/"
+
+
+def test_project_pack_no_mcp_json_when_no_servers():
+    ir = AgentExportIR(name="X", mcp_servers=[])
+    pack = to_claude_project_pack(ir)
+    assert not any(f["path"] == ".mcp.json" for f in pack)
+
+
+def test_pr_reviewer_pack_emits_mcp_json():
+    ir = AgentExportIR(name="X", mcp_servers=["slack"])
+    pack = to_claude_pr_reviewer_pack(ir)
+    assert any(f["path"] == ".mcp.json" for f in pack)
+
+
+def test_mcp_readme_notes_unregistered_servers():
+    ir = AgentExportIR(name="X", mcp_servers=["github", "figma", "jira"])
+    pack = to_claude_project_pack(ir)
+    readme = next(f for f in pack if f["path"] == ".claude/mcp/README.md")
+    assert "figma" in readme["content"]
+    assert "jira" in readme["content"]
+
+
+def test_mcp_readme_no_note_when_all_registered():
+    ir = AgentExportIR(name="X", mcp_servers=["github"])
+    pack = to_claude_project_pack(ir)
+    readme = next(f for f in pack if f["path"] == ".claude/mcp/README.md")
+    assert "not auto-configured" not in readme["content"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest "tests/test_export_adapters.py::test_project_pack_emits_mcp_json_for_known_servers" "tests/test_export_adapters.py::test_mcp_readme_notes_unregistered_servers" -q`
+Expected: FAIL — no `.mcp.json` file / README lacks the note (and possibly ImportError until the import line is added).
+
+- [ ] **Step 3: Implement in `claude_code.py`**
+
+(a) Add the import after the existing `from .agent_ir import AgentExportIR` line:
+```python
+from .mcp_servers import render_mcp_json, unregistered_servers
+```
+
+(b) Replace `to_claude_project_pack` with:
+```python
+def to_claude_project_pack(ir: AgentExportIR) -> list[dict[str, str]]:
+    files = [
+        {"path": "CLAUDE.md", "content": _project_claude_md(ir)},
+        {"path": ".claude/settings.json", "content": _project_settings_json(ir)},
+        to_claude_subagent(ir),
+        {"path": ".github/workflows/claude.yml", "content": _github_action_workflow(ir)},
+        {"path": ".claude/mcp/README.md", "content": _mcp_integration_notes(ir)},
+    ]
+    mcp_json = render_mcp_json(ir.mcp_servers)
+    if mcp_json is not None:
+        files.append({"path": ".mcp.json", "content": mcp_json})
+    return files
+```
+
+(c) In `to_claude_pr_reviewer_pack`, insert the same append immediately before `return files`:
+```python
+    mcp_json = render_mcp_json(ir.mcp_servers)
+    if mcp_json is not None:
+        files.append({"path": ".mcp.json", "content": mcp_json})
+    return files
+```
+
+(d) Replace `_mcp_integration_notes` with (keep the existing prose verbatim, add the trailing note):
+```python
+def _mcp_integration_notes(ir: AgentExportIR) -> str:
+    notes = textwrap.dedent(
+        f"""\
+# MCP integration notes for {ir.name}
+
+No MCP server configuration is generated because the request did not provide a verified command or server path.
+
+Before adding an MCP server:
+
+1. Identify an existing server entry point in the repository.
+2. Run it locally and confirm its tool schema.
+3. Add the verified command to the host client's MCP configuration.
+4. Keep secrets in the host environment; do not write credentials into this pack.
+"""
+    )
+    extra = unregistered_servers(ir.mcp_servers)
+    if extra:
+        notes += f"\nDetected but not auto-configured (add manually): {', '.join(extra)}.\n"
+    return notes
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_export_adapters.py -q`
+Expected: PASS (new tests green; existing `test_claude_project_pack_output` etc. still green — additive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/adapters/claude_code.py tests/test_export_adapters.py
+git commit -m "feat(agent-packs): emit .mcp.json from project-pack and pr-reviewer
+
+Renders mcp_servers into a real .mcp.json for registered servers; unregistered
+detected servers are noted in the MCP README instead of silently dropped.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Hooks-example helpers (`_select_post_edit_suggestions`, `_hooks_example_json`)
+
+**Files:**
+- Modify: `app/adapters/claude_code.py`
+- Modify: `tests/test_export_adapters.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_export_adapters.py`:
+```python
+def test_select_post_edit_suggestions_exact():
+    from app.adapters.claude_code import _select_post_edit_suggestions
+
+    ir = AgentExportIR(
+        name="X",
+        hook_suggestions=[
+            "Block reads of .env and secrets before tool execution.",
+            "Run targeted tests or lint checks after code edits.",
+            "Run frontend lint/build hooks after editing TSX or CSS.",
+            "Require human confirmation before git push or deploy commands.",
+        ],
+    )
+    assert _select_post_edit_suggestions(ir) == [
+        "Run targeted tests or lint checks after code edits.",
+        "Run frontend lint/build hooks after editing TSX or CSS.",
+    ]
+
+
+def test_hooks_example_none_without_post_edit():
+    from app.adapters.claude_code import _hooks_example_json
+
+    ir = AgentExportIR(
+        name="X",
+        hook_suggestions=[
+            "Block reads of .env and secrets before tool execution.",
+            "Require human confirmation before git push or deploy commands.",
+        ],
+    )
+    assert _hooks_example_json(ir) is None
+
+
+def test_hooks_example_shape_and_shell_safety():
+    import subprocess
+
+    from app.adapters.claude_code import _hooks_example_json
+
+    tricky = "Run tests after code edits: it's `safe` $HOME \"ok\""
+    ir = AgentExportIR(name="X", hook_suggestions=[tricky])
+    content = _hooks_example_json(ir)
+    data = json.loads(content)
+    entry = data["hooks"]["PostToolUse"][0]
+    assert entry["matcher"] == "Edit|Write"
+    cmd = entry["hooks"][0]
+    assert cmd["type"] == "command"
+    assert cmd["command"].startswith("echo ")
+
+    # The command is valid shell and echoes the literal text (no $HOME/backtick expansion).
+    result = subprocess.run(cmd["command"], shell=True, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == tricky
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest "tests/test_export_adapters.py::test_select_post_edit_suggestions_exact" -q`
+Expected: FAIL — `ImportError: cannot import name '_select_post_edit_suggestions'`.
+
+- [ ] **Step 3: Implement in `claude_code.py`**
+
+(a) Add `import shlex` to the imports block (after `import re`):
+```python
+import json
+import re
+import shlex
+import textwrap
+```
+
+(b) Add the two helpers (place them just above `_project_settings_json`):
+```python
+def _select_post_edit_suggestions(ir: AgentExportIR) -> list[str]:
+    """Hook suggestions that describe a post-edit action (test/lint/frontend build)."""
+    return [
+        s
+        for s in ir.hook_suggestions
+        if "after" in s.lower() and ("edit" in s.lower() or "code" in s.lower())
+    ]
+
+
+def _hooks_example_json(ir: AgentExportIR) -> str | None:
+    """Render an example Claude Code hooks file from post-edit suggestions.
+
+    Returns None when there is nothing to render. This is an *example* file the
+    user adopts; it is never read live by Claude Code, so it does not nag on edits.
+    The suggestion text is passed through shlex.quote so the echo command is valid
+    shell for any content (no injection/expansion).
+    """
+    selected = _select_post_edit_suggestions(ir)
+    if not selected:
+        return None
+    post_tool_use = [
+        {
+            "matcher": "Edit|Write",
+            "hooks": [{"type": "command", "command": f"echo {shlex.quote(s)}"}],
+        }
+        for s in selected
+    ]
+    data = {
+        "//": (
+            'Example Claude Code hooks. Copy the "hooks" block into '
+            ".claude/settings.json and replace each echo with your real command."
+        ),
+        "hooks": {"PostToolUse": post_tool_use},
+    }
+    return json.dumps(data, indent=2)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest "tests/test_export_adapters.py::test_select_post_edit_suggestions_exact" "tests/test_export_adapters.py::test_hooks_example_none_without_post_edit" "tests/test_export_adapters.py::test_hooks_example_shape_and_shell_safety" -q`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/adapters/claude_code.py tests/test_export_adapters.py
+git commit -m "feat(agent-packs): render hook_suggestions into an example hooks scaffold
+
+Adds _select_post_edit_suggestions + _hooks_example_json: post-edit suggestions
+become a shell-safe (shlex.quote) example hooks JSON, no live per-edit hook.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Emit `.claude/hooks.example.json` from the pack builders
+
+**Files:**
+- Modify: `app/adapters/claude_code.py`
+- Modify: `tests/test_export_adapters.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_export_adapters.py`, extend the claude_code import block to also import `to_claude_subagent_bundle`:
+```python
+from app.adapters.claude_code import (
+    to_agent_sdk_python,
+    to_agent_sdk_typescript,
+    to_claude_project_pack,
+    to_claude_pr_reviewer_pack,
+    to_claude_subagent,
+    to_claude_subagent_bundle,
+    to_claude_mcp_tool_stub,
+)
+```
+Add these tests:
+```python
+def test_project_pack_emits_hooks_example():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    pack = to_claude_project_pack(ir)
+    hooks_files = [f for f in pack if f["path"] == ".claude/hooks.example.json"]
+    assert len(hooks_files) == 1
+    data = json.loads(hooks_files[0]["content"])
+    assert data["hooks"]["PostToolUse"][0]["matcher"] == "Edit|Write"
+    assert data["hooks"]["PostToolUse"][0]["hooks"][0]["command"].startswith("echo ")
+    # settings.json is unchanged (no hooks key)
+    settings = next(f for f in pack if f["path"] == ".claude/settings.json")
+    assert "hooks" not in json.loads(settings["content"])
+
+
+def test_pr_reviewer_pack_emits_hooks_example():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    pack = to_claude_pr_reviewer_pack(ir)
+    assert any(f["path"] == ".claude/hooks.example.json" for f in pack)
+
+
+def test_subagent_bundle_has_no_hooks_or_mcp_or_settings():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    bundle = to_claude_subagent_bundle(ir)
+    paths = {f["path"] for f in bundle}
+    assert ".mcp.json" not in paths
+    assert ".claude/hooks.example.json" not in paths
+    assert ".claude/settings.json" not in paths
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest "tests/test_export_adapters.py::test_project_pack_emits_hooks_example" -q`
+Expected: FAIL — no `.claude/hooks.example.json` in the pack.
+
+- [ ] **Step 3: Implement in `claude_code.py`**
+
+In `to_claude_project_pack`, add the hooks append after the `.mcp.json` append (before `return files`):
+```python
+    mcp_json = render_mcp_json(ir.mcp_servers)
+    if mcp_json is not None:
+        files.append({"path": ".mcp.json", "content": mcp_json})
+    hooks_example = _hooks_example_json(ir)
+    if hooks_example is not None:
+        files.append({"path": ".claude/hooks.example.json", "content": hooks_example})
+    return files
+```
+Add the identical two hooks lines in `to_claude_pr_reviewer_pack`, right after its `.mcp.json` append and before `return files`:
+```python
+    hooks_example = _hooks_example_json(ir)
+    if hooks_example is not None:
+        files.append({"path": ".claude/hooks.example.json", "content": hooks_example})
+    return files
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_export_adapters.py -q`
+Expected: PASS (all new + existing tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/adapters/claude_code.py tests/test_export_adapters.py
+git commit -m "feat(agent-packs): emit .claude/hooks.example.json from packs
+
+project-pack and pr-reviewer now ship an example hooks scaffold; settings.json
+stays unchanged and subagent/mcp-stub packs are unaffected.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Focused export + MCP suites**
+
+Run: `python -m pytest tests/test_export_adapters.py tests/test_mcp_servers.py -q`
+Expected: PASS.
+
+- [ ] **Step 2: Full backend suite**
+
+Run: `python -m pytest tests/ -q`
+Expected: PASS, except the known pre-existing flake `test_validate_summary_and_api_schemas` (hits 127.0.0.1:8000, also fails on `main`). If that is the only failure, the gate passes.
+
+- [ ] **Step 3: Stop for review — do NOT open a PR automatically**
+
+Per project rules, never push/PR/merge without Mehmet's explicit approval. Report: changed files, out-of-scope changes (none — backend adapter only), test results, and the boundary note (no `.env`/auth/LLM/deploy/secrets touched; `.mcp.json` uses env placeholders / OAuth only). Then ask whether to open the PR.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- `hook_suggestions` → `.claude/hooks.example.json` → Task 3 (helpers) + Task 4 (wiring). ✅
+- Selection rule (deterministic, exact-string tested, substring semantics) → Task 3 tests. ✅
+- Shell-safety via `shlex.quote` (quotes/`$`/backtick test) → Task 3. ✅
+- `settings.json` unchanged (no live hooks) → asserted in Task 4. ✅
+- `mcp_servers` → `.mcp.json` with docs-verified current configs → Task 1 + Task 2. ✅
+- Secret invariant (env placeholder / OAuth, no literal secret; no archived npx) → Task 1 tests. ✅
+- Unregistered figma/jira → README note (reachable, tested) → Task 2. ✅
+- project-pack + pr-reviewer only; subagent/mcp-stub unaffected → Task 4 test. ✅
+- Existing project-pack assertions still pass (additive) → Task 2 Step 4 / Task 4 Step 4. ✅
+- Gate (`pytest tests/`) → Task 5. ✅
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N" — every code step shows complete code. ✅
+
+**3. Type/name consistency:**
+- `render_mcp_json`, `unregistered_servers`, `MCP_SERVER_REGISTRY` (Task 1) used identically in Task 2. ✅
+- `_select_post_edit_suggestions`, `_hooks_example_json` (Task 3) used in Task 4. ✅
+- Import block grows monotonically: `to_claude_pr_reviewer_pack` (Task 2), `to_claude_subagent_bundle` (Task 4) — final block matches every symbol used. ✅
+- `.mcp.json` and `.claude/hooks.example.json` path strings identical across builder edits and tests. ✅

--- a/docs/superpowers/specs/2026-07-04-agent-packs-b3-render-ir-fields-design.md
+++ b/docs/superpowers/specs/2026-07-04-agent-packs-b3-render-ir-fields-design.md
@@ -1,0 +1,225 @@
+# Agent Packs B3 (slice 1) — Render Dead IR Fields (Design)
+
+- **Date:** 2026-07-04
+- **Status:** Approved (design), pending spec review
+- **Branch:** `feat/agent-packs-render-ir-b3` (off `main`, independent of B1 / PR #933)
+- **Surface:** `app/adapters/**` only — backend adapter. No web, API-route, or MCP changes.
+
+## Problem
+
+`AgentExportIR` (in `app/adapters/agent_ir.py`) infers two fields that no pack renders
+into a file:
+
+- `hook_suggestions` — natural-language hook ideas. `_infer_hook_suggestions` always emits
+  two base items ("Block reads of .env and secrets before tool execution.", "Run targeted
+  tests or lint checks after code edits.") and, by keyword, up to two more ("Run frontend
+  lint/build hooks after editing TSX or CSS.", "Require human confirmation before git push
+  or deploy commands.").
+- `mcp_servers` — recognized server names from a fixed mapping in `_infer_mcp_servers`:
+  `github`, `figma`, `slack`, `notion`, `jira`, `sentry` (only these six are ever emitted).
+
+Both are computed and dropped: `_project_settings_json(ir)` emits only a `permissions`
+block, and the only MCP artifact is a prose `.claude/mcp/README.md` — no real `.mcp.json`.
+
+This is the first of four independent B3 slices (CLAUDE.md smart-merge, CLI vehicle,
+GitHub-PR vehicle are separate specs). This slice renders the two dead fields into files.
+
+## Goals / Non-goals
+
+**Goals:** render `hook_suggestions` and `mcp_servers` into real, honest artifacts for the
+pack types that carry `.claude/settings.json` — **project-pack** and **pr-reviewer** — with
+no fake commands, no fake secrets, and no per-edit nag.
+
+**Non-goals:** subagent and mcp-tool-stub packs (verified below: neither emits
+`.claude/settings.json`); a **live** `hooks` block in `.claude/settings.json` (deferred to
+the B1 follow-up, which supplies the real `detected_commands`); repo-aware real commands;
+CLAUDE.md smart-merge; CLI / GitHub-PR vehicles; any web, API-route, or MCP-server change
+(the web file tree already renders any file in `manifest.files`).
+
+## Approved decisions
+
+- **Approach A — safe-real + honest.** Emit real, valid files; never a guessed command,
+  stale package, or literal secret.
+- **Hooks render as an example file, not live settings** (user decision). Because slice 1
+  has no real test/lint command, a live `PostToolUse` hook would fire on every edit and
+  only print a reminder — the "prompt-pretty, not executable" anti-pattern the project
+  ethos forbids. Instead we emit a clearly-labeled `.claude/hooks.example.json` scaffold the
+  user adopts. `.claude/settings.json` is **unchanged** in this slice.
+- **`.mcp.json` uses current, verified configs** — the old `@modelcontextprotocol/server-*`
+  npx packages are archived; the current GitHub/Slack/Notion/Sentry servers are remote HTTP.
+- **Independent of B1** — branch off `main`.
+- Honors CLAUDE.md: "executable, not just prompt-pretty" **and** "avoid hallucinated
+  requirements and fake APIs" **and** "never expose secrets".
+
+## Design
+
+All changes are in `app/adapters/`. `agent_ir.py` and `agent_packs.py` are unchanged.
+
+### 1. `hook_suggestions` → `.claude/hooks.example.json`
+
+New helper in `claude_code.py`:
+
+- **Selection** — `_select_post_edit_suggestions(ir) -> list[str]`: from `ir.hook_suggestions`,
+  keep each `s` where `"after" in s.lower() and ("edit" in s.lower() or "code" in s.lower())`
+  (two complete membership tests). Applied to the current fixed suggestion set this selects
+  exactly:
+  - "Run targeted tests or lint checks after code edits." (`after` + `code`)
+  - "Run frontend lint/build hooks after editing TSX or CSS." (`after` + `edit` as a
+    **substring** of "editing" — keep substring semantics, do not switch to word boundaries)
+
+  and excludes the `.env`-block and push/deploy suggestions — not because of any
+  cross-check against `permissions` (there is none) but because they are not post-edit
+  (no `after`). This slice's classifier is asserted against these exact strings in tests;
+  it is coupled to the current fixed set owned by `_infer_hook_suggestions`.
+- **Rendering** — `_hooks_example_json(ir) -> str | None`: returns `None` when the selection
+  is empty; otherwise a JSON string of the form below, built as a Python dict then
+  `json.dumps(..., indent=2)` (never string concatenation):
+  ```json
+  {
+    "//": "Example Claude Code hooks. Copy the \"hooks\" block into .claude/settings.json and replace each echo with your real command.",
+    "hooks": {
+      "PostToolUse": [
+        { "matcher": "Edit|Write", "hooks": [ { "type": "command", "command": "echo 'Run targeted tests or lint checks after code edits.'" } ] },
+        { "matcher": "Edit|Write", "hooks": [ { "type": "command", "command": "echo 'Run frontend lint/build hooks after editing TSX or CSS.'" } ] }
+      ]
+    }
+  }
+  ```
+  - One `PostToolUse` entry per selected suggestion; the suggestion text is the echo
+    payload (so the field is actually rendered and visible).
+  - **Shell safety:** the echo argument is produced with `shlex.quote(suggestion)`, so the
+    command is valid shell for **any** suggestion content (quotes, `$`, backticks) — not a
+    hand-rolled quote-strip. A test feeds a suggestion containing `'`, `"`, `$`, and a
+    backtick and asserts the emitted command parses (`bash -n`) and echoes the literal.
+  - It is an **example** file: Claude Code never reads `.claude/hooks.example.json`, so it
+    does not nag on edits. If a user copies the `hooks` block into `settings.json`, the
+    echoes are harmless and the `"//"` note tells them to replace each with a real command.
+- **Schema (verified 2026-07-04 against code.claude.com/docs/en/hooks):** hooks config is
+  `hooks.<Event>[].{matcher, hooks: [{type: "command", command}]}`; the `matcher` is an
+  **exact-string, pipe/comma-separated list** (so `"Edit|Write"` matches the `Edit` and
+  `Write` tools — it is not a regex, hence no escaping concerns). This shape is normative
+  for the example; verification only confirmed field names.
+- **Wiring:** `to_claude_project_pack` and `to_claude_pr_reviewer_pack` append
+  `{"path": ".claude/hooks.example.json", "content": ...}` only when `_hooks_example_json`
+  returns non-None. `.claude/hooks.example.json` classifies as kind `"files"` via the
+  existing `_classify_kind` (it is not CLAUDE.md/settings.json/agents/mcp/workflow/README),
+  is in `_preview_order()`, and is rendered by the web tree with no client change. In
+  practice it is always emitted for these two pack types (the base "tests/lint after code
+  edits" suggestion is always present).
+
+### 2. `mcp_servers` → `.mcp.json`
+
+New module `app/adapters/mcp_servers.py`:
+
+- `MCP_SERVER_REGISTRY: dict[str, dict]` — pinned to the servers whose **current** config is
+  verified (2026-07-04) against code.claude.com/docs/en/mcp. All four are remote HTTP:
+  ```python
+  {
+    "github":  {"type": "http", "url": "https://api.githubcopilot.com/mcp/",
+                "headers": {"Authorization": "Bearer ${GITHUB_PAT}"}},
+    "slack":   {"type": "http", "url": "https://mcp.slack.com/mcp"},
+    "notion":  {"type": "http", "url": "https://mcp.notion.com/mcp"},
+    "sentry":  {"type": "http", "url": "https://mcp.sentry.dev/mcp"},
+  }
+  ```
+  `figma` and `jira` are **deliberately not registered** — the Claude Code docs do not
+  confirm a current config for them, so shipping a guessed one would violate the ethos.
+- `render_mcp_json(server_names) -> str | None` — returns a pretty-printed
+  `{"mcpServers": {…}}` for the names present in the registry (preserving a stable order),
+  or `None` when none are registered. Names not in the registry are **not** written.
+- `unregistered_servers(server_names) -> list[str]` — the detected names absent from the
+  registry (e.g. `["figma", "jira"]`), used for the README note (below).
+- **Secret invariant:** no value under `headers`/`env` is ever a literal secret; any
+  credential is a `${VAR}` expansion (e.g. GitHub's `Bearer ${GITHUB_PAT}`). OAuth servers
+  (slack/notion/sentry) carry **no** `env`/`headers` at all — authentication is `/mcp`
+  OAuth. Env expansion (`${VAR}` / `${VAR:-default}`) is supported in `.mcp.json`
+  command/args/env/url/headers.
+- **Wiring:** `to_claude_project_pack` and `to_claude_pr_reviewer_pack` append
+  `{"path": ".mcp.json", "content": render_mcp_json(ir.mcp_servers)}` only when it returns
+  non-None. `.mcp.json` classifies as kind `"mcp"` via `_classify_kind` (`"mcp" in
+  normalized.lower()`) — confirmed it does not hit an earlier branch (it is not `CLAUDE.md`,
+  does not end with `settings.json`, is not under `/agents/`). `"mcp"` is in
+  `_preview_order()`; the web tree renders it.
+
+### 3. `.claude/mcp/README.md` — note unregistered detected servers
+
+`_mcp_integration_notes(ir)` appends one short line when `unregistered_servers(ir.mcp_servers)`
+is non-empty, e.g. "Detected but not auto-configured (add manually): figma, jira." This keeps
+`figma`/`jira` from being silently dropped. Required (not optional) and tested.
+
+## File-level impact
+
+**New:**
+- `app/adapters/mcp_servers.py` — registry, `render_mcp_json`, `unregistered_servers`.
+- Tests (in `tests/test_export_adapters.py`, plus a focused `tests/test_mcp_servers.py` for
+  the pure registry/renderer).
+
+**Changed:**
+- `app/adapters/claude_code.py` — add `_select_post_edit_suggestions` and
+  `_hooks_example_json`; `to_claude_project_pack` and `to_claude_pr_reviewer_pack`
+  conditionally append `.claude/hooks.example.json` and `.mcp.json`; `_mcp_integration_notes`
+  appends the unregistered-servers line.
+
+**Unchanged (intentionally):**
+- `app/adapters/claude_code.py :: _project_settings_json` — `.claude/settings.json` is not
+  touched this slice (no live `hooks`).
+- `app/adapters/agent_ir.py`, `app/adapters/agent_packs.py`.
+- All web, API-route, and MCP-server code.
+
+## Testing
+
+Add to `tests/test_export_adapters.py` / `tests/test_mcp_servers.py` (pure, deterministic,
+no network):
+
+- **hooks example present:** `to_claude_project_pack(ir)` (default IR → base suggestions
+  present) yields a `.claude/hooks.example.json` whose JSON parses, has
+  `hooks.PostToolUse[0].matcher == "Edit|Write"` and `hooks.PostToolUse[0].hooks[0]` ==
+  `{"type": "command", "command": <starts with "echo ">}`; and the settings.json in the same
+  pack has **no** `hooks` key (unchanged).
+- **selection exactness:** `_select_post_edit_suggestions` over the real base+frontend+deploy
+  suggestion set returns exactly the two post-edit strings; over the env/push-only subset
+  returns `[]` and `_hooks_example_json` returns `None`.
+- **shell safety:** `_hooks_example_json` for a suggestion containing `'`, `"`, `$`, and a
+  backtick produces a `command` that `bash -n` accepts and that echoes the literal (no
+  expansion).
+- **pr-reviewer parity:** `to_claude_pr_reviewer_pack` emits the same
+  `.claude/hooks.example.json` behavior.
+- **.mcp.json present + secret-safe:** `render_mcp_json(["github", "slack"])` parses, has
+  `mcpServers.github.type == "http"` and `...url == "https://api.githubcopilot.com/mcp/"`,
+  `mcpServers.slack.url == "https://mcp.slack.com/mcp"`, github's
+  `headers.Authorization` contains `${` (an env expansion, **not** a literal token), and
+  slack has no `env`/`headers`. Assert no value anywhere matches a literal-secret shape
+  (every value that appears under `headers`/`env` starts with `${`).
+- **.mcp.json omits unregistered + None:** `render_mcp_json(["figma"])` is `None`;
+  `render_mcp_json([])` is `None`; `render_mcp_json(["github", "figma"])` contains `github`
+  and not `figma`.
+- **README note:** an IR with `mcp_servers` including `figma`/`jira` yields
+  `.claude/mcp/README.md` mentioning `figma` and `jira`; an IR with only registered servers
+  does not add the note.
+- **unaffected packs:** `to_claude_subagent_bundle` and `to_claude_mcp_tool_stub` emit no
+  `.mcp.json` and no `.claude/hooks.example.json` (verified by construction: neither builder
+  lists `.claude/settings.json` or these files).
+- Existing assertions (`test_claude_project_pack_output`,
+  `test_export_api_endpoint_claude_project_pack`) still pass — changes are additive (they
+  only assert `.claude/settings.json` is present).
+
+**Gate before PR:** `python -m pytest tests/test_export_adapters.py -q`, then
+`python -m pytest tests/test_export_adapters.py tests/test_mcp_servers.py -q`, then
+`python -m pytest tests/ -q`.
+
+## Risks & mitigations
+
+- **Stale MCP configs.** Registry pinned to docs-verified current configs (2026-07-04);
+  unverified servers (figma/jira) are documented, not fake-configured. A dated comment in
+  `mcp_servers.py` records the verification source for future re-checks.
+- **Invalid JSON / shell injection.** Both files are built as Python objects then
+  `json.dumps`; the only free text reaching a shell is passed through `shlex.quote`.
+- **Coupling to a fixed suggestion set.** Selection correctness is asserted against the exact
+  current strings; if `_infer_hook_suggestions` changes, the tests catch drift.
+
+## Out of scope / follow-ups
+
+- Live `hooks` in `.claude/settings.json` using B1's real `detected_commands` (needs B1).
+- `figma` / `jira` registry entries once a current config is confirmed.
+- Other B3 slices: CLAUDE.md smart-merge; CLI vehicle; GitHub-PR vehicle.
+- Hooks/`.mcp.json` for subagent / mcp-tool-stub packs.

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -17,6 +17,7 @@ from app.adapters.claude_code import (
     to_agent_sdk_python,
     to_agent_sdk_typescript,
     to_claude_project_pack,
+    to_claude_pr_reviewer_pack,
     to_claude_subagent,
     to_claude_mcp_tool_stub,
 )
@@ -678,3 +679,44 @@ def test_export_api_python_only(client):
     data = response.json()
     assert data["python_code"] is not None
     assert data["yaml_config"] is None
+
+
+# ---------------------------------------------------------------------------
+# B3 slice 1 — render dead IR fields (.mcp.json + hooks example)
+# ---------------------------------------------------------------------------
+
+
+def test_project_pack_emits_mcp_json_for_known_servers():
+    ir = AgentExportIR(name="X", mcp_servers=["github"])
+    pack = to_claude_project_pack(ir)
+    mcp_files = [f for f in pack if f["path"] == ".mcp.json"]
+    assert len(mcp_files) == 1
+    payload = json.loads(mcp_files[0]["content"])
+    assert payload["mcpServers"]["github"]["url"] == "https://api.githubcopilot.com/mcp/"
+
+
+def test_project_pack_no_mcp_json_when_no_servers():
+    ir = AgentExportIR(name="X", mcp_servers=[])
+    pack = to_claude_project_pack(ir)
+    assert not any(f["path"] == ".mcp.json" for f in pack)
+
+
+def test_pr_reviewer_pack_emits_mcp_json():
+    ir = AgentExportIR(name="X", mcp_servers=["slack"])
+    pack = to_claude_pr_reviewer_pack(ir)
+    assert any(f["path"] == ".mcp.json" for f in pack)
+
+
+def test_mcp_readme_notes_unregistered_servers():
+    ir = AgentExportIR(name="X", mcp_servers=["github", "figma", "jira"])
+    pack = to_claude_project_pack(ir)
+    readme = next(f for f in pack if f["path"] == ".claude/mcp/README.md")
+    assert "figma" in readme["content"]
+    assert "jira" in readme["content"]
+
+
+def test_mcp_readme_no_note_when_all_registered():
+    ir = AgentExportIR(name="X", mcp_servers=["github"])
+    pack = to_claude_project_pack(ir)
+    readme = next(f for f in pack if f["path"] == ".claude/mcp/README.md")
+    assert "not auto-configured" not in readme["content"]

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -759,7 +759,7 @@ def test_hooks_example_shape_and_shell_safety():
 
     from app.adapters.claude_code import _hooks_example_json
 
-    tricky = "Run tests after code edits: it's `safe` $HOME \"ok\""
+    tricky = 'Run tests after code edits: it\'s `safe` $HOME "ok"'
     ir = AgentExportIR(name="X", hook_suggestions=[tricky])
     content = _hooks_example_json(ir)
     data = json.loads(content)

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -19,6 +19,7 @@ from app.adapters.claude_code import (
     to_claude_project_pack,
     to_claude_pr_reviewer_pack,
     to_claude_subagent,
+    to_claude_subagent_bundle,
     to_claude_mcp_tool_stub,
 )
 from app.adapters.claude_sdk import to_python, to_yaml
@@ -772,3 +773,31 @@ def test_hooks_example_shape_and_shell_safety():
     result = subprocess.run(cmd["command"], shell=True, capture_output=True, text=True)
     assert result.returncode == 0
     assert result.stdout.strip() == tricky
+
+
+def test_project_pack_emits_hooks_example():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    pack = to_claude_project_pack(ir)
+    hooks_files = [f for f in pack if f["path"] == ".claude/hooks.example.json"]
+    assert len(hooks_files) == 1
+    data = json.loads(hooks_files[0]["content"])
+    assert data["hooks"]["PostToolUse"][0]["matcher"] == "Edit|Write"
+    assert data["hooks"]["PostToolUse"][0]["hooks"][0]["command"].startswith("echo ")
+    # settings.json is unchanged (no hooks key)
+    settings = next(f for f in pack if f["path"] == ".claude/settings.json")
+    assert "hooks" not in json.loads(settings["content"])
+
+
+def test_pr_reviewer_pack_emits_hooks_example():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    pack = to_claude_pr_reviewer_pack(ir)
+    assert any(f["path"] == ".claude/hooks.example.json" for f in pack)
+
+
+def test_subagent_bundle_has_no_hooks_or_mcp_or_settings():
+    ir = parse_agent_markdown(SINGLE_AGENT_MARKDOWN)
+    bundle = to_claude_subagent_bundle(ir)
+    paths = {f["path"] for f in bundle}
+    assert ".mcp.json" not in paths
+    assert ".claude/hooks.example.json" not in paths
+    assert ".claude/settings.json" not in paths

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -720,3 +720,55 @@ def test_mcp_readme_no_note_when_all_registered():
     pack = to_claude_project_pack(ir)
     readme = next(f for f in pack if f["path"] == ".claude/mcp/README.md")
     assert "not auto-configured" not in readme["content"]
+
+
+def test_select_post_edit_suggestions_exact():
+    from app.adapters.claude_code import _select_post_edit_suggestions
+
+    ir = AgentExportIR(
+        name="X",
+        hook_suggestions=[
+            "Block reads of .env and secrets before tool execution.",
+            "Run targeted tests or lint checks after code edits.",
+            "Run frontend lint/build hooks after editing TSX or CSS.",
+            "Require human confirmation before git push or deploy commands.",
+        ],
+    )
+    assert _select_post_edit_suggestions(ir) == [
+        "Run targeted tests or lint checks after code edits.",
+        "Run frontend lint/build hooks after editing TSX or CSS.",
+    ]
+
+
+def test_hooks_example_none_without_post_edit():
+    from app.adapters.claude_code import _hooks_example_json
+
+    ir = AgentExportIR(
+        name="X",
+        hook_suggestions=[
+            "Block reads of .env and secrets before tool execution.",
+            "Require human confirmation before git push or deploy commands.",
+        ],
+    )
+    assert _hooks_example_json(ir) is None
+
+
+def test_hooks_example_shape_and_shell_safety():
+    import subprocess
+
+    from app.adapters.claude_code import _hooks_example_json
+
+    tricky = "Run tests after code edits: it's `safe` $HOME \"ok\""
+    ir = AgentExportIR(name="X", hook_suggestions=[tricky])
+    content = _hooks_example_json(ir)
+    data = json.loads(content)
+    entry = data["hooks"]["PostToolUse"][0]
+    assert entry["matcher"] == "Edit|Write"
+    cmd = entry["hooks"][0]
+    assert cmd["type"] == "command"
+    assert cmd["command"].startswith("echo ")
+
+    # The command is valid shell and echoes the literal text (no $HOME/backtick expansion).
+    result = subprocess.run(cmd["command"], shell=True, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == tricky

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+from app.adapters.mcp_servers import (
+    MCP_SERVER_REGISTRY,
+    render_mcp_json,
+    unregistered_servers,
+)
+
+
+def test_render_none_for_empty():
+    assert render_mcp_json([]) is None
+
+
+def test_render_none_for_unregistered_only():
+    assert render_mcp_json(["figma", "jira"]) is None
+
+
+def test_render_github_slack_secret_safe():
+    payload = json.loads(render_mcp_json(["github", "slack"]))
+    servers = payload["mcpServers"]
+    assert servers["github"]["type"] == "http"
+    assert servers["github"]["url"] == "https://api.githubcopilot.com/mcp/"
+    assert servers["slack"]["url"] == "https://mcp.slack.com/mcp"
+    # github's secret is an env placeholder, not a literal token
+    assert servers["github"]["headers"]["Authorization"].startswith("Bearer ${")
+    # slack (OAuth) carries no headers/env
+    assert "headers" not in servers["slack"]
+    assert "env" not in servers["slack"]
+    # No literal secret anywhere: every headers/env value is a ${...} expansion
+    for cfg in servers.values():
+        for section in ("headers", "env"):
+            for value in cfg.get(section, {}).values():
+                assert "${" in value
+
+
+def test_render_omits_unregistered():
+    payload = json.loads(render_mcp_json(["github", "figma"]))
+    assert "github" in payload["mcpServers"]
+    assert "figma" not in payload["mcpServers"]
+
+
+def test_registry_has_no_archived_npx_packages():
+    # Guard against re-introducing the archived @modelcontextprotocol/server-* stubs.
+    blob = json.dumps(MCP_SERVER_REGISTRY)
+    assert "@modelcontextprotocol/server-" not in blob
+
+
+def test_unregistered_servers():
+    assert unregistered_servers(["github", "figma", "jira"]) == ["figma", "jira"]
+    assert unregistered_servers(["github", "slack"]) == []


### PR DESCRIPTION
## Summary
Render the two previously-unused `AgentExportIR` fields into real pack files for **project-pack** and **pr-reviewer**:

- **`mcp_servers` → `.mcp.json`** using current, docs-verified remote-HTTP configs (`github`, `slack`, `notion`, `sentry`). Secrets are `${ENV}` placeholders or OAuth — never literal. `figma`/`jira` are intentionally **not** registered (no current config confirmed) and are noted in `.claude/mcp/README.md` instead of guessed.
- **`hook_suggestions` → `.claude/hooks.example.json`** — a labelled example scaffold the user adopts (copy into `settings.json`, replace each echo). Not a live per-edit hook. Commands are shell-safe via `shlex.quote`.

`.claude/settings.json` is unchanged; subagent / mcp-tool-stub packs are unaffected.

## Notes / boundaries
- Backend adapter only (`app/adapters/`); no web / API-route / MCP-server / deploy / dependency changes.
- No secrets emitted: `.mcp.json` uses env-var placeholders or OAuth. The archived `@modelcontextprotocol/server-*` npx packages are deliberately avoided — a test guards against reintroducing them.
- Live repo-aware hook commands (real test/lint) are deferred to the B1 follow-up (needs `detected_commands`).
- First of four independent B3 slices (CLAUDE.md smart-merge, CLI vehicle, GitHub-PR vehicle are separate).

## Test plan
- [x] `python -m pytest tests/test_export_adapters.py tests/test_mcp_servers.py -q` — 51 pass
- [x] `python -m pytest tests/ -q` — 1886 pass / 5 skip. The only failure is the pre-existing `test_validate_summary_and_api_schemas` network flake (hits 127.0.0.1:8000, also fails on `main`; has zero references to this change).
- [x] Manually eyeballed a generated project-pack: `.mcp.json` current + secret-free, `hooks.example.json` valid, figma noted in README.

Spec: `docs/superpowers/specs/2026-07-04-agent-packs-b3-render-ir-fields-design.md`
Plan: `docs/superpowers/plans/2026-07-04-agent-packs-b3-render-ir-fields.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)