### PR TITLE
feat(agent-packs): B3 slice-2 — CLAUDE.md smart merge (repo-aware)

### DIFF
--- a/api/routes/agent_packs.py
+++ b/api/routes/agent_packs.py
@@ -14,6 +14,7 @@ from app.adapters.agent_packs import (
     create_download_response,
 )
 from app.repo_inspect import RepoFacts, derive_repo_context
+from app.repo_inspect.claude_md_merge import merge_claude_md
 
 router = APIRouter(tags=["agent-packs"])
 
@@ -101,12 +102,23 @@ async def repo_plan_claude_agent_pack(
         raise HTTPException(status_code=500, detail="An internal error occurred.") from exc
 
     existing = req.repo_facts.files
-    plan = [
-        {"path": f.path, "action": _diff_action(existing, f.path, f.content)}
-        for f in manifest.files
-    ]
+    data = manifest.model_dump()
+    plan: list[dict] = []
+    for f in data["files"]:
+        path, content = f["path"], f["content"]
+        if path == "CLAUDE.md" and "CLAUDE.md" in existing:
+            merged = merge_claude_md(existing["CLAUDE.md"], content)
+            f["content"] = merged
+            plan.append(
+                {
+                    "path": path,
+                    "action": "identical" if merged == existing["CLAUDE.md"] else "merge",
+                }
+            )
+        else:
+            plan.append({"path": path, "action": _diff_action(existing, path, content)})
     return {
-        "manifest": manifest.model_dump(),
+        "manifest": data,
         "plan": plan,
         "detected": {
             "stack": ctx.stack_summary(),

--- a/app/repo_inspect/claude_md_merge.py
+++ b/app/repo_inspect/claude_md_merge.py
@@ -1,0 +1,63 @@
+"""Section-aware, append-new-only merge of a generated CLAUDE.md into an existing one.
+
+The user's existing content is preserved verbatim; only generated level-2 (``## ``)
+sections whose heading the user lacks are appended, under a marker comment. Idempotent for
+a fixed ``generated`` input. See the design spec for the full contract.
+"""
+
+from __future__ import annotations
+
+import re
+
+MARKER = "<!-- Added by Prompt Compiler: sections not already in your CLAUDE.md -->"
+
+_HEADING_RE = re.compile(r"^##[ \t]+(.+?)\s*$")  # level-2 only; "##Foo" (no space) is not a heading
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")  # >=3 backticks or tildes after leading whitespace
+
+
+def _heading_key(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().casefold()
+
+
+def _iter_sections(md: str) -> list[tuple[str, str]]:
+    """(heading_key, section_text) for each level-2 section, fence-aware."""
+    fence: tuple[str, int] | None = None
+    out: list[tuple[str, str]] = []
+    key: str | None = None
+    buf: list[str] = []
+    for line in md.splitlines():
+        fence_m = _FENCE_RE.match(line.lstrip())
+        if fence_m:
+            run = fence_m.group(1)
+            if fence is None:
+                fence = (run[0], len(run))
+            elif fence[0] == run[0] and len(run) >= fence[1]:
+                fence = None
+            if key is not None:
+                buf.append(line)
+            continue
+        heading = None if fence is not None else _HEADING_RE.match(line)
+        if heading:
+            if key is not None:
+                out.append((key, "\n".join(buf)))
+            key = _heading_key(heading.group(1))
+            buf = [line]
+        elif key is not None:
+            buf.append(line)
+    if key is not None:
+        out.append((key, "\n".join(buf)))
+    return out
+
+
+def merge_claude_md(existing: str, generated: str) -> str:
+    """Append generated ``##`` sections the user lacks; preserve existing verbatim."""
+    seen = {k for k, _ in _iter_sections(existing)}
+    new_sections: list[str] = []
+    for key, text in _iter_sections(generated):
+        if key in seen:
+            continue
+        seen.add(key)
+        new_sections.append(text.rstrip())
+    if not new_sections:
+        return existing
+    return existing.rstrip() + "\n\n" + MARKER + "\n\n" + "\n\n".join(new_sections) + "\n"

--- a/docs/superpowers/plans/2026-07-04-agent-packs-b3-claude-md-merge.md
+++ b/docs/superpowers/plans/2026-07-04-agent-packs-b3-claude-md-merge.md
@@ -1,0 +1,481 @@
+# Agent Packs B3 (slice 2) — CLAUDE.md Smart Merge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a repo already has a `CLAUDE.md`, non-destructively merge the generated guidance into it (append only the `##` sections the user lacks) and apply that merge in place instead of writing `CLAUDE.md.new`.
+
+**Architecture:** A pure `merge_claude_md` in `app/repo_inspect/`; the backend `repo-plan` handler calls it for the `CLAUDE.md` path and returns a `"merge"` plan action with the merged content in the manifest; the MCP `apply_agent_pack` treats `"merge"` paths as overwrite-able so the merge lands in place. B1's `write_pack_files` is unchanged.
+
+**Tech Stack:** Python 3, FastAPI (repo-plan), pytest. Pure functions built with `re` + `str`; the MCP client uses `httpx` (mocked in tests).
+
+**Spec:** `docs/superpowers/specs/2026-07-04-agent-packs-b3-claude-md-merge-design.md`
+
+**Branch:** `feat/agent-packs-claude-md-merge` (already created off `main`; spec committed on it).
+
+---
+
+## File Structure
+
+**New:**
+- `app/repo_inspect/claude_md_merge.py` — `MARKER`, `merge_claude_md`.
+- `tests/test_claude_md_merge.py` — pure-function tests.
+
+**Modified:**
+- `api/routes/agent_packs.py` — CLAUDE.md merge special-case in `repo_plan_claude_agent_pack`.
+- `integrations/mcp-server/server.py` — `apply_agent_pack` merge-path auto-overwrite.
+- `tests/test_agent_packs_repo_plan.py` — update the existing `"overwrite"` assertion to `"merge"`; add identical/create cases.
+- `integrations/mcp-server/test_server.py` — apply-merge-in-place test.
+
+**Unchanged:** `integrations/mcp-server/repo_write.py`, `app/adapters/**`, `app/repo_inspect/models.py`/`detect.py`, all web/download code.
+
+**Command notes:** run from repo root. Single file: `python -m pytest tests/test_claude_md_merge.py -q`. Format changed Python before pushing: `uvx ruff@0.1.14 format <files>` (the CI "Smoke" check is pre-commit ruff v0.1.14). Known pre-existing flake unrelated to this work: `test_validate_summary_and_api_schemas` (hits 127.0.0.1:8000; also fails on `main`).
+
+---
+
+## Task 1: `merge_claude_md` — the pure section-aware merge
+
+**Files:**
+- Create: `app/repo_inspect/claude_md_merge.py`
+- Test: `tests/test_claude_md_merge.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_claude_md_merge.py`:
+```python
+from app.repo_inspect.claude_md_merge import MARKER, merge_claude_md
+
+
+def test_preserve_prefix_and_append_new():
+    existing = "# My Guide\n\n## Setup\nrun make\n"
+    generated = "# Gen\n\n## Setup\nother setup\n\n## Deploy\nship it\n"
+    merged = merge_claude_md(existing, generated)
+    # existing content is preserved verbatim as the prefix (up to the marker)
+    assert merged.startswith(existing.rstrip())
+    assert merged.split("\n\n" + MARKER, 1)[0] == existing.rstrip()
+    # only the section the user lacks is appended
+    assert "## Deploy\nship it" in merged
+    # the generated "Setup" body is NOT appended (heading already present)
+    assert "other setup" not in merged
+
+
+def test_no_new_sections_returns_existing_unchanged():
+    existing = "# G\n\n## Setup\na\n\n## Deploy\nb\n"
+    generated = "# Gen\n\n## setup\nx\n\n## DEPLOY\ny\n"  # same keys, different case
+    assert merge_claude_md(existing, generated) == existing
+
+
+def test_idempotent():
+    existing = "# G\n\n## Setup\na\n"
+    generated = "# Gen\n\n## Setup\na\n\n## Deploy\nb\n"
+    once = merge_claude_md(existing, generated)
+    assert merge_claude_md(once, generated) == once
+
+
+def test_same_heading_different_body_is_dropped():
+    # Accepted limitation: same heading key -> generated section not merged.
+    existing = "## Security\nshort\n"
+    generated = "## Security\nlong detailed policy\n"
+    assert merge_claude_md(existing, generated) == existing
+
+
+def test_duplicate_key_within_generated_appended_once():
+    existing = "# Title only\n"
+    generated = "## Setup\na\n\n## setup\nb\n"
+    merged = merge_claude_md(existing, generated)
+    assert merged.count("<!--") == 1
+    assert merged.count("## Setup") + merged.count("## setup") == 1
+
+
+def test_existing_without_sections_appends_all():
+    existing = "# Just a title\n"
+    generated = "## A\nx\n\n## B\ny\n"
+    merged = merge_claude_md(existing, generated)
+    assert "## A\nx" in merged
+    assert "## B\ny" in merged
+
+
+def test_generated_without_sections_returns_existing():
+    existing = "# G\n\n## Setup\na\n"
+    generated = "# Gen\n\nsome intro prose only\n"
+    assert merge_claude_md(existing, generated) == existing
+
+
+def test_heading_without_space_is_not_a_heading():
+    existing = "# G\n"
+    generated = "##NotAHeading\nbody\n\n## Real\nkeep\n"
+    merged = merge_claude_md(existing, generated)
+    # only "## Real" is a section; "##NotAHeading" is body of nothing (before first heading)
+    assert "## Real\nkeep" in merged
+    assert "##NotAHeading" not in merged
+
+
+def test_fence_in_generated_not_a_heading():
+    existing = "# G\n"
+    generated = "## Code\n```\n## inside fence\n```\nafter\n\n## Real\nkeep\n"
+    merged = merge_claude_md(existing, generated)
+    # "## inside fence" stays inside the Code section body, not a separate section
+    assert "## inside fence" in merged
+    assert merged.count("<!--") == 1  # single marker
+    # both real sections appended
+    assert "## Code" in merged and "## Real" in merged
+
+
+def test_fence_in_existing_does_not_shadow_generated_heading():
+    existing = "# G\n\n```\n## Deploy\nfake\n```\n"
+    generated = "## Deploy\nreal deploy steps\n"
+    merged = merge_claude_md(existing, generated)
+    # the fenced "## Deploy" in existing is NOT a real heading, so generated Deploy IS added
+    assert "real deploy steps" in merged
+
+
+def test_mixed_fence_delimiters():
+    existing = "# G\n"
+    generated = "## A\nx\n\n~~~\n```\n## Y\n~~~\n\n## B\nz\n"
+    merged = merge_claude_md(existing, generated)
+    # "## Y" is inside the ~~~ block (which is not closed by ```), so not a section
+    assert "## A" in merged and "## B" in merged
+    assert "## Y" in merged  # present, but as body of section A, not its own section
+
+
+def test_crlf_existing_preserved():
+    existing = "# Guide\r\n\r\n## Setup\r\nrun\r\n"
+    generated = "## Deploy\nship\n"
+    merged = merge_claude_md(existing, generated)
+    assert merged.startswith("# Guide\r\n")
+    assert "\r\n## Setup\r\nrun" in merged
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_claude_md_merge.py -q`
+Expected: FAIL — `ModuleNotFoundError: app.repo_inspect.claude_md_merge`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `app/repo_inspect/claude_md_merge.py`:
+```python
+"""Section-aware, append-new-only merge of a generated CLAUDE.md into an existing one.
+
+The user's existing content is preserved verbatim; only generated level-2 (``## ``)
+sections whose heading the user lacks are appended, under a marker comment. Idempotent for
+a fixed ``generated`` input. See the design spec for the full contract.
+"""
+
+from __future__ import annotations
+
+import re
+
+MARKER = "<!-- Added by Prompt Compiler: sections not already in your CLAUDE.md -->"
+
+_HEADING_RE = re.compile(r"^##[ \t]+(.+?)\s*$")  # level-2 only; "##Foo" (no space) is not a heading
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")         # >=3 backticks or tildes after leading whitespace
+
+
+def _heading_key(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().casefold()
+
+
+def _iter_sections(md: str) -> list[tuple[str, str]]:
+    """(heading_key, section_text) for each level-2 section, fence-aware."""
+    fence: tuple[str, int] | None = None
+    out: list[tuple[str, str]] = []
+    key: str | None = None
+    buf: list[str] = []
+    for line in md.splitlines():
+        fence_m = _FENCE_RE.match(line.lstrip())
+        if fence_m:
+            run = fence_m.group(1)
+            if fence is None:
+                fence = (run[0], len(run))
+            elif fence[0] == run[0] and len(run) >= fence[1]:
+                fence = None
+            if key is not None:
+                buf.append(line)
+            continue
+        heading = None if fence is not None else _HEADING_RE.match(line)
+        if heading:
+            if key is not None:
+                out.append((key, "\n".join(buf)))
+            key = _heading_key(heading.group(1))
+            buf = [line]
+        elif key is not None:
+            buf.append(line)
+    if key is not None:
+        out.append((key, "\n".join(buf)))
+    return out
+
+
+def merge_claude_md(existing: str, generated: str) -> str:
+    """Append generated ``##`` sections the user lacks; preserve existing verbatim."""
+    seen = {k for k, _ in _iter_sections(existing)}
+    new_sections: list[str] = []
+    for key, text in _iter_sections(generated):
+        if key in seen:
+            continue
+        seen.add(key)
+        new_sections.append(text.rstrip())
+    if not new_sections:
+        return existing
+    return existing.rstrip() + "\n\n" + MARKER + "\n\n" + "\n\n".join(new_sections) + "\n"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_claude_md_merge.py -q`
+Expected: PASS (12 tests).
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+uvx ruff@0.1.14 format app/repo_inspect/claude_md_merge.py tests/test_claude_md_merge.py
+git add app/repo_inspect/claude_md_merge.py tests/test_claude_md_merge.py
+git commit -m "feat(agent-packs): section-aware CLAUDE.md merge helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire the merge into the `repo-plan` handler
+
+**Files:**
+- Modify: `api/routes/agent_packs.py`
+- Modify: `tests/test_agent_packs_repo_plan.py`
+
+- [ ] **Step 1: Update the existing test + add cases**
+
+In `tests/test_agent_packs_repo_plan.py`, change the existing assertion in
+`test_repo_plan_returns_manifest_and_diffs` from:
+```python
+    # CLAUDE.md already exists -> flagged as an overwrite in the plan
+    claude = next(p for p in data["plan"] if p["path"] == "CLAUDE.md")
+    assert claude["action"] == "overwrite"
+```
+to:
+```python
+    # CLAUDE.md already exists -> merged (existing "# existing guide" has no ## sections,
+    # so every generated ## section is appended)
+    claude = next(p for p in data["plan"] if p["path"] == "CLAUDE.md")
+    assert claude["action"] == "merge"
+    claude_file = next(f for f in data["manifest"]["files"] if f["path"] == "CLAUDE.md")
+    assert claude_file["content"].startswith("# existing guide")
+    assert "Added by Prompt Compiler" in claude_file["content"]
+```
+Then add two tests at the end of the file:
+```python
+def test_repo_plan_claude_md_identical_when_all_sections_present():
+    # An existing CLAUDE.md that already contains every generated ## heading -> "identical"
+    # (merge finds no new section, so merged == existing). The generated project-pack
+    # CLAUDE.md emits exactly these level-2 headings (see _project_claude_md).
+    existing_claude = (
+        "# My Guide\n\n## Project context\n\n## Objectives\n\n## Constraints\n\n"
+        "## Workflow\n\n## Declared technology context\n\n## Validation contract\n\n"
+        "## Claude Code configuration\n"
+    )
+    body = {
+        "pack_type": "project-pack",
+        "goal": "g",
+        "repo_facts": {"files": {"CLAUDE.md": existing_claude}, "tree": ["CLAUDE.md"]},
+    }
+    r = client.post("/agent-packs/claude/repo-plan", json=body)
+    assert r.status_code == 200
+    claude = next(p for p in r.json()["plan"] if p["path"] == "CLAUDE.md")
+    assert claude["action"] == "identical"
+
+
+def test_repo_plan_claude_md_create_when_absent():
+    body = {
+        "pack_type": "project-pack",
+        "goal": "g",
+        "repo_facts": {"files": {"package.json": "{}"}, "tree": ["package.json"]},
+    }
+    r = client.post("/agent-packs/claude/repo-plan", json=body)
+    assert r.status_code == 200
+    claude = next(p for p in r.json()["plan"] if p["path"] == "CLAUDE.md")
+    assert claude["action"] == "create"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_agent_packs_repo_plan.py -q`
+Expected: FAIL — `test_repo_plan_returns_manifest_and_diffs` (still "overwrite") and the new merge/create-action assertions.
+
+- [ ] **Step 3: Implement in `api/routes/agent_packs.py`**
+
+(a) Add the import next to the existing repo_inspect import:
+```python
+from app.repo_inspect import RepoFacts, derive_repo_context
+from app.repo_inspect.claude_md_merge import merge_claude_md
+```
+
+(b) Replace the plan-building + return block (the current `existing = req.repo_facts.files` / `plan = [...]` / `return {...}`) with:
+```python
+    existing = req.repo_facts.files
+    data = manifest.model_dump()
+    plan: list[dict] = []
+    for f in data["files"]:
+        path, content = f["path"], f["content"]
+        if path == "CLAUDE.md" and "CLAUDE.md" in existing:
+            merged = merge_claude_md(existing["CLAUDE.md"], content)
+            f["content"] = merged
+            plan.append(
+                {
+                    "path": path,
+                    "action": "identical" if merged == existing["CLAUDE.md"] else "merge",
+                }
+            )
+        else:
+            plan.append({"path": path, "action": _diff_action(existing, path, content)})
+    return {
+        "manifest": data,
+        "plan": plan,
+        "detected": {
+            "stack": ctx.stack_summary(),
+            "commands": ctx.command_map(),
+            "has_existing_claude_md": ctx.has_existing_claude_md,
+        },
+    }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_agent_packs_repo_plan.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+uvx ruff@0.1.14 format api/routes/agent_packs.py tests/test_agent_packs_repo_plan.py
+git add api/routes/agent_packs.py tests/test_agent_packs_repo_plan.py
+git commit -m "feat(agent-packs): repo-plan merges an existing CLAUDE.md
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Apply the merge in place (`apply_agent_pack`)
+
+**Files:**
+- Modify: `integrations/mcp-server/server.py`
+- Modify: `integrations/mcp-server/test_server.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `integrations/mcp-server/test_server.py`:
+```python
+def test_apply_agent_pack_merges_claude_md_in_place(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / "CLAUDE.md").write_text("# Existing\n\n## Setup\nrun make\n")
+    merged = "# Existing\n\n## Setup\nrun make\n\n<!-- marker -->\n\n## Deploy\nship\n"
+    manifest = {"files": [{"path": "CLAUDE.md", "content": merged}]}
+    client = _MockAsyncClient()
+    client.responses.append(
+        _MockResponse({"manifest": manifest, "plan": [{"path": "CLAUDE.md", "action": "merge"}]})
+    )
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        result = asyncio.run(server.apply_agent_pack("project-pack", goal="x", path=str(tmp_path)))
+
+    assert (tmp_path / "CLAUDE.md").read_text() == merged  # written in place
+    assert not (tmp_path / "CLAUDE.md.new").exists()       # not a .new conflict
+    assert result["written"]["overwritten"] == ["CLAUDE.md"]
+
+
+def test_apply_agent_pack_non_merge_conflict_still_new(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / "README.md").write_text("old")
+    manifest = {"files": [{"path": "README.md", "content": "new"}]}
+    client = _MockAsyncClient()
+    client.responses.append(
+        _MockResponse({"manifest": manifest, "plan": [{"path": "README.md", "action": "overwrite"}]})
+    )
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        asyncio.run(server.apply_agent_pack("project-pack", goal="x", path=str(tmp_path)))
+
+    # An "overwrite"-action file the caller did NOT confirm still lands as .new (no-clobber).
+    assert (tmp_path / "README.md").read_text() == "old"
+    assert (tmp_path / "README.md.new").read_text() == "new"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd integrations/mcp-server && python -m pytest test_server.py -q -k "merges_claude_md_in_place"`
+Expected: FAIL — the merged CLAUDE.md is currently written as `CLAUDE.md.new` (merge path not yet auto-overwritten), so the in-place assertion fails.
+
+- [ ] **Step 3: Implement in `integrations/mcp-server/server.py`**
+
+Replace the body of `apply_agent_pack` (the `result = await _post_json(...)` through `return ...`) with:
+```python
+    facts = collect_repo_facts(path)
+    result = await _post_json(
+        "/agent-packs/claude/repo-plan",
+        {"pack_type": pack_type, "goal": goal, "risk_mode": risk_mode, "repo_facts": facts},
+    )
+    merge_paths = [p["path"] for p in result["plan"] if p.get("action") == "merge"]
+    effective_overwrite = list(dict.fromkeys((overwrite or []) + merge_paths))
+    written = write_pack_files(path, result["manifest"]["files"], effective_overwrite)
+    return {"written": written, "plan": result["plan"]}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd integrations/mcp-server && python -m pytest test_server.py -q`
+Expected: PASS (existing tests + the two new ones).
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+uvx ruff@0.1.14 format integrations/mcp-server/server.py integrations/mcp-server/test_server.py
+git add integrations/mcp-server/server.py integrations/mcp-server/test_server.py
+git commit -m "feat(agent-packs): apply CLAUDE.md merge in place, not as .new
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full verification gate
+
+**Files:** none.
+
+- [ ] **Step 1: Focused suites**
+
+Run: `python -m pytest tests/test_claude_md_merge.py tests/test_agent_packs_repo_plan.py -q` then `cd integrations/mcp-server && python -m pytest -q`
+Expected: PASS.
+
+- [ ] **Step 2: Full backend suite**
+
+Run: `python -m pytest tests/ -q`
+Expected: PASS except the known pre-existing flake `test_validate_summary_and_api_schemas` (127.0.0.1:8000; also fails on `main`). If that is the only failure, the gate passes.
+
+- [ ] **Step 3: Format check (Smoke parity)**
+
+Run: `uvx ruff@0.1.14 format --check app/repo_inspect/claude_md_merge.py api/routes/agent_packs.py integrations/mcp-server/server.py tests/test_claude_md_merge.py tests/test_agent_packs_repo_plan.py integrations/mcp-server/test_server.py`
+Expected: "already formatted" for all changed files.
+
+- [ ] **Step 4: Stop for review — do NOT open a PR automatically**
+
+Per project rules, never push/PR/merge without Mehmet's explicit approval. Report: changed files, out-of-scope changes (none), test results, and the boundary note (only `CLAUDE.md` merged, non-destructively; no `.env`/auth/deploy/secret touched). Then ask whether to open the PR.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Pure section-aware append-new merge (fence-aware both sides, idempotent, dedup, edge cases) → Task 1 (impl + 12 tests). ✅
+- Accepted limitation (same-key drop) as a conscious contract → Task 1 `test_same_heading_different_body_is_dropped`. ✅
+- CRLF / preserve-prefix invariants → Task 1 `test_crlf_existing_preserved`, `test_preserve_prefix_and_append_new`. ✅
+- repo-plan "merge"/"identical"/"create" + merged manifest content, `_diff_action` not called for existing CLAUDE.md → Task 2. ✅
+- Update the existing `"overwrite"` assertion → Task 2 Step 1. ✅
+- apply auto-overwrites "merge" paths (in place, not `.new`); other conflicts still `.new` → Task 3 (two tests). ✅
+- `repo_write.py` unchanged → confirmed (no task touches it). ✅
+- Gate + Smoke format parity → Task 4. ✅
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N"; every code step shows complete code. ✅
+
+**3. Type/name consistency:**
+- `merge_claude_md`, `MARKER` (Task 1) imported/used identically in Task 2 and the merge tests. ✅
+- repo-plan uses `data = manifest.model_dump()` then mutates `data["files"]` dicts (`f["content"]`) — consistent with the `list[dict]` shape the client (`result["manifest"]["files"]`) and `write_pack_files` expect. ✅
+- Plan action strings `"merge"` / `"identical"` / `"create"` / `"overwrite"` consistent across Task 2 (producer) and Task 3 (`apply` consumer filters `action == "merge"`). ✅

--- a/docs/superpowers/specs/2026-07-04-agent-packs-b3-claude-md-merge-design.md
+++ b/docs/superpowers/specs/2026-07-04-agent-packs-b3-claude-md-merge-design.md
@@ -1,0 +1,246 @@
+# Agent Packs B3 (slice 2) — CLAUDE.md Smart Merge (Design)
+
+- **Date:** 2026-07-04
+- **Status:** Approved (design), pending spec review
+- **Branch:** `feat/agent-packs-claude-md-merge` (off `main`, which now includes B1 / #933)
+- **Surface:** `app/repo_inspect/`, `api/routes/agent_packs.py` (repo-plan), and
+  `integrations/mcp-server/server.py` (apply). No web change.
+
+## Problem
+
+B1's repo-aware apply path writes generated files into a real repo with a **no-clobber**
+policy: an existing path not in the `overwrite` list is written to `<path>.new`
+(`integrations/mcp-server/repo_write.py:27-35`). So when a repo already has a `CLAUDE.md`,
+the generated guidance lands as `CLAUDE.md.new` and the user must hand-merge it.
+
+`repo-plan` already receives the repo's existing files (`req.repo_facts.files: dict[str,
+str]`, path → content) **and** the generated `CLAUDE.md`, and classifies each file as
+create / identical / overwrite (`_diff_action`, `api/routes/agent_packs.py:64-67`). This
+slice adds a **merge** path for `CLAUDE.md`. (Second of the remaining B3 slices; B1 is
+merged, so this apply path is on `main`.)
+
+## Goals / Non-goals
+
+**Goals:** when the repo already has a `CLAUDE.md`, non-destructively merge the generated
+guidance into it — preserve the user's existing content and append only the generated `##`
+sections whose heading the user doesn't already have — and apply that merge in place.
+
+**Non-goals / accepted limitations:**
+- The web download path (no repo, no existing file) — unchanged.
+- Any file other than exactly `CLAUDE.md` — settings.json / `.mcp.json` / hooks.example /
+  agents keep create/overwrite/identical/`.new`.
+- **Same-heading, different body is not merged** (see Risks): if the user already has `##
+  Security`, a generated `## Security` with a richer body is *intentionally dropped*. Body-
+  diff-aware merge is a follow-up.
+- Sub-section (`###`) / line-level / three-way merge.
+- No `.env`/auth/deploy/secret changes.
+
+## Approved decisions
+
+- **Strategy A — section-aware, append-new-only, idempotent** (user decision).
+- **Merge logic in the pure backend** (matches B1: FastAPI pure — repo facts in → pack +
+  plan out; MCP client owns disk I/O).
+- **Merge applied in place** — a section-append merge is non-destructive by construction.
+
+## Design
+
+### 1. Pure merge — `app/repo_inspect/claude_md_merge.py`
+
+The whole algorithm is pinned below so two implementers produce byte-identical output.
+
+```python
+import re
+
+MARKER = "<!-- Added by Prompt Compiler: sections not already in your CLAUDE.md -->"
+
+_HEADING_RE = re.compile(r"^##[ \t]+(.+?)\s*$")   # level-2 only; "##Foo" (no space) is NOT a heading
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")          # >=3 backticks or tildes after leading whitespace
+
+
+def _heading_key(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().casefold()
+
+
+def _iter_sections(md: str) -> list[tuple[str, str]]:
+    """(heading_key, section_text) for each level-2 section, fence-aware.
+
+    A section's text is the ``## `` line plus every following line up to (but not
+    including) the next level-2 heading or EOF, joined with "\\n". A ``## `` line inside a
+    fenced code block is body, not a heading. Fences opened by ``` close only on ``` (same
+    char, >= run length); likewise ~~~.
+    """
+    lines = md.splitlines()
+    fence: tuple[str, int] | None = None
+    out: list[tuple[str, str]] = []
+    key: str | None = None
+    buf: list[str] = []
+    for line in lines:
+        fence_m = _FENCE_RE.match(line.lstrip())
+        if fence_m:
+            run = fence_m.group(1)
+            if fence is None:
+                fence = (run[0], len(run))
+            elif fence[0] == run[0] and len(run) >= fence[1]:
+                fence = None
+            if key is not None:
+                buf.append(line)
+            continue
+        heading = None if fence is not None else _HEADING_RE.match(line)
+        if heading:
+            if key is not None:
+                out.append((key, "\n".join(buf)))
+            key = _heading_key(heading.group(1))
+            buf = [line]
+        elif key is not None:
+            buf.append(line)
+    if key is not None:
+        out.append((key, "\n".join(buf)))
+    return out
+
+
+def merge_claude_md(existing: str, generated: str) -> str:
+    seen = {k for k, _ in _iter_sections(existing)}   # existing headings (fence-aware)
+    new_sections: list[str] = []
+    for key, text in _iter_sections(generated):
+        if key in seen:          # already in the user's file OR already chosen this run
+            continue
+        seen.add(key)            # de-dupe within generated too (keep first)
+        new_sections.append(text.rstrip())
+    if not new_sections:
+        return existing
+    return existing.rstrip() + "\n\n" + MARKER + "\n\n" + "\n\n".join(new_sections) + "\n"
+```
+
+- **Preserved prefix:** the merged output starts with `existing.rstrip()` (trailing
+  whitespace/newlines removed); the user's interior bytes — including any `\r\n` — are
+  untouched (`existing` is prepended verbatim, never re-split). Trailing whitespace on the
+  final existing line is the only thing normalized.
+- **Idempotency (same `generated`):** after a merge, the appended sections' `## ` headings
+  are in the output, and `MARKER` is a comment (not a heading), so
+  `merge_claude_md(merge_claude_md(e, g), g) == merge_claude_md(e, g)`.
+- **Matching keys drop the generated section** (accepted limitation above). **Duplicate
+  keys within `generated`** collapse to the first (the `seen` set).
+- **Preconditions:** the generator always emits `##`-sectioned CLAUDE.md
+  (`_project_claude_md` / `_pr_reviewer_memory` — verified: Project context, Objectives,
+  Constraints, Workflow, Declared technology context, Validation contract, Claude Code
+  configuration). So "generated has no `##`" (→ return existing) does not occur for our
+  generator; it is handled only for robustness.
+- **Fence rationale:** today's *generated* CLAUDE.md has no triple-fenced blocks (only
+  inline backticks), so fence-awareness is for the **user's existing** file (which may
+  hand-author fenced `## ` lines) and for forward-safety.
+
+### 2. `repo-plan` integration (pure) — `api/routes/agent_packs.py`
+
+Replace the current plan-building (lines 103-107) with a CLAUDE.md-aware version that also
+returns the merged content. Pin the mechanic: dump the manifest, mutate the dumped
+`files`, and build the plan in the same pass. `_diff_action` is **not** called for the
+`CLAUDE.md` path when `CLAUDE.md` exists in `existing`.
+
+```python
+existing = req.repo_facts.files
+data = manifest.model_dump()
+plan: list[dict] = []
+for f in data["files"]:                       # f is a dict {"path", "content", "kind"}
+    path, content = f["path"], f["content"]
+    if path == "CLAUDE.md" and "CLAUDE.md" in existing:   # exact, case-sensitive
+        merged = merge_claude_md(existing["CLAUDE.md"], content)
+        f["content"] = merged                 # mutates the dict inside data["files"]
+        plan.append({"path": path, "action": "identical" if merged == existing["CLAUDE.md"] else "merge"})
+    else:
+        plan.append({"path": path, "action": _diff_action(existing, path, content)})
+return {"manifest": data, "plan": plan, "detected": {...unchanged...}}
+```
+
+`CLAUDE.md` not in `existing` → `_diff_action` returns `"create"` and content stays the
+generated content (regression-safe vs B1).
+
+### 3. `apply_agent_pack` integration — `integrations/mcp-server/server.py`
+
+`apply_agent_pack` (server.py:165-183) currently passes the caller's `overwrite` straight
+to `write_pack_files`. Add `"merge"`-action paths to the effective overwrite set (the
+merged content is non-destructive, so writing in place is safe):
+
+```python
+result = await _post_json("/agent-packs/claude/repo-plan", payload)
+merge_paths = [p["path"] for p in result["plan"] if p.get("action") == "merge"]
+effective_overwrite = list(dict.fromkeys((overwrite or []) + merge_paths))
+written = write_pack_files(path, result["manifest"]["files"], effective_overwrite)
+return {"written": written, "plan": result["plan"]}
+```
+
+`repo_write.write_pack_files` is **unchanged**: a path in the overwrite set writes in place,
+so the merged `CLAUDE.md` lands as `CLAUDE.md` (not `.new`), while other genuine conflicts
+still `.new`. The `"merge"` action is visible in `plan_agent_pack` before applying.
+
+## File-level impact
+
+**New:** `app/repo_inspect/claude_md_merge.py`; `tests/test_claude_md_merge.py`.
+
+**Changed:**
+- `api/routes/agent_packs.py` — CLAUDE.md merge special-case in the repo-plan handler.
+- `integrations/mcp-server/server.py` — `apply_agent_pack` merge-path auto-overwrite.
+- `tests/test_agent_packs_repo_plan.py` — **update the existing assertion** at
+  `test_repo_plan_returns_manifest_and_diffs` (currently asserts the differing `CLAUDE.md`
+  is action `"overwrite"`, `~line 29`) to `"merge"`, plus new merge/identical/create cases.
+- `integrations/mcp-server/test_server.py` — apply writes merge in place.
+
+**Unchanged:** `integrations/mcp-server/repo_write.py`; `app/adapters/**`;
+`app/repo_inspect/models.py`/`detect.py`; all web / plain-generate / download code.
+
+## Testing
+
+`tests/test_claude_md_merge.py` (pure, deterministic, byte-level):
+- **preserve:** for a non-empty merge, `merged.startswith(existing.rstrip())` **and** the
+  slice of `merged` before `"\n\n" + MARKER` equals `existing.rstrip()` exactly.
+- **append-new-only:** a generated section whose heading exists in the user's file is not
+  duplicated; a section the user lacks is appended after `MARKER`.
+- **idempotent:** `merge(merge(e, g), g) == merge(e, g)`.
+- **no-new → unchanged:** every generated heading already present → `merged == existing`.
+- **same-key different-body drop (contract):** existing `## Security\nshort`, generated `##
+  Security\nlong policy` → the long body is NOT appended (documents the accepted limitation).
+- **dup within generated:** generated with `## Setup` and `## setup` (existing lacks it) →
+  exactly one appended section.
+- **edge:** existing with no `##` (append all generated sections); generated with no `##`
+  (return existing); heading key is case/whitespace-insensitive (`## Objectives` vs `##
+  objectives  ` collide); `##Foo` (no space) is not a heading.
+- **fence-aware, both sides:** (i) a `## X` inside a ```` ``` ```` fence in `generated` is
+  not treated as a heading; (ii) a `## Deploy` inside a fence in the **existing** file does
+  not shadow a real generated `## Deploy` (it IS appended); (iii) a `~~~`-opened block
+  containing a ```` ``` ```` line and a `## Y` line parses correctly (mixed delimiters).
+- **CRLF preserved:** an existing file with `\r\n` line endings keeps them verbatim in the
+  merged prefix.
+
+`tests/test_agent_packs_repo_plan.py`:
+- Update the existing differing-CLAUDE.md assertion to `action == "merge"`; assert the
+  returned `manifest` `CLAUDE.md` content contains the existing content and `MARKER`.
+- Existing `CLAUDE.md` already containing all generated headings → `action == "identical"`.
+- No `CLAUDE.md` in repo_facts → `action == "create"` (regression).
+
+`integrations/mcp-server/test_server.py` (reuse the existing `_MockAsyncClient` +
+`patch("server.httpx.AsyncClient", return_value=client)` style, as in
+`test_apply_agent_pack_writes_files`): a repo-plan response with a `CLAUDE.md` `"merge"`
+action + an existing `CLAUDE.md` on disk → after `apply_agent_pack`, `CLAUDE.md` holds the
+merged content and no `CLAUDE.md.new` exists; a separate genuinely-conflicting file still
+produces `.new`.
+
+**Gate before PR:** `python -m pytest tests/test_claude_md_merge.py tests/test_agent_packs_repo_plan.py -q`, then `python -m pytest integrations/mcp-server/ -q`, then `python -m pytest tests/ -q`. Format changed Python with `uvx ruff@0.1.14 format` before pushing (Smoke gate).
+
+## Risks & mitigations
+
+- **Corrupting the user's CLAUDE.md.** The merge only appends; interior bytes are preserved
+  verbatim. Enforced by the `preserve` test (prefix-before-marker equals `existing.rstrip()`
+  exactly) + the CRLF test.
+- **Accepted content loss (same-key different-body, preamble-only generated).** Documented
+  in Non-goals; the same-key-drop test makes it a conscious contract. Preamble-only-generated
+  cannot occur for our generator (precondition above).
+- **Fence mis-parse.** Marker-aware fence rule (char + run length) applied to both parses;
+  mixed-delimiter test.
+- **In-place write of a merge.** Safe (non-destructive); still surfaced as `"merge"` in
+  `plan_agent_pack`.
+
+## Out of scope / follow-ups
+
+- Body-diff-aware merge for same-heading sections (append under a disambiguated heading).
+- Merging other files (settings.json / `.mcp.json` / hooks) — they keep no-clobber `.new`.
+- Web UI surfacing (web path has no existing repo file).
+- Remaining B3 slices: CLI vehicle; GitHub-PR vehicle.

--- a/integrations/mcp-server/server.py
+++ b/integrations/mcp-server/server.py
@@ -179,7 +179,9 @@ async def apply_agent_pack(
         "/agent-packs/claude/repo-plan",
         {"pack_type": pack_type, "goal": goal, "risk_mode": risk_mode, "repo_facts": facts},
     )
-    written = write_pack_files(path, result["manifest"]["files"], overwrite or [])
+    merge_paths = [p["path"] for p in result["plan"] if p.get("action") == "merge"]
+    effective_overwrite = list(dict.fromkeys((overwrite or []) + merge_paths))
+    written = write_pack_files(path, result["manifest"]["files"], effective_overwrite)
     return {"written": written, "plan": result["plan"]}
 
 

--- a/integrations/mcp-server/test_server.py
+++ b/integrations/mcp-server/test_server.py
@@ -153,3 +153,40 @@ def test_apply_agent_pack_writes_files(tmp_path, monkeypatch: pytest.MonkeyPatch
 
     assert (tmp_path / "CLAUDE.md").read_text() == "NEW"
     assert result["written"]["created"] == ["CLAUDE.md"]
+
+
+def test_apply_agent_pack_merges_claude_md_in_place(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / "CLAUDE.md").write_text("# Existing\n\n## Setup\nrun make\n")
+    merged = "# Existing\n\n## Setup\nrun make\n\n<!-- marker -->\n\n## Deploy\nship\n"
+    manifest = {"files": [{"path": "CLAUDE.md", "content": merged}]}
+    client = _MockAsyncClient()
+    client.responses.append(
+        _MockResponse({"manifest": manifest, "plan": [{"path": "CLAUDE.md", "action": "merge"}]})
+    )
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        result = asyncio.run(server.apply_agent_pack("project-pack", goal="x", path=str(tmp_path)))
+
+    assert (tmp_path / "CLAUDE.md").read_text() == merged  # written in place
+    assert not (tmp_path / "CLAUDE.md.new").exists()  # not a .new conflict
+    assert result["written"]["overwritten"] == ["CLAUDE.md"]
+
+
+def test_apply_agent_pack_non_merge_conflict_still_new(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    (tmp_path / "README.md").write_text("old")
+    manifest = {"files": [{"path": "README.md", "content": "new"}]}
+    client = _MockAsyncClient()
+    client.responses.append(
+        _MockResponse(
+            {"manifest": manifest, "plan": [{"path": "README.md", "action": "overwrite"}]}
+        )
+    )
+
+    monkeypatch.setenv("PROMPTC_BACKEND_URL", "https://api.example")
+    with patch("server.httpx.AsyncClient", return_value=client):
+        asyncio.run(server.apply_agent_pack("project-pack", goal="x", path=str(tmp_path)))
+
+    # An "overwrite"-action file the caller did NOT confirm still lands as .new (no-clobber).
+    assert (tmp_path / "README.md").read_text() == "old"
+    assert (tmp_path / "README.md.new").read_text() == "new"

--- a/tests/test_agent_packs_repo_plan.py
+++ b/tests/test_agent_packs_repo_plan.py
@@ -24,10 +24,51 @@ def test_repo_plan_returns_manifest_and_diffs():
     assert r.status_code == 200
     data = r.json()
     assert data["manifest"]["pack_type"] == "project-pack"
-    # CLAUDE.md already exists -> flagged as an overwrite in the plan
+    # CLAUDE.md already exists -> merged (existing "# existing guide" has no ## sections,
+    # so every generated ## section is appended)
     claude = next(p for p in data["plan"] if p["path"] == "CLAUDE.md")
-    assert claude["action"] == "overwrite"
+    assert claude["action"] == "merge"
+    claude_file = next(f for f in data["manifest"]["files"] if f["path"] == "CLAUDE.md")
+    assert claude_file["content"].startswith("# existing guide")
+    assert "Added by Prompt Compiler" in claude_file["content"]
     # a brand-new file is a create
     assert any(p["action"] == "create" for p in data["plan"])
     # detected npm test command surfaced
     assert "npm run test" in str(data["detected"]["commands"])
+
+
+def test_repo_plan_claude_md_identical_when_all_sections_present():
+    # Feed the generated CLAUDE.md back as the existing file: every generated ## heading is
+    # already present, so merge finds nothing new -> action "identical". (Generation is
+    # deterministic for a fixed goal, so the two generations match.)
+    gen_body = {
+        "pack_type": "project-pack",
+        "goal": "g",
+        "repo_facts": {"files": {"package.json": "{}"}, "tree": ["package.json"]},
+    }
+    gen = client.post("/agent-packs/claude/repo-plan", json=gen_body)
+    generated_claude = next(
+        f["content"] for f in gen.json()["manifest"]["files"] if f["path"] == "CLAUDE.md"
+    )
+
+    body = {
+        "pack_type": "project-pack",
+        "goal": "g",
+        "repo_facts": {"files": {"CLAUDE.md": generated_claude}, "tree": ["CLAUDE.md"]},
+    }
+    r = client.post("/agent-packs/claude/repo-plan", json=body)
+    assert r.status_code == 200
+    claude = next(p for p in r.json()["plan"] if p["path"] == "CLAUDE.md")
+    assert claude["action"] == "identical"
+
+
+def test_repo_plan_claude_md_create_when_absent():
+    body = {
+        "pack_type": "project-pack",
+        "goal": "g",
+        "repo_facts": {"files": {"package.json": "{}"}, "tree": ["package.json"]},
+    }
+    r = client.post("/agent-packs/claude/repo-plan", json=body)
+    assert r.status_code == 200
+    claude = next(p for p in r.json()["plan"] if p["path"] == "CLAUDE.md")
+    assert claude["action"] == "create"

--- a/tests/test_claude_md_merge.py
+++ b/tests/test_claude_md_merge.py
@@ -1,0 +1,100 @@
+from app.repo_inspect.claude_md_merge import MARKER, merge_claude_md
+
+
+def test_preserve_prefix_and_append_new():
+    existing = "# My Guide\n\n## Setup\nrun make\n"
+    generated = "# Gen\n\n## Setup\nother setup\n\n## Deploy\nship it\n"
+    merged = merge_claude_md(existing, generated)
+    # existing content is preserved verbatim as the prefix (up to the marker)
+    assert merged.startswith(existing.rstrip())
+    assert merged.split("\n\n" + MARKER, 1)[0] == existing.rstrip()
+    # only the section the user lacks is appended
+    assert "## Deploy\nship it" in merged
+    # the generated "Setup" body is NOT appended (heading already present)
+    assert "other setup" not in merged
+
+
+def test_no_new_sections_returns_existing_unchanged():
+    existing = "# G\n\n## Setup\na\n\n## Deploy\nb\n"
+    generated = "# Gen\n\n## setup\nx\n\n## DEPLOY\ny\n"  # same keys, different case
+    assert merge_claude_md(existing, generated) == existing
+
+
+def test_idempotent():
+    existing = "# G\n\n## Setup\na\n"
+    generated = "# Gen\n\n## Setup\na\n\n## Deploy\nb\n"
+    once = merge_claude_md(existing, generated)
+    assert merge_claude_md(once, generated) == once
+
+
+def test_same_heading_different_body_is_dropped():
+    # Accepted limitation: same heading key -> generated section not merged.
+    existing = "## Security\nshort\n"
+    generated = "## Security\nlong detailed policy\n"
+    assert merge_claude_md(existing, generated) == existing
+
+
+def test_duplicate_key_within_generated_appended_once():
+    existing = "# Title only\n"
+    generated = "## Setup\na\n\n## setup\nb\n"
+    merged = merge_claude_md(existing, generated)
+    assert merged.count("<!--") == 1
+    assert merged.count("## Setup") + merged.count("## setup") == 1
+
+
+def test_existing_without_sections_appends_all():
+    existing = "# Just a title\n"
+    generated = "## A\nx\n\n## B\ny\n"
+    merged = merge_claude_md(existing, generated)
+    assert "## A\nx" in merged
+    assert "## B\ny" in merged
+
+
+def test_generated_without_sections_returns_existing():
+    existing = "# G\n\n## Setup\na\n"
+    generated = "# Gen\n\nsome intro prose only\n"
+    assert merge_claude_md(existing, generated) == existing
+
+
+def test_heading_without_space_is_not_a_heading():
+    existing = "# G\n"
+    generated = "##NotAHeading\nbody\n\n## Real\nkeep\n"
+    merged = merge_claude_md(existing, generated)
+    # only "## Real" is a section; "##NotAHeading" is before the first real heading
+    assert "## Real\nkeep" in merged
+    assert "##NotAHeading" not in merged
+
+
+def test_fence_in_generated_not_a_heading():
+    existing = "# G\n"
+    generated = "## Code\n```\n## inside fence\n```\nafter\n\n## Real\nkeep\n"
+    merged = merge_claude_md(existing, generated)
+    # "## inside fence" stays inside the Code section body, not a separate section
+    assert "## inside fence" in merged
+    assert merged.count("<!--") == 1  # single marker
+    assert "## Code" in merged and "## Real" in merged
+
+
+def test_fence_in_existing_does_not_shadow_generated_heading():
+    existing = "# G\n\n```\n## Deploy\nfake\n```\n"
+    generated = "## Deploy\nreal deploy steps\n"
+    merged = merge_claude_md(existing, generated)
+    # the fenced "## Deploy" in existing is NOT a real heading, so generated Deploy IS added
+    assert "real deploy steps" in merged
+
+
+def test_mixed_fence_delimiters():
+    existing = "# G\n"
+    generated = "## A\nx\n\n~~~\n```\n## Y\n~~~\n\n## B\nz\n"
+    merged = merge_claude_md(existing, generated)
+    # "## Y" is inside the ~~~ block (not closed by ```), so not its own section
+    assert "## A" in merged and "## B" in merged
+    assert "## Y" in merged  # present, but as body of section A
+
+
+def test_crlf_existing_preserved():
+    existing = "# Guide\r\n\r\n## Setup\r\nrun\r\n"
+    generated = "## Deploy\nship\n"
+    merged = merge_claude_md(existing, generated)
+    assert merged.startswith("# Guide\r\n")
+    assert "\r\n## Setup\r\nrun" in merged


### PR DESCRIPTION
## Summary
When a repo already has a `CLAUDE.md`, the repo-aware apply path now **merges** the generated guidance into it non-destructively instead of writing `CLAUDE.md.new`:

- **`app/repo_inspect/claude_md_merge.py`** — pure, section-aware, append-new-only, idempotent merge. Keeps 100% of the user's existing content; appends only the generated `##` sections whose heading the user lacks, under a clear `<!-- Added by Prompt Compiler -->` marker. Fence-aware on both sides.
- **`repo-plan`** — for an existing `CLAUDE.md` it returns plan action `"merge"` (or `"identical"`) with the merged content in the manifest; absent → `"create"` (unchanged).
- **`apply_agent_pack`** — auto-includes `"merge"`-action paths in the overwrite set, so the merged `CLAUDE.md` is written in place. Other unconfirmed conflicts still land as `.new` (no-clobber unchanged).

## Notes / boundaries
- Backend + MCP client only (`app/repo_inspect/`, `api/routes/`, `integrations/mcp-server/`). No web / dependency / deploy change.
- Only `CLAUDE.md` is merged; settings.json / `.mcp.json` / hooks / agents keep create/overwrite/identical/`.new`.
- Non-destructive: the merge only appends; existing bytes (incl. CRLF) are preserved verbatim.
- Accepted limitation (documented + tested): same heading key with a different/richer body is not merged. Body-diff-aware merge is a follow-up.
- Builds on B1 (#933, merged); second of the remaining B3 slices (CLI / GitHub-PR vehicles are separate).

## Test plan
- [x] `python -m pytest tests/test_claude_md_merge.py -q` — 12 pass (preserve / idempotent / same-key-drop / dup-within / fence both sides / mixed delimiters / CRLF)
- [x] `python -m pytest tests/test_agent_packs_repo_plan.py -q` — merge / identical / create
- [x] `cd integrations/mcp-server && python -m pytest -q` — 19 pass (in-place merge write + non-merge still `.new`)
- [x] `python -m pytest tests/ -q` — 1907 pass / 5 skip; only failure is the pre-existing `test_validate_summary_and_api_schemas` network flake (127.0.0.1:8000; also fails on `main`)
- [x] Manually verified a real end-to-end merge: user's custom sections preserved, only new sections appended, repo-aware Objectives generated

Spec: `docs/superpowers/specs/2026-07-04-agent-packs-b3-claude-md-merge-design.md`
Plan: `docs/superpowers/plans/2026-07-04-agent-packs-b3-claude-md-merge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)