### PR TITLE
fix(tests): make hooks-example shell-safety test OS-independent (fix Windows CI)

### DIFF
--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -755,7 +755,7 @@ def test_hooks_example_none_without_post_edit():
 
 
 def test_hooks_example_shape_and_shell_safety():
-    import subprocess
+    import shlex
 
     from app.adapters.claude_code import _hooks_example_json
 
@@ -769,10 +769,11 @@ def test_hooks_example_shape_and_shell_safety():
     assert cmd["type"] == "command"
     assert cmd["command"].startswith("echo ")
 
-    # The command is valid shell and echoes the literal text (no $HOME/backtick expansion).
-    result = subprocess.run(cmd["command"], shell=True, capture_output=True, text=True)
-    assert result.returncode == 0
-    assert result.stdout.strip() == tricky
+    # The command is a single `echo <quoted>` where the payload is one opaque argument, so it
+    # cannot inject or expand ($HOME/backticks stay literal). shlex.split proves this
+    # OS-independently — subprocess(shell=True) would use cmd.exe on Windows, which does not
+    # honour POSIX single-quote quoting.
+    assert shlex.split(cmd["command"]) == ["echo", tricky]
 
 
 def test_project_pack_emits_hooks_example():


### PR DESCRIPTION
## Problem
The push-to-main **Full Test** matrix is red on **Windows** (3.10/3.11/3.12) since the B3 slice-1 merge (#938). Only one test fails: `tests/test_export_adapters.py::test_hooks_example_shape_and_shell_safety`.

The test ran the generated hook command (`echo '<shlex.quote payload>'`) via `subprocess.run(shell=True)`. `shlex.quote` produces POSIX-shell quoting; on Windows `shell=True` invokes **cmd.exe**, which does not honour POSIX single-quotes, so `echo '...'` prints the surrounding quotes and the output comparison fails. It passes on Linux/macOS (`/bin/sh`).

This is a **test-only** issue — the product output (the example hook command) is correct for Claude Code hooks, prod (Vercel) is green, and the backend runs fine.

## Fix
Assert `shlex.split(cmd["command"]) == ["echo", payload]` instead of shelling out. This proves the exact safety property (the whole payload is a single opaque argument — no injection or `$HOME`/backtick expansion) **OS-independently**, with no shell spawned. No product behavior change.

## Test plan
- [x] `python -m pytest tests/test_export_adapters.py::test_hooks_example_shape_and_shell_safety -q` — pass
- [x] `uvx ruff@0.1.14 format --check tests/test_export_adapters.py` — already formatted
- Note: the Windows "Full Test" matrix runs on push to main (not on PRs), so it is verified after merge; the fix is OS-independent so it will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)