### PR TITLE
test: cover untested compiler pipeline helpers and heuristic extractors

### DIFF
--- a/tests/test_compiler_pipeline_helpers.py
+++ b/tests/test_compiler_pipeline_helpers.py
@@ -1,0 +1,212 @@
+"""Coverage for three pure app.compiler helpers that had no direct tests:
+
+- decompose_task: splits a task string into ordered sub-steps.
+- generate_trace: builds a deterministic debug trace from IR metadata.
+- optimize_ir: dedupes goals/tasks by a first-60-chars key and injects a
+  domain baseline constraint (EN/TR) when missing.
+
+These are exercised directly (not just through build_steps/compile_text_v2)
+so regressions in the underlying logic surface here first.
+"""
+
+from app.compiler import decompose_task, generate_trace, optimize_ir
+from app.models import IR
+
+
+# ---------------------------------------------------------------------------
+# decompose_task
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_task_and_conjunction_splits_in_two():
+    parts = decompose_task("parse the access log and email a daily summary to the team")
+    assert parts == ["parse the access log", "email a daily summary to the team"]
+
+
+def test_decompose_task_then_conjunction_splits():
+    parts = decompose_task("write the report then send it to the client")
+    assert parts == ["write the report", "send it to the client"]
+
+
+def test_decompose_task_oxford_list_splits_into_three():
+    parts = decompose_task("validate the input, sanitize the output, and log the result")
+    assert len(parts) == 3
+    assert parts == ["validate the input", "sanitize the output", "log the result"]
+
+
+def test_decompose_task_quoted_payload_double_quotes_never_split():
+    task = 'Turn this into a brief: "export button does nothing on Safari; works on Chrome."'
+    assert decompose_task(task) == [task.strip()]
+
+
+def test_decompose_task_quoted_payload_curly_quotes_never_split():
+    task = "Summarize this feedback: “the app crashes and loses my data”"
+    assert decompose_task(task) == [task.strip()]
+
+
+def test_decompose_task_single_clause_stays_one_step():
+    task = "Build me a dashboard that shows my Stripe revenue"
+    assert decompose_task(task) == [task.strip()]
+
+
+def test_decompose_task_min_two_word_fragment_filter_drops_short_pieces():
+    # "cats" and "dogs" are single-word fragments after the split and must be
+    # dropped by the >=2-word filter, collapsing to the whole task instead.
+    parts = decompose_task("cats and dogs")
+    assert parts == ["cats and dogs"]
+
+
+def test_decompose_task_prose_comma_is_not_split():
+    task = "My React app re-renders too much, help me fix the performance"
+    assert decompose_task(task) == [task.strip()]
+
+
+def test_decompose_task_empty_string_returns_itself():
+    assert decompose_task("") == [""]
+
+
+# ---------------------------------------------------------------------------
+# generate_trace
+# ---------------------------------------------------------------------------
+
+
+def _make_ir(**overrides) -> IR:
+    defaults = dict(
+        language="en",
+        persona="assistant",
+        role="test role",
+        domain="software",
+        output_format="markdown",
+        length_hint="medium",
+    )
+    defaults.update(overrides)
+    return IR(**defaults)
+
+
+def test_generate_trace_minimal_ir_has_core_fields_only():
+    ir = _make_ir()
+    lines = generate_trace(ir)
+
+    assert "language=en" in lines
+    assert "persona=assistant" in lines
+    assert "domain=software" in lines
+    # No metadata was set, so optional sections must not appear.
+    assert not any(line.startswith("risk_flags=") for line in lines)
+    assert not any(line.startswith("domain_evidence:") for line in lines)
+    assert not any(line.startswith("entities=") for line in lines)
+
+
+def test_generate_trace_includes_metadata_driven_sections():
+    ir = _make_ir(domain="security", tools=["shell", "browser"])
+    ir.metadata = {
+        "heuristic_version": "v2.0",
+        "detected_domain_evidence": ["security:oauth", "security:jwt"],
+        "summary": True,
+        "summary_limit": 5,
+        "variant_count": 2,
+        "domain_confidence": 0.875,
+        "domain_scores": {"security": 3, "software": 1},
+        "risk_flags": ["destructive_operation"],
+        "ambiguous_terms": ["optimize", "fast"],
+        "clarify_questions": ["Which metric?"],
+        "code_request": True,
+        "pii_flags": ["email"],
+        "domain_candidates": ["security", "software"],
+        "entities": ["Kubernetes", "GPT-4"],
+        "complexity": "high",
+        "persona_evidence": {"scores": {"developer": 2, "mentor": 1}},
+        "ir_signature": "abc123",
+    }
+
+    lines = generate_trace(ir)
+
+    assert "heuristic_version=v2.0" in lines
+    assert "domain=security (2 evid)" in lines
+    assert "domain_evidence:security:oauth,security:jwt" in lines
+    assert "summary=True" in lines
+    assert "summary_limit=5" in lines
+    assert "variant_count=2" in lines
+    assert "domain_conf=0.88" in lines
+    assert "domain_scores=security:3,software:1" in lines
+    assert "tools=shell,browser" in lines
+    assert "risk_flags=destructive_operation" in lines
+    assert "ambiguous_terms=fast,optimize" in lines  # sorted alphabetically
+    assert "clarify_q_count=1" in lines
+    assert "code_request=True" in lines
+    assert "pii_flags=email" in lines
+    assert "domain_candidates=security,software" in lines
+    assert "entities=Kubernetes,GPT-4" in lines
+    assert "complexity=high" in lines
+    assert "persona_scores=developer:2,mentor:1" in lines
+    assert "ir_signature=abc123" in lines
+
+
+def test_generate_trace_single_domain_candidate_is_omitted():
+    ir = _make_ir()
+    ir.metadata = {"domain_candidates": ["software"]}
+    lines = generate_trace(ir)
+    assert not any(line.startswith("domain_candidates=") for line in lines)
+
+
+def test_generate_trace_is_deterministic_for_same_ir():
+    ir = _make_ir()
+    ir.metadata = {"domain_scores": {"b": 1, "a": 2}}
+    assert generate_trace(ir) == generate_trace(ir)
+
+
+# ---------------------------------------------------------------------------
+# optimize_ir
+# ---------------------------------------------------------------------------
+
+
+def test_optimize_ir_dedupes_goals_and_tasks_by_first_60_chars():
+    long_prefix = "a" * 60
+    ir = _make_ir(
+        domain="general",
+        goals=[long_prefix + " tail one", long_prefix + " tail two (different ending)"],
+        tasks=["short unique task one", "short unique task two"],
+    )
+    result = optimize_ir(ir)
+    # Both goals share the same first-60-chars key, so only the first survives.
+    assert result.goals == [long_prefix + " tail one"]
+    assert result.tasks == ["short unique task one", "short unique task two"]
+
+
+def test_optimize_ir_keeps_distinct_goals():
+    ir = _make_ir(domain="general", goals=["first distinct goal", "second distinct goal"])
+    result = optimize_ir(ir)
+    assert result.goals == ["first distinct goal", "second distinct goal"]
+
+
+def test_optimize_ir_injects_english_domain_baseline_for_coding():
+    ir = _make_ir(domain="coding", language="en", constraints=["Keep it concise."])
+    result = optimize_ir(ir)
+    assert any(
+        "type hints, docstrings" in c for c in result.constraints
+    ), result.constraints
+
+
+def test_optimize_ir_injects_turkish_domain_baseline_for_security():
+    ir = _make_ir(domain="security", language="tr", constraints=[])
+    result = optimize_ir(ir)
+    assert any("En az ayrıcalık ilkesini uygula" in c for c in result.constraints)
+
+
+def test_optimize_ir_does_not_duplicate_existing_baseline_constraint():
+    baseline = "Include type hints, docstrings, and handle edge cases defensively."
+    ir = _make_ir(domain="coding", language="en", constraints=[baseline])
+    result = optimize_ir(ir)
+    baseline_count = sum(1 for c in result.constraints if "type hints, docstrings" in c)
+    assert baseline_count == 1
+
+
+def test_optimize_ir_no_baseline_for_unknown_domain():
+    ir = _make_ir(domain="general", language="en", constraints=["Be concise."])
+    result = optimize_ir(ir)
+    assert result.constraints == ["Be concise."]
+
+
+def test_optimize_ir_marks_metadata_optimized():
+    ir = _make_ir(domain="general")
+    result = optimize_ir(ir)
+    assert result.metadata["optimized"] is True

--- a/tests/test_heuristics_extractors_new.py
+++ b/tests/test_heuristics_extractors_new.py
@@ -1,0 +1,285 @@
+"""Edge-case coverage for pure heuristics extractors/detectors in
+app/heuristics/__init__.py that had zero direct tests.
+
+Each function is exercised with: an empty string, a punctuation-only string,
+a normal case, and (where the underlying keyword table is bilingual) at
+least one English and one Turkish case.
+"""
+
+from app.heuristics import (
+    detect_code_request,
+    detect_conflicts,
+    detect_domain_candidates,
+    detect_length_hint,
+    estimate_complexity,
+    extract_entities,
+    extract_format,
+    extract_quantities,
+    extract_temporal_flags,
+    generate_clarify_questions,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_entities
+# ---------------------------------------------------------------------------
+
+
+def test_extract_entities_empty_string():
+    assert extract_entities("") == []
+
+
+def test_extract_entities_punctuation_only():
+    assert extract_entities("!!! ??? ...") == []
+
+
+def test_extract_entities_normal_case_captures_tech_tokens():
+    text = "We use Kubernetes and GPT-4 with ISO 27001 compliance and AWS"
+    entities = extract_entities(text)
+    assert "Kubernetes" in entities
+    assert "GPT-4" in entities
+    assert "AWS" in entities
+
+
+def test_extract_entities_caps_at_thirty_and_dedupes():
+    text = " ".join(f"Entity{i}" for i in range(40)) + " Entity0 Entity1"
+    entities = extract_entities(text)
+    assert len(entities) <= 30
+    assert len(entities) == len(set(entities))
+
+
+# ---------------------------------------------------------------------------
+# estimate_complexity
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_complexity_empty_string_is_low():
+    assert estimate_complexity("") == "low"
+
+
+def test_estimate_complexity_punctuation_only_is_low():
+    assert estimate_complexity("!!!") == "low"
+
+
+def test_estimate_complexity_long_unique_text_is_medium():
+    # >40 words and >30 unique tokens, no "vs"/compare/teach signal -> score 2.
+    long_text = " ".join(f"word{i}" for i in range(45))
+    assert estimate_complexity(long_text) == "medium"
+
+
+def test_estimate_complexity_long_with_compare_and_teach_is_high():
+    long_text = " ".join(f"word{i}" for i in range(45))
+    text = "please teach me and compare vs alternatives " + long_text
+    assert estimate_complexity(text) == "high"
+
+
+def test_estimate_complexity_short_text_is_low():
+    assert estimate_complexity("fix this bug") == "low"
+
+
+def test_estimate_complexity_turkish_teach_keyword_contributes():
+    # Short text, so only the "öğret" signal can fire -> still low overall,
+    # but must not raise and must return a valid bucket.
+    result = estimate_complexity("bunu bana öğret")
+    assert result in {"low", "medium", "high"}
+
+
+# ---------------------------------------------------------------------------
+# generate_clarify_questions
+# ---------------------------------------------------------------------------
+
+
+def test_generate_clarify_questions_empty_list():
+    assert generate_clarify_questions([]) == []
+
+
+def test_generate_clarify_questions_unknown_term_is_ignored():
+    assert generate_clarify_questions(["banana"]) == []
+
+
+def test_generate_clarify_questions_known_term_returns_its_question():
+    questions = generate_clarify_questions(["optimize"])
+    assert questions == [
+        "Which metric or aspect should be optimized? (performance, cost, memory?)"
+    ]
+
+
+def test_generate_clarify_questions_deduplicates_and_caps_at_five():
+    terms = ["optimize", "improve", "better", "efficient", "scalable", "fast", "robust"]
+    questions = generate_clarify_questions(terms)
+    assert len(questions) == 5
+    assert len(questions) == len(set(questions))
+
+
+# ---------------------------------------------------------------------------
+# extract_temporal_flags
+# ---------------------------------------------------------------------------
+
+
+def test_extract_temporal_flags_empty_string():
+    assert extract_temporal_flags("") == []
+
+
+def test_extract_temporal_flags_punctuation_only():
+    assert extract_temporal_flags("...") == []
+
+
+def test_extract_temporal_flags_english_mixed_signals():
+    text = "Let us meet today, also relevant for Q1 2025 and March 2024"
+    flags = extract_temporal_flags(text)
+    assert flags == ["2025", "2024", "Q1 2025", "march", "today"]
+
+
+def test_extract_temporal_flags_turkish_month():
+    flags = extract_temporal_flags("ocak ayında görüşelim")
+    assert "ocak" in flags
+
+
+# ---------------------------------------------------------------------------
+# extract_quantities
+# ---------------------------------------------------------------------------
+
+
+def test_extract_quantities_empty_string():
+    assert extract_quantities("") == []
+
+
+def test_extract_quantities_punctuation_only():
+    assert extract_quantities("...") == []
+
+
+def test_extract_quantities_normal_case():
+    text = "Handle 500 requests within 200ms for 100 users, budget 5gb"
+    quantities = extract_quantities(text)
+    assert {"value": "500", "unit": "requests"} in quantities
+    assert {"value": "200", "unit": "ms"} in quantities
+    assert {"value": "100", "unit": "users"} in quantities
+    assert {"value": "5", "unit": "gb"} in quantities
+
+
+def test_extract_quantities_range_pattern():
+    quantities = extract_quantities("latency should be 1500-3000 ms")
+    assert {"value": "1500-3000", "unit": "ms"} in quantities
+
+
+# ---------------------------------------------------------------------------
+# detect_code_request
+# ---------------------------------------------------------------------------
+
+
+def test_detect_code_request_empty_string_is_false():
+    assert detect_code_request("") is False
+
+
+def test_detect_code_request_punctuation_only_is_false():
+    assert detect_code_request("???") is False
+
+
+def test_detect_code_request_english_case():
+    assert detect_code_request("Write a python function to parse logs") is True
+
+
+def test_detect_code_request_turkish_case():
+    assert detect_code_request("örnek kod yazar mısın") is True
+
+
+def test_detect_code_request_no_keyword_is_false():
+    assert detect_code_request("What is the weather today") is False
+
+
+# ---------------------------------------------------------------------------
+# extract_format
+# ---------------------------------------------------------------------------
+
+
+def test_extract_format_empty_string_defaults_to_markdown():
+    assert extract_format("") == "markdown"
+
+
+def test_extract_format_punctuation_only_defaults_to_markdown():
+    assert extract_format("???") == "markdown"
+
+
+def test_extract_format_english_json():
+    assert extract_format("Return the result as JSON") == "json"
+
+
+def test_extract_format_turkish_table():
+    assert extract_format("Sonucu tablo olarak ver") == "table"
+
+
+def test_extract_format_no_keyword_defaults_to_markdown():
+    assert extract_format("Just answer normally") == "markdown"
+
+
+# ---------------------------------------------------------------------------
+# detect_length_hint
+# ---------------------------------------------------------------------------
+
+
+def test_detect_length_hint_empty_string_defaults_to_medium():
+    assert detect_length_hint("") == "medium"
+
+
+def test_detect_length_hint_punctuation_only_defaults_to_medium():
+    assert detect_length_hint("???") == "medium"
+
+
+def test_detect_length_hint_english_short():
+    assert detect_length_hint("Give me a short answer") == "short"
+
+
+def test_detect_length_hint_turkish_short():
+    assert detect_length_hint("kısa bir cevap ver") == "short"
+
+
+def test_detect_length_hint_english_long():
+    assert detect_length_hint("I want a comprehensive detailed long answer") == "long"
+
+
+def test_detect_length_hint_no_keyword_defaults_to_medium():
+    assert detect_length_hint("Just answer") == "medium"
+
+
+# ---------------------------------------------------------------------------
+# detect_conflicts
+# ---------------------------------------------------------------------------
+
+
+def test_detect_conflicts_empty_list():
+    assert detect_conflicts([]) == []
+
+
+def test_detect_conflicts_no_conflict():
+    assert detect_conflicts(["Be nice", "Be accurate"]) == []
+
+
+def test_detect_conflicts_english_length_vs_detail():
+    assert detect_conflicts(["very short", "high detail"]) == ["length_vs_detail"]
+
+
+def test_detect_conflicts_turkish_length_vs_detail():
+    assert detect_conflicts(["kısa", "detaylı"]) == ["length_vs_detail"]
+
+
+# ---------------------------------------------------------------------------
+# detect_domain_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_detect_domain_candidates_empty_evidence():
+    assert detect_domain_candidates([]) == []
+
+
+def test_detect_domain_candidates_single_domain():
+    assert detect_domain_candidates(["software:api"]) == ["software"]
+
+
+def test_detect_domain_candidates_multiple_domains_ranked_and_capped():
+    evidence = [
+        "software:api",
+        "software:react",
+        "security:oauth",
+        "finance:stock",
+    ]
+    assert detect_domain_candidates(evidence, top_k=2) == ["software", "finance"]

--- a/tests/test_prompt_diff_similarity.py
+++ b/tests/test_prompt_diff_similarity.py
@@ -1,0 +1,37 @@
+"""Coverage for PromptComparison.calculate_similarity, a thin wrapper around
+difflib.SequenceMatcher.ratio() * 100 that had no direct test.
+"""
+
+import pytest
+
+from app.prompt_diff import PromptComparison
+
+
+@pytest.fixture
+def comparator():
+    """PromptComparison instance without running __init__ (pure method under test)."""
+    return PromptComparison.__new__(PromptComparison)
+
+
+def test_calculate_similarity_identical_strings_is_100(comparator):
+    assert comparator.calculate_similarity("hello world", "hello world") == 100.0
+
+
+def test_calculate_similarity_both_empty_is_100(comparator):
+    assert comparator.calculate_similarity("", "") == 100.0
+
+
+def test_calculate_similarity_completely_different_strings_is_low(comparator):
+    score = comparator.calculate_similarity("hello world", "xyz completely different")
+    assert score == pytest.approx(22.857142857142858)
+    assert score < 50.0
+
+
+def test_calculate_similarity_one_empty_string_is_zero(comparator):
+    assert comparator.calculate_similarity("abc", "") == 0.0
+
+
+def test_calculate_similarity_partial_overlap_is_between_0_and_100(comparator):
+    score = comparator.calculate_similarity("The quick brown fox", "The quick red fox")
+    assert score == pytest.approx(83.33333333333334)
+    assert 0.0 < score < 100.0


### PR DESCRIPTION
## Summary
- Adds direct unit tests for `decompose_task`, `optimize_ir`, and `generate_trace` in `app/compiler.py` — the legacy v1 compile pipeline's post-processing trio, previously exercised only indirectly through end-to-end `compile_text` assertions and with no dedicated edge-case coverage of their own branches (quoted payloads, Oxford-list vs "and"/"then" splits, EN/TR domain-baseline injection, dedup-by-first-60-chars).
- Adds coverage for 10 previously zero-coverage pure heuristic extractors/detectors in `app/heuristics/__init__.py` (`extract_entities`, `estimate_complexity`, `generate_clarify_questions`, `extract_temporal_flags`, `extract_quantities`, `detect_code_request`, `extract_format`, `detect_length_hint`, `detect_conflicts`, `detect_domain_candidates`), each with empty/punctuation-only/normal-case and EN/TR variants where the underlying keyword tables are bilingual.
- Adds coverage for `PromptComparison.calculate_similarity` in `app/prompt_diff.py` (its sibling methods already had tests; this one didn't).

This is a test-only change produced by an automated test-coverage audit — no source, config, or CI files were modified.

## Test plan
- [x] `python -m pytest tests/ -q` — full suite: 1976 passed, 7 skipped (pre-existing, unrelated `@pytest.mark.live` skips), 0 failures
- [x] `git status` / `git diff --stat` confirm only 3 new test files were added, nothing else touched

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_013YyoKVsg7vzTXNvJfyma5q)_