### PR TITLE
docs: fix README install to use working GitHub pipx command

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ API keys are stored in VS Code secret storage, not workspace settings.
 
 ### CLI (pip / pipx)
 
-Install the command-line compiler from PyPI:
+Install the command-line compiler directly from GitHub:
 
 ```bash
-pipx install prcompiler        # recommended — isolated install
+pipx install git+https://github.com/madara88645/Compiler.git   # recommended — isolated install
 # or
-pip install prcompiler
+pip install git+https://github.com/madara88645/Compiler.git
 ```
 
 Then compile a prompt:
@@ -317,6 +317,14 @@ Then compile a prompt:
 promptc compile "write a haiku about the sea"
 promptc --version
 ```
+
+> **Once published on PyPI**, you will also be able to install with:
+>
+> ```bash
+> pipx install prcompiler        # recommended — isolated install
+> # or
+> pip install prcompiler
+> ```
 
 ### From source (development)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The README **Installation** section now leads with a GitHub-based install command that works today:

```bash
pipx install git+https://github.com/madara88645/Compiler.git
```

The old PyPI commands (`pipx install prcompiler` / `pip install prcompiler`) are moved into a short **“Once published on PyPI”** note, since the package is not on PyPI yet and those commands fail for every visitor.

From-source development instructions are unchanged. No publish workflows were modified.

## Verification

Locally verified:

- `pipx install git+https://github.com/madara88645/Compiler.git` — succeeds (prcompiler 2.0.46)
- `promptc --version` — prints `2.0.46`
- `promptc compile "test"` — runs and returns compile output

## Risk

Documentation-only change. No runtime or build impact.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cfecc72-d554-487c-93c3-05a3467b5cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cfecc72-d554-487c-93c3-05a3467b5cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

