### PR TITLE
docs: fix VS Code extension install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Every report also surfaces **risky areas**, a **test-coverage** signal, **branch
 
 **CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
 
+**CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
+
 ---
 
 ### Conservative Mode

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Every report also surfaces **risky areas**, a **test-coverage** signal, **branch
 
 **v1 is an offline, deterministic advisory.** It runs only on what you paste — no GitHub API, no AI calls, no sign-in — and never blocks a merge. Open it in the sidebar or at [`/pr-safety`](https://prcompiler.com/pr-safety); the [PR Safety guide](docs/pr-safety.md) has worked examples (docs-only, auth-risk, stale branch, split-needed), a `curl` recipe for `POST /pr-safety/report`, and an advisory [GitHub Action sketch](docs/pr-safety-github-action.md).
 
+**CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
+
 ---
 
 ### Conservative Mode
@@ -280,12 +282,23 @@ python -m cli.main github render --type pr-review-brief --from-file prompt.txt
 
 ### VS Code Extension
 
-The VS Code package lives in [`integrations/vscode-extension`](integrations/vscode-extension). Once the Marketplace publisher is claimed and the first `vscode-v*` tag is pushed, it installs from:
+The VS Code package lives in [`integrations/vscode-extension`](integrations/vscode-extension).
+
+Start the backend before using the extension (default API URL is `http://127.0.0.1:8080`):
+
+```bash
+python -m uvicorn api.main:app --reload --port 8080
+```
+
+**Install today:**
+
+- **From a `.vsix`** — download the `promptc-vscode-vsix` artifact from the latest [Publish VS Code Extension](https://github.com/madara88645/Compiler/actions/workflows/publish-vscode.yml) workflow run, then install via **Extensions: Install from VSIX...**
+- **From source** — see [Local development](integrations/vscode-extension/README.md#local-development) in the extension README (`F5` / Extension Development Host)
+
+**Once published** (after the Marketplace publisher is claimed and the first `vscode-v*` tag is pushed):
 
 - **VS Code Marketplace** — [`madara88645.promptc-vscode`](https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode)
 - **Open VSX** (VSCodium / Cursor) — [`madara88645/promptc-vscode`](https://open-vsx.org/extension/madara88645/promptc-vscode)
-
-Until then, install from source (see [the extension README](integrations/vscode-extension/README.md#local-development)) or the `.vsix` artifact on the `Publish VS Code Extension` workflow run.
 
 Features:
 

--- a/docs/pr-safety.md
+++ b/docs/pr-safety.md
@@ -42,6 +42,82 @@ No sign-in, no setup, nothing leaves your machine beyond the single analysis req
 
 ---
 
+## CLI (no server needed)
+
+The same offline analyzer ships as a CLI command — no backend, no network, no API key.
+After `pip install -e .`, use `promptc`; otherwise run `python -m cli.main` from the repo
+root.
+
+### Analyze the current branch from local git
+
+```bash
+promptc pr-safety --from-git
+```
+
+`--from-git` reads your **local** repository: changed files vs the resolved base ref
+(`origin/main`, `main`, …), commits behind base, and the latest commit subject/body as the
+PR title and description. Override the base with `--base` or freshness with
+`--commits-behind` when needed.
+
+### Pass files and metadata manually
+
+```bash
+# Positional file list
+promptc pr-safety --title "Add login endpoint" --description "Adds POST /auth/login" \
+  app/auth/login.py api/routes/auth.py
+
+# One path per line from a file
+promptc pr-safety --files-from changed.txt --title "Add login endpoint" \
+  --description "Adds POST /auth/login"
+
+# Pipe paths on stdin (non-TTY)
+git diff --name-only origin/main | promptc pr-safety --title "My PR" --description "…"
+```
+
+### Output formats
+
+```bash
+promptc pr-safety --from-git                      # human (default)
+promptc pr-safety --from-git --format json        # machine-readable
+promptc pr-safety --from-git --format md          # GitHub-ready Markdown
+promptc pr-safety --from-git --format md --out report.md
+```
+
+Use `--exit-code` in scripts: exits non-zero when the verdict is not `merge`.
+
+### Sample output (`--from-git`, human format)
+
+Captured from `python -m cli.main pr-safety --from-git` in this repo:
+
+```
+╭───────────────────────────────── PR Safety ──────────────────────────────────╮
+│ Verdict: HOLD — Address the flagged signals before merging                   │
+│ PR: Merge pull request #941 from                                             │
+│ madara88645/fix/hooks-example-shell-test-windows                             │
+│                                                                              │
+│ Signals: risky=ok  tests=ok  branch=ok  scope=mismatch                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+────────────────────────────── Changed files (0) ───────────────────────────────
+No files provided.
+─────────────────────────── Risky areas (status: ok) ───────────────────────────
+No risky areas detected
+────────────────────────── Test coverage (status: ok) ──────────────────────────
+No missing test coverage detected for changed source files
+──────────────────────── Branch freshness (status: ok) ─────────────────────────
+  Branch is 0 commits behind the base branch
+──────────────────────── Scope match (status: mismatch) ────────────────────────
+  No changed files were provided
+─────────────────────────────── Recommendations ────────────────────────────────
+  - Hold merge until the flagged safety signals are addressed
+  - No changed files were provided
+```
+
+The same run with `--format json` returns a structured payload (`verdict`, `changed_files`,
+`risky_areas`, `test_coverage`, `branch_freshness`, `scope_match`, `recommendations`) suitable
+for CI or jq pipelines.
+
+---
+
 ## Use it from the API
 
 The browser page is a thin client over one endpoint: `POST /pr-safety/report`.

--- a/integrations/vscode-extension/README.md
+++ b/integrations/vscode-extension/README.md
@@ -10,9 +10,21 @@ Compile selected text or full files into structured prompts with policy visibili
 
 ## Install
 
-- **VS Code / VS Code Insiders** - search `PromptC` in the Extensions view, or install from the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode).
-- **VSCodium / Cursor / others** - install from [Open VSX](https://open-vsx.org/extension/madara88645/promptc-vscode).
-- **From a `.vsix`** - download the artifact attached to the latest `Publish VS Code Extension` workflow run on GitHub, then install it from the VS Code Extensions menu.
+Start the backend from the repo root before using PromptC (default API URL is `http://127.0.0.1:8080`):
+
+```bash
+python -m uvicorn api.main:app --reload --port 8080
+```
+
+- **From a `.vsix`** — download the `promptc-vscode-vsix` artifact from the latest [Publish VS Code Extension](https://github.com/madara88645/Compiler/actions/workflows/publish-vscode.yml) workflow run, then in VS Code choose **Extensions: Install from VSIX...**
+- **From source** — see [Local development](#local-development) below (`F5` / Extension Development Host)
+
+### Once published
+
+After publisher setup in [PUBLISHING.md](PUBLISHING.md) completes and a `vscode-v*` tag is pushed:
+
+- **VS Code / VS Code Insiders** — search `PromptC` in the Extensions view, or install from the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode)
+- **VSCodium / Cursor / others** — install from [Open VSX](https://open-vsx.org/extension/madara88645/promptc-vscode)
 
 ## Local development
 


### PR DESCRIPTION
## Summary
- Reorder VS Code extension install docs in both `integrations/vscode-extension/README.md` and the root `README.md` so working paths come first: `.vsix` from the Publish VS Code Extension workflow, then from-source (`F5` / dev host).
- Move Marketplace and Open VSX links under a "once published" note since the extension is not yet live (no `vscode-v*` tag).
- Add the required local backend startup command (`python -m uvicorn api.main:app --reload --port 8080`) before using the extension.

## Test plan
- [x] Docs-only change — no code or package.json changes
- [ ] Verify install section order and backend note read clearly in both READMEs
- [ ] Confirm workflow link resolves to Publish VS Code Extension GitHub Actions page

Made with [Cursor](https://cursor.com)