### PR TITLE
docs: document offline PR Safety CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Every report also surfaces **risky areas**, a **test-coverage** signal, **branch
 
 **v1 is an offline, deterministic advisory.** It runs only on what you paste — no GitHub API, no AI calls, no sign-in — and never blocks a merge. Open it in the sidebar or at [`/pr-safety`](https://prcompiler.com/pr-safety); the [PR Safety guide](docs/pr-safety.md) has worked examples (docs-only, auth-risk, stale branch, split-needed), a `curl` recipe for `POST /pr-safety/report`, and an advisory [GitHub Action sketch](docs/pr-safety-github-action.md).
 
+**CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
+
 ---
 
 ### Conservative Mode

--- a/docs/pr-safety.md
+++ b/docs/pr-safety.md
@@ -42,6 +42,82 @@ No sign-in, no setup, nothing leaves your machine beyond the single analysis req
 
 ---
 
+## CLI (no server needed)
+
+The same offline analyzer ships as a CLI command — no backend, no network, no API key.
+After `pip install -e .`, use `promptc`; otherwise run `python -m cli.main` from the repo
+root.
+
+### Analyze the current branch from local git
+
+```bash
+promptc pr-safety --from-git
+```
+
+`--from-git` reads your **local** repository: changed files vs the resolved base ref
+(`origin/main`, `main`, …), commits behind base, and the latest commit subject/body as the
+PR title and description. Override the base with `--base` or freshness with
+`--commits-behind` when needed.
+
+### Pass files and metadata manually
+
+```bash
+# Positional file list
+promptc pr-safety --title "Add login endpoint" --description "Adds POST /auth/login" \
+  app/auth/login.py api/routes/auth.py
+
+# One path per line from a file
+promptc pr-safety --files-from changed.txt --title "Add login endpoint" \
+  --description "Adds POST /auth/login"
+
+# Pipe paths on stdin (non-TTY)
+git diff --name-only origin/main | promptc pr-safety --title "My PR" --description "…"
+```
+
+### Output formats
+
+```bash
+promptc pr-safety --from-git                      # human (default)
+promptc pr-safety --from-git --format json        # machine-readable
+promptc pr-safety --from-git --format md          # GitHub-ready Markdown
+promptc pr-safety --from-git --format md --out report.md
+```
+
+Use `--exit-code` in scripts: exits non-zero when the verdict is not `merge`.
+
+### Sample output (`--from-git`, human format)
+
+Captured from `python -m cli.main pr-safety --from-git` in this repo:
+
+```
+╭───────────────────────────────── PR Safety ──────────────────────────────────╮
+│ Verdict: HOLD — Address the flagged signals before merging                   │
+│ PR: Merge pull request #941 from                                             │
+│ madara88645/fix/hooks-example-shell-test-windows                             │
+│                                                                              │
+│ Signals: risky=ok  tests=ok  branch=ok  scope=mismatch                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+────────────────────────────── Changed files (0) ───────────────────────────────
+No files provided.
+─────────────────────────── Risky areas (status: ok) ───────────────────────────
+No risky areas detected
+────────────────────────── Test coverage (status: ok) ──────────────────────────
+No missing test coverage detected for changed source files
+──────────────────────── Branch freshness (status: ok) ─────────────────────────
+  Branch is 0 commits behind the base branch
+──────────────────────── Scope match (status: mismatch) ────────────────────────
+  No changed files were provided
+─────────────────────────────── Recommendations ────────────────────────────────
+  - Hold merge until the flagged safety signals are addressed
+  - No changed files were provided
+```
+
+The same run with `--format json` returns a structured payload (`verdict`, `changed_files`,
+`risky_areas`, `test_coverage`, `branch_freshness`, `scope_match`, `recommendations`) suitable
+for CI or jq pipelines.
+
+---
+
 ## Use it from the API
 
 The browser page is a thin client over one endpoint: `POST /pr-safety/report`.


### PR DESCRIPTION
## Summary

- Add a **CLI (no server needed)** section to `docs/pr-safety.md` above the API curl recipe, covering `promptc pr-safety --from-git`, manual `--files-from` / positional inputs, `--format human|json|md`, `--exit-code`, and real sample output from a local run.
- Add a one-line CLI mention and link in the README PR Safety section so the zero-server path is visible next to the web UI and API docs.

## Test plan

- [x] Ran `python -m cli.main pr-safety --from-git` to capture sample output
- [x] Docs-only change — no code or tests affected
- [ ] Review rendered markdown on GitHub


Made with [Cursor](https://cursor.com)