### PR TITLE
docs(mcp): align MCP README with port 8080 and Claude Code setup

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "prompt-compiler": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["${CLAUDE_PROJECT_DIR}/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}

--- a/integrations/mcp-server/README.md
+++ b/integrations/mcp-server/README.md
@@ -1,78 +1,158 @@
-# myCompiler MCP Server
+# Prompt Compiler MCP Server
 
-This directory contains a Model Context Protocol (MCP) server integration for `myCompiler`.
-It exposes Prompt Compiler tools to MCP clients such as Claude Code, Claude Desktop, and Cursor.
+Model Context Protocol (MCP) bridge that exposes Prompt Compiler tools to Claude Code, Claude Desktop, Cursor, and other MCP clients.
 
-## Setup
+**The Prompt Compiler HTTP backend must be running before you use these tools.** Local development uses port **8080** (same as the web app and VS Code extension).
 
-1.  **Install Dependencies**:
-    ```bash
-    pip install -r requirements.txt
-    ```
+## Prerequisites
 
-2.  **Start the API Server**:
-    Ensure the main `myCompiler` API is running:
-    ```bash
-    # From project root
-    uvicorn api.main:app --port 8000
-    ```
+### 1. Start the backend (required)
+
+From the repository root:
+
+```bash
+python -m uvicorn api.main:app --reload --port 8080
+```
+
+Verify it is up:
+
+```bash
+curl http://127.0.0.1:8080/health
+```
+
+### 2. Install MCP server dependencies
+
+```bash
+cd integrations/mcp-server
+pip install -r requirements.txt
+```
 
 ## Configuration
 
-Environment variables (optional; align with the Chrome extension’s `/compile` request):
+Environment variables (optional; align with the Chrome extension `/compile` request):
 
 | Variable | Purpose |
 |----------|---------|
-| `PROMPTC_BACKEND_URL` | API origin (default `http://localhost:8000`); the tool posts to `{origin}/compile`. |
+| `PROMPTC_BACKEND_URL` | API origin (default `http://localhost:8080`); tools call `{origin}/compile` and related routes. |
 | `PROMPTC_API_URL` | Full compile URL if set (overrides backend + `/compile`). |
 | `PROMPTC_API_KEY` | Sent as `x-api-key` when the API requires optional key verification. |
 | `PROMPTC_PROMPT_MODE` | `conservative` (default) or `default`; sent as `X-Prompt-Mode` and in the JSON body `mode`. |
 
-The request body matches the extension: `v2`, `render_v2_prompts`, `diagnostics`, and `mode`.
+The compile request body matches the browser extension: `v2`, `render_v2_prompts`, `diagnostics`, and `mode`.
 
-### Claude Desktop
+## Claude Code
 
-Add the following to your `claude_desktop_config.json` (usually in `%APPDATA%\Claude\` on Windows or `~/Library/Application Support/Claude/` on macOS):
+### One-line setup (`claude mcp add`)
+
+Run from the repository root (replace the path if your clone lives elsewhere):
+
+```bash
+claude mcp add --scope project \
+  --env PROMPTC_BACKEND_URL=http://127.0.0.1:8080 \
+  prompt-compiler -- \
+  python integrations/mcp-server/server.py
+```
+
+Inside a Claude Code session, run `/mcp` to confirm `prompt-compiler` is connected.
+
+### Project `.mcp.json` (macOS / Linux)
+
+Check this file into your project root so teammates get the same server. Paths use `${CLAUDE_PROJECT_DIR}` so they work on any machine:
 
 ```json
 {
   "mcpServers": {
-    "myCompiler": {
+    "prompt-compiler": {
+      "type": "stdio",
       "command": "python",
-      "args": [
-        "C:\\Users\\User\\Desktop\\myCompiler\\integrations\\mcp-server\\server.py"
-      ]
+      "args": ["${CLAUDE_PROJECT_DIR}/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
     }
   }
 }
 ```
 
-> **Note**: Verify the path to `server.py`.
+A copy-paste template also lives at [`.mcp.json.example`](../../.mcp.json.example) in the repo root.
 
-### Cursor
+### Windows `.mcp.json`
 
-1.  Go to **Settings > Features > MCP**.
-2.  Click **Add New MCP Server**.
-3.  **Name**: `myCompiler`
-4.  **Type**: `stdio`
-5.  **Command**: `python C:\Users\User\Desktop\myCompiler\integrations\mcp-server\server.py`
+Use forward slashes or escaped backslashes in `args`:
 
-## Exposed Tools
+```json
+{
+  "mcpServers": {
+    "prompt-compiler": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["${CLAUDE_PROJECT_DIR}/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}
+```
 
-- `optimize_prompt(text)` — returns the compiled prompt string
-- `compile_prompt(text)` — returns the full `/compile` payload
-- `generate_agent(description, multi_agent=false)` — returns generated agent markdown
-- `generate_skill(description)` — returns generated skill markdown
-- `export_claude_pack(system_prompt)` — returns a Claude Code project-pack manifest
-- `benchmark_prompt(text, model?)` — returns the benchmark comparison payload
+## Claude Desktop
+
+Add to `claude_desktop_config.json` (`~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows):
+
+```json
+{
+  "mcpServers": {
+    "prompt-compiler": {
+      "command": "python",
+      "args": ["/absolute/path/to/Compiler/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/Compiler` with your clone path.
+
+## Cursor
+
+1. Open **Settings → Features → MCP**.
+2. Click **Add New MCP Server**.
+3. **Name**: `prompt-compiler`
+4. **Type**: `stdio`
+5. **Command**: `python /absolute/path/to/Compiler/integrations/mcp-server/server.py`
+6. **Environment**: `PROMPTC_BACKEND_URL=http://127.0.0.1:8080`
+
+## Exposed tools
+
+| Tool | Description |
+|------|-------------|
+| `optimize_prompt(text)` | Returns the compiled prompt string |
+| `compile_prompt(text)` | Returns the full `/compile` payload |
+| `generate_agent(description, multi_agent=false)` | Returns generated agent markdown |
+| `generate_skill(description)` | Returns generated skill markdown |
+| `export_claude_pack(system_prompt)` | Returns a Claude Code project-pack manifest |
+| `benchmark_prompt(text, model?)` | Returns the benchmark comparison payload |
+| `plan_agent_pack(pack_type, goal?, risk_mode?, path?)` | Previews a repo-aware agent pack (no writes) |
+| `apply_agent_pack(pack_type, goal?, risk_mode?, path?, overwrite?)` | Writes a repo-aware agent pack to disk |
 
 ## Usage
 
-Once configured, you can ask Claude or Cursor:
-> "Optimize this prompt for me: 'write a snake game in python'"
+Once configured, ask your MCP client:
+
+> "Optimize this prompt for me: write a snake game in python"
 
 Or:
 
 > "Generate an agent for reviewing React performance and export it as a Claude project pack."
 
-The MCP server will call the corresponding Prompt Compiler backend route and return the result in the same session.
+The MCP server calls the Prompt Compiler backend on port 8080 and returns the result in the same session.
+
+## Tests
+
+From the repository root:
+
+```bash
+python -m pytest integrations/mcp-server/ -q
+```

--- a/integrations/mcp-server/compile_settings.py
+++ b/integrations/mcp-server/compile_settings.py
@@ -10,13 +10,13 @@ def resolve_compile_post_url() -> str:
     """
     Full URL for POST /compile.
 
-    PROMPTC_API_URL: full URL including path (legacy; e.g. http://localhost:8000/compile).
+    PROMPTC_API_URL: full URL including path (legacy; e.g. http://localhost:8080/compile).
     PROMPTC_BACKEND_URL: origin only; /compile is appended.
     """
     explicit = os.environ.get("PROMPTC_API_URL", "").strip()
     if explicit:
         return explicit.rstrip("/")
-    backend = os.environ.get("PROMPTC_BACKEND_URL", "http://localhost:8000").strip().rstrip("/")
+    backend = os.environ.get("PROMPTC_BACKEND_URL", "http://localhost:8080").strip().rstrip("/")
     return f"{backend}/compile"
 
 

--- a/integrations/mcp-server/test_compile_settings.py
+++ b/integrations/mcp-server/test_compile_settings.py
@@ -12,7 +12,7 @@ from compile_settings import (
 def test_resolve_compile_post_url_prefers_full_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PROMPTC_API_URL", raising=False)
     monkeypatch.delenv("PROMPTC_BACKEND_URL", raising=False)
-    assert resolve_compile_post_url() == "http://localhost:8000/compile"
+    assert resolve_compile_post_url() == "http://localhost:8080/compile"
 
     monkeypatch.setenv("PROMPTC_API_URL", "https://api.example/compile/")
     assert resolve_compile_post_url() == "https://api.example/compile"


### PR DESCRIPTION
## Summary
- Rewrites `integrations/mcp-server/README.md` with the correct **Prompt Compiler** product name and states up front that the HTTP backend must run on port **8080**
- Adds copy-paste `claude mcp add` setup, project `.mcp.json` examples (macOS/Linux first), and Claude Desktop / Cursor config with `PROMPTC_BACKEND_URL=http://127.0.0.1:8080`
- Adds repo-root `.mcp.json.example` template
- Changes default `PROMPTC_BACKEND_URL` in `compile_settings.py` from 8000 → 8080 and updates `test_compile_settings.py`

## Test plan
- [x] `python -m pytest integrations/mcp-server/ -q` — 19 passed


Made with [Cursor](https://cursor.com)