### PR TITLE
fix: make GitHub artifact workflow portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ docs/           Product, pattern, and workflow docs
 - [`docs/pr-safety-github-action.md`](docs/pr-safety-github-action.md) — advisory CI integration sketch
 - [`docs/pattern-library.md`](docs/pattern-library.md)
 - [`docs/promptc-safe-workflows.md`](docs/promptc-safe-workflows.md)
-- [`examples/github/promptc-artifact.yml`](examples/github/promptc-artifact.yml)
+- [`examples/github/promptc-artifact.yml`](examples/github/promptc-artifact.yml) — portable GitHub Action example (`pip install` from GitHub + `promptc github render`; works in any repo)
 
 ---
 

--- a/examples/github/promptc-artifact.yml
+++ b/examples/github/promptc-artifact.yml
@@ -1,12 +1,20 @@
 name: PromptC Artifact Example
 
+# Portable workflow: install Prompt Compiler from GitHub and render a
+# GitHub-friendly artifact from any text file in your repo.
+# Copy to .github/workflows/ in your project and adjust inputs as needed.
+
 on:
   workflow_dispatch:
     inputs:
       artifact_type:
-        description: Artifact type
+        description: Artifact type (issue-brief, implementation-checklist, pr-review-brief)
         required: true
         default: pr-review-brief
+      source_file:
+        description: Path to the source text file (relative to repo root)
+        required: true
+        default: .github/PULL_REQUEST_TEMPLATE.md
 
 jobs:
   compile-artifact:
@@ -18,14 +26,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Install Prompt Compiler
+        run: pip install "git+https://github.com/madara88645/Compiler.git"
 
       - name: Render PromptC artifact
         run: |
-          python -m cli.main github render \
+          promptc github render \
             --type "${{ github.event.inputs.artifact_type }}" \
-            --from-file .github/PULL_REQUEST_TEMPLATE.md \
+            --from-file "${{ github.event.inputs.source_file }}" \
             > promptc-artifact.md
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

- Rewrites `examples/github/promptc-artifact.yml` to install Prompt Compiler via `pip install git+https://github.com/madara88645/Compiler.git` instead of checking out and using `requirements.txt` from this repo.
- Invokes the `promptc` console script (`promptc github render`) so the workflow works in any repository.
- Adds a `source_file` workflow input (default `.github/PULL_REQUEST_TEMPLATE.md`) instead of hardcoding the path.
- Updates the README Docs bullet to describe the portable pattern.

## Test plan

- [x] Fresh Python 3.12 venv: `pip install git+https://github.com/madara88645/Compiler.git`
- [x] `promptc github render --help` shows `pr-review-brief` artifact type
- [ ] Copy workflow to a sample repo and run `workflow_dispatch` manually


Made with [Cursor](https://cursor.com)