### PR TITLE
feat: add sidebar outbound links to repo integrations

### DIFF
--- a/web/app/components/Sidebar.test.tsx
+++ b/web/app/components/Sidebar.test.tsx
@@ -27,4 +27,25 @@ describe("Sidebar", () => {
     expect(link.getAttribute("href")).toBe("/agent-packs");
     expect(link.getAttribute("aria-current")).toBe("page");
   });
+
+  test("renders outbound links for repo, CLI, VS Code, and MCP", () => {
+    render(<Sidebar />);
+
+    expect(screen.getByLabelText("GitHub repo").getAttribute("href")).toBe(
+      "https://github.com/madara88645/Compiler",
+    );
+    expect(screen.getByLabelText("CLI install").getAttribute("href")).toContain("docs/cli.md");
+    expect(screen.getByLabelText("VS Code extension").getAttribute("href")).toContain(
+      "madara88645.promptc-vscode",
+    );
+    expect(screen.getByLabelText("MCP setup").getAttribute("href")).toContain(
+      "integrations/mcp-server/README.md",
+    );
+
+    for (const label of ["GitHub repo", "CLI install", "VS Code extension", "MCP setup"]) {
+      const external = screen.getByLabelText(label);
+      expect(external.getAttribute("target")).toBe("_blank");
+      expect(external.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
 });

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -2,7 +2,21 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Code2, Sparkles, WifiOff, Swords, Bot, Zap, FolderArchive, ShieldCheck, type LucideIcon } from "lucide-react";
+import {
+    Code2,
+    Sparkles,
+    WifiOff,
+    Swords,
+    Bot,
+    Zap,
+    FolderArchive,
+    ShieldCheck,
+    Github,
+    Terminal,
+    Blocks,
+    Plug,
+    type LucideIcon,
+} from "lucide-react";
 
 const navItems: { name: string; path: string; Icon: LucideIcon }[] = [
     { name: "Compiler",          path: "/",                 Icon: Code2    },
@@ -13,6 +27,29 @@ const navItems: { name: string; path: string; Icon: LucideIcon }[] = [
     { name: "Agent Packs",       path: "/agent-packs",      Icon: FolderArchive },
     { name: "Agent Generator",   path: "/agent-generator",  Icon: Bot      },
     { name: "Skills Generator",  path: "/skills-generator", Icon: Zap      },
+];
+
+const outboundLinks: { name: string; href: string; Icon: LucideIcon }[] = [
+    {
+        name: "GitHub repo",
+        href: "https://github.com/madara88645/Compiler",
+        Icon: Github,
+    },
+    {
+        name: "CLI install",
+        href: "https://github.com/madara88645/Compiler/blob/main/docs/cli.md",
+        Icon: Terminal,
+    },
+    {
+        name: "VS Code extension",
+        href: "https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode",
+        Icon: Blocks,
+    },
+    {
+        name: "MCP setup",
+        href: "https://github.com/madara88645/Compiler/blob/main/integrations/mcp-server/README.md",
+        Icon: Plug,
+    },
 ];
 
 const accentBarMap: Record<string, string> = {
@@ -46,6 +83,7 @@ export default function Sidebar() {
                 P
             </div>
 
+            <nav className="flex flex-col items-center gap-6 flex-1" aria-label="Main">
             {navItems.map((item) => {
                 const isActive = pathname === item.path;
                 const accentBar = accentBarMap[item.path] ?? "bg-blue-500";
@@ -76,6 +114,29 @@ export default function Sidebar() {
                     </Link>
                 );
             })}
+            </nav>
+
+            <div
+                className="flex flex-col items-center gap-3 border-t border-white/5 pt-4 w-full"
+                aria-label="Use it in your editor or repo"
+            >
+                {outboundLinks.map((item) => (
+                    <a
+                        key={item.href}
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-300 relative group text-zinc-500 hover:text-white hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        aria-label={item.name}
+                    >
+                        <item.Icon size={18} strokeWidth={1.75} aria-hidden="true" />
+
+                        <div className="absolute left-14 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                            {item.name}
+                        </div>
+                    </a>
+                ))}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

- Adds a compact "Use it in your editor or repo" section at the bottom of the sidebar with four external links: GitHub repo, CLI reference (`docs/cli.md`), VS Code extension marketplace, and MCP setup guide.
- Matches existing icon + tooltip styling; links open in a new tab with `noopener noreferrer`.
- Extends `Sidebar.test.tsx` to assert outbound link targets and security attributes.

## Test plan

- [x] `cd web && npm run test` (170 tests passed)
- [x] `cd web && npm run build` (Next.js build succeeded)
- [ ] Manually verify sidebar footer links in the browser

## Notes

- CLI link targets `docs/cli.md` on `main` (added in PR #954). Merge that PR first or the link 404s until `docs/cli.md` lands on `main`.


Made with [Cursor](https://cursor.com)