### PR TITLE
feat(web): group sidebar into labeled sections

### DIFF
--- a/web/app/components/Sidebar.test.tsx
+++ b/web/app/components/Sidebar.test.tsx
@@ -27,4 +27,52 @@ describe("Sidebar", () => {
     expect(link.getAttribute("href")).toBe("/agent-packs");
     expect(link.getAttribute("aria-current")).toBe("page");
   });
+
+  test("renders a visible text label under every icon", () => {
+    render(<Sidebar />);
+
+    const labels = [
+      "Compiler",
+      "Optimizer",
+      "Offline",
+      "Benchmark",
+      "PR Safety",
+      "Agent Packs",
+      "Agent Generator",
+      "Skills Generator",
+    ];
+
+    for (const label of labels) {
+      // getByLabelText matches the link's aria-label; getAllByText also
+      // matches the visible <span> rendered under the icon.
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("groups nav items into labeled sections with separators between them", () => {
+    render(<Sidebar />);
+
+    const groups = screen.getAllByRole("group");
+    const groupLabels = groups.map((group) => group.getAttribute("aria-label"));
+
+    expect(groupLabels).toEqual([
+      "Compile",
+      "Prove",
+      "Ship agent assets",
+      "Repo checks",
+    ]);
+
+    // One separator between each pair of groups.
+    const separators = screen.getAllByRole("separator");
+    expect(separators).toHaveLength(groups.length - 1);
+  });
+
+  test("keeps Compiler as the first item in the primary Compile group", () => {
+    render(<Sidebar />);
+
+    const compileGroup = screen.getByRole("group", { name: "Compile" });
+    const firstLink = compileGroup.querySelector("a");
+    expect(firstLink?.getAttribute("aria-label")).toBe("Compiler");
+    expect(firstLink?.getAttribute("href")).toBe("/");
+  });
 });

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -4,15 +4,39 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Code2, Sparkles, WifiOff, Swords, Bot, Zap, FolderArchive, ShieldCheck, type LucideIcon } from "lucide-react";
 
-const navItems: { name: string; path: string; Icon: LucideIcon }[] = [
-    { name: "Compiler",          path: "/",                 Icon: Code2    },
-    { name: "Optimizer",         path: "/optimizer",        Icon: Sparkles },
-    { name: "Offline",           path: "/offline",          Icon: WifiOff  },
-    { name: "Benchmark",         path: "/benchmark",        Icon: Swords   },
-    { name: "PR Safety",         path: "/pr-safety",        Icon: ShieldCheck },
-    { name: "Agent Packs",       path: "/agent-packs",      Icon: FolderArchive },
-    { name: "Agent Generator",   path: "/agent-generator",  Icon: Bot      },
-    { name: "Skills Generator",  path: "/skills-generator", Icon: Zap      },
+type NavItem = { name: string; path: string; Icon: LucideIcon };
+type NavGroup = { label: string; items: NavItem[] };
+
+// Compiler is intentionally first: it is the primary, always-on entry point.
+const navGroups: NavGroup[] = [
+    {
+        label: "Compile",
+        items: [
+            { name: "Compiler",  path: "/",         Icon: Code2    },
+            { name: "Optimizer", path: "/optimizer", Icon: Sparkles },
+            { name: "Offline",   path: "/offline",   Icon: WifiOff  },
+        ],
+    },
+    {
+        label: "Prove",
+        items: [
+            { name: "Benchmark", path: "/benchmark", Icon: Swords },
+        ],
+    },
+    {
+        label: "Ship agent assets",
+        items: [
+            { name: "Agent Packs",      path: "/agent-packs",      Icon: FolderArchive },
+            { name: "Agent Generator",  path: "/agent-generator",  Icon: Bot           },
+            { name: "Skills Generator", path: "/skills-generator", Icon: Zap           },
+        ],
+    },
+    {
+        label: "Repo checks",
+        items: [
+            { name: "PR Safety", path: "/pr-safety", Icon: ShieldCheck },
+        ],
+    },
 ];
 
 const accentBarMap: Record<string, string> = {
@@ -41,41 +65,66 @@ export default function Sidebar() {
     const pathname = usePathname();
 
     return (
-        <div className="w-16 md:w-20 h-screen bg-black/20 border-r border-white/5 flex flex-col items-center py-6 gap-6 backdrop-blur-md z-50">
-            <div className="h-10 w-10 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center font-bold text-white shadow-lg shadow-blue-500/20 mb-4">
+        <div className="w-16 md:w-24 h-screen bg-black/20 border-r border-white/5 flex flex-col items-center py-6 gap-1 backdrop-blur-md z-50 overflow-y-auto">
+            <div className="h-10 w-10 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center font-bold text-white shadow-lg shadow-blue-500/20 mb-4 shrink-0">
                 P
             </div>
 
-            {navItems.map((item) => {
-                const isActive = pathname === item.path;
-                const accentBar = accentBarMap[item.path] ?? "bg-blue-500";
-                const accentRing = accentRingMap[item.path] ?? "ring-white/20";
+            {navGroups.map((group, groupIndex) => (
+                <div key={group.label} className="w-full flex flex-col items-center">
+                    {groupIndex > 0 && (
+                        <div
+                            role="separator"
+                            aria-orientation="horizontal"
+                            className="w-8 h-px bg-white/10 my-3 shrink-0"
+                        />
+                    )}
 
-                return (
-                    <Link
-                        key={item.path}
-                        href={item.path}
-                        className={`w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-300 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
-                            isActive
-                                ? `bg-white/[0.08] text-white shadow-lg shadow-white/5 ring-1 ${accentRing}`
-                                : "text-zinc-500 hover:text-white hover:bg-white/5"
-                        }`}
-                        aria-label={item.name}
-                        aria-current={isActive ? "page" : undefined}
+                    <div
+                        role="group"
+                        aria-label={group.label}
+                        className="flex flex-col items-center gap-2 w-full"
                     >
-                        <item.Icon size={20} strokeWidth={1.75} aria-hidden="true" />
+                        {group.items.map((item) => {
+                            const isActive = pathname === item.path;
+                            const accentBar = accentBarMap[item.path] ?? "bg-blue-500";
+                            const accentRing = accentRingMap[item.path] ?? "ring-white/20";
 
-                        {isActive && (
-                            <div className={`animate-slide-in absolute left-[-2px] top-2 bottom-2 w-1 ${accentBar} rounded-full`} />
-                        )}
+                            return (
+                                <Link
+                                    key={item.path}
+                                    href={item.path}
+                                    className={`w-12 md:w-16 py-2 rounded-xl flex flex-col items-center justify-center gap-1 transition-all duration-300 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                                        isActive
+                                            ? `bg-white/[0.08] text-white shadow-lg shadow-white/5 ring-1 ${accentRing}`
+                                            : "text-zinc-500 hover:text-white hover:bg-white/5"
+                                    }`}
+                                    aria-label={item.name}
+                                    aria-current={isActive ? "page" : undefined}
+                                >
+                                    <item.Icon size={20} strokeWidth={1.75} aria-hidden="true" />
 
-                        {/* Tooltip */}
-                        <div className="absolute left-14 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
-                            {item.name}
-                        </div>
-                    </Link>
-                );
-            })}
+                                    <span
+                                        className="hidden md:block text-[9px] leading-none font-medium tracking-tight text-center truncate max-w-full"
+                                        aria-hidden="true"
+                                    >
+                                        {item.name}
+                                    </span>
+
+                                    {isActive && (
+                                        <div className={`animate-slide-in absolute left-[-2px] top-2 bottom-2 w-1 ${accentBar} rounded-full`} />
+                                    )}
+
+                                    {/* Tooltip */}
+                                    <div className="absolute left-full ml-2 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                                        {item.name}
+                                    </div>
+                                </Link>
+                            );
+                        })}
+                    </div>
+                </div>
+            ))}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Restructure the sidebar's flat icon rail into labeled groups — Compile (Compiler, Optimizer, Offline), Prove (Benchmark), Ship agent assets (Agent Packs, Agent Generator, Skills Generator), Repo checks (PR Safety) — separated by thin dividers, with Compiler kept first/primary as the always-on entry point.
- Add a small (9px) always-visible text label under each icon on md+ screens so navigation isn't tooltip-only; hover tooltips were the sole way to see item names, which is useless on touch/mobile.
- Widen the rail slightly on md+ (`w-20` → `w-24`) to fit icon + label without crowding; mobile width is unchanged.
- Preserve existing tooltips, `aria-label`/`aria-current` attributes, and the active-accent bar/ring color maps — this is a layout/grouping change only, not a redesign of icons or colors.

## Test plan
- [x] `cd web && npm run test` — 32 test files / 172 tests pass, including updated `Sidebar.test.tsx` (visible labels, group `role="group"` + `aria-label` structure, separator count, Compiler-first-in-Compile-group)
- [x] `cd web && npm run build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)