### PR TITLE
fix(web): unify optimizer naming to Token Optimizer

### DIFF
--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -63,7 +63,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("Original estimate")).toBeTruthy();
     expect(screen.getByText("Optimized estimate")).toBeTruthy();
@@ -114,7 +114,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Write a clear implementation plan." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("EN")).toBeTruthy();
     expect(screen.queryByText("English compact suggestion")).toBeNull();
@@ -136,7 +136,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Write a clear implementation plan." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("UNKNOWN")).toBeTruthy();
     expect(screen.queryByText("English compact suggestion")).toBeNull();
@@ -169,7 +169,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Bu PDF'i ozetle ve plan yaz." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("TR")).toBeTruthy();
     expect(screen.queryByText("English compact suggestion")).toBeNull();
@@ -202,7 +202,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Write a clear plan." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(
       await screen.findByText(
@@ -239,7 +239,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "ok" },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     const inputCostNode = await screen.findByText(/input cost$/);
     expect(inputCostNode.textContent).toMatch(/\$1\.70e-7\s+input cost/);

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { Code2, Sparkles, WifiOff, Swords, Bot, Zap, FolderArchive, ShieldCheck,
 
 const navItems: { name: string; path: string; Icon: LucideIcon }[] = [
     { name: "Compiler",          path: "/",                 Icon: Code2    },
-    { name: "Optimizer",         path: "/optimizer",        Icon: Sparkles },
+    { name: "Token Optimizer",   path: "/optimizer",        Icon: Sparkles },
     { name: "Offline",           path: "/offline",          Icon: WifiOff  },
     { name: "Benchmark",         path: "/benchmark",        Icon: Swords   },
     { name: "PR Safety",         path: "/pr-safety",        Icon: ShieldCheck },

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -304,7 +304,7 @@ export default function OptimizerPage() {
                         </div>
                     </div>
                     <InfoButton
-                        title="Prompt Optimizer"
+                        title="Token Optimizer"
                         description="Shortens prompts while keeping intent, constraints, variables, and safety details visible. Estimates OpenRouter cost and compares language efficiency."
                     />
                 </div>
@@ -353,12 +353,12 @@ export default function OptimizerPage() {
                         onClick={handleOptimize}
                         disabled={loading || !input.trim()}
                         aria-busy={loading}
-                        title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
+                        title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}
                         className="w-full rounded-lg bg-emerald-600 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-emerald-950/30 transition-colors hover:bg-emerald-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 sm:w-auto"
                     >
                         {loading ? "Analyzing..." : (
                             <>
-                                Analyze cost
+                                Optimize & estimate cost
                                 <kbd className="ml-2 hidden rounded border border-white/20 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] opacity-60 md:inline-block">
                                     Ctrl/Cmd Enter
                                 </kbd>
@@ -486,10 +486,10 @@ export default function OptimizerPage() {
                                     onClick={handleOptimize}
                                     disabled={loading || !input.trim()}
                                     aria-busy={loading}
-                                    title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
+                                    title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}
                                     className="rounded-lg bg-emerald-600/20 border border-emerald-500/30 px-5 py-2 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-600/30 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
                                 >
-                                    {loading ? "Analyzing..." : "Analyze cost"}
+                                    {loading ? "Analyzing..." : "Optimize & estimate cost"}
                                 </button>
                                 {!input.trim() && (
                                     <button


### PR DESCRIPTION
## Summary
- One surface had four different identities: Sidebar said "Optimizer", the page h1 said "Token Optimizer", the InfoButton said "Prompt Optimizer", and both CTA buttons said "Analyze cost".
- Standardized on a single name and verb everywhere on the optimizer surface: **"Token Optimizer"** for the label/title/InfoButton, and **"Optimize & estimate cost"** for both CTA button instances (including their `title` tooltips).
- Copy-only change: no logic, routing, or styling changes.

## Test plan
- [x] `cd web && npm run test` — 32 test files / 169 tests passed
- [x] `cd web && npm run build` — production build succeeds
- [x] Manually verified all four "Optimizer" identity references now read "Token Optimizer" and both CTA instances read "Optimize & estimate cost"