### PR TITLE
feat(web): outcome-focused metadata and per-route titles

### DIFF
--- a/web/app/agent-generator/layout.tsx
+++ b/web/app/agent-generator/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Agent Generator — Prompt Compiler",
+  description:
+    "Define a role or task, and architect a comprehensive, constraint-driven system prompt for an autonomous AI agent or multi-agent swarm.",
+};
+
+export default function AgentGeneratorLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/web/app/agent-packs/layout.tsx
+++ b/web/app/agent-packs/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Agent Packs — Prompt Compiler",
+  description:
+    "Turn one short brief into runnable, repo-ready assets, Claude-first, review every generated file before production use.",
+};
+
+export default function AgentPacksLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/web/app/benchmark/layout.tsx
+++ b/web/app/benchmark/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Prompt Benchmark — Prompt Compiler",
+  description:
+    "Send a prompt to a real model twice, raw versus compiled, and compare which answer is clearer, safer, and more concise.",
+};
+
+export default function BenchmarkLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,9 +3,21 @@ import "./globals.css";
 import Sidebar from "./components/Sidebar";
 import ToastProvider from "./components/ToastProvider";
 
+const TAGLINE = "Catch weak prompts before you spend an agent run";
+
 export const metadata: Metadata = {
   title: "Prompt Compiler",
-  description: "Policy-aware prompt compilation and optimization",
+  description: TAGLINE,
+  openGraph: {
+    title: "Prompt Compiler",
+    description: TAGLINE,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Prompt Compiler",
+    description: TAGLINE,
+  },
 };
 
 export default function RootLayout({

--- a/web/app/offline/layout.tsx
+++ b/web/app/offline/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Offline Compiler — Prompt Compiler",
+  description:
+    "A fast, local-only prompt compiler that uses deterministic heuristics instead of an LLM — secure, instant, no API keys.",
+};
+
+export default function OfflineLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/web/app/optimizer/layout.tsx
+++ b/web/app/optimizer/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Token Optimizer — Prompt Compiler",
+  description:
+    "Shorten prompts while keeping intent, constraints, variables, and safety details visible, with OpenRouter cost estimates.",
+};
+
+export default function OptimizerLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/web/app/pr-safety/layout.tsx
+++ b/web/app/pr-safety/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "PR Safety — Prompt Compiler",
+  description:
+    "Paste a pull request's title, description, and changed files for an offline, deterministic merge-readiness report — advisory only.",
+};
+
+export default function PrSafetyLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/web/app/skills-generator/layout.tsx
+++ b/web/app/skills-generator/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Skill Generator — Prompt Compiler",
+  description:
+    "Describe a capability, and generate a structured Tool/Skill definition, with input/output schemas, ready to integrate into your AI agents.",
+};
+
+export default function SkillsGeneratorLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}


### PR DESCRIPTION
## Summary
- Replace the root layout's jargon-y description ("Policy-aware prompt compilation and optimization") with the in-app tagline ("Catch weak prompts before you spend an agent run") and add `openGraph`/`twitter` metadata (title, description, type) so shared links render a real preview.
- Add a minimal server-component `layout.tsx` under each feature route (optimizer, offline, benchmark, pr-safety, agent-packs, agent-generator, skills-generator) exporting a route-specific `title`/`description`, so every browser tab and search/social preview reflects that page's actual job instead of the single global title. Descriptions are trimmed versions of each page's existing in-app `InfoButton` copy — no new claims.
- Existing `page.tsx` files are untouched (still client components); each new `layout.tsx` just exports `metadata` and renders `{children}`.

## Test plan
- [x] `cd web && npm run test` — 32 files / 169 tests passed (including `layout.fonts.test.mts`)
- [x] `cd web && npm run build` — Next.js Turbopack production build succeeds, all 7 new routes still statically prerender (`○`)