### PR TITLE
feat(web): clickable example chips matching promised use-cases

### DIFF
--- a/web/app/__tests__/page-example-chips.test.tsx
+++ b/web/app/__tests__/page-example-chips.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const useCompilerMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+describe("Empty state example chips", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // Skip the typewriter animation so fillExample() sets the prompt synchronously.
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+  });
+
+  it("fills the prompt with a messy GitHub issue when the issue chip is clicked", () => {
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("button", { name: "GitHub issue → implementation brief" }));
+
+    const textarea = screen.getByLabelText("Describe what you want compiled") as HTMLTextAreaElement;
+    expect(textarea.value.length).toBeGreaterThan(0);
+    expect(
+      "bug: export button doesnt work on safari??? users complaining in slack, cant repro locally on chrome tho. might be related to the blob download thing we added last sprint. someone said it also happens on firefox mobile sometimes. need this fixed before the friday release, no repro steps written down anywhere sorry",
+    ).toContain(textarea.value);
+  });
+
+  it("fills the prompt with a messy PR description when the PR chip is clicked", () => {
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("button", { name: "PR description → review checklist" }));
+
+    const textarea = screen.getByLabelText("Describe what you want compiled") as HTMLTextAreaElement;
+    expect(textarea.value.length).toBeGreaterThan(0);
+    expect(
+      "fixes the thing where auth tokens expire too early. changed the refresh logic in useAuth.ts and also touched the login page a bit bc it kept throwing an error. didnt write tests yet, will add if reviewers want. also bumped a couple deps while i was in there, hope thats fine",
+    ).toContain(textarea.value);
+  });
+
+  it("fills the prompt with a messy spec when the spec chip is clicked", () => {
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Spec → implementation plan" }));
+
+    const textarea = screen.getByLabelText("Describe what you want compiled") as HTMLTextAreaElement;
+    expect(textarea.value.length).toBeGreaterThan(0);
+    expect(
+      "we need a notifications system. users should get emails and maybe push too. admins need to be able to turn it off per user. should probably use some kind of queue so it doesnt slow down the main app but not sure which one, also needs to somehow work with the mobile app",
+    ).toContain(textarea.value);
+  });
+});

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -567,9 +567,44 @@ export default function Home() {
                       </button>
                     )}
                   </div>
-                  <p className="text-xs italic text-zinc-500 leading-relaxed mt-4">
-                    Good first inputs: GitHub issue to implementation brief, PR description to review checklist, or a spec to implementation plan.
-                  </p>
+                  <div className="mt-4 flex flex-col items-center gap-2">
+                    <p className="text-[11px] text-zinc-500">Or try a job like:</p>
+                    <div className="flex flex-wrap items-center justify-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          fillExample(
+                            "bug: export button doesnt work on safari??? users complaining in slack, cant repro locally on chrome tho. might be related to the blob download thing we added last sprint. someone said it also happens on firefox mobile sometimes. need this fixed before the friday release, no repro steps written down anywhere sorry"
+                          )
+                        }
+                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] text-zinc-400 hover:border-blue-500/40 hover:text-blue-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+                      >
+                        GitHub issue &rarr; implementation brief
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          fillExample(
+                            "fixes the thing where auth tokens expire too early. changed the refresh logic in useAuth.ts and also touched the login page a bit bc it kept throwing an error. didnt write tests yet, will add if reviewers want. also bumped a couple deps while i was in there, hope thats fine"
+                          )
+                        }
+                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] text-zinc-400 hover:border-blue-500/40 hover:text-blue-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+                      >
+                        PR description &rarr; review checklist
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          fillExample(
+                            "we need a notifications system. users should get emails and maybe push too. admins need to be able to turn it off per user. should probably use some kind of queue so it doesnt slow down the main app but not sure which one, also needs to somehow work with the mobile app"
+                          )
+                        }
+                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] text-zinc-400 hover:border-blue-500/40 hover:text-blue-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+                      >
+                        Spec &rarr; implementation plan
+                      </button>
+                    </div>
+                  </div>
                 </div>
 
                 <div className="w-full max-w-md space-y-3 border-t border-white/5 pt-5 text-left">


### PR DESCRIPTION
## Summary
- The empty state pitched three use-cases ("GitHub issue to implementation brief, PR description to review checklist, spec to implementation plan") as static italic text, while the only clickable example nearby was an unrelated nginx-log task — the pitch and the demo didn't line up.
- Replaced the static line with three small chips ("GitHub issue → implementation brief", "PR description → review checklist", "Spec → implementation plan"), each calling the existing `fillExample()` typewriter with a realistic, deliberately messy input matching that job (a rough GitHub issue, a rough PR description, a rough spec).
- Chips are styled as small pill buttons consistent with (but visually subordinate to) the existing "or try an example" link and the primary Compile button — no competing visual weight.
- Kept using the current `fillExample()` from main as-is (no dependency on any in-flight refactor).

## Notes for reviewers
- PR #932 ("typewriter animation parity") is open and also touches this area (extracts the typewriter logic into a `useTypewriterFill` hook, -32/+5 in `page.tsx`) — this PR may need a rebase after #932 merges.
- A parallel task (T9) is making the existing single example button auto-compile after typewriting, touching the same file/region (~line 560-572) — expect a possible merge conflict with that change too.

## Test plan
- [x] `cd web && npm run test` — 33 test files / 172 tests passed, including new `web/app/__tests__/page-example-chips.test.tsx` (3 tests, one per chip, asserting `fillExample` is invoked with the expected messy text).
- [x] `cd web && npm run build` — production build succeeds.