### PR TITLE
feat(web): auto-compile after typewriter example fill

### DIFF
--- a/web/app/__tests__/page-example-autocompile.test.tsx
+++ b/web/app/__tests__/page-example-autocompile.test.tsx
@@ -1,0 +1,111 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const runCompileMock = vi.fn();
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+function mockMatchMedia(prefersReducedMotion: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: prefersReducedMotion,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+describe("Example autocompile", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    runCompileMock.mockReset();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: runCompileMock,
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({
+      indexStats: null,
+    });
+  });
+
+  it("auto-compiles the example text once the typewriter fill completes (reduced motion)", () => {
+    mockMatchMedia(true);
+    render(<Home />);
+
+    const exampleButton = screen.getByRole("button", { name: "or try an example" });
+    fireEvent.click(exampleButton);
+
+    expect(runCompileMock).toHaveBeenCalledTimes(1);
+    const [text, mode] = runCompileMock.mock.calls[0];
+    expect(text).toMatch(/nginx access\.log/);
+    expect(mode).toBe("conservative");
+  });
+
+  it("auto-compiles after the typewriter animation finishes (motion allowed)", async () => {
+    mockMatchMedia(false);
+    vi.useFakeTimers();
+
+    render(<Home />);
+
+    const exampleButton = screen.getByRole("button", { name: "or try an example" });
+    fireEvent.click(exampleButton);
+
+    // Typewriter has not finished yet — no compile call should have happened.
+    expect(runCompileMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(runCompileMock).toHaveBeenCalledTimes(1);
+    const [text] = runCompileMock.mock.calls[0];
+    expect(text).toMatch(/nginx access\.log/);
+
+    vi.useRealTimers();
+  });
+
+  it("does not auto-compile when the visitor types manually into the textarea", () => {
+    mockMatchMedia(true);
+    render(<Home />);
+
+    const textarea = screen.getByLabelText("Describe what you want compiled");
+    fireEvent.change(textarea, { target: { value: "My own manual prompt" } });
+
+    expect(runCompileMock).not.toHaveBeenCalled();
+
+    const compileButtons = screen.getAllByRole("button", { name: /Compile Prompt/ });
+    fireEvent.click(compileButtons[0]);
+
+    expect(runCompileMock).toHaveBeenCalledTimes(1);
+    expect(runCompileMock.mock.calls[0][0]).toBe("My own manual prompt");
+  });
+});

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -172,7 +172,9 @@ export default function Home() {
   };
   useEffect(() => stopTypewriter, []);
 
-  const fillExample = (text: string) => {
+  // `autoCompile` is only used by the "try an example" entry point — manual typing
+  // into the textarea (and the regular Compile button) must never trigger it.
+  const fillExample = (text: string, autoCompile = false) => {
     stopTypewriter();
     document
       .querySelector<HTMLTextAreaElement>('textarea[aria-label="Describe what you want compiled"]')
@@ -183,6 +185,7 @@ export default function Home() {
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (prefersReduced) {
       setPrompt(text);
+      if (autoCompile) void runCompile(text, activeMode);
       return;
     }
     setPrompt("");
@@ -191,7 +194,10 @@ export default function Home() {
     typewriterRef.current = window.setInterval(() => {
       i = Math.min(text.length, i + stepChars);
       setPrompt(text.slice(0, i));
-      if (i >= text.length) stopTypewriter();
+      if (i >= text.length) {
+        stopTypewriter();
+        if (autoCompile) void runCompile(text, activeMode);
+      }
     }, 16);
   };
 
@@ -560,7 +566,7 @@ export default function Home() {
                     {!prompt.trim() && (
                       <button
                         type="button"
-                        onClick={() => fillExample("Write a Python script that analyzes an nginx access.log file, counts requests by IP, and flags IPs with more than 100 requests in a minute.")}
+                        onClick={() => fillExample("Write a Python script that analyzes an nginx access.log file, counts requests by IP, and flags IPs with more than 100 requests in a minute.", true)}
                         className="text-xs text-blue-400/80 hover:text-blue-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded px-2 py-1"
                       >
                         or try an example


### PR DESCRIPTION
## Summary
- The empty-state "or try an example" button previously only typewrote a sample prompt into the textarea, leaving the visitor to find and click Compile themselves.
- `fillExample` now takes an `autoCompile` flag; the example button passes `true`, so after the typewriter finishes (or immediately under `prefers-reduced-motion`) it calls the same `runCompile(text, activeMode)` path the Compile button uses.
- Manual typing into the textarea and the Compile button are unchanged — `autoCompile` defaults to `false` and is only opted into by the example entry point.

## Notes on overlapping in-flight work
- PR #932 ("typewriter animation parity") is open and also touches this `fillExample` flow (extracts it into a `useTypewriterFill` hook). Since it isn't merged, this PR is built against the current `main` implementation of `fillExample` and will likely need a rebase after #932 merges.
- A parallel task (T10) is turning the empty-state italic use-case text into clickable chips that also call `fillExample()`, in the same file/adjacent region — expect a possible merge conflict with that PR too.

## Test plan
- [x] `cd web && npm run test` — 33 test files / 172 tests pass, including a new `web/app/__tests__/page-example-autocompile.test.tsx` covering: auto-compile on reduced motion, auto-compile after the typewriter interval finishes, and no auto-compile on manual typing (Compile button still required)
- [x] `cd web && npm run build` — production build succeeds