### PR TITLE
fix(web): remove fake always-on AI MODE badge

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -259,11 +259,6 @@ export default function Home() {
               </span>
             </button>
 
-            <div className="px-3 py-1.5 rounded-full text-xs font-medium border flex items-center gap-2 transition-all duration-300 bg-green-500/10 border-green-500/30 text-green-400">
-              <div className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
-              AI MODE
-            </div>
-
             <div className="flex items-center gap-2">
               <div className="min-w-0 rounded-lg border border-white/5 bg-black/30 px-3 py-1.5 text-center font-mono text-xs text-zinc-300 sm:min-w-[88px]">
                 {status}


### PR DESCRIPTION
## Summary
- Removes the hardcoded, permanently-green pulsing "AI MODE" pill from the header of `web/app/page.tsx`. It was bound to no real state and always rendered the same regardless of what the app was doing (pure status theater).
- Real compile status (`Ready`, `Generating...`, `AI Thinking...`, `Done in Nms`, `Error`, etc.) is already surfaced right next to it in the existing status box, so the badge duplicated nothing useful and was removed outright rather than rebound.
- No change to the header's responsive flex-wrap layout, spacing, or the Conservative/Aggressive toggle next to it.

## Test plan
- [x] `cd web && npm run test` — 32 test files / 169 tests passed
- [x] `cd web && npm run build` — Next.js production build succeeds