### PR TITLE
feat(web): link compile results to benchmark page

### DIFF
--- a/web/app/__tests__/page-benchmark-cta.test.tsx
+++ b/web/app/__tests__/page-benchmark-cta.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+const routerPushMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+const BENCHMARK_CTA_LABEL = "Benchmark this prompt — raw vs compiled";
+
+describe("Compile-to-benchmark handoff", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    routerPushMock.mockReset();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({
+      indexStats: null,
+    });
+  });
+
+  it("does not render the benchmark CTA before a compile result exists", () => {
+    render(<Home />);
+
+    expect(screen.queryByRole("button", { name: BENCHMARK_CTA_LABEL })).toBeNull();
+  });
+
+  it("writes the raw typed prompt to localStorage and navigates to /benchmark after a compile result exists", () => {
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: { system_prompt: "Compiled system prompt", user_prompt: "Compiled user prompt" },
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+
+    render(<Home />);
+
+    fireEvent.change(screen.getByLabelText("Describe what you want compiled"), {
+      target: { value: "Summarize this nginx log file for suspicious IPs." },
+    });
+
+    const cta = screen.getByRole("button", { name: BENCHMARK_CTA_LABEL });
+    fireEvent.click(cta);
+
+    expect(localStorage.getItem("promptc_benchmark_prompt")).toBe(
+      "Summarize this nginx log file for suspicious IPs.",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/benchmark");
+  });
+});

--- a/web/app/__tests__/page-conservative-toggle.test.tsx
+++ b/web/app/__tests__/page-conservative-toggle.test.tsx
@@ -10,6 +10,12 @@ vi.mock("../hooks/useCompiler", () => ({
   useCompiler: () => useCompilerMock(),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
 vi.mock("../hooks/useContextManager", () => ({
   useContextManager: () => useContextManagerMock(),
 }));

--- a/web/app/__tests__/page-error-state.test.tsx
+++ b/web/app/__tests__/page-error-state.test.tsx
@@ -11,6 +11,12 @@ vi.mock("../hooks/useCompiler", () => ({
   useCompiler: () => useCompilerMock(),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
 vi.mock("../components/ContextManager", () => ({
   default: () => <div data-testid="context-manager" />,
 }));

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useId, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
@@ -114,6 +115,7 @@ function CompilerErrorState({
 }
 
 export default function Home() {
+  const router = useRouter();
   const [prompt, setPrompt] = useState(() => {
     if (typeof window === "undefined") {
       return "";
@@ -160,6 +162,12 @@ export default function Home() {
 
   const handleSecurityDecision = async (useRedacted: boolean) => {
     await resolveSecurityDecision(useRedacted, activeMode);
+  };
+
+  const handleBenchmarkThisPrompt = () => {
+    if (!result) return;
+    window.localStorage.setItem("promptc_benchmark_prompt", prompt);
+    router.push("/benchmark");
   };
 
   // Typewriter entrance when an example prompt is inserted.
@@ -369,6 +377,17 @@ export default function Home() {
             ) : result ? (
               <>
                 {result?.readiness && <ReadinessBanner report={result.readiness} />}
+                <div className="flex items-center justify-end px-4 pt-3">
+                  <button
+                    type="button"
+                    onClick={handleBenchmarkThisPrompt}
+                    className="group inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-zinc-400 transition-colors hover:border-purple-400/30 hover:bg-purple-500/5 hover:text-purple-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/50"
+                    aria-label="Benchmark this prompt — raw vs compiled"
+                  >
+                    Benchmark this prompt — raw vs compiled
+                    <span aria-hidden="true" className="transition-transform group-hover:translate-x-0.5">{"->"}</span>
+                  </button>
+                </div>
                 {/* Tabs + policy verdict */}
                 <div className="animate-fade-in flex items-center gap-3 border-b border-white/5 px-4 pt-4 pb-1">
                   <div className="relative flex min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- The `/benchmark` page already renders the raw-vs-compiled DiffViewer, radar chart, and winner/improvement score, and reads its prompt from `localStorage["promptc_benchmark_prompt"]` — but nothing on the main compile surface (`web/app/page.tsx`) linked to it, so this evidence was unreachable from the primary flow.
- After a successful compile, render a quiet secondary CTA ("Benchmark this prompt — raw vs compiled") that writes the **original typed prompt** (not the compiled output) to `promptc_benchmark_prompt` and navigates to `/benchmark`, mirroring the existing `optimizer -> compiler` handoff pattern (`web/app/optimizer/page.tsx`).
- The CTA only renders once a compile `result` exists.
- Added `useRouter` mocks to two existing `page.tsx` tests that previously rendered `Home` without a Next.js router context (needed once `page.tsx` calls `useRouter`).

## Test plan
- [x] `cd web && npm run test` — 171 tests pass (33 files), including a new `app/__tests__/page-benchmark-cta.test.tsx` verifying: the CTA is absent before a result exists, and clicking it after a result exists writes the raw prompt to `localStorage["promptc_benchmark_prompt"]` and calls `router.push("/benchmark")`.
- [x] `cd web && npm run build` — production build succeeds.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>