### PR TITLE
feat(web): add compile result value strip

### DIFF
--- a/web/app/components/ResultValueStrip.tsx
+++ b/web/app/components/ResultValueStrip.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { CompileResponse } from "../../lib/api/types";
+import { getResultValuePills, type ResultValuePillTone } from "../../lib/resultValueStrip";
+
+type ResultValueStripProps = {
+  result: CompileResponse;
+};
+
+const TONE_CLASSES: Record<ResultValuePillTone, string> = {
+  green: "border-emerald-400/40 bg-emerald-400/10 text-emerald-200",
+  amber: "border-amber-400/40 bg-amber-400/10 text-amber-200",
+  red: "border-red-400/40 bg-red-400/10 text-red-200",
+  blue: "border-sky-400/40 bg-sky-400/10 text-sky-200",
+  zinc: "border-zinc-400/30 bg-zinc-400/10 text-zinc-200",
+};
+
+const DOT_CLASSES: Record<ResultValuePillTone, string> = {
+  green: "bg-emerald-400",
+  amber: "bg-amber-400",
+  red: "bg-red-400",
+  blue: "bg-sky-400",
+  zinc: "bg-zinc-400",
+};
+
+/**
+ * Compact "why this beats what you typed" stat strip: readiness verdict,
+ * clarify-question count, plan step count, detected risk level, and
+ * critique score — all derived from the existing CompileResponse, nothing
+ * fetched or computed server-side just for this UI.
+ */
+export default function ResultValueStrip({ result }: ResultValueStripProps) {
+  const pills = getResultValuePills(result);
+  if (pills.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="result-value-strip"
+      role="list"
+      aria-label="Compile result summary"
+      className="animate-fade-in flex flex-wrap items-center gap-1.5 px-4 pt-3"
+    >
+      {pills.map((pill) => (
+        <span
+          key={pill.key}
+          role="listitem"
+          title={pill.title}
+          data-testid={`result-value-pill-${pill.key}`}
+          className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium ${TONE_CLASSES[pill.tone]}`}
+        >
+          <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${DOT_CLASSES[pill.tone]}`} />
+          <span>{pill.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -5,6 +5,7 @@ import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
 import ReadinessBanner, { VERDICT_META } from "./components/ReadinessBanner";
+import ResultValueStrip from "./components/ResultValueStrip";
 import SecurityAlert from "./components/SecurityAlert";
 import IntentPolicyPanel from "./components/IntentPolicyPanel";
 import OutputSkeleton from "./components/OutputSkeleton";
@@ -369,6 +370,7 @@ export default function Home() {
             ) : result ? (
               <>
                 {result?.readiness && <ReadinessBanner report={result.readiness} />}
+                <ResultValueStrip result={result} />
                 {/* Tabs + policy verdict */}
                 <div className="animate-fade-in flex items-center gap-3 border-b border-white/5 px-4 pt-4 pb-1">
                   <div className="relative flex min-w-0 flex-1">

--- a/web/lib/resultValueStrip.test.ts
+++ b/web/lib/resultValueStrip.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { getResultValuePills } from "./resultValueStrip";
+import type { CompileResponse } from "./api/types";
+
+function makeResult(overrides: Partial<CompileResponse> = {}): CompileResponse {
+  return {
+    ir: {},
+    system_prompt: "system",
+    user_prompt: "user",
+    plan: "1. Analyze request\n   Rationale: establish understanding\n2. Draft the change\n   Rationale: implement\n3. Verify\n   Rationale: check output",
+    expanded_prompt: "expanded",
+    processing_ms: 1,
+    readiness_markdown: "",
+    ...overrides,
+  };
+}
+
+describe("getResultValuePills", () => {
+  it("returns all five pills when every field is present", () => {
+    const result = makeResult({
+      readiness: {
+        verdict: "clarify",
+        signals: [],
+        questions: ["What language?", "Which repo?"],
+      },
+      ir: {
+        policy: {
+          risk_level: "high",
+          risk_domains: [],
+          allowed_tools: [],
+          forbidden_tools: [],
+          sanitization_rules: [],
+          data_sensitivity: "public",
+          execution_mode: "human_approval_required",
+        },
+      },
+      critique: {
+        verdict: "ACCEPT",
+        score: 87,
+        issues: [],
+        feedback: "Looks solid.",
+      },
+    });
+
+    const pills = getResultValuePills(result);
+    const keys = pills.map((p) => p.key);
+
+    expect(keys).toEqual(["readiness", "clarify", "plan", "risk", "critique"]);
+
+    expect(pills.find((p) => p.key === "readiness")).toMatchObject({ label: "Clarify", tone: "amber" });
+    expect(pills.find((p) => p.key === "clarify")).toMatchObject({ label: "2 to clarify", tone: "amber" });
+    expect(pills.find((p) => p.key === "plan")).toMatchObject({ label: "3 plan steps", tone: "blue" });
+    expect(pills.find((p) => p.key === "risk")).toMatchObject({ label: "High risk", tone: "red" });
+    expect(pills.find((p) => p.key === "critique")).toMatchObject({ label: "Critique 87/100", tone: "green" });
+  });
+
+  it("omits the critique pill when critique is absent", () => {
+    const result = makeResult({
+      readiness: { verdict: "ready", signals: [], questions: [] },
+      critique: null,
+    });
+
+    const pills = getResultValuePills(result);
+
+    expect(pills.some((p) => p.key === "critique")).toBe(false);
+  });
+
+  it("still renders a clarify pill with a positive message for zero clarify questions", () => {
+    const result = makeResult({
+      readiness: { verdict: "ready", signals: [], questions: [] },
+    });
+
+    const pills = getResultValuePills(result);
+    const clarifyPill = pills.find((p) => p.key === "clarify");
+
+    expect(clarifyPill).toMatchObject({ label: "No open questions", tone: "green" });
+  });
+
+  it("omits the readiness and clarify pills when readiness is absent, and the risk pill when policy is absent", () => {
+    const result = makeResult({ readiness: null, ir: {} });
+
+    const pills = getResultValuePills(result);
+    const keys = pills.map((p) => p.key);
+
+    expect(keys).not.toContain("readiness");
+    expect(keys).not.toContain("clarify");
+    expect(keys).not.toContain("risk");
+    expect(keys).toContain("plan");
+  });
+});

--- a/web/lib/resultValueStrip.ts
+++ b/web/lib/resultValueStrip.ts
@@ -1,0 +1,97 @@
+import type { CompileResponse, ReadinessVerdict } from "./api/types";
+import { normalizeIntentPolicy } from "../app/components/intent-policy-utils";
+
+export type ResultValuePillTone = "green" | "amber" | "red" | "blue" | "zinc";
+
+export type ResultValuePill = {
+  key: "readiness" | "clarify" | "plan" | "risk" | "critique";
+  label: string;
+  tone: ResultValuePillTone;
+  title: string;
+};
+
+const READINESS_PILL_META: Record<ReadinessVerdict, { label: string; tone: ResultValuePillTone }> = {
+  ready: { label: "Ready", tone: "green" },
+  clarify: { label: "Clarify", tone: "amber" },
+  risky: { label: "Risky", tone: "red" },
+  noise: { label: "Not a task", tone: "zinc" },
+};
+
+const RISK_PILL_META: Record<string, { label: string; tone: ResultValuePillTone }> = {
+  low: { label: "Low risk", tone: "green" },
+  medium: { label: "Medium risk", tone: "amber" },
+  high: { label: "High risk", tone: "red" },
+};
+
+/** Plan text uses "1. ", "2. " ... step markers (see app/emitters.py emit_plan / emit_plan_v2). */
+function countPlanSteps(planText: string): number {
+  const matches = planText.match(/^\d+\.\s/gm);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Maps a CompileResponse to a compact set of "why this output is better than
+ * what you typed" pills. Every value here is derived from fields already on
+ * CompileResponse — no extra API calls, no new backend fields.
+ *
+ * A pill is omitted entirely when its underlying signal is absent (e.g. no
+ * readiness report, no policy, no critique) rather than rendered as a
+ * placeholder.
+ */
+export function getResultValuePills(result: CompileResponse): ResultValuePill[] {
+  const pills: ResultValuePill[] = [];
+
+  if (result.readiness) {
+    const meta = READINESS_PILL_META[result.readiness.verdict];
+    if (meta) {
+      pills.push({
+        key: "readiness",
+        label: meta.label,
+        tone: meta.tone,
+        title: "Readiness verdict from the deterministic pre-compile check.",
+      });
+    }
+
+    const clarifyCount = result.readiness.questions.length;
+    pills.push({
+      key: "clarify",
+      label: clarifyCount === 0 ? "No open questions" : `${clarifyCount} to clarify`,
+      tone: clarifyCount === 0 ? "green" : "amber",
+      title: "Number of clarifying questions the compiler surfaced before you spend a run.",
+    });
+  }
+
+  const planText = result.plan_v2 || result.plan || "";
+  const planStepCount = countPlanSteps(planText);
+  if (planStepCount > 0) {
+    pills.push({
+      key: "plan",
+      label: `${planStepCount} plan step${planStepCount === 1 ? "" : "s"}`,
+      tone: "blue",
+      title: "Number of steps in the generated execution plan.",
+    });
+  }
+
+  const policy = result.ir_v2?.policy ?? result.ir?.policy;
+  if (policy) {
+    const { riskLevel } = normalizeIntentPolicy(result);
+    const meta = RISK_PILL_META[riskLevel] ?? { label: `${riskLevel} risk`, tone: "zinc" as const };
+    pills.push({
+      key: "risk",
+      label: meta.label,
+      tone: meta.tone,
+      title: "Detected risk level from the policy handler.",
+    });
+  }
+
+  if (result.critique) {
+    pills.push({
+      key: "critique",
+      label: `Critique ${result.critique.score}/100`,
+      tone: result.critique.verdict === "REJECT" ? "red" : "green",
+      title: "Self-critique score the compiler assigned to its own output.",
+    });
+  }
+
+  return pills;
+}


### PR DESCRIPTION
## Summary
- The compile result view never contrasted input vs. output — nothing told the user *why* the compiled output beats what they typed.
- Adds a compact stat strip (3-5 pills) above the output tabs in `web/app/page.tsx`, driven by a pure mapping function `getResultValuePills` in `web/lib/resultValueStrip.ts` that derives everything from the existing `CompileResponse` type — no new API calls or backend fields.
- Pills shown when the underlying signal is present: readiness verdict, clarify-question count, plan step count, detected risk level, and critique score. A pill is fully omitted (not a placeholder) when its field is absent (e.g. no critique, no policy, no readiness report).
- New `ResultValueStrip` component reuses the existing pill/badge visual language (rounded-full border + dot, matching `PolicyBadge`).

## Files changed
- `web/lib/resultValueStrip.ts` (new) — `getResultValuePills(result)` mapping function
- `web/lib/resultValueStrip.test.ts` (new) — unit tests: all fields present, critique absent, zero clarify questions, readiness/policy absent
- `web/app/components/ResultValueStrip.tsx` (new) — renders the pills
- `web/app/page.tsx` — mounts `<ResultValueStrip result={result} />` above the output tabs

## Test plan
- [x] `cd web && npm run test` — 33 files / 173 tests pass
- [x] `cd web && npm run build` — production build succeeds
- [x] `npx eslint` on touched files — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)