### PR TITLE
feat(web): handoff compiled prompt to Agent Packs + honest empty-state copy

### DIFF
--- a/web/app/__tests__/page-conservative-toggle.test.tsx
+++ b/web/app/__tests__/page-conservative-toggle.test.tsx
@@ -10,6 +10,12 @@ vi.mock("../hooks/useCompiler", () => ({
   useCompiler: () => useCompilerMock(),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
 vi.mock("../hooks/useContextManager", () => ({
   useContextManager: () => useContextManagerMock(),
 }));

--- a/web/app/__tests__/page-error-state.test.tsx
+++ b/web/app/__tests__/page-error-state.test.tsx
@@ -11,6 +11,12 @@ vi.mock("../hooks/useCompiler", () => ({
   useCompiler: () => useCompilerMock(),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
 vi.mock("../components/ContextManager", () => ({
   default: () => <div data-testid="context-manager" />,
 }));

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -2,7 +2,7 @@
 
 import { toast } from "sonner";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Bot, Copy, Download, FileCode2, FolderArchive, Loader2, ShieldCheck, Sparkles, X } from "lucide-react";
 
 import { apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
@@ -65,7 +65,13 @@ function bundleFiles(files: AgentPackFile[]): string {
 
 export default function AgentPacksPage() {
   const provider = agentPackProviders[0];
-  const [request, setRequest] = useState<AgentPackRequest>(DEFAULT_REQUEST);
+  const [request, setRequest] = useState<AgentPackRequest>(() => {
+    if (typeof window === "undefined") {
+      return DEFAULT_REQUEST;
+    }
+    const handoffGoal = window.localStorage.getItem("promptc_agent_pack_goal");
+    return handoffGoal ? { ...DEFAULT_REQUEST, goal: handoffGoal } : DEFAULT_REQUEST;
+  });
   const [manifest, setManifest] = useState<AgentPackManifest | null>(null);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -74,6 +80,12 @@ export default function AgentPacksPage() {
   const [copiedState, setCopiedState] = useState<"single" | "all" | null>(null);
   const [downloaded, setDownloaded] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+
+  // Clear the handoff key once we've read it so a stale value doesn't leak
+  // into a later, unrelated visit to this page.
+  useEffect(() => {
+    window.localStorage.removeItem("promptc_agent_pack_goal");
+  }, []);
 
   const requestHeaders = useMemo(
     () => buildGeneratorApiHeaders({ "Content-Type": "application/json" }),

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useId, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import ContextManager from "./components/ContextManager";
 import InfoButton from "./components/InfoButton";
 import QualityCoach from "./components/QualityCoach";
@@ -114,6 +115,7 @@ function CompilerErrorState({
 }
 
 export default function Home() {
+  const router = useRouter();
   const [prompt, setPrompt] = useState(() => {
     if (typeof window === "undefined") {
       return "";
@@ -160,6 +162,14 @@ export default function Home() {
 
   const handleSecurityDecision = async (useRedacted: boolean) => {
     await resolveSecurityDecision(useRedacted, activeMode);
+  };
+
+  const handleBuildAgentPack = () => {
+    if (!result) return;
+    const compiledPrompt = getCompileTabContent(result, "user");
+    if (!compiledPrompt) return;
+    window.localStorage.setItem("promptc_agent_pack_goal", compiledPrompt);
+    router.push("/agent-packs");
   };
 
   // Typewriter entrance when an example prompt is inserted.
@@ -400,6 +410,15 @@ export default function Home() {
                       <span className="ml-[-14px] rounded-full border border-white/10 bg-black/60 px-1.5 text-[11px] leading-none text-zinc-300 backdrop-blur-sm">›</span>
                     </div>
                   </div>
+                  <button
+                    type="button"
+                    onClick={handleBuildAgentPack}
+                    className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1.5 text-xs font-semibold text-cyan-100 transition-colors hover:bg-cyan-400/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/50"
+                    title="Send this compiled prompt to Agent Packs to generate repo-ready files"
+                    aria-label="Build agent pack from this compiled prompt"
+                  >
+                    Build agent pack from this
+                  </button>
                   <PolicyBadge result={result} />
                 </div>
 
@@ -544,7 +563,7 @@ export default function Home() {
                 <div className="max-w-sm space-y-2">
                   <h3 className="text-zinc-100 font-semibold tracking-tight text-lg">Compile a rough request into a prompt your AI can actually run</h3>
                   <p className="text-sm text-zinc-400 leading-relaxed mb-4">
-                    Paste a vague task. Get a structured prompt, an execution plan, and repo-ready agent files &mdash; plus a rule-based readiness check that flags risky or unclear requests before you waste a run.
+                    Paste a vague task. Get a structured prompt and an execution plan &mdash; plus a rule-based readiness check that flags risky or unclear requests before you waste a run.
                   </p>
                   <div className="flex flex-col items-center gap-3 mt-2 w-full">
                     <button


### PR DESCRIPTION
## Summary
- Add a "Build agent pack from this" button on the compile RESULT panel that stores the compiled user prompt (`getCompileTabContent(result, "user")`) under `localStorage["promptc_agent_pack_goal"]` and navigates to `/agent-packs`, mirroring the existing optimizer -> compiler handoff pattern.
- Initialize `request.goal` on the Agent Packs page from that localStorage key on mount, then clear the key immediately after so a stale handoff value can't leak into a later, unrelated visit.
- Reword the compile EMPTY STATE copy to only describe what the compile step itself outputs (structured prompt, execution plan, readiness check) — the "repo-ready agent files" claim is removed from the empty state since that capability now lives behind the result-panel handoff button, not before a compile happens.
- Update two existing page tests that render `<Home />` directly to mock `next/navigation`'s `useRouter`, which is now used by the new handoff button.

## Test plan
- [x] `cd web && npm run test` — 32 test files / 169 tests pass
- [x] `cd web && npm run build` — Turbopack production build succeeds

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>