### PR TITLE
refactor(web): Agent Generator hands off to Agent Packs instead of duplicating file bundles

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -7,13 +7,22 @@ const { apiFetch } = vi.hoisted(() => ({
   apiFetch: vi.fn(),
 }));
 
+const { push } = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
+
 vi.mock("@/config", () => ({
   apiFetch,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
 }));
 
 describe("Agent ExportPanel", () => {
   beforeEach(() => {
     apiFetch.mockReset();
+    push.mockReset();
     apiFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -29,9 +38,10 @@ describe("Agent ExportPanel", () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     });
+    window.localStorage.clear();
   });
 
-  test("exposes pressed state for the selected target and output mode", async () => {
+  test("exposes pressed state for the selected target and clears output mode tabs for the handoff target", async () => {
     render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
 
     fireEvent.click(screen.getByRole("button", { name: /export/i }));
@@ -50,27 +60,28 @@ describe("Agent ExportPanel", () => {
 
     fireEvent.click(projectPackButton);
 
-    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
-
     expect(sdkButton.getAttribute("aria-checked")).toBe("false");
     expect(projectPackButton.getAttribute("aria-checked")).toBe("true");
     expect(screen.queryByRole("radio", { name: "Python" })).toBeNull();
     expect(screen.queryByRole("radio", { name: "TypeScript" })).toBeNull();
 
-    const filesButton = screen.getByRole("radio", { name: "Files" });
-    expect(filesButton.getAttribute("aria-checked")).toBe("true");
+    // Selecting the handoff target must not trigger another export call.
+    expect(apiFetch).toHaveBeenCalledTimes(1);
   });
 
-  test("requests the Claude project pack export", async () => {
+  test("Claude Project Pack hands off to Agent Packs instead of exporting inline", async () => {
     render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
 
     fireEvent.click(screen.getByRole("button", { name: /export/i }));
     fireEvent.click(screen.getByRole("radio", { name: "Claude Project Pack" }));
 
-    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
-    const [, options] = apiFetch.mock.calls.at(-1);
-    expect(options.method).toBe("POST");
-    expect(JSON.parse(options.body).format).toBe("claude-project-pack");
+    const handoffButton = await screen.findByRole("button", { name: /continue in agent packs/i });
+    fireEvent.click(handoffButton);
+
+    expect(window.localStorage.getItem("promptc_agent_pack_goal")).toBe("# Agent\n\n## Role\nTest");
+    expect(push).toHaveBeenCalledWith("/agent-packs");
+    // Still only the initial (Claude Agent SDK) export call — no duplicate export request.
+    expect(apiFetch).toHaveBeenCalledTimes(1);
   });
 
   test("requests the TypeScript Claude Agent SDK export when TypeScript tab is selected", async () => {

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { toast } from "sonner";
+import { ArrowRight } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { apiFetch } from "@/config";
+
+const AGENT_PACKS_HANDOFF_KEY = "promptc_agent_pack_goal";
 
 type ExportTarget =
   | "claude-agent-sdk"
@@ -11,7 +15,7 @@ type ExportTarget =
   | "claude-project-pack"
   | "langchain"
   | "langgraph";
-type OutputMode = "python" | "typescript" | "markdown" | "files";
+type OutputMode = "python" | "typescript" | "markdown";
 
 interface ExportFile {
   path: string;
@@ -48,6 +52,8 @@ const TARGETS: {
     color: "text-zinc-400 border-transparent hover:border-amber-500/40 hover:text-amber-300",
     activeColor: "text-amber-300 border-amber-500/60 bg-amber-500/10",
   },
+  // Hands off to Agent Packs — the single home for repo-ready file bundles — instead of
+  // duplicating file-bundle generation inline (see isAgentPacksHandoff below).
   {
     id: "claude-project-pack",
     label: "Claude Project Pack",
@@ -74,12 +80,13 @@ const OUTPUT_OPTIONS: Record<ExportTarget, { id: OutputMode; label: string }[]> 
     { id: "typescript", label: "TypeScript" },
   ],
   "claude-subagent": [{ id: "markdown", label: "Markdown" }],
-  "claude-project-pack": [{ id: "files", label: "Files" }],
+  "claude-project-pack": [],
   langchain: [{ id: "python", label: "Python" }],
   langgraph: [{ id: "python", label: "Python" }],
 };
 
 export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelProps) {
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [target, setTarget] = useState<ExportTarget>("claude-agent-sdk");
   const [outputMode, setOutputMode] = useState<OutputMode>("python");
@@ -87,7 +94,6 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
   const prevPromptRef = useRef<string | null>(null);
   const panelId = useId();
 
@@ -96,13 +102,13 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
       prevPromptRef.current = systemPrompt;
       setCache({});
       setError(null);
-      setSelectedFilePath(null);
       setTarget("claude-agent-sdk");
       setOutputMode("python");
     }
   }, [systemPrompt]);
 
   const activeTarget = TARGETS.find((item) => item.id === target)!;
+  const isAgentPacksHandoff = target === "claude-project-pack";
   const format = resolveFormat(target, outputMode);
   const currentResult = cache[format] ?? null;
   const outputTabs = OUTPUT_OPTIONS[target];
@@ -115,25 +121,13 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     if (outputMode === "markdown") {
       return currentResult.files?.[0]?.content ?? currentResult.code ?? null;
     }
-    if (outputMode === "files") {
-      const files = currentResult.files ?? [];
-      if (!files.length) return null;
-      const selected = files.find((file) => file.path === selectedFilePath) ?? files[0];
-      return selected.content;
-    }
     return null;
-  }, [currentResult, outputMode, selectedFilePath]);
-
-  const visibleFiles = currentResult?.files ?? [];
+  }, [currentResult, outputMode]);
 
   const fetchExport = async (nextTarget: ExportTarget, nextMode: OutputMode) => {
     if (!systemPrompt) return;
     const nextFormat = resolveFormat(nextTarget, nextMode);
     if (cache[nextFormat]) {
-      const files = cache[nextFormat].files ?? [];
-      if (files.length && !selectedFilePath) {
-        setSelectedFilePath(files[0].path);
-      }
       return;
     }
 
@@ -158,10 +152,6 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
 
       const data: ExportResult = await res.json();
       setCache((prev) => ({ ...prev, [nextFormat]: data }));
-      const files = data.files ?? [];
-      if (files.length) {
-        setSelectedFilePath(files[0].path);
-      }
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Export failed");
     } finally {
@@ -172,14 +162,18 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
   const handleToggle = () => {
     const next = !isOpen;
     setIsOpen(next);
-    if (next) {
+    if (next && !isAgentPacksHandoff) {
       void fetchExport(target, outputMode);
     }
   };
 
   const handleTargetClick = (nextTarget: ExportTarget) => {
-    const firstMode = OUTPUT_OPTIONS[nextTarget][0].id;
     setTarget(nextTarget);
+    if (nextTarget === "claude-project-pack") {
+      // Agent Packs is the single home for file bundles — no export call here.
+      return;
+    }
+    const firstMode = OUTPUT_OPTIONS[nextTarget][0].id;
     setOutputMode(firstMode);
     void fetchExport(nextTarget, firstMode);
   };
@@ -196,6 +190,12 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
+  };
+
+  const handleAgentPacksHandoff = () => {
+    if (!systemPrompt) return;
+    window.localStorage.setItem(AGENT_PACKS_HANDOFF_KEY, systemPrompt);
+    router.push("/agent-packs");
   };
 
   if (!systemPrompt) return null;
@@ -252,47 +252,45 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
             ))}
           </div>
 
-          <div className="flex gap-1 px-3 pt-3 flex-wrap" role="radiogroup" aria-label="Output Format">
-            {outputTabs.map((tab) => (
-              <button
-                type="button"
-                key={tab.id}
-                role="radio"
-                aria-checked={outputMode === tab.id}
-                onClick={() => handleOutputModeClick(tab.id)}
-                className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
-                  outputMode === tab.id
-                    ? "bg-white/10 text-zinc-100"
-                    : "text-zinc-500 hover:text-zinc-300"
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-
-          {visibleFiles.length > 1 && (
-            <div className="px-3 pt-3">
-              <label htmlFor="agent-export-file" className="sr-only">
-                Exported file
-              </label>
-              <select
-                id="agent-export-file"
-                value={selectedFilePath ?? visibleFiles[0].path}
-                onChange={(event) => setSelectedFilePath(event.target.value)}
-                className="w-full bg-black/20 border border-white/10 text-zinc-300 text-xs rounded-xl px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
-              >
-                {visibleFiles.map((file) => (
-                  <option key={file.path} value={file.path}>
-                    {file.path}
-                  </option>
-                ))}
-              </select>
+          {outputTabs.length > 0 && (
+            <div className="flex gap-1 px-3 pt-3 flex-wrap" role="radiogroup" aria-label="Output Format">
+              {outputTabs.map((tab) => (
+                <button
+                  type="button"
+                  key={tab.id}
+                  role="radio"
+                  aria-checked={outputMode === tab.id}
+                  onClick={() => handleOutputModeClick(tab.id)}
+                  className={`px-3 py-1 text-[11px] font-mono rounded-md transition-all ${
+                    outputMode === tab.id
+                      ? "bg-white/10 text-zinc-100"
+                      : "text-zinc-500 hover:text-zinc-300"
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
             </div>
           )}
 
           <div className="relative p-3">
-            {loading ? (
+            {isAgentPacksHandoff ? (
+              <div className="flex flex-col items-center gap-3 py-6 px-4 text-center">
+                <p className="text-xs leading-relaxed text-zinc-400 max-w-sm">
+                  Agent Packs is the single home for repo-ready Claude file bundles — CLAUDE.md,
+                  settings, subagents, and workflow assets, generated and reviewed together. Continue
+                  there with this agent description carried over.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleAgentPacksHandoff}
+                  className="inline-flex items-center gap-2 rounded-xl border border-blue-400/30 bg-blue-500/10 px-4 py-2 text-xs font-semibold text-blue-200 transition hover:bg-blue-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                >
+                  Continue in Agent Packs
+                  <ArrowRight size={13} aria-hidden="true" />
+                </button>
+              </div>
+            ) : loading ? (
               <div className="flex items-center justify-center h-24 text-zinc-500 text-xs animate-pulse">
                 Generating {activeTarget.label} export...
               </div>


### PR DESCRIPTION
## Summary
- Agent Generator's "Claude Project Pack" export target no longer duplicates file-bundle generation inline. Selecting it now shows a short explanation plus a "Continue in Agent Packs" button that carries the generated agent description into Agent Packs via `localStorage` (`promptc_agent_pack_goal`) + `router.push("/agent-packs")`, mirroring the existing "Send to Compiler" handoff in `web/app/optimizer/page.tsx:276-280`.
- Removed the now-dead `files` output-mode branch, the multi-file `<select>` switcher, and the `selectedFilePath` state in `ExportPanel.tsx` — all of that machinery existed only to render the Claude Project Pack's file list, which no longer fetches inline.
- Agent Packs (`/agent-packs`) remains the single home for repo-ready Claude file bundles (CLAUDE.md, settings, subagents, workflow assets) per issue #905.

## Adapter reachability investigation
Before touching anything, I checked whether the backend export adapter behind the `claude-project-pack` format is reachable from clients other than the web UI:
- `integrations/mcp-server/server.py` exposes an MCP tool `export_claude_pack(system_prompt)` that POSTs to `/agent-generator/export` with `format: "claude-project-pack"` (covered by `integrations/mcp-server/test_server.py::test_export_claude_pack_posts_to_export_endpoint`).
- No CLI command references `claude-project-pack` or `/agent-generator/export`.

Since the adapter is reachable independent of the web UI (via MCP), this had to stay a **web-only UI change** — I did not touch `app/adapters/`, `api/routes/export.py`, or any backend code. The backend `claude-project-pack` export format keeps working for MCP clients; only the Agent Generator web UI stops calling it.

## Scope note
Per the task's explicit file-scope restriction, only `web/app/agent-generator/` files were changed. The receiving side (`web/app/agent-packs/page.tsx`) does not yet read the `promptc_agent_pack_goal` localStorage key to pre-fill its "goal" field — that's a natural, small follow-up PR scoped to `web/app/agent-packs/` if/when wanted.

## Test plan
- [x] `cd web && npm run test` — 32 files / 169 tests passed
- [x] `cd web && npm run build` — production build succeeds
- [x] Updated `ExportPanel.test.tsx`: removed assertions for the old direct-export behavior on Claude Project Pack, added assertions that selecting the target triggers no extra export call and that the handoff button writes `localStorage` + calls `router.push("/agent-packs")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)