### PR TITLE
feat(adapters): include MCP client config snippet in tool-stub export

### DIFF
--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -217,12 +217,42 @@ if __name__ == "__main__":
 ## Safety and verification
 
 {_skill_safety_markdown(ir)}
+
+## Client configuration
+
+`.mcp.json` is a ready-to-use launch config for `server.py`. Where it goes
+depends on the client:
+
+- **Claude Code**: place `.mcp.json` at your project root (or merge the
+  `{tool_name}` entry into an existing one); Claude Code loads project-level
+  MCP servers from that file automatically.
+- **Claude Desktop**: Claude Desktop does not read project-level `.mcp.json`
+  files. Merge the `mcpServers` entry into its own config instead
+  (Settings > Developer > Edit Config, i.e. `claude_desktop_config.json`).
 """
     )
+    mcp_config = _mcp_client_config(tool_name)
     return [
         {"path": "server.py", "content": content},
         {"path": "README.md", "content": readme},
+        {"path": ".mcp.json", "content": mcp_config},
     ]
+
+
+def _mcp_client_config(tool_name: str) -> str:
+    """Render a launch config for the generated ``server.py`` entry point.
+
+    Uses the same ``{"mcpServers": {...}}`` envelope that ``render_mcp_json``
+    produces for registered servers, so both Claude Code and Claude Desktop
+    can consume this file without translation. The generated stub is a local
+    stdio server (not one of the remote HTTP servers in
+    ``MCP_SERVER_REGISTRY``), so it is launched via ``command``/``args``
+    rather than a ``url``.
+    """
+    return json.dumps(
+        {"mcpServers": {tool_name: {"command": "python", "args": ["server.py"]}}},
+        indent=2,
+    )
 
 
 def _project_claude_md(ir: AgentExportIR) -> str:

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -24,6 +24,7 @@ from app.adapters.claude_code import (
 )
 from app.adapters.claude_sdk import to_python, to_yaml
 from app.adapters.langchain import to_langchain_python, to_langgraph_python
+from app.adapters.mcp_servers import render_mcp_json
 from app.adapters.skill_adapter import to_agent_skill, to_claude_tool_use, to_langchain_tool
 from app.adapters.skill_ir import SkillExportIR, parse_skill_markdown
 
@@ -369,11 +370,35 @@ def test_claude_mcp_tool_stub_output():
     stub = to_claude_mcp_tool_stub(ir)
     paths = {item["path"] for item in stub}
 
+    assert len(stub) == 3
     assert "server.py" in paths
     assert "README.md" in paths
+    assert ".mcp.json" in paths
     server_file = next(item for item in stub if item["path"] == "server.py")
     assert "FastMCP" in server_file["content"]
     assert "web_search" in server_file["content"]
+
+
+def test_claude_mcp_tool_stub_includes_client_config():
+    ir = parse_skill_markdown(SKILL_MARKDOWN)
+    stub = to_claude_mcp_tool_stub(ir)
+
+    config_file = next(item for item in stub if item["path"] == ".mcp.json")
+    config = json.loads(config_file["content"])
+
+    # Matches the {"mcpServers": {...}} envelope render_mcp_json produces for
+    # registered servers, so any client that reads one can read the other.
+    reference_shape = json.loads(render_mcp_json(["github"]))
+    assert list(config.keys()) == list(reference_shape.keys())
+    assert config["mcpServers"]["web_search"] == {
+        "command": "python",
+        "args": ["server.py"],
+    }
+
+    readme_file = next(item for item in stub if item["path"] == "README.md")
+    assert "Claude Code" in readme_file["content"]
+    assert "Claude Desktop" in readme_file["content"]
+    assert ".mcp.json" in readme_file["content"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `to_claude_mcp_tool_stub` previously exported only `server.py` and a `README.md`, leaving the user to hand-write the Claude MCP client registration.
- Adds a third generated file, `.mcp.json`, containing a launch config (`command: "python"`, `args: ["server.py"]`) keyed by the generated tool's name, reusing the same `{"mcpServers": {...}}` envelope shape that `render_mcp_json` already produces for the project pack export.
- Adds a "Client configuration" section to the generated README explaining where `.mcp.json` goes for Claude Code (project-level `.mcp.json`) vs Claude Desktop (its own MCP config, e.g. `claude_desktop_config.json`).

## Test plan
- [x] `python -m pytest tests/test_export_adapters.py -q` — 46 passed
- [x] `uvx ruff@0.1.14 format app/adapters/claude_code.py tests/test_export_adapters.py` — no changes needed
- [x] Added tests asserting the stub returns 3 files, the `.mcp.json` content parses and matches the `render_mcp_json` envelope shape, and the README mentions both Claude Code and Claude Desktop placement

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>