### PR TITLE
feat(web): show destination path for single-file exports

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -95,6 +95,27 @@ describe("Agent ExportPanel", () => {
     expect(JSON.parse(options.body).format).toBe("claude-agent-sdk-ts");
   });
 
+  test("shows the destination file path for a single-file export result", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        python_code: null,
+        yaml_config: null,
+        code: "# Agent\n\nRole: Test",
+        files: [{ path: ".claude/agents/test-agent.md", content: "# Agent\n\nRole: Test" }],
+      }),
+    });
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "Claude Subagent" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+
+    expect(await screen.findByText(".claude/agents/test-agent.md")).toBeInTheDocument();
+  });
+
   test("announces copy success via sr-only live region, not the copy button", async () => {
     render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
 

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -112,6 +112,8 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
   const format = resolveFormat(target, outputMode);
   const currentResult = cache[format] ?? null;
   const outputTabs = OUTPUT_OPTIONS[target];
+  const visibleFiles = currentResult?.files ?? [];
+  const currentFilePath = visibleFiles.length === 1 ? visibleFiles[0].path : null;
 
   const currentContent = useMemo(() => {
     if (!currentResult) return null;
@@ -300,6 +302,11 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
               </div>
             ) : currentContent ? (
               <div className="relative group/code">
+                {currentFilePath && (
+                  <div className="mb-2 text-[10px] font-mono text-zinc-500 truncate" title={currentFilePath}>
+                    {currentFilePath}
+                  </div>
+                )}
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -72,6 +72,27 @@ describe("Skill ExportPanel", () => {
     expect(JSON.parse(options.body).format).toBe("claude-mcp-tool-stub");
   });
 
+  test("shows the destination file path for a single-file export result", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        python_code: null,
+        json_config: null,
+        code: null,
+        files: [{ path: ".claude/mcp/tool.py", content: "def tool(): pass" }],
+      }),
+    });
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "Claude MCP Tool" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+
+    expect(await screen.findByText(".claude/mcp/tool.py")).toBeInTheDocument();
+  });
+
   test("announces copy success via sr-only live region, not the copy button", async () => {
     render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
 

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -89,6 +89,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
   const format = resolveFormat(target);
   const currentResult = cache[format] ?? null;
   const visibleFiles = currentResult?.files ?? [];
+  const currentFilePath = visibleFiles.length === 1 ? visibleFiles[0].path : null;
 
   const currentContent = useMemo(() => {
     if (!currentResult) return null;
@@ -274,6 +275,11 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
               </div>
             ) : currentContent ? (
               <div className="relative group/code">
+                {currentFilePath && (
+                  <div className="mb-2 text-[10px] font-mono text-zinc-500 truncate" title={currentFilePath}>
+                    {currentFilePath}
+                  </div>
+                )}
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>


### PR DESCRIPTION
## Summary
- Exporting a Claude Subagent (or a single-file Claude MCP Tool export) never told the user where the resulting file goes; the backend already returns a `path` (e.g. `.claude/agents/{slug}.md`, see `app/adapters/claude_code.py:103`) but the frontend only surfaced it once a result had more than one file.
- Both `ExportPanel.tsx` components (agent-generator and skills-generator) now render the file's path as a small monospace label directly above the code block whenever the export result has exactly one file, using the same `path` value already present on the file object. Multi-file behavior (the skills-generator file-select dropdown) is unchanged.
- Updated both `ExportPanel.test.tsx` files with a new test asserting the path is visible when there's exactly one file.

Note: PR #970 previously rewrote `web/app/agent-generator/components/ExportPanel.tsx` significantly — it is already merged into `main`, so this branch already includes those changes and no reconciliation is needed there.

Note: a parallel task (T23, download/zip buttons) touches the same two `ExportPanel` files in a nearby region (~line 274 area). Expect a small merge conflict when both land — both changes are additive (a path label vs. download buttons), so it should be trivial to reconcile.

## Test plan
- [x] `cd web && npm run test` — 38 test files / 194 tests passed (pre-existing happy-dom `AbortError` teardown console noise, unrelated to this change and not a failure)
- [x] `cd web && npm run build` — succeeds (Next.js/Turbopack build + TypeScript check)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>