### PR TITLE
feat(web): add download buttons to compile output tabs

### DIFF
--- a/web/app/__tests__/page-download-buttons.test.tsx
+++ b/web/app/__tests__/page-download-buttons.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+import type { CompileResponse } from "../../lib/api/types";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+const { downloadFileMock } = vi.hoisted(() => ({
+  downloadFileMock: vi.fn(),
+}));
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+vi.mock("../lib/downloadFile", () => ({
+  downloadFile: downloadFileMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+function makeResult(): CompileResponse {
+  return {
+    ir: {},
+    system_prompt: "system content",
+    user_prompt: "user content",
+    plan: "plan content",
+    expanded_prompt: "expanded content",
+    processing_ms: 1,
+    request_id: "req_test",
+    heuristic_version: "v1",
+  } as CompileResponse;
+}
+
+describe("Compile output download buttons", () => {
+  beforeEach(() => {
+    downloadFileMock.mockReset();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: makeResult(),
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({
+      indexStats: null,
+    });
+  });
+
+  it("downloads the active text tab's content as <tab>-prompt.md", () => {
+    render(<Home />);
+
+    // Default active tab is "user".
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "user content",
+      "user-prompt.md",
+      "text/markdown",
+    );
+
+    downloadFileMock.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: /system prompt/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "system content",
+      "system-prompt.md",
+      "text/markdown",
+    );
+
+    downloadFileMock.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: /execution plan/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "plan content",
+      "plan-prompt.md",
+      "text/markdown",
+    );
+
+    downloadFileMock.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: /long-form/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "expanded content",
+      "expanded-prompt.md",
+      "text/markdown",
+    );
+  });
+
+  it("downloads the raw compile response as compile-result.json from the JSON tab", () => {
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /^json$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as json/i }));
+
+    expect(downloadFileMock).toHaveBeenCalledTimes(1);
+    const [content, filename, mimeType] = downloadFileMock.mock.calls[0];
+    expect(filename).toBe("compile-result.json");
+    expect(mimeType).toBe("application/json");
+    expect(JSON.parse(content)).toMatchObject({ user_prompt: "user content" });
+  });
+});

--- a/web/app/components/DownloadButton.tsx
+++ b/web/app/components/DownloadButton.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { downloadFile } from "../lib/downloadFile";
+
+interface DownloadButtonProps {
+  content: string;
+  filename: string;
+  mimeType?: string;
+  className?: string;
+  label?: string;
+  variant?: "default" | "gray";
+}
+
+export default function DownloadButton({
+  content,
+  filename,
+  mimeType = "text/plain",
+  className = "",
+  label = "Download",
+  variant = "gray",
+}: DownloadButtonProps) {
+  const [downloaded, setDownloaded] = useState(false);
+
+  const handleDownload = () => {
+    downloadFile(content, filename, mimeType);
+    setDownloaded(true);
+    toast.success(`Downloaded ${filename}`);
+    setTimeout(() => setDownloaded(false), 2000);
+  };
+
+  const baseClasses = "p-3 rounded-xl shadow-lg transition-all hover:scale-105 active:scale-95 z-20 focus-visible:outline-none focus-visible:ring-2";
+  const variantClasses =
+    variant === "gray"
+      ? "bg-zinc-700 hover:bg-zinc-600 text-white focus-visible:ring-zinc-500"
+      : "bg-blue-600 hover:bg-blue-500 text-white shadow-blue-500/20 focus-visible:ring-blue-500";
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      className={`${baseClasses} ${variantClasses} ${className}`}
+      title={downloaded ? "Downloaded!" : `${label} (${filename})`}
+      aria-label={downloaded ? "Downloaded" : `${label} ${filename}`}
+      aria-live="polite"
+    >
+      {downloaded ? (
+        <>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+          <span className="sr-only">Downloaded!</span>
+        </>
+      ) : (
+        <>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+          <span className="sr-only">{label}</span>
+        </>
+      )}
+    </button>
+  );
+}

--- a/web/app/lib/downloadFile.test.ts
+++ b/web/app/lib/downloadFile.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadFile } from "./downloadFile";
+
+describe("downloadFile", () => {
+  const createObjectURL = vi.fn(() => "blob:mock-url");
+  const revokeObjectURL = vi.fn();
+  const originalCreateElement = document.createElement.bind(document);
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let lastAnchor: HTMLAnchorElement | null;
+
+  beforeEach(() => {
+    createObjectURL.mockClear();
+    revokeObjectURL.mockClear();
+    URL.createObjectURL = createObjectURL as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as unknown as typeof URL.revokeObjectURL;
+
+    clickSpy = vi.fn();
+    lastAnchor = null;
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName === "a") {
+        element.click = clickSpy;
+        lastAnchor = element as HTMLAnchorElement;
+      }
+      return element;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a Blob with the given content and mime type, and clicks a download anchor", () => {
+    downloadFile("hello world", "greeting.txt", "text/plain");
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/plain");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("defaults to text/plain when no mime type is provided", () => {
+    downloadFile("content", "file.txt");
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/plain");
+  });
+
+  it("sets the anchor's download attribute to the given filename", () => {
+    downloadFile("data", "compile-result.json", "application/json");
+
+    expect(lastAnchor?.download).toBe("compile-result.json");
+  });
+});

--- a/web/app/lib/downloadFile.ts
+++ b/web/app/lib/downloadFile.ts
@@ -1,0 +1,22 @@
+/**
+ * Triggers a browser download of `content` as a file named `filename`.
+ *
+ * Shared by any page that offers a "download this output" action (e.g. the
+ * compile result tabs, the PR Safety report) so there is a single
+ * anchor+Blob implementation instead of one copy per page.
+ */
+export function downloadFile(
+  content: string,
+  filename: string,
+  mimeType: string = "text/plain",
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -12,6 +12,7 @@ import IntentPolicyPanel from "./components/IntentPolicyPanel";
 import OutputSkeleton from "./components/OutputSkeleton";
 import PolicyBadge from "./components/PolicyBadge";
 import CopyButton from "./components/CopyButton";
+import DownloadButton from "./components/DownloadButton";
 import { useCompiler } from "./hooks/useCompiler";
 import { useContextManager } from "./hooks/useContextManager";
 
@@ -592,10 +593,17 @@ export default function Home() {
                           value={getCompileTabContent(result, tab)}
                         />
 
-                        <CopyButton
-                          text={getCompileTabContent(result, tab)}
-                          className="absolute bottom-6 right-6"
-                        />
+                        <div className="absolute bottom-6 right-6 flex items-center gap-2">
+                          <DownloadButton
+                            content={getCompileTabContent(result, tab)}
+                            filename={`${tab}-prompt.md`}
+                            mimeType="text/markdown"
+                            label="Download as Markdown"
+                          />
+                          <CopyButton
+                            text={getCompileTabContent(result, tab)}
+                          />
+                        </div>
                       </>
                     )}
                   </div>
@@ -616,10 +624,17 @@ export default function Home() {
                           {JSON.stringify(result, null, 2)}
                         </pre>
                       </div>
-                      <CopyButton
-                        text={JSON.stringify(result, null, 2)}
-                        className="absolute bottom-6 right-6"
-                      />
+                      <div className="absolute bottom-6 right-6 flex items-center gap-2">
+                        <DownloadButton
+                          content={JSON.stringify(result, null, 2)}
+                          filename="compile-result.json"
+                          mimeType="application/json"
+                          label="Download as JSON"
+                        />
+                        <CopyButton
+                          text={JSON.stringify(result, null, 2)}
+                        />
+                      </div>
                     </>
                   )}
                 </div>

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import { showError } from "../lib/showError";
+import { downloadFile } from "../lib/downloadFile";
 import InfoButton from "../components/InfoButton";
 import GeneratorErrorState from "../components/GeneratorErrorState";
 import { reportToMarkdown } from "./markdown";
@@ -168,15 +169,7 @@ export default function PrSafetyPage() {
 
   const downloadMarkdown = () => {
     if (!report) return;
-    const blob = new Blob([reportToMarkdown(report)], { type: "text/markdown" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = "pr-safety-report.md";
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
+    downloadFile(reportToMarkdown(report), "pr-safety-report.md", "text/markdown");
   };
 
   const verdictView = report ? VERDICT_VIEW[report.verdict] : null;


### PR DESCRIPTION
## Summary
- The JSON tab's hint markets it as "useful for piping into other tools," but the clipboard was the only way to get compile output off the page.
- Adds a download button beside the existing `CopyButton` on every output tab:
  - Text tabs (`user`, `system`, `plan`, `expanded`) download the active tab's content as `<tab>-prompt.md` (e.g. `user-prompt.md`).
  - The JSON tab downloads the raw compile response as `compile-result.json`.
- Extracts the anchor+Blob download pattern already used by `pr-safety/page.tsx`'s `downloadMarkdown` into a shared `web/app/lib/downloadFile.ts` helper, and updates `pr-safety/page.tsx` to use it instead of its own inline copy. This is a refactor only — PR Safety's download behavior (filename, mime type, click flow) is unchanged.
- Adds a `DownloadButton` component (`web/app/components/DownloadButton.tsx`) mirroring `CopyButton`'s styling/behavior so the new buttons look and feel native to the row, not bolted on.

## Test plan
- [x] `npm run test` — all 40 test files / 197 tests pass, including:
  - new `web/app/lib/downloadFile.test.ts` (unit tests for the extracted helper)
  - new `web/app/__tests__/page-download-buttons.test.tsx` (verifies each text tab downloads `<tab>-prompt.md` with the tab's content, and the JSON tab downloads `compile-result.json` with the raw compile response)
  - existing `web/app/pr-safety/page.test.tsx` and `markdown.test.ts` — unchanged, still green, confirming the refactor didn't alter PR Safety's behavior
- [x] `npm run build` — succeeds (Next.js/Turbopack)

## Overlap notes (for reviewers/merge order)
- T25 (Send to Optimizer button) touches the same `CopyButton` region in `page.tsx` — expect a merge conflict there, should be trivial to reconcile (both are additive buttons in the same row).
- Multiple other open PRs from a prior batch (#963, #962, #967, #964, #968, #966, #969) also touch `page.tsx` — this PR may need a rebase depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)