### PR TITLE
feat(web): two-way compile <-> optimizer handoff

### DIFF
--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -8,9 +8,11 @@ vi.mock("@/config", () => ({
   apiJson: vi.fn(),
 }));
 
+const routerPushMock = vi.fn();
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    push: vi.fn(),
+    push: routerPushMock,
   }),
 }));
 
@@ -23,6 +25,8 @@ const apiJsonMock = vi.mocked(apiJson);
 describe("Optimizer page", () => {
   beforeEach(() => {
     apiJsonMock.mockReset();
+    routerPushMock.mockReset();
+    localStorage.clear();
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {
@@ -245,5 +249,82 @@ describe("Optimizer page", () => {
     expect(inputCostNode.textContent).toMatch(/\$1\.70e-7\s+input cost/);
     const optimizedCostNode = screen.getByText(/optimized cost$/);
     expect(optimizedCostNode.textContent).toMatch(/^\$0\s+optimized cost/);
+  });
+
+  it("sends the English variant — not the main optimized output — to the compiler from the English compact panel", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      text: "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
+      before_chars: 96,
+      after_chars: 62,
+      before_tokens: 34,
+      after_tokens: 21,
+      saved_percent: 38.2,
+      changed: true,
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
+      source_language: "tr",
+      tokenizer_method: "tiktoken:o200k_base:estimated",
+      estimated_input_cost_usd: 0.0000017,
+      estimated_output_cost_usd: 0.0000011,
+      estimated_savings_usd: 0.0000006,
+      english_variant: "Summarize PDF. Write implementation plan for junior developer.",
+      english_variant_tokens: 13,
+      english_variant_cost_usd: 0.0000007,
+      warnings: [],
+    });
+
+    render(<OptimizerPage />);
+
+    fireEvent.change(screen.getByLabelText("Original Prompt"), {
+      target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+
+    expect(await screen.findByRole("heading", { name: "English compact suggestion" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send English variant to compiler" }));
+
+    expect(localStorage.getItem("promptc_compiler_prompt")).toBe(
+      "Summarize PDF. Write implementation plan for junior developer.",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/");
+  });
+
+  it("still sends the main optimized output — not the English variant — from the primary Send to Compiler button", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      text: "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
+      before_chars: 96,
+      after_chars: 62,
+      before_tokens: 34,
+      after_tokens: 21,
+      saved_percent: 38.2,
+      changed: true,
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
+      source_language: "tr",
+      tokenizer_method: "tiktoken:o200k_base:estimated",
+      estimated_input_cost_usd: 0.0000017,
+      estimated_output_cost_usd: 0.0000011,
+      estimated_savings_usd: 0.0000006,
+      english_variant: "Summarize PDF. Write implementation plan for junior developer.",
+      english_variant_tokens: 13,
+      english_variant_cost_usd: 0.0000007,
+      warnings: [],
+    });
+
+    render(<OptimizerPage />);
+
+    fireEvent.change(screen.getByLabelText("Original Prompt"), {
+      target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+
+    await screen.findByRole("button", { name: "Send optimized result to compiler" });
+    fireEvent.click(screen.getByRole("button", { name: "Send optimized result to compiler" }));
+
+    expect(localStorage.getItem("promptc_compiler_prompt")).toBe(
+      "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/");
   });
 });

--- a/web/app/__tests__/page-optimizer-handoff.test.tsx
+++ b/web/app/__tests__/page-optimizer-handoff.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+const routerPushMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+const SEND_TO_OPTIMIZER_LABEL = "Send to Optimizer";
+
+describe("Compile-to-optimizer handoff", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    routerPushMock.mockReset();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({
+      indexStats: null,
+    });
+  });
+
+  it("does not render the Send to Optimizer button before a compile result exists", () => {
+    render(<Home />);
+
+    expect(screen.queryByRole("button", { name: SEND_TO_OPTIMIZER_LABEL })).toBeNull();
+  });
+
+  it("writes the active tab's (user prompt) content to promptc_optimizer_prompt and navigates to /optimizer", () => {
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: {
+        system_prompt: "Compiled system prompt",
+        user_prompt: "Compiled user prompt for the active tab",
+      },
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+
+    render(<Home />);
+
+    const cta = screen.getByRole("button", { name: SEND_TO_OPTIMIZER_LABEL });
+    fireEvent.click(cta);
+
+    expect(localStorage.getItem("promptc_optimizer_prompt")).toBe(
+      "Compiled user prompt for the active tab",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/optimizer");
+  });
+
+  it("sends the active tab's content — not the user tab's — when a different tab is selected", () => {
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: {
+        system_prompt: "Compiled system prompt for the system tab",
+        user_prompt: "Compiled user prompt",
+      },
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /System Prompt/i }));
+
+    const cta = screen.getByRole("button", { name: SEND_TO_OPTIMIZER_LABEL });
+    fireEvent.click(cta);
+
+    expect(localStorage.getItem("promptc_optimizer_prompt")).toBe(
+      "Compiled system prompt for the system tab",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/optimizer");
+  });
+});

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -273,9 +273,9 @@ export default function OptimizerPage() {
         }
     };
 
-    const handleSendToCompiler = () => {
-        if (!output) return;
-        window.localStorage.setItem("promptc_compiler_prompt", output);
+    const handleSendToCompiler = (text: string = output) => {
+        if (!text) return;
+        window.localStorage.setItem("promptc_compiler_prompt", text);
         router.push("/");
     };
 
@@ -449,7 +449,7 @@ export default function OptimizerPage() {
                             <div className="flex items-center gap-2">
                                 <button
                                     type="button"
-                                    onClick={handleSendToCompiler}
+                                    onClick={() => handleSendToCompiler()}
                                     className="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-bold text-white shadow-md shadow-emerald-950/30 transition-all hover:bg-emerald-500 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
                                     aria-label="Send optimized result to compiler"
                                 >
@@ -573,18 +573,28 @@ export default function OptimizerPage() {
                                     aria-label="English compact suggestion"
                                     className="min-h-24 w-full resize-none rounded-lg border border-white/10 bg-black/20 p-3 font-mono text-sm text-cyan-50 outline-none"
                                 />
-                                <div className="flex items-center justify-between gap-3">
+                                <div className="flex flex-wrap items-center justify-between gap-3">
                                     <span className="text-xs text-zinc-500">
                                         Estimated cost: {formatUsd(result.english_variant_cost_usd)}
                                     </span>
-                                    <button
-                                        type="button"
-                                        onClick={() => copyText(englishVariant)}
-                                        className="rounded-lg bg-cyan-700 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
-                                        aria-label="Copy English variant"
-                                    >
-                                        Copy English variant
-                                    </button>
+                                    <div className="flex items-center gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => handleSendToCompiler(englishVariant)}
+                                            className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                                            aria-label="Send English variant to compiler"
+                                        >
+                                            Send to Compiler
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => copyText(englishVariant)}
+                                            className="rounded-lg bg-cyan-700 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                                            aria-label="Copy English variant"
+                                        >
+                                            Copy English variant
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -194,6 +194,12 @@ export default function Home() {
     router.push("/agent-packs");
   };
 
+  const handleSendToOptimizer = (text: string) => {
+    if (!text) return;
+    window.localStorage.setItem("promptc_optimizer_prompt", text);
+    router.push("/optimizer");
+  };
+
   // Typewriter entrance when an example prompt is inserted.
   const typewriterRef = useRef<number | null>(null);
   const stopTypewriter = () => {
@@ -592,10 +598,18 @@ export default function Home() {
                           value={getCompileTabContent(result, tab)}
                         />
 
-                        <CopyButton
-                          text={getCompileTabContent(result, tab)}
-                          className="absolute bottom-6 right-6"
-                        />
+                        <div className="absolute bottom-6 right-6 z-20 flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleSendToOptimizer(getCompileTabContent(result, tab))}
+                            className="inline-flex items-center gap-1.5 rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-3 text-xs font-semibold text-emerald-200 shadow-lg transition-all hover:scale-105 hover:bg-emerald-500/20 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                            title="Send this tab's content to the Token Optimizer"
+                            aria-label="Send to Optimizer"
+                          >
+                            Send to Optimizer
+                          </button>
+                          <CopyButton text={getCompileTabContent(result, tab)} />
+                        </div>
                       </>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- The optimizer -> compiler handoff already existed (`handleSendToCompiler` in `web/app/optimizer/page.tsx`, writing `promptc_compiler_prompt` and navigating to `/`). This PR adds the missing reverse direction: a "Send to Optimizer" button on the compile result panel's text tabs (User Prompt / System Prompt / Execution Plan / Long-form — not the JSON tab, not the empty state) next to the existing `CopyButton`. It writes the **active tab's** rendered content to `localStorage["promptc_optimizer_prompt"]` and navigates to `/optimizer`, which already reads that key on mount.
- Parameterized `handleSendToCompiler` in `web/app/optimizer/page.tsx` to accept an optional `text` argument (defaulting to the existing `output` value), and added a "Send to Compiler" button on the optimizer's English-compact-variant panel so that panel's headline value proposition (shorter English variant for non-English prompts) can be sent onward too, instead of only offering "Copy".

## Files changed
- `web/app/page.tsx` — new `handleSendToOptimizer` handler + "Send to Optimizer" button beside `CopyButton` on the text-content tabs.
- `web/app/optimizer/page.tsx` — parameterized `handleSendToCompiler(text = output)`; added "Send to Compiler" button on the English-compact-variant panel calling it with the variant text.
- `web/app/__tests__/page-optimizer-handoff.test.tsx` (new) — covers the button being absent before a compile result exists, writing the active tab's content to `promptc_optimizer_prompt` + navigating to `/optimizer`, and sending a non-default (system) tab's content instead of the user tab's.
- `web/app/__tests__/optimizer-page.test.tsx` — extended with tests asserting the English-variant button sends the variant text (not the main `output`) to `promptc_compiler_prompt`, and the original button still sends `output` untouched.

## Notes on overlapping work
- T27 (download buttons), from this same task batch, also adds a button beside `CopyButton` in the same region of `page.tsx` (~line 488 pre-change). Expect a merge conflict there — should be trivial to reconcile, both are additive buttons in the same row.
- Multiple other open PRs from a prior batch (#963, #962, #967, #964, #968, #966, #969) also touch `web/app/page.tsx`. This PR may need a rebase depending on merge order.

## Test plan
- [x] `cd web && npm run test` — 39 test files / 197 tests passed.
- [x] `cd web && npm run build` — Next.js production build succeeds, no type errors.