### PR TITLE
feat(web): per-file and ZIP download in export panels

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import ExportPanel from "./ExportPanel";
 
@@ -39,7 +39,32 @@ describe("Agent ExportPanel", () => {
       },
     });
     window.localStorage.clear();
+    vi.stubGlobal("URL", {
+      ...globalThis.URL,
+      createObjectURL: vi.fn(() => "blob:export"),
+      revokeObjectURL: vi.fn(),
+    });
   });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function spyOnAnchorClicks() {
+    const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
+      }
+      return element;
+    });
+    return { clickSpy, anchors };
+  }
 
   test("exposes pressed state for the selected target and clears output mode tabs for the handoff target", async () => {
     render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
@@ -116,5 +141,67 @@ describe("Agent ExportPanel", () => {
     expect(liveRegion?.getAttribute("aria-live")).toBe("polite");
     expect(liveRegion).toHaveTextContent("Copied to clipboard");
     expect(copyButton.getAttribute("aria-label")).toBe("Copied to clipboard");
+  });
+
+  test("downloads the current single-file export as a blob named after its format", async () => {
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    // No zip button for a single-file (in this case zero bundled files) result.
+    expect(screen.queryByRole("button", { name: "Download .zip" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download file" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-agent-sdk-py.py");
+  });
+
+  test("shows a working zip download only when the export produced multiple files", async () => {
+    apiFetch.mockImplementation(async (_url: string, options: { body: string }) => {
+      const body = JSON.parse(options.body);
+      if (body.format === "claude-subagent") {
+        return {
+          ok: true,
+          json: async () => ({
+            python_code: null,
+            yaml_config: null,
+            code: "---\nname: agent\n---\nSystem prompt",
+            files: [
+              { path: ".claude/agents/agent.md", content: "---\nname: agent\n---\nSystem prompt" },
+              { path: ".claude/agents/README.md", content: "Drop this subagent into your repo." },
+            ],
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          python_code: "print('hello')",
+          yaml_config: null,
+          code: "print('hello')",
+          files: [],
+        }),
+      };
+    });
+
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("radio", { name: "Claude Subagent" }));
+    await screen.findByRole("button", { name: "Download .zip" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Download .zip" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-subagent-export.zip");
   });
 });

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { toast } from "sonner";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "@/config";
+import { buildPackZip } from "../../lib/packZip";
 
 const AGENT_PACKS_HANDOFF_KEY = "promptc_agent_pack_goal";
 
@@ -124,6 +125,20 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     return null;
   }, [currentResult, outputMode]);
 
+  const currentFiles = currentResult?.files ?? [];
+
+  // Named after the currently selected file's path when the export produced
+  // one (e.g. the Claude Subagent markdown file); otherwise a sensible
+  // extension is derived from the output mode so raw code exports still
+  // download with a runnable filename.
+  const downloadFilename = useMemo(() => {
+    if (!currentContent) return null;
+    const selectedPath = currentFiles[0]?.path;
+    if (selectedPath) return selectedPath.split("/").pop() || selectedPath;
+    const extension = outputMode === "typescript" ? "ts" : outputMode === "markdown" ? "md" : "py";
+    return `${format}.${extension}`;
+  }, [currentContent, currentFiles, outputMode, format]);
+
   const fetchExport = async (nextTarget: ExportTarget, nextMode: OutputMode) => {
     if (!systemPrompt) return;
     const nextFormat = resolveFormat(nextTarget, nextMode);
@@ -196,6 +211,16 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     if (!systemPrompt) return;
     window.localStorage.setItem(AGENT_PACKS_HANDOFF_KEY, systemPrompt);
     router.push("/agent-packs");
+  };
+
+  const handleDownloadFile = () => {
+    if (!currentContent || !downloadFilename) return;
+    downloadBlob(new Blob([currentContent], { type: "text/plain" }), downloadFilename);
+  };
+
+  const handleDownloadZip = () => {
+    if (currentFiles.length < 2) return;
+    downloadBlob(buildPackZip(currentFiles), `${format}-export.zip`);
   };
 
   if (!systemPrompt) return null;
@@ -303,17 +328,42 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
-                  aria-label={copied ? "Copied to clipboard" : "Copy code"}
-                >
-                  <span className="sr-only" aria-live="polite">
-                    {copied ? "Copied to clipboard" : ""}
-                  </span>
-                  {copied ? "Copied!" : "Copy"}
-                </button>
+                <div className="absolute top-3 right-3 flex items-center gap-1.5 opacity-0 group-hover/code:opacity-100 focus-within:opacity-100 transition-opacity">
+                  {currentFiles.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={handleDownloadZip}
+                      className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                      aria-label="Download .zip"
+                      title="Download all exported files as a .zip"
+                    >
+                      <FolderArchive size={12} aria-hidden="true" />
+                      .zip
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleDownloadFile}
+                    disabled={!downloadFilename}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Download file"
+                    title={downloadFilename ? `Download ${downloadFilename}` : "Download file"}
+                  >
+                    <Download size={12} aria-hidden="true" />
+                    Download
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCopy}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                    aria-label={copied ? "Copied to clipboard" : "Copy code"}
+                  >
+                    <span className="sr-only" aria-live="polite">
+                      {copied ? "Copied to clipboard" : ""}
+                    </span>
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
               </div>
             ) : (
               <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
@@ -335,4 +385,21 @@ function resolveFormat(target: ExportTarget, outputMode: OutputMode): string {
   if (target === "claude-project-pack") return "claude-project-pack";
   if (target === "langgraph") return "langgraph";
   return "langchain";
+}
+
+/** Trigger a browser download for the given blob, then release the object URL. */
+function downloadBlob(blob: Blob, filename: string) {
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  anchor.style.display = "none";
+  // The anchor must be in the document for the synthetic click to trigger a
+  // download in Firefox, and the object URL must outlive the click — revoking
+  // it synchronously cancels the download in Chromium-based browsers.
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(href), 0);
 }

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -11,7 +11,7 @@ import { showError } from "../lib/showError";
 import FileTree from "./components/FileTree";
 import InstallChecklist from "./components/InstallChecklist";
 import { buildInstallChecklist } from "./installChecklist";
-import { buildPackZip } from "./lib/packZip";
+import { buildPackZip } from "../lib/packZip";
 import { agentPackProviders } from "./providerRegistry";
 import type {
   AgentPackFile,

--- a/web/app/lib/packZip.test.ts
+++ b/web/app/lib/packZip.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { unzipSync, strFromU8 } from "fflate";
 
 import { zipPackBytes, buildPackZip } from "./packZip";
-import type { AgentPackFile } from "../types";
+import type { AgentPackFile } from "../agent-packs/types";
 
 const files: AgentPackFile[] = [
   { path: "CLAUDE.md", content: "# Memory\n", kind: "claude_md" },

--- a/web/app/lib/packZip.ts
+++ b/web/app/lib/packZip.ts
@@ -1,9 +1,18 @@
 import { zipSync, strToU8 } from "fflate";
 
-import type { AgentPackFile } from "../agent-packs/types";
+/**
+ * Minimal shape zipping needs. Kept intentionally narrower than
+ * `AgentPackFile` (see `../agent-packs/types`) so any export result shaped
+ * like `{ path, content }` — e.g. agent-generator/skills-generator export
+ * files — can be zipped without an extra mapping step.
+ */
+export interface ZipEntryFile {
+  path: string;
+  content: string;
+}
 
 /** Zip the given files into raw bytes (in-memory, synchronous). */
-export function zipPackBytes(files: AgentPackFile[]): Uint8Array {
+export function zipPackBytes(files: ZipEntryFile[]): Uint8Array {
   const entries: Record<string, Uint8Array> = {};
   for (const file of files) {
     entries[file.path] = strToU8(file.content);
@@ -12,7 +21,7 @@ export function zipPackBytes(files: AgentPackFile[]): Uint8Array {
 }
 
 /** Build a downloadable application/zip Blob from the given files. */
-export function buildPackZip(files: AgentPackFile[]): Blob {
+export function buildPackZip(files: ZipEntryFile[]): Blob {
   const bytes = zipPackBytes(files);
   // Copy into an ArrayBuffer-backed view so the bytes satisfy BlobPart
   // (fflate types its output as Uint8Array<ArrayBufferLike>).

--- a/web/app/lib/packZip.ts
+++ b/web/app/lib/packZip.ts
@@ -1,6 +1,6 @@
 import { zipSync, strToU8 } from "fflate";
 
-import type { AgentPackFile } from "../types";
+import type { AgentPackFile } from "../agent-packs/types";
 
 /** Zip the given files into raw bytes (in-memory, synchronous). */
 export function zipPackBytes(files: AgentPackFile[]): Uint8Array {

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import SkillExportPanel from "./ExportPanel";
 
@@ -29,7 +29,32 @@ describe("Skill ExportPanel", () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     });
+    vi.stubGlobal("URL", {
+      ...globalThis.URL,
+      createObjectURL: vi.fn(() => "blob:export"),
+      revokeObjectURL: vi.fn(),
+    });
   });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function spyOnAnchorClicks() {
+    const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
+      }
+      return element;
+    });
+    return { clickSpy, anchors };
+  }
 
   test("exposes pressed state for the selected target and output mode", async () => {
     render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
@@ -93,5 +118,71 @@ describe("Skill ExportPanel", () => {
     expect(liveRegion?.getAttribute("aria-live")).toBe("polite");
     expect(liveRegion).toHaveTextContent("Copied to clipboard");
     expect(copyButton.getAttribute("aria-label")).toBe("Copied to clipboard");
+  });
+
+  test("downloads the current single-value export as a blob named after its format", async () => {
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    // No zip button for a single-value (in this case zero bundled files) result.
+    expect(screen.queryByRole("button", { name: "Download .zip" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download file" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-tool-use.json");
+  });
+
+  test("shows a working zip download only when the export produced multiple files", async () => {
+    apiFetch.mockImplementation(async (_url: string, options: { body: string }) => {
+      const body = JSON.parse(options.body);
+      if (body.format === "claude-mcp-tool-stub") {
+        return {
+          ok: true,
+          json: async () => ({
+            python_code: "from mcp.server.fastmcp import FastMCP",
+            json_config: null,
+            code: "from mcp.server.fastmcp import FastMCP",
+            files: [
+              { path: "server.py", content: "from mcp.server.fastmcp import FastMCP" },
+              { path: "README.md", content: "# web_search MCP Tool Stub" },
+            ],
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          python_code: "def tool(): pass",
+          json_config: '{"name":"tool"}',
+          code: "def tool(): pass",
+          files: [],
+        }),
+      };
+    });
+
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("radio", { name: "Claude MCP Tool" }));
+    await screen.findByRole("button", { name: "Download .zip" });
+
+    // Both files still show up in the existing multi-file selector.
+    expect(screen.getByRole("option", { name: "server.py" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "README.md" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download .zip" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-mcp-tool-stub-export.zip");
   });
 });

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { toast } from "sonner";
+import { Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { apiFetch } from "@/config";
+import { buildPackZip } from "../../lib/packZip";
 
 type SkillTarget = "claude-tool" | "claude-mcp-tool" | "langchain-tool";
 type OutputMode = "python" | "json" | "files";
@@ -100,6 +102,21 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
     return selected.content;
   }, [currentResult, outputMode, selectedFilePath]);
 
+  // Named after the currently selected file's path when browsing a multi-file
+  // export; otherwise a sensible extension is derived from the output mode so
+  // single-value exports (JSON config, Python tool) still download runnably.
+  const downloadFilename = useMemo(() => {
+    if (!currentContent) return null;
+    if (outputMode === "files") {
+      const files = currentResult?.files ?? [];
+      const selected = files.find((file) => file.path === selectedFilePath) ?? files[0];
+      const path = selected?.path;
+      if (path) return path.split("/").pop() || path;
+    }
+    const extension = outputMode === "json" ? "json" : "py";
+    return `${format}.${extension}`;
+  }, [currentContent, currentResult, outputMode, selectedFilePath, format]);
+
   const fetchExport = async (nextTarget: SkillTarget, nextMode: OutputMode) => {
     if (!skillDefinition) return;
     const nextFormat = resolveFormat(nextTarget);
@@ -168,6 +185,17 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
+  };
+
+  const handleDownloadFile = () => {
+    if (!currentContent || !downloadFilename) return;
+    downloadBlob(new Blob([currentContent], { type: "text/plain" }), downloadFilename);
+  };
+
+  const handleDownloadZip = () => {
+    const files = currentResult?.files ?? [];
+    if (files.length < 2) return;
+    downloadBlob(buildPackZip(files), `${format}-export.zip`);
   };
 
   if (!skillDefinition) return null;
@@ -277,17 +305,42 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
-                  aria-label={copied ? "Copied to clipboard" : "Copy code"}
-                >
-                  <span className="sr-only" aria-live="polite">
-                    {copied ? "Copied to clipboard" : ""}
-                  </span>
-                  {copied ? "Copied!" : "Copy"}
-                </button>
+                <div className="absolute top-3 right-3 flex items-center gap-1.5 opacity-0 group-hover/code:opacity-100 focus-within:opacity-100 transition-opacity">
+                  {visibleFiles.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={handleDownloadZip}
+                      className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                      aria-label="Download .zip"
+                      title="Download all exported files as a .zip"
+                    >
+                      <FolderArchive size={12} aria-hidden="true" />
+                      .zip
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleDownloadFile}
+                    disabled={!downloadFilename}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Download file"
+                    title={downloadFilename ? `Download ${downloadFilename}` : "Download file"}
+                  >
+                    <Download size={12} aria-hidden="true" />
+                    Download
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCopy}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                    aria-label={copied ? "Copied to clipboard" : "Copy code"}
+                  >
+                    <span className="sr-only" aria-live="polite">
+                      {copied ? "Copied to clipboard" : ""}
+                    </span>
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
               </div>
             ) : (
               <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
@@ -305,4 +358,21 @@ function resolveFormat(target: SkillTarget): string {
   if (target === "claude-mcp-tool") return "claude-mcp-tool-stub";
   if (target === "langchain-tool") return "langchain-tool";
   return "claude-tool-use";
+}
+
+/** Trigger a browser download for the given blob, then release the object URL. */
+function downloadBlob(blob: Blob, filename: string) {
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  anchor.style.display = "none";
+  // The anchor must be in the document for the synthetic click to trigger a
+  // download in Firefox, and the object URL must outlive the click — revoking
+  // it synchronously cancels the download in Chromium-based browsers.
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(href), 0);
 }


### PR DESCRIPTION
## Summary
- Moved `buildPackZip`/`zipPackBytes` from `web/app/agent-packs/lib/packZip.ts` to the shared `web/app/lib/packZip.ts` so both export panels can reuse the same zipping logic as Agent Packs. The zip helper's parameter type was narrowed to a minimal `{ path, content }` shape instead of importing `AgentPackFile`, so it also directly accepts the lighter `ExportFile` shape used by the agent-generator/skills-generator export results without any extra mapping.
- Added a "Download file" button to both `web/app/agent-generator/components/ExportPanel.tsx` and `web/app/skills-generator/components/ExportPanel.tsx` that downloads the currently selected export as a blob, named by its file path's basename (falling back to a format+extension name when the export has no `files` array, e.g. raw Python/TypeScript/JSON code).
- Added a "Download .zip" button, shown only when the export result contains more than one file, that bundles all of them via the shared `buildPackZip`.
- Existing copy-to-clipboard behavior is unchanged — these are additive buttons alongside Copy in the same toolbar.

## Overlap notes
- PR #970 already rewrote `web/app/agent-generator/components/ExportPanel.tsx` to hand off the "Claude Project Pack" target to `/agent-packs` instead of an inline multi-file dropdown — that PR is merged on `main` already (commit `b41025f9`), so this PR was built directly against that current shape (no reconciliation needed there). Flagging in case any other still-open branch based on the pre-#970 shape needs a rebase.
- T24 (destination path label) touches the same two `ExportPanel.tsx` files — expect a merge conflict there, should be trivial to reconcile (adjacent lines, no logic overlap).

## Test plan
- [x] `cd web && npm run test` — 38 files / 196 tests passed (pre-existing `ECONNREFUSED` noise from unrelated tests hitting a local port, not caused by this change)
- [x] `cd web && npm run build` — Next.js build succeeds
- [x] New tests: single-file download triggers a blob download with the correct filename; ZIP download button only renders (and works) when the export result has more than one file, in both `agent-generator` and `skills-generator` `ExportPanel.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)