### PR TITLE
integrate: resolve the 5 C-cluster output-actionability PRs (#973-#977)

### DIFF
--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -217,12 +217,42 @@ if __name__ == "__main__":
 ## Safety and verification
 
 {_skill_safety_markdown(ir)}
+
+## Client configuration
+
+`.mcp.json` is a ready-to-use launch config for `server.py`. Where it goes
+depends on the client:
+
+- **Claude Code**: place `.mcp.json` at your project root (or merge the
+  `{tool_name}` entry into an existing one); Claude Code loads project-level
+  MCP servers from that file automatically.
+- **Claude Desktop**: Claude Desktop does not read project-level `.mcp.json`
+  files. Merge the `mcpServers` entry into its own config instead
+  (Settings > Developer > Edit Config, i.e. `claude_desktop_config.json`).
 """
     )
+    mcp_config = _mcp_client_config(tool_name)
     return [
         {"path": "server.py", "content": content},
         {"path": "README.md", "content": readme},
+        {"path": ".mcp.json", "content": mcp_config},
     ]
+
+
+def _mcp_client_config(tool_name: str) -> str:
+    """Render a launch config for the generated ``server.py`` entry point.
+
+    Uses the same ``{"mcpServers": {...}}`` envelope that ``render_mcp_json``
+    produces for registered servers, so both Claude Code and Claude Desktop
+    can consume this file without translation. The generated stub is a local
+    stdio server (not one of the remote HTTP servers in
+    ``MCP_SERVER_REGISTRY``), so it is launched via ``command``/``args``
+    rather than a ``url``.
+    """
+    return json.dumps(
+        {"mcpServers": {tool_name: {"command": "python", "args": ["server.py"]}}},
+        indent=2,
+    )
 
 
 def _project_claude_md(ir: AgentExportIR) -> str:

--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -105,7 +105,7 @@ def test_agent_packs_download_returns_single_file_when_manifest_has_one_file():
         assert response.headers["content-type"].startswith("application/zip")
 
         archive = zipfile.ZipFile(io.BytesIO(response.content))
-        assert set(archive.namelist()) == {"server.py", "README.md"}
+        assert set(archive.namelist()) == {"server.py", "README.md", ".mcp.json"}
 
 
 def test_agent_packs_download_multi_file_pack_returns_nonempty_zip():

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -24,6 +24,7 @@ from app.adapters.claude_code import (
 )
 from app.adapters.claude_sdk import to_python, to_yaml
 from app.adapters.langchain import to_langchain_python, to_langgraph_python
+from app.adapters.mcp_servers import render_mcp_json
 from app.adapters.skill_adapter import to_agent_skill, to_claude_tool_use, to_langchain_tool
 from app.adapters.skill_ir import SkillExportIR, parse_skill_markdown
 
@@ -369,11 +370,35 @@ def test_claude_mcp_tool_stub_output():
     stub = to_claude_mcp_tool_stub(ir)
     paths = {item["path"] for item in stub}
 
+    assert len(stub) == 3
     assert "server.py" in paths
     assert "README.md" in paths
+    assert ".mcp.json" in paths
     server_file = next(item for item in stub if item["path"] == "server.py")
     assert "FastMCP" in server_file["content"]
     assert "web_search" in server_file["content"]
+
+
+def test_claude_mcp_tool_stub_includes_client_config():
+    ir = parse_skill_markdown(SKILL_MARKDOWN)
+    stub = to_claude_mcp_tool_stub(ir)
+
+    config_file = next(item for item in stub if item["path"] == ".mcp.json")
+    config = json.loads(config_file["content"])
+
+    # Matches the {"mcpServers": {...}} envelope render_mcp_json produces for
+    # registered servers, so any client that reads one can read the other.
+    reference_shape = json.loads(render_mcp_json(["github"]))
+    assert list(config.keys()) == list(reference_shape.keys())
+    assert config["mcpServers"]["web_search"] == {
+        "command": "python",
+        "args": ["server.py"],
+    }
+
+    readme_file = next(item for item in stub if item["path"] == "README.md")
+    assert "Claude Code" in readme_file["content"]
+    assert "Claude Desktop" in readme_file["content"]
+    assert ".mcp.json" in readme_file["content"]
 
 
 # ---------------------------------------------------------------------------

--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -8,9 +8,11 @@ vi.mock("@/config", () => ({
   apiJson: vi.fn(),
 }));
 
+const routerPushMock = vi.fn();
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    push: vi.fn(),
+    push: routerPushMock,
   }),
 }));
 
@@ -23,6 +25,8 @@ const apiJsonMock = vi.mocked(apiJson);
 describe("Optimizer page", () => {
   beforeEach(() => {
     apiJsonMock.mockReset();
+    routerPushMock.mockReset();
+    localStorage.clear();
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {
@@ -245,5 +249,82 @@ describe("Optimizer page", () => {
     expect(inputCostNode.textContent).toMatch(/\$1\.70e-7\s+input cost/);
     const optimizedCostNode = screen.getByText(/optimized cost$/);
     expect(optimizedCostNode.textContent).toMatch(/^\$0\s+optimized cost/);
+  });
+
+  it("sends the English variant — not the main optimized output — to the compiler from the English compact panel", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      text: "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
+      before_chars: 96,
+      after_chars: 62,
+      before_tokens: 34,
+      after_tokens: 21,
+      saved_percent: 38.2,
+      changed: true,
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
+      source_language: "tr",
+      tokenizer_method: "tiktoken:o200k_base:estimated",
+      estimated_input_cost_usd: 0.0000017,
+      estimated_output_cost_usd: 0.0000011,
+      estimated_savings_usd: 0.0000006,
+      english_variant: "Summarize PDF. Write implementation plan for junior developer.",
+      english_variant_tokens: 13,
+      english_variant_cost_usd: 0.0000007,
+      warnings: [],
+    });
+
+    render(<OptimizerPage />);
+
+    fireEvent.change(screen.getByLabelText("Original Prompt"), {
+      target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+
+    expect(await screen.findByRole("heading", { name: "English compact suggestion" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send English variant to compiler" }));
+
+    expect(localStorage.getItem("promptc_compiler_prompt")).toBe(
+      "Summarize PDF. Write implementation plan for junior developer.",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/");
+  });
+
+  it("still sends the main optimized output — not the English variant — from the primary Send to Compiler button", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      text: "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
+      before_chars: 96,
+      after_chars: 62,
+      before_tokens: 34,
+      after_tokens: 21,
+      saved_percent: 38.2,
+      changed: true,
+      provider: "openrouter",
+      model: "openai/gpt-oss-20b",
+      source_language: "tr",
+      tokenizer_method: "tiktoken:o200k_base:estimated",
+      estimated_input_cost_usd: 0.0000017,
+      estimated_output_cost_usd: 0.0000011,
+      estimated_savings_usd: 0.0000006,
+      english_variant: "Summarize PDF. Write implementation plan for junior developer.",
+      english_variant_tokens: 13,
+      english_variant_cost_usd: 0.0000007,
+      warnings: [],
+    });
+
+    render(<OptimizerPage />);
+
+    fireEvent.change(screen.getByLabelText("Original Prompt"), {
+      target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+
+    await screen.findByRole("button", { name: "Send optimized result to compiler" });
+    fireEvent.click(screen.getByRole("button", { name: "Send optimized result to compiler" }));
+
+    expect(localStorage.getItem("promptc_compiler_prompt")).toBe(
+      "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/");
   });
 });

--- a/web/app/__tests__/page-download-buttons.test.tsx
+++ b/web/app/__tests__/page-download-buttons.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+import type { CompileResponse } from "../../lib/api/types";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+const { downloadFileMock } = vi.hoisted(() => ({
+  downloadFileMock: vi.fn(),
+}));
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+vi.mock("../lib/downloadFile", () => ({
+  downloadFile: downloadFileMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+function makeResult(): CompileResponse {
+  return {
+    ir: {},
+    system_prompt: "system content",
+    user_prompt: "user content",
+    plan: "plan content",
+    expanded_prompt: "expanded content",
+    processing_ms: 1,
+    request_id: "req_test",
+    heuristic_version: "v1",
+  } as CompileResponse;
+}
+
+describe("Compile output download buttons", () => {
+  beforeEach(() => {
+    downloadFileMock.mockReset();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: makeResult(),
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({
+      indexStats: null,
+    });
+  });
+
+  it("downloads the active text tab's content as <tab>-prompt.md", () => {
+    render(<Home />);
+
+    // Default active tab is "user".
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "user content",
+      "user-prompt.md",
+      "text/markdown",
+    );
+
+    downloadFileMock.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: /system prompt/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "system content",
+      "system-prompt.md",
+      "text/markdown",
+    );
+
+    downloadFileMock.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: /execution plan/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "plan content",
+      "plan-prompt.md",
+      "text/markdown",
+    );
+
+    downloadFileMock.mockClear();
+    fireEvent.click(screen.getByRole("tab", { name: /long-form/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as markdown/i }));
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      "expanded content",
+      "expanded-prompt.md",
+      "text/markdown",
+    );
+  });
+
+  it("downloads the raw compile response as compile-result.json from the JSON tab", () => {
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /^json$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /download as json/i }));
+
+    expect(downloadFileMock).toHaveBeenCalledTimes(1);
+    const [content, filename, mimeType] = downloadFileMock.mock.calls[0];
+    expect(filename).toBe("compile-result.json");
+    expect(mimeType).toBe("application/json");
+    expect(JSON.parse(content)).toMatchObject({ user_prompt: "user content" });
+  });
+});

--- a/web/app/__tests__/page-optimizer-handoff.test.tsx
+++ b/web/app/__tests__/page-optimizer-handoff.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Home from "../page";
+
+const useCompilerMock = vi.fn();
+const useContextManagerMock = vi.fn();
+const routerPushMock = vi.fn();
+
+vi.mock("../hooks/useCompiler", () => ({
+  useCompiler: () => useCompilerMock(),
+}));
+
+vi.mock("../hooks/useContextManager", () => ({
+  useContextManager: () => useContextManagerMock(),
+}));
+
+vi.mock("../components/ContextManager", () => ({
+  default: () => <div data-testid="context-manager" />,
+}));
+
+vi.mock("../components/OutputSkeleton", () => ({
+  default: () => <div data-testid="output-skeleton" />,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+const SEND_TO_OPTIMIZER_LABEL = "Send to Optimizer";
+
+describe("Compile-to-optimizer handoff", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    routerPushMock.mockReset();
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: null,
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+    useContextManagerMock.mockReturnValue({
+      indexStats: null,
+    });
+  });
+
+  it("does not render the Send to Optimizer button before a compile result exists", () => {
+    render(<Home />);
+
+    expect(screen.queryByRole("button", { name: SEND_TO_OPTIMIZER_LABEL })).toBeNull();
+  });
+
+  it("writes the active tab's (user prompt) content to promptc_optimizer_prompt and navigates to /optimizer", () => {
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: {
+        system_prompt: "Compiled system prompt",
+        user_prompt: "Compiled user prompt for the active tab",
+      },
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+
+    render(<Home />);
+
+    const cta = screen.getByRole("button", { name: SEND_TO_OPTIMIZER_LABEL });
+    fireEvent.click(cta);
+
+    expect(localStorage.getItem("promptc_optimizer_prompt")).toBe(
+      "Compiled user prompt for the active tab",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/optimizer");
+  });
+
+  it("sends the active tab's content — not the user tab's — when a different tab is selected", () => {
+    useCompilerMock.mockReturnValue({
+      loading: false,
+      result: {
+        system_prompt: "Compiled system prompt for the system tab",
+        user_prompt: "Compiled user prompt",
+      },
+      status: "Ready",
+      lastError: null,
+      securityFindings: [],
+      redactedText: "",
+      runCompile: vi.fn(),
+      retry: vi.fn(),
+      resolveSecurityDecision: vi.fn(),
+      cancelSecurityReview: vi.fn(),
+    });
+
+    render(<Home />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /System Prompt/i }));
+
+    const cta = screen.getByRole("button", { name: SEND_TO_OPTIMIZER_LABEL });
+    fireEvent.click(cta);
+
+    expect(localStorage.getItem("promptc_optimizer_prompt")).toBe(
+      "Compiled system prompt for the system tab",
+    );
+    expect(routerPushMock).toHaveBeenCalledWith("/optimizer");
+  });
+});

--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import ExportPanel from "./ExportPanel";
 
@@ -39,7 +39,32 @@ describe("Agent ExportPanel", () => {
       },
     });
     window.localStorage.clear();
+    vi.stubGlobal("URL", {
+      ...globalThis.URL,
+      createObjectURL: vi.fn(() => "blob:export"),
+      revokeObjectURL: vi.fn(),
+    });
   });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function spyOnAnchorClicks() {
+    const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
+      }
+      return element;
+    });
+    return { clickSpy, anchors };
+  }
 
   test("exposes pressed state for the selected target and clears output mode tabs for the handoff target", async () => {
     render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
@@ -116,5 +141,67 @@ describe("Agent ExportPanel", () => {
     expect(liveRegion?.getAttribute("aria-live")).toBe("polite");
     expect(liveRegion).toHaveTextContent("Copied to clipboard");
     expect(copyButton.getAttribute("aria-label")).toBe("Copied to clipboard");
+  });
+
+  test("downloads the current single-file export as a blob named after its format", async () => {
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    // No zip button for a single-file (in this case zero bundled files) result.
+    expect(screen.queryByRole("button", { name: "Download .zip" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download file" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-agent-sdk-py.py");
+  });
+
+  test("shows a working zip download only when the export produced multiple files", async () => {
+    apiFetch.mockImplementation(async (_url: string, options: { body: string }) => {
+      const body = JSON.parse(options.body);
+      if (body.format === "claude-subagent") {
+        return {
+          ok: true,
+          json: async () => ({
+            python_code: null,
+            yaml_config: null,
+            code: "---\nname: agent\n---\nSystem prompt",
+            files: [
+              { path: ".claude/agents/agent.md", content: "---\nname: agent\n---\nSystem prompt" },
+              { path: ".claude/agents/README.md", content: "Drop this subagent into your repo." },
+            ],
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          python_code: "print('hello')",
+          yaml_config: null,
+          code: "print('hello')",
+          files: [],
+        }),
+      };
+    });
+
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("radio", { name: "Claude Subagent" }));
+    await screen.findByRole("button", { name: "Download .zip" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Download .zip" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-subagent-export.zip");
   });
 });

--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -95,6 +95,27 @@ describe("Agent ExportPanel", () => {
     expect(JSON.parse(options.body).format).toBe("claude-agent-sdk-ts");
   });
 
+  test("shows the destination file path for a single-file export result", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        python_code: null,
+        yaml_config: null,
+        code: "# Agent\n\nRole: Test",
+        files: [{ path: ".claude/agents/test-agent.md", content: "# Agent\n\nRole: Test" }],
+      }),
+    });
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "Claude Subagent" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+
+    expect(await screen.findByText(".claude/agents/test-agent.md")).toBeInTheDocument();
+  });
+
   test("announces copy success via sr-only live region, not the copy button", async () => {
     render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
 

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { toast } from "sonner";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "@/config";
+import { buildPackZip } from "../../lib/packZip";
 
 const AGENT_PACKS_HANDOFF_KEY = "promptc_agent_pack_goal";
 
@@ -124,6 +125,20 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     return null;
   }, [currentResult, outputMode]);
 
+  const currentFiles = currentResult?.files ?? [];
+
+  // Named after the currently selected file's path when the export produced
+  // one (e.g. the Claude Subagent markdown file); otherwise a sensible
+  // extension is derived from the output mode so raw code exports still
+  // download with a runnable filename.
+  const downloadFilename = useMemo(() => {
+    if (!currentContent) return null;
+    const selectedPath = currentFiles[0]?.path;
+    if (selectedPath) return selectedPath.split("/").pop() || selectedPath;
+    const extension = outputMode === "typescript" ? "ts" : outputMode === "markdown" ? "md" : "py";
+    return `${format}.${extension}`;
+  }, [currentContent, currentFiles, outputMode, format]);
+
   const fetchExport = async (nextTarget: ExportTarget, nextMode: OutputMode) => {
     if (!systemPrompt) return;
     const nextFormat = resolveFormat(nextTarget, nextMode);
@@ -196,6 +211,16 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     if (!systemPrompt) return;
     window.localStorage.setItem(AGENT_PACKS_HANDOFF_KEY, systemPrompt);
     router.push("/agent-packs");
+  };
+
+  const handleDownloadFile = () => {
+    if (!currentContent || !downloadFilename) return;
+    downloadBlob(new Blob([currentContent], { type: "text/plain" }), downloadFilename);
+  };
+
+  const handleDownloadZip = () => {
+    if (currentFiles.length < 2) return;
+    downloadBlob(buildPackZip(currentFiles), `${format}-export.zip`);
   };
 
   if (!systemPrompt) return null;
@@ -303,17 +328,42 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
-                  aria-label={copied ? "Copied to clipboard" : "Copy code"}
-                >
-                  <span className="sr-only" aria-live="polite">
-                    {copied ? "Copied to clipboard" : ""}
-                  </span>
-                  {copied ? "Copied!" : "Copy"}
-                </button>
+                <div className="absolute top-3 right-3 flex items-center gap-1.5 opacity-0 group-hover/code:opacity-100 focus-within:opacity-100 transition-opacity">
+                  {currentFiles.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={handleDownloadZip}
+                      className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                      aria-label="Download .zip"
+                      title="Download all exported files as a .zip"
+                    >
+                      <FolderArchive size={12} aria-hidden="true" />
+                      .zip
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleDownloadFile}
+                    disabled={!downloadFilename}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Download file"
+                    title={downloadFilename ? `Download ${downloadFilename}` : "Download file"}
+                  >
+                    <Download size={12} aria-hidden="true" />
+                    Download
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCopy}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                    aria-label={copied ? "Copied to clipboard" : "Copy code"}
+                  >
+                    <span className="sr-only" aria-live="polite">
+                      {copied ? "Copied to clipboard" : ""}
+                    </span>
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
               </div>
             ) : (
               <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
@@ -335,4 +385,21 @@ function resolveFormat(target: ExportTarget, outputMode: OutputMode): string {
   if (target === "claude-project-pack") return "claude-project-pack";
   if (target === "langgraph") return "langgraph";
   return "langchain";
+}
+
+/** Trigger a browser download for the given blob, then release the object URL. */
+function downloadBlob(blob: Blob, filename: string) {
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  anchor.style.display = "none";
+  // The anchor must be in the document for the synthetic click to trigger a
+  // download in Firefox, and the object URL must outlive the click — revoking
+  // it synchronously cancels the download in Chromium-based browsers.
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(href), 0);
 }

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -112,6 +112,8 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
   const format = resolveFormat(target, outputMode);
   const currentResult = cache[format] ?? null;
   const outputTabs = OUTPUT_OPTIONS[target];
+  const visibleFiles = currentResult?.files ?? [];
+  const currentFilePath = visibleFiles.length === 1 ? visibleFiles[0].path : null;
 
   const currentContent = useMemo(() => {
     if (!currentResult) return null;
@@ -300,6 +302,11 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
               </div>
             ) : currentContent ? (
               <div className="relative group/code">
+                {currentFilePath && (
+                  <div className="mb-2 text-[10px] font-mono text-zinc-500 truncate" title={currentFilePath}>
+                    {currentFilePath}
+                  </div>
+                )}
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -11,7 +11,7 @@ import { showError } from "../lib/showError";
 import FileTree from "./components/FileTree";
 import InstallChecklist from "./components/InstallChecklist";
 import { buildInstallChecklist } from "./installChecklist";
-import { buildPackZip } from "./lib/packZip";
+import { buildPackZip } from "../lib/packZip";
 import { agentPackProviders } from "./providerRegistry";
 import type {
   AgentPackFile,

--- a/web/app/components/DownloadButton.tsx
+++ b/web/app/components/DownloadButton.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { downloadFile } from "../lib/downloadFile";
+
+interface DownloadButtonProps {
+  content: string;
+  filename: string;
+  mimeType?: string;
+  className?: string;
+  label?: string;
+  variant?: "default" | "gray";
+}
+
+export default function DownloadButton({
+  content,
+  filename,
+  mimeType = "text/plain",
+  className = "",
+  label = "Download",
+  variant = "gray",
+}: DownloadButtonProps) {
+  const [downloaded, setDownloaded] = useState(false);
+
+  const handleDownload = () => {
+    downloadFile(content, filename, mimeType);
+    setDownloaded(true);
+    toast.success(`Downloaded ${filename}`);
+    setTimeout(() => setDownloaded(false), 2000);
+  };
+
+  const baseClasses = "p-3 rounded-xl shadow-lg transition-all hover:scale-105 active:scale-95 z-20 focus-visible:outline-none focus-visible:ring-2";
+  const variantClasses =
+    variant === "gray"
+      ? "bg-zinc-700 hover:bg-zinc-600 text-white focus-visible:ring-zinc-500"
+      : "bg-blue-600 hover:bg-blue-500 text-white shadow-blue-500/20 focus-visible:ring-blue-500";
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      className={`${baseClasses} ${variantClasses} ${className}`}
+      title={downloaded ? "Downloaded!" : `${label} (${filename})`}
+      aria-label={downloaded ? "Downloaded" : `${label} ${filename}`}
+      aria-live="polite"
+    >
+      {downloaded ? (
+        <>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+          <span className="sr-only">Downloaded!</span>
+        </>
+      ) : (
+        <>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+          <span className="sr-only">{label}</span>
+        </>
+      )}
+    </button>
+  );
+}

--- a/web/app/lib/downloadFile.test.ts
+++ b/web/app/lib/downloadFile.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadFile } from "./downloadFile";
+
+describe("downloadFile", () => {
+  const createObjectURL = vi.fn(() => "blob:mock-url");
+  const revokeObjectURL = vi.fn();
+  const originalCreateElement = document.createElement.bind(document);
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let lastAnchor: HTMLAnchorElement | null;
+
+  beforeEach(() => {
+    createObjectURL.mockClear();
+    revokeObjectURL.mockClear();
+    URL.createObjectURL = createObjectURL as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as unknown as typeof URL.revokeObjectURL;
+
+    clickSpy = vi.fn();
+    lastAnchor = null;
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName === "a") {
+        element.click = clickSpy;
+        lastAnchor = element as HTMLAnchorElement;
+      }
+      return element;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a Blob with the given content and mime type, and clicks a download anchor", () => {
+    downloadFile("hello world", "greeting.txt", "text/plain");
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/plain");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("defaults to text/plain when no mime type is provided", () => {
+    downloadFile("content", "file.txt");
+
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe("text/plain");
+  });
+
+  it("sets the anchor's download attribute to the given filename", () => {
+    downloadFile("data", "compile-result.json", "application/json");
+
+    expect(lastAnchor?.download).toBe("compile-result.json");
+  });
+});

--- a/web/app/lib/downloadFile.ts
+++ b/web/app/lib/downloadFile.ts
@@ -1,0 +1,22 @@
+/**
+ * Triggers a browser download of `content` as a file named `filename`.
+ *
+ * Shared by any page that offers a "download this output" action (e.g. the
+ * compile result tabs, the PR Safety report) so there is a single
+ * anchor+Blob implementation instead of one copy per page.
+ */
+export function downloadFile(
+  content: string,
+  filename: string,
+  mimeType: string = "text/plain",
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/web/app/lib/packZip.test.ts
+++ b/web/app/lib/packZip.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { unzipSync, strFromU8 } from "fflate";
 
 import { zipPackBytes, buildPackZip } from "./packZip";
-import type { AgentPackFile } from "../types";
+import type { AgentPackFile } from "../agent-packs/types";
 
 const files: AgentPackFile[] = [
   { path: "CLAUDE.md", content: "# Memory\n", kind: "claude_md" },

--- a/web/app/lib/packZip.ts
+++ b/web/app/lib/packZip.ts
@@ -1,9 +1,18 @@
 import { zipSync, strToU8 } from "fflate";
 
-import type { AgentPackFile } from "../agent-packs/types";
+/**
+ * Minimal shape zipping needs. Kept intentionally narrower than
+ * `AgentPackFile` (see `../agent-packs/types`) so any export result shaped
+ * like `{ path, content }` — e.g. agent-generator/skills-generator export
+ * files — can be zipped without an extra mapping step.
+ */
+export interface ZipEntryFile {
+  path: string;
+  content: string;
+}
 
 /** Zip the given files into raw bytes (in-memory, synchronous). */
-export function zipPackBytes(files: AgentPackFile[]): Uint8Array {
+export function zipPackBytes(files: ZipEntryFile[]): Uint8Array {
   const entries: Record<string, Uint8Array> = {};
   for (const file of files) {
     entries[file.path] = strToU8(file.content);
@@ -12,7 +21,7 @@ export function zipPackBytes(files: AgentPackFile[]): Uint8Array {
 }
 
 /** Build a downloadable application/zip Blob from the given files. */
-export function buildPackZip(files: AgentPackFile[]): Blob {
+export function buildPackZip(files: ZipEntryFile[]): Blob {
   const bytes = zipPackBytes(files);
   // Copy into an ArrayBuffer-backed view so the bytes satisfy BlobPart
   // (fflate types its output as Uint8Array<ArrayBufferLike>).

--- a/web/app/lib/packZip.ts
+++ b/web/app/lib/packZip.ts
@@ -1,6 +1,6 @@
 import { zipSync, strToU8 } from "fflate";
 
-import type { AgentPackFile } from "../types";
+import type { AgentPackFile } from "../agent-packs/types";
 
 /** Zip the given files into raw bytes (in-memory, synchronous). */
 export function zipPackBytes(files: AgentPackFile[]): Uint8Array {

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -273,9 +273,9 @@ export default function OptimizerPage() {
         }
     };
 
-    const handleSendToCompiler = () => {
-        if (!output) return;
-        window.localStorage.setItem("promptc_compiler_prompt", output);
+    const handleSendToCompiler = (text: string = output) => {
+        if (!text) return;
+        window.localStorage.setItem("promptc_compiler_prompt", text);
         router.push("/");
     };
 
@@ -449,7 +449,7 @@ export default function OptimizerPage() {
                             <div className="flex items-center gap-2">
                                 <button
                                     type="button"
-                                    onClick={handleSendToCompiler}
+                                    onClick={() => handleSendToCompiler()}
                                     className="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-bold text-white shadow-md shadow-emerald-950/30 transition-all hover:bg-emerald-500 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
                                     aria-label="Send optimized result to compiler"
                                 >
@@ -573,18 +573,28 @@ export default function OptimizerPage() {
                                     aria-label="English compact suggestion"
                                     className="min-h-24 w-full resize-none rounded-lg border border-white/10 bg-black/20 p-3 font-mono text-sm text-cyan-50 outline-none"
                                 />
-                                <div className="flex items-center justify-between gap-3">
+                                <div className="flex flex-wrap items-center justify-between gap-3">
                                     <span className="text-xs text-zinc-500">
                                         Estimated cost: {formatUsd(result.english_variant_cost_usd)}
                                     </span>
-                                    <button
-                                        type="button"
-                                        onClick={() => copyText(englishVariant)}
-                                        className="rounded-lg bg-cyan-700 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
-                                        aria-label="Copy English variant"
-                                    >
-                                        Copy English variant
-                                    </button>
+                                    <div className="flex items-center gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => handleSendToCompiler(englishVariant)}
+                                            className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                                            aria-label="Send English variant to compiler"
+                                        >
+                                            Send to Compiler
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => copyText(englishVariant)}
+                                            className="rounded-lg bg-cyan-700 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-cyan-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                                            aria-label="Copy English variant"
+                                        >
+                                            Copy English variant
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -12,6 +12,7 @@ import IntentPolicyPanel from "./components/IntentPolicyPanel";
 import OutputSkeleton from "./components/OutputSkeleton";
 import PolicyBadge from "./components/PolicyBadge";
 import CopyButton from "./components/CopyButton";
+import DownloadButton from "./components/DownloadButton";
 import { useCompiler } from "./hooks/useCompiler";
 import { useContextManager } from "./hooks/useContextManager";
 
@@ -592,10 +593,17 @@ export default function Home() {
                           value={getCompileTabContent(result, tab)}
                         />
 
-                        <CopyButton
-                          text={getCompileTabContent(result, tab)}
-                          className="absolute bottom-6 right-6"
-                        />
+                        <div className="absolute bottom-6 right-6 flex items-center gap-2">
+                          <DownloadButton
+                            content={getCompileTabContent(result, tab)}
+                            filename={`${tab}-prompt.md`}
+                            mimeType="text/markdown"
+                            label="Download as Markdown"
+                          />
+                          <CopyButton
+                            text={getCompileTabContent(result, tab)}
+                          />
+                        </div>
                       </>
                     )}
                   </div>
@@ -616,10 +624,17 @@ export default function Home() {
                           {JSON.stringify(result, null, 2)}
                         </pre>
                       </div>
-                      <CopyButton
-                        text={JSON.stringify(result, null, 2)}
-                        className="absolute bottom-6 right-6"
-                      />
+                      <div className="absolute bottom-6 right-6 flex items-center gap-2">
+                        <DownloadButton
+                          content={JSON.stringify(result, null, 2)}
+                          filename="compile-result.json"
+                          mimeType="application/json"
+                          label="Download as JSON"
+                        />
+                        <CopyButton
+                          text={JSON.stringify(result, null, 2)}
+                        />
+                      </div>
                     </>
                   )}
                 </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -194,6 +194,12 @@ export default function Home() {
     router.push("/agent-packs");
   };
 
+  const handleSendToOptimizer = (text: string) => {
+    if (!text) return;
+    window.localStorage.setItem("promptc_optimizer_prompt", text);
+    router.push("/optimizer");
+  };
+
   // Typewriter entrance when an example prompt is inserted.
   const typewriterRef = useRef<number | null>(null);
   const stopTypewriter = () => {
@@ -592,10 +598,18 @@ export default function Home() {
                           value={getCompileTabContent(result, tab)}
                         />
 
-                        <CopyButton
-                          text={getCompileTabContent(result, tab)}
-                          className="absolute bottom-6 right-6"
-                        />
+                        <div className="absolute bottom-6 right-6 z-20 flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleSendToOptimizer(getCompileTabContent(result, tab))}
+                            className="inline-flex items-center gap-1.5 rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-3 text-xs font-semibold text-emerald-200 shadow-lg transition-all hover:scale-105 hover:bg-emerald-500/20 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                            title="Send this tab's content to the Token Optimizer"
+                            aria-label="Send to Optimizer"
+                          >
+                            Send to Optimizer
+                          </button>
+                          <CopyButton text={getCompileTabContent(result, tab)} />
+                        </div>
                       </>
                     )}
                   </div>

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import { showError } from "../lib/showError";
+import { downloadFile } from "../lib/downloadFile";
 import InfoButton from "../components/InfoButton";
 import GeneratorErrorState from "../components/GeneratorErrorState";
 import { reportToMarkdown } from "./markdown";
@@ -168,15 +169,7 @@ export default function PrSafetyPage() {
 
   const downloadMarkdown = () => {
     if (!report) return;
-    const blob = new Blob([reportToMarkdown(report)], { type: "text/markdown" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = "pr-safety-report.md";
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
+    downloadFile(reportToMarkdown(report), "pr-safety-report.md", "text/markdown");
   };
 
   const verdictView = report ? VERDICT_VIEW[report.verdict] : null;

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -72,6 +72,27 @@ describe("Skill ExportPanel", () => {
     expect(JSON.parse(options.body).format).toBe("claude-mcp-tool-stub");
   });
 
+  test("shows the destination file path for a single-file export result", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        python_code: null,
+        json_config: null,
+        code: null,
+        files: [{ path: ".claude/mcp/tool.py", content: "def tool(): pass" }],
+      }),
+    });
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "Claude MCP Tool" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+
+    expect(await screen.findByText(".claude/mcp/tool.py")).toBeInTheDocument();
+  });
+
   test("announces copy success via sr-only live region, not the copy button", async () => {
     render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
 

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import SkillExportPanel from "./ExportPanel";
 
@@ -29,7 +29,32 @@ describe("Skill ExportPanel", () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     });
+    vi.stubGlobal("URL", {
+      ...globalThis.URL,
+      createObjectURL: vi.fn(() => "blob:export"),
+      revokeObjectURL: vi.fn(),
+    });
   });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function spyOnAnchorClicks() {
+    const clickSpy = vi.fn();
+    const anchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "a") {
+        Object.defineProperty(element, "click", { configurable: true, value: clickSpy });
+        anchors.push(element as HTMLAnchorElement);
+      }
+      return element;
+    });
+    return { clickSpy, anchors };
+  }
 
   test("exposes pressed state for the selected target and output mode", async () => {
     render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
@@ -93,5 +118,71 @@ describe("Skill ExportPanel", () => {
     expect(liveRegion?.getAttribute("aria-live")).toBe("polite");
     expect(liveRegion).toHaveTextContent("Copied to clipboard");
     expect(copyButton.getAttribute("aria-label")).toBe("Copied to clipboard");
+  });
+
+  test("downloads the current single-value export as a blob named after its format", async () => {
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    // No zip button for a single-value (in this case zero bundled files) result.
+    expect(screen.queryByRole("button", { name: "Download .zip" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download file" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-tool-use.json");
+  });
+
+  test("shows a working zip download only when the export produced multiple files", async () => {
+    apiFetch.mockImplementation(async (_url: string, options: { body: string }) => {
+      const body = JSON.parse(options.body);
+      if (body.format === "claude-mcp-tool-stub") {
+        return {
+          ok: true,
+          json: async () => ({
+            python_code: "from mcp.server.fastmcp import FastMCP",
+            json_config: null,
+            code: "from mcp.server.fastmcp import FastMCP",
+            files: [
+              { path: "server.py", content: "from mcp.server.fastmcp import FastMCP" },
+              { path: "README.md", content: "# web_search MCP Tool Stub" },
+            ],
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          python_code: "def tool(): pass",
+          json_config: '{"name":"tool"}',
+          code: "def tool(): pass",
+          files: [],
+        }),
+      };
+    });
+
+    const { clickSpy, anchors } = spyOnAnchorClicks();
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("radio", { name: "Claude MCP Tool" }));
+    await screen.findByRole("button", { name: "Download .zip" });
+
+    // Both files still show up in the existing multi-file selector.
+    expect(screen.getByRole("option", { name: "server.py" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "README.md" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download .zip" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchors[anchors.length - 1].download).toBe("claude-mcp-tool-stub-export.zip");
   });
 });

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { toast } from "sonner";
+import { Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { apiFetch } from "@/config";
+import { buildPackZip } from "../../lib/packZip";
 
 type SkillTarget = "claude-tool" | "claude-mcp-tool" | "langchain-tool";
 type OutputMode = "python" | "json" | "files";
@@ -100,6 +102,21 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
     return selected.content;
   }, [currentResult, outputMode, selectedFilePath]);
 
+  // Named after the currently selected file's path when browsing a multi-file
+  // export; otherwise a sensible extension is derived from the output mode so
+  // single-value exports (JSON config, Python tool) still download runnably.
+  const downloadFilename = useMemo(() => {
+    if (!currentContent) return null;
+    if (outputMode === "files") {
+      const files = currentResult?.files ?? [];
+      const selected = files.find((file) => file.path === selectedFilePath) ?? files[0];
+      const path = selected?.path;
+      if (path) return path.split("/").pop() || path;
+    }
+    const extension = outputMode === "json" ? "json" : "py";
+    return `${format}.${extension}`;
+  }, [currentContent, currentResult, outputMode, selectedFilePath, format]);
+
   const fetchExport = async (nextTarget: SkillTarget, nextMode: OutputMode) => {
     if (!skillDefinition) return;
     const nextFormat = resolveFormat(nextTarget);
@@ -168,6 +185,17 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
+  };
+
+  const handleDownloadFile = () => {
+    if (!currentContent || !downloadFilename) return;
+    downloadBlob(new Blob([currentContent], { type: "text/plain" }), downloadFilename);
+  };
+
+  const handleDownloadZip = () => {
+    const files = currentResult?.files ?? [];
+    if (files.length < 2) return;
+    downloadBlob(buildPackZip(files), `${format}-export.zip`);
   };
 
   if (!skillDefinition) return null;
@@ -277,17 +305,42 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>
-                <button
-                  type="button"
-                  onClick={handleCopy}
-                  className="absolute top-3 right-3 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-opacity bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
-                  aria-label={copied ? "Copied to clipboard" : "Copy code"}
-                >
-                  <span className="sr-only" aria-live="polite">
-                    {copied ? "Copied to clipboard" : ""}
-                  </span>
-                  {copied ? "Copied!" : "Copy"}
-                </button>
+                <div className="absolute top-3 right-3 flex items-center gap-1.5 opacity-0 group-hover/code:opacity-100 focus-within:opacity-100 transition-opacity">
+                  {visibleFiles.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={handleDownloadZip}
+                      className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                      aria-label="Download .zip"
+                      title="Download all exported files as a .zip"
+                    >
+                      <FolderArchive size={12} aria-hidden="true" />
+                      .zip
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleDownloadFile}
+                    disabled={!downloadFilename}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Download file"
+                    title={downloadFilename ? `Download ${downloadFilename}` : "Download file"}
+                  >
+                    <Download size={12} aria-hidden="true" />
+                    Download
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCopy}
+                    className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10"
+                    aria-label={copied ? "Copied to clipboard" : "Copy code"}
+                  >
+                    <span className="sr-only" aria-live="polite">
+                      {copied ? "Copied to clipboard" : ""}
+                    </span>
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
               </div>
             ) : (
               <div className="flex items-center justify-center h-16 text-zinc-600 text-xs">
@@ -305,4 +358,21 @@ function resolveFormat(target: SkillTarget): string {
   if (target === "claude-mcp-tool") return "claude-mcp-tool-stub";
   if (target === "langchain-tool") return "langchain-tool";
   return "claude-tool-use";
+}
+
+/** Trigger a browser download for the given blob, then release the object URL. */
+function downloadBlob(blob: Blob, filename: string) {
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  anchor.style.display = "none";
+  // The anchor must be in the document for the synthetic click to trigger a
+  // download in Firefox, and the object URL must outlive the click — revoking
+  // it synchronously cancels the download in Chromium-based browsers.
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(href), 0);
 }

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -89,6 +89,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
   const format = resolveFormat(target);
   const currentResult = cache[format] ?? null;
   const visibleFiles = currentResult?.files ?? [];
+  const currentFilePath = visibleFiles.length === 1 ? visibleFiles[0].path : null;
 
   const currentContent = useMemo(() => {
     if (!currentResult) return null;
@@ -274,6 +275,11 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
               </div>
             ) : currentContent ? (
               <div className="relative group/code">
+                {currentFilePath && (
+                  <div className="mb-2 text-[10px] font-mono text-zinc-500 truncate" title={currentFilePath}>
+                    {currentFilePath}
+                  </div>
+                )}
                 <pre className="overflow-x-auto overflow-y-auto max-h-72 text-[11px] leading-relaxed font-mono text-zinc-300 bg-black/40 rounded-xl p-4 border border-white/5 whitespace-pre">
                   <code>{currentContent}</code>
                 </pre>


### PR DESCRIPTION
## What this is

Integration of the **5 C-cluster PRs** (output actionability) into one conflict-resolved, tested branch. Two mini-clusters collided; one PR shipped with a stale test in an unrelated file.

Supersedes (close once merged): #973, #974, #975, #976, #977.

## Included
- #973 MCP tool-stub export now includes a `.mcp.json` client config snippet (backend)
- #974 show destination path for single-file exports
- #977 per-file + ZIP download in Agent/Skills export panels
- #975 download buttons on compile output tabs
- #976 two-way compile ↔ optimizer handoff

## Conflict / breakage resolutions (human-reviewed)
1. **page.tsx (#975 vs #976):** both replaced the single output-tab CopyButton with a button row. Merged into one row: **Download → Send to Optimizer → Copy** (kept #976's `z-20` wrapper).
2. **`.mcp.json` test breakage from #973:** #973 added `.mcp.json` to the stub but only updated its own adapter test; `tests/test_agent_packs_api.py:108` still asserted the 2-file zip `{server.py, README.md}` and failed in the full suite. Updated it to expect `.mcp.json`. Swept `tests/` for other stale stub assertions — none.
3. **Export panels (#974 dest-path + #977 zip-download):** touch the same two ExportPanels but different regions — git-clean; both features verified present via the passing merged test suite.

## Verification
- Python: focused sweep (stub / mcp / download / export / agent_pack) — 170 pass; `test_agent_packs_api` + `test_export_adapters` — 69 pass.
- Web: `npm run test` — 41 files / 208 tests pass.
- Web: `npm run lint` — 0 errors.
- Web: `npm run build` — production build succeeds.

## Note
No page.tsx-cluster PRs (#932/#942) or Sidebar cluster included — those remain per the standing merge plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
