### PR TITLE
docs: integrate the 6 adoption-path doc PRs (#949-#955)

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "prompt-compiler": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["${CLAUDE_PROJECT_DIR}/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ API keys are stored in VS Code secret storage, not workspace settings.
 
 ### CLI (pip / pipx)
 
-Install the command-line compiler from PyPI:
+Install the command-line compiler directly from GitHub:
 
 ```bash
-pipx install prcompiler        # recommended — isolated install
+pipx install git+https://github.com/madara88645/Compiler.git   # recommended — isolated install
 # or
-pip install prcompiler
+pip install git+https://github.com/madara88645/Compiler.git
 ```
 
 Then compile a prompt:
@@ -317,6 +317,14 @@ Then compile a prompt:
 promptc compile "write a haiku about the sea"
 promptc --version
 ```
+
+> **Once published on PyPI**, you will also be able to install with:
+>
+> ```bash
+> pipx install prcompiler        # recommended — isolated install
+> # or
+> pip install prcompiler
+> ```
 
 ### From source (development)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Every report also surfaces **risky areas**, a **test-coverage** signal, **branch
 
 **CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
 
+**CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
+
 ---
 
 ### Conservative Mode

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Every report also surfaces **risky areas**, a **test-coverage** signal, **branch
 
 **v1 is an offline, deterministic advisory.** It runs only on what you paste — no GitHub API, no AI calls, no sign-in — and never blocks a merge. Open it in the sidebar or at [`/pr-safety`](https://prcompiler.com/pr-safety); the [PR Safety guide](docs/pr-safety.md) has worked examples (docs-only, auth-risk, stale branch, split-needed), a `curl` recipe for `POST /pr-safety/report`, and an advisory [GitHub Action sketch](docs/pr-safety-github-action.md).
 
+**CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
+
 ---
 
 ### Conservative Mode
@@ -280,12 +282,23 @@ python -m cli.main github render --type pr-review-brief --from-file prompt.txt
 
 ### VS Code Extension
 
-The VS Code package lives in [`integrations/vscode-extension`](integrations/vscode-extension). Once the Marketplace publisher is claimed and the first `vscode-v*` tag is pushed, it installs from:
+The VS Code package lives in [`integrations/vscode-extension`](integrations/vscode-extension).
+
+Start the backend before using the extension (default API URL is `http://127.0.0.1:8080`):
+
+```bash
+python -m uvicorn api.main:app --reload --port 8080
+```
+
+**Install today:**
+
+- **From a `.vsix`** — download the `promptc-vscode-vsix` artifact from the latest [Publish VS Code Extension](https://github.com/madara88645/Compiler/actions/workflows/publish-vscode.yml) workflow run, then install via **Extensions: Install from VSIX...**
+- **From source** — see [Local development](integrations/vscode-extension/README.md#local-development) in the extension README (`F5` / Extension Development Host)
+
+**Once published** (after the Marketplace publisher is claimed and the first `vscode-v*` tag is pushed):
 
 - **VS Code Marketplace** — [`madara88645.promptc-vscode`](https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode)
 - **Open VSX** (VSCodium / Cursor) — [`madara88645/promptc-vscode`](https://open-vsx.org/extension/madara88645/promptc-vscode)
-
-Until then, install from source (see [the extension README](integrations/vscode-extension/README.md#local-development)) or the `.vsix` artifact on the `Publish VS Code Extension` workflow run.
 
 Features:
 

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ docs/           Product, pattern, and workflow docs
 - [`docs/pr-safety-github-action.md`](docs/pr-safety-github-action.md) — advisory CI integration sketch
 - [`docs/pattern-library.md`](docs/pattern-library.md)
 - [`docs/promptc-safe-workflows.md`](docs/promptc-safe-workflows.md)
-- [`examples/github/promptc-artifact.yml`](examples/github/promptc-artifact.yml)
+- [`examples/github/promptc-artifact.yml`](examples/github/promptc-artifact.yml) — portable GitHub Action example (`pip install` from GitHub + `promptc github render`; works in any repo)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ docs/           Product, pattern, and workflow docs
 
 ## Docs
 
+- [`docs/cli.md`](docs/cli.md) — full `promptc` CLI reference (all commands and sub-apps)
 - [`docs/pr-safety.md`](docs/pr-safety.md) — PR Safety usage guide, examples, and `curl` recipe
 - [`docs/pr-safety-github-action.md`](docs/pr-safety-github-action.md) — advisory CI integration sketch
 - [`docs/pattern-library.md`](docs/pattern-library.md)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Every report also surfaces **risky areas**, a **test-coverage** signal, **branch
 
 **v1 is an offline, deterministic advisory.** It runs only on what you paste — no GitHub API, no AI calls, no sign-in — and never blocks a merge. Open it in the sidebar or at [`/pr-safety`](https://prcompiler.com/pr-safety); the [PR Safety guide](docs/pr-safety.md) has worked examples (docs-only, auth-risk, stale branch, split-needed), a `curl` recipe for `POST /pr-safety/report`, and an advisory [GitHub Action sketch](docs/pr-safety-github-action.md).
 
+**CLI (no server):** analyze your local branch without starting the API — `promptc pr-safety --from-git` (or `python -m cli.main pr-safety --from-git` from the repo). See [docs/pr-safety.md](docs/pr-safety.md#cli-no-server-needed) for `--files-from`, `--format human|json|md`, and `--exit-code`.
+
 ---
 
 ### Conservative Mode

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,252 @@
+# Prompt Compiler CLI reference
+
+The `promptc` command turns natural-language requests into structured prompts, plans, and exportable artifacts. Install from PyPI (`pip install prcompiler` or `pipx install prcompiler`), or run from a dev checkout with `python -m cli.main` (examples below use `promptc`; substitute `python -m cli.main` when working from source).
+
+```bash
+promptc --help
+promptc --version
+```
+
+## Top-level commands
+
+### `version`
+
+Print the installed package version.
+
+```bash
+promptc version
+```
+
+### `compile`
+
+Compile prompt text into structured IR and rendered prompts (offline heuristics by default).
+
+```bash
+promptc compile "write a haiku about the sea" --quiet
+```
+
+### `compile-export`
+
+Compile a prompt offline and write executable Markdown plus structured JSON to a directory.
+
+```bash
+promptc compile-export "build a login flow for a FastAPI app" --out-dir ./exports
+```
+
+### `batch`
+
+Batch-compile every `.txt` file in a directory to JSON, Markdown, or YAML outputs.
+
+```bash
+promptc batch ./prompts --out-dir ./compiled --format json
+```
+
+### `validate`
+
+Validate one or more IR JSON files against the Prompt Compiler schema.
+
+```bash
+promptc validate compiled/output.json
+```
+
+### `fix`
+
+Suggest or apply automatic fixes for prompt validation issues.
+
+```bash
+promptc fix "teach me gradient descent" --diff
+```
+
+### `compare`
+
+Compare two prompts side by side and show IR differences.
+
+```bash
+promptc compare "summarize this article" "write a one-paragraph summary of this article" --label-a Draft --label-b Revision
+```
+
+### `pack`
+
+Export a single-file prompt pack (System / User / Plan / Expanded) for copy-paste.
+
+```bash
+promptc pack "debug flaky CI tests in a Python monorepo" --format md --out review-pack.md
+```
+
+### `json-path`
+
+Read a value from a JSON file using dot-path syntax (supports list indexes).
+
+```bash
+promptc json-path compiled/output.json metadata.domain
+```
+
+### `diff`
+
+Compare two JSON files with a unified diff (useful in CI or review workflows).
+
+```bash
+promptc diff before.json after.json --sort-keys
+```
+
+### `pr-safety`
+
+Analyze a pull request for merge safety using offline heuristics (no GitHub API).
+
+```bash
+promptc pr-safety --title "Add auth middleware" --description "Adds session validation." app/auth.py tests/test_auth.py
+```
+
+## `rag` — local RAG (SQLite FTS5)
+
+Lightweight on-machine retrieval over your own files.
+
+| Subcommand | Description |
+|---|---|
+| `index` | Index files or folders into the local RAG database |
+| `query` | Search the index (FTS, embeddings, or hybrid) |
+| `pack` | Pack top matching chunks into a context window |
+| `stats` | Show index statistics |
+| `prune` | Remove stale or orphaned index entries |
+
+```bash
+promptc rag index ./docs --ext .md
+promptc rag query "how does conservative mode work" --k 3
+promptc rag pack "deployment runbook" --max-chars 2000
+promptc rag stats --json
+promptc rag prune
+```
+
+## `template` — template management
+
+| Subcommand | Description |
+|---|---|
+| `list` | List available built-in and user templates |
+| `show` | Show full details for a template ID |
+
+```bash
+promptc template list --tag code
+promptc template show code-review
+```
+
+## `analytics` — prompt analytics
+
+| Subcommand | Description |
+|---|---|
+| `record` | Record a prompt compilation in the analytics database |
+| `summary` | Summarize metrics for a time window |
+| `trends` | Show score trends over time |
+| `domains` | Break down usage by domain |
+| `list` | List recent prompt records |
+| `stats` | Show overall database statistics |
+| `clean` | Delete analytics records older than N days |
+
+```bash
+promptc analytics record prompts/onboarding.txt --task-type teaching
+promptc analytics summary --days 7
+promptc analytics trends --days 30 --json
+promptc analytics domains --persona teacher
+promptc analytics list --limit 5 --min-score 70
+promptc analytics stats
+promptc analytics clean --days 90 --force
+```
+
+## `history` — prompt history
+
+| Subcommand | Description |
+|---|---|
+| `list` | List recent prompt history entries |
+| `search` | Full-text search across history |
+| `show` | Show one history entry by ID |
+| `stats` | Show history database statistics |
+
+```bash
+promptc history list --limit 10
+promptc history search "gradient descent"
+promptc history show abc123
+promptc history stats
+```
+
+## `test` — prompt testing suite
+
+| Subcommand | Description |
+|---|---|
+| `run` | Run a YAML test suite against a prompt |
+
+```bash
+promptc test run tests/fixtures/demo_suite.yaml
+```
+
+## `optimize` — evolutionary prompt optimization
+
+| Subcommand | Description |
+|---|---|
+| `run` | Optimize a prompt using test feedback (mock provider by default) |
+| `resume` | Resume a previous optimization run |
+| `history list` | List past optimization runs |
+| `history show` | Show details for one run |
+
+```bash
+promptc optimize run prompts/draft.txt tests/fixtures/demo_suite.yaml --provider mock --generations 2
+promptc optimize resume run-abc --suite tests/fixtures/demo_suite.yaml
+promptc optimize history list --limit 5
+promptc optimize history show run-abc
+```
+
+## `github` — GitHub artifact helpers
+
+| Subcommand | Description |
+|---|---|
+| `render` | Render GitHub-friendly Markdown from natural-language intent |
+
+Artifact types: `issue-brief`, `implementation-checklist`, `pr-review-brief`.
+
+```bash
+promptc github render --type pr-review-brief --from-file .github/PULL_REQUEST_TEMPLATE.md
+```
+
+## `plugins` — plugin utilities
+
+| Subcommand | Description |
+|---|---|
+| `list` | List installed Prompt Compiler plugins |
+
+```bash
+promptc plugins list --json
+```
+
+## `profile` — settings profiles
+
+Profiles are shared with the desktop UI (conservative mode, API base URL, etc.).
+
+| Subcommand | Description |
+|---|---|
+| `list` | List saved profiles |
+| `show` | Print a profile payload as JSON |
+| `save` | Save a new profile (snapshots current UI settings by default) |
+| `activate` | Set the active profile for the UI |
+| `clear` | Clear the active profile |
+| `delete` | Delete a profile by name |
+| `rename` | Rename a profile |
+| `export` | Export a profile to a portable JSON file |
+| `import` | Import a profile from JSON |
+
+```bash
+promptc profile list
+promptc profile show work
+promptc profile save work
+promptc profile activate work
+promptc profile clear
+promptc profile delete old-draft
+promptc profile rename work work-laptop
+promptc profile export work --output work-profile.json
+promptc profile import work-profile.json
+```
+
+## Related docs
+
+- [PR Safety guide](pr-safety.md)
+- [PR Safety GitHub Action sketch](pr-safety-github-action.md)
+- [Portable GitHub artifact workflow](../examples/github/promptc-artifact.yml)
+- [MCP server setup](../integrations/mcp-server/README.md)
+- [VS Code extension](../integrations/vscode-extension/README.md)

--- a/docs/pr-safety.md
+++ b/docs/pr-safety.md
@@ -42,6 +42,82 @@ No sign-in, no setup, nothing leaves your machine beyond the single analysis req
 
 ---
 
+## CLI (no server needed)
+
+The same offline analyzer ships as a CLI command — no backend, no network, no API key.
+After `pip install -e .`, use `promptc`; otherwise run `python -m cli.main` from the repo
+root.
+
+### Analyze the current branch from local git
+
+```bash
+promptc pr-safety --from-git
+```
+
+`--from-git` reads your **local** repository: changed files vs the resolved base ref
+(`origin/main`, `main`, …), commits behind base, and the latest commit subject/body as the
+PR title and description. Override the base with `--base` or freshness with
+`--commits-behind` when needed.
+
+### Pass files and metadata manually
+
+```bash
+# Positional file list
+promptc pr-safety --title "Add login endpoint" --description "Adds POST /auth/login" \
+  app/auth/login.py api/routes/auth.py
+
+# One path per line from a file
+promptc pr-safety --files-from changed.txt --title "Add login endpoint" \
+  --description "Adds POST /auth/login"
+
+# Pipe paths on stdin (non-TTY)
+git diff --name-only origin/main | promptc pr-safety --title "My PR" --description "…"
+```
+
+### Output formats
+
+```bash
+promptc pr-safety --from-git                      # human (default)
+promptc pr-safety --from-git --format json        # machine-readable
+promptc pr-safety --from-git --format md          # GitHub-ready Markdown
+promptc pr-safety --from-git --format md --out report.md
+```
+
+Use `--exit-code` in scripts: exits non-zero when the verdict is not `merge`.
+
+### Sample output (`--from-git`, human format)
+
+Captured from `python -m cli.main pr-safety --from-git` in this repo:
+
+```
+╭───────────────────────────────── PR Safety ──────────────────────────────────╮
+│ Verdict: HOLD — Address the flagged signals before merging                   │
+│ PR: Merge pull request #941 from                                             │
+│ madara88645/fix/hooks-example-shell-test-windows                             │
+│                                                                              │
+│ Signals: risky=ok  tests=ok  branch=ok  scope=mismatch                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+────────────────────────────── Changed files (0) ───────────────────────────────
+No files provided.
+─────────────────────────── Risky areas (status: ok) ───────────────────────────
+No risky areas detected
+────────────────────────── Test coverage (status: ok) ──────────────────────────
+No missing test coverage detected for changed source files
+──────────────────────── Branch freshness (status: ok) ─────────────────────────
+  Branch is 0 commits behind the base branch
+──────────────────────── Scope match (status: mismatch) ────────────────────────
+  No changed files were provided
+─────────────────────────────── Recommendations ────────────────────────────────
+  - Hold merge until the flagged safety signals are addressed
+  - No changed files were provided
+```
+
+The same run with `--format json` returns a structured payload (`verdict`, `changed_files`,
+`risky_areas`, `test_coverage`, `branch_freshness`, `scope_match`, `recommendations`) suitable
+for CI or jq pipelines.
+
+---
+
 ## Use it from the API
 
 The browser page is a thin client over one endpoint: `POST /pr-safety/report`.

--- a/examples/github/promptc-artifact.yml
+++ b/examples/github/promptc-artifact.yml
@@ -1,12 +1,20 @@
 name: PromptC Artifact Example
 
+# Portable workflow: install Prompt Compiler from GitHub and render a
+# GitHub-friendly artifact from any text file in your repo.
+# Copy to .github/workflows/ in your project and adjust inputs as needed.
+
 on:
   workflow_dispatch:
     inputs:
       artifact_type:
-        description: Artifact type
+        description: Artifact type (issue-brief, implementation-checklist, pr-review-brief)
         required: true
         default: pr-review-brief
+      source_file:
+        description: Path to the source text file (relative to repo root)
+        required: true
+        default: .github/PULL_REQUEST_TEMPLATE.md
 
 jobs:
   compile-artifact:
@@ -18,14 +26,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Install Prompt Compiler
+        run: pip install "git+https://github.com/madara88645/Compiler.git"
 
       - name: Render PromptC artifact
         run: |
-          python -m cli.main github render \
+          promptc github render \
             --type "${{ github.event.inputs.artifact_type }}" \
-            --from-file .github/PULL_REQUEST_TEMPLATE.md \
+            --from-file "${{ github.event.inputs.source_file }}" \
             > promptc-artifact.md
 
       - name: Upload artifact

--- a/integrations/mcp-server/README.md
+++ b/integrations/mcp-server/README.md
@@ -1,78 +1,158 @@
-# myCompiler MCP Server
+# Prompt Compiler MCP Server
 
-This directory contains a Model Context Protocol (MCP) server integration for `myCompiler`.
-It exposes Prompt Compiler tools to MCP clients such as Claude Code, Claude Desktop, and Cursor.
+Model Context Protocol (MCP) bridge that exposes Prompt Compiler tools to Claude Code, Claude Desktop, Cursor, and other MCP clients.
 
-## Setup
+**The Prompt Compiler HTTP backend must be running before you use these tools.** Local development uses port **8080** (same as the web app and VS Code extension).
 
-1.  **Install Dependencies**:
-    ```bash
-    pip install -r requirements.txt
-    ```
+## Prerequisites
 
-2.  **Start the API Server**:
-    Ensure the main `myCompiler` API is running:
-    ```bash
-    # From project root
-    uvicorn api.main:app --port 8000
-    ```
+### 1. Start the backend (required)
+
+From the repository root:
+
+```bash
+python -m uvicorn api.main:app --reload --port 8080
+```
+
+Verify it is up:
+
+```bash
+curl http://127.0.0.1:8080/health
+```
+
+### 2. Install MCP server dependencies
+
+```bash
+cd integrations/mcp-server
+pip install -r requirements.txt
+```
 
 ## Configuration
 
-Environment variables (optional; align with the Chrome extension’s `/compile` request):
+Environment variables (optional; align with the Chrome extension `/compile` request):
 
 | Variable | Purpose |
 |----------|---------|
-| `PROMPTC_BACKEND_URL` | API origin (default `http://localhost:8000`); the tool posts to `{origin}/compile`. |
+| `PROMPTC_BACKEND_URL` | API origin (default `http://localhost:8080`); tools call `{origin}/compile` and related routes. |
 | `PROMPTC_API_URL` | Full compile URL if set (overrides backend + `/compile`). |
 | `PROMPTC_API_KEY` | Sent as `x-api-key` when the API requires optional key verification. |
 | `PROMPTC_PROMPT_MODE` | `conservative` (default) or `default`; sent as `X-Prompt-Mode` and in the JSON body `mode`. |
 
-The request body matches the extension: `v2`, `render_v2_prompts`, `diagnostics`, and `mode`.
+The compile request body matches the browser extension: `v2`, `render_v2_prompts`, `diagnostics`, and `mode`.
 
-### Claude Desktop
+## Claude Code
 
-Add the following to your `claude_desktop_config.json` (usually in `%APPDATA%\Claude\` on Windows or `~/Library/Application Support/Claude/` on macOS):
+### One-line setup (`claude mcp add`)
+
+Run from the repository root (replace the path if your clone lives elsewhere):
+
+```bash
+claude mcp add --scope project \
+  --env PROMPTC_BACKEND_URL=http://127.0.0.1:8080 \
+  prompt-compiler -- \
+  python integrations/mcp-server/server.py
+```
+
+Inside a Claude Code session, run `/mcp` to confirm `prompt-compiler` is connected.
+
+### Project `.mcp.json` (macOS / Linux)
+
+Check this file into your project root so teammates get the same server. Paths use `${CLAUDE_PROJECT_DIR}` so they work on any machine:
 
 ```json
 {
   "mcpServers": {
-    "myCompiler": {
+    "prompt-compiler": {
+      "type": "stdio",
       "command": "python",
-      "args": [
-        "C:\\Users\\User\\Desktop\\myCompiler\\integrations\\mcp-server\\server.py"
-      ]
+      "args": ["${CLAUDE_PROJECT_DIR}/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
     }
   }
 }
 ```
 
-> **Note**: Verify the path to `server.py`.
+A copy-paste template also lives at [`.mcp.json.example`](../../.mcp.json.example) in the repo root.
 
-### Cursor
+### Windows `.mcp.json`
 
-1.  Go to **Settings > Features > MCP**.
-2.  Click **Add New MCP Server**.
-3.  **Name**: `myCompiler`
-4.  **Type**: `stdio`
-5.  **Command**: `python C:\Users\User\Desktop\myCompiler\integrations\mcp-server\server.py`
+Use forward slashes or escaped backslashes in `args`:
 
-## Exposed Tools
+```json
+{
+  "mcpServers": {
+    "prompt-compiler": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["${CLAUDE_PROJECT_DIR}/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}
+```
 
-- `optimize_prompt(text)` — returns the compiled prompt string
-- `compile_prompt(text)` — returns the full `/compile` payload
-- `generate_agent(description, multi_agent=false)` — returns generated agent markdown
-- `generate_skill(description)` — returns generated skill markdown
-- `export_claude_pack(system_prompt)` — returns a Claude Code project-pack manifest
-- `benchmark_prompt(text, model?)` — returns the benchmark comparison payload
+## Claude Desktop
+
+Add to `claude_desktop_config.json` (`~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows):
+
+```json
+{
+  "mcpServers": {
+    "prompt-compiler": {
+      "command": "python",
+      "args": ["/absolute/path/to/Compiler/integrations/mcp-server/server.py"],
+      "env": {
+        "PROMPTC_BACKEND_URL": "http://127.0.0.1:8080"
+      }
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/Compiler` with your clone path.
+
+## Cursor
+
+1. Open **Settings → Features → MCP**.
+2. Click **Add New MCP Server**.
+3. **Name**: `prompt-compiler`
+4. **Type**: `stdio`
+5. **Command**: `python /absolute/path/to/Compiler/integrations/mcp-server/server.py`
+6. **Environment**: `PROMPTC_BACKEND_URL=http://127.0.0.1:8080`
+
+## Exposed tools
+
+| Tool | Description |
+|------|-------------|
+| `optimize_prompt(text)` | Returns the compiled prompt string |
+| `compile_prompt(text)` | Returns the full `/compile` payload |
+| `generate_agent(description, multi_agent=false)` | Returns generated agent markdown |
+| `generate_skill(description)` | Returns generated skill markdown |
+| `export_claude_pack(system_prompt)` | Returns a Claude Code project-pack manifest |
+| `benchmark_prompt(text, model?)` | Returns the benchmark comparison payload |
+| `plan_agent_pack(pack_type, goal?, risk_mode?, path?)` | Previews a repo-aware agent pack (no writes) |
+| `apply_agent_pack(pack_type, goal?, risk_mode?, path?, overwrite?)` | Writes a repo-aware agent pack to disk |
 
 ## Usage
 
-Once configured, you can ask Claude or Cursor:
-> "Optimize this prompt for me: 'write a snake game in python'"
+Once configured, ask your MCP client:
+
+> "Optimize this prompt for me: write a snake game in python"
 
 Or:
 
 > "Generate an agent for reviewing React performance and export it as a Claude project pack."
 
-The MCP server will call the corresponding Prompt Compiler backend route and return the result in the same session.
+The MCP server calls the Prompt Compiler backend on port 8080 and returns the result in the same session.
+
+## Tests
+
+From the repository root:
+
+```bash
+python -m pytest integrations/mcp-server/ -q
+```

--- a/integrations/mcp-server/compile_settings.py
+++ b/integrations/mcp-server/compile_settings.py
@@ -10,13 +10,13 @@ def resolve_compile_post_url() -> str:
     """
     Full URL for POST /compile.
 
-    PROMPTC_API_URL: full URL including path (legacy; e.g. http://localhost:8000/compile).
+    PROMPTC_API_URL: full URL including path (legacy; e.g. http://localhost:8080/compile).
     PROMPTC_BACKEND_URL: origin only; /compile is appended.
     """
     explicit = os.environ.get("PROMPTC_API_URL", "").strip()
     if explicit:
         return explicit.rstrip("/")
-    backend = os.environ.get("PROMPTC_BACKEND_URL", "http://localhost:8000").strip().rstrip("/")
+    backend = os.environ.get("PROMPTC_BACKEND_URL", "http://localhost:8080").strip().rstrip("/")
     return f"{backend}/compile"
 
 

--- a/integrations/mcp-server/test_compile_settings.py
+++ b/integrations/mcp-server/test_compile_settings.py
@@ -12,7 +12,7 @@ from compile_settings import (
 def test_resolve_compile_post_url_prefers_full_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PROMPTC_API_URL", raising=False)
     monkeypatch.delenv("PROMPTC_BACKEND_URL", raising=False)
-    assert resolve_compile_post_url() == "http://localhost:8000/compile"
+    assert resolve_compile_post_url() == "http://localhost:8080/compile"
 
     monkeypatch.setenv("PROMPTC_API_URL", "https://api.example/compile/")
     assert resolve_compile_post_url() == "https://api.example/compile"

--- a/integrations/vscode-extension/README.md
+++ b/integrations/vscode-extension/README.md
@@ -10,9 +10,21 @@ Compile selected text or full files into structured prompts with policy visibili
 
 ## Install
 
-- **VS Code / VS Code Insiders** - search `PromptC` in the Extensions view, or install from the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode).
-- **VSCodium / Cursor / others** - install from [Open VSX](https://open-vsx.org/extension/madara88645/promptc-vscode).
-- **From a `.vsix`** - download the artifact attached to the latest `Publish VS Code Extension` workflow run on GitHub, then install it from the VS Code Extensions menu.
+Start the backend from the repo root before using PromptC (default API URL is `http://127.0.0.1:8080`):
+
+```bash
+python -m uvicorn api.main:app --reload --port 8080
+```
+
+- **From a `.vsix`** — download the `promptc-vscode-vsix` artifact from the latest [Publish VS Code Extension](https://github.com/madara88645/Compiler/actions/workflows/publish-vscode.yml) workflow run, then in VS Code choose **Extensions: Install from VSIX...**
+- **From source** — see [Local development](#local-development) below (`F5` / Extension Development Host)
+
+### Once published
+
+After publisher setup in [PUBLISHING.md](PUBLISHING.md) completes and a `vscode-v*` tag is pushed:
+
+- **VS Code / VS Code Insiders** — search `PromptC` in the Extensions view, or install from the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode)
+- **VSCodium / Cursor / others** — install from [Open VSX](https://open-vsx.org/extension/madara88645/promptc-vscode)
 
 ## Local development
 


### PR DESCRIPTION
Integrates the 6 docs/adoption PRs that mostly edit README.md into one branch. Only conflict: #951's 'CLI (no server)' PR-Safety paragraph duplicated one already present — kept a single copy. #952 also bumps the MCP server default port 8000→8080 (compile_settings.py) — mcp-server tests pass (19). Supersedes #949 #950 #951 #952 #954 #955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)