### PR TITLE
integrate: sidebar grouping + outbound links + optimizer naming (#958,#956,#960)

### DIFF
--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -278,7 +278,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByRole("heading", { name: "English compact suggestion" })).toBeTruthy();
 
@@ -317,7 +317,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     await screen.findByRole("button", { name: "Send optimized result to compiler" });
     fireEvent.click(screen.getByRole("button", { name: "Send optimized result to compiler" }));

--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -63,7 +63,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Bu PDF'i ozetle ve junior gelistirici icin uygulama plani yaz." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("Original estimate")).toBeTruthy();
     expect(screen.getByText("Optimized estimate")).toBeTruthy();
@@ -114,7 +114,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Write a clear implementation plan." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("EN")).toBeTruthy();
     expect(screen.queryByText("English compact suggestion")).toBeNull();
@@ -136,7 +136,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Write a clear implementation plan." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("UNKNOWN")).toBeTruthy();
     expect(screen.queryByText("English compact suggestion")).toBeNull();
@@ -169,7 +169,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Bu PDF'i ozetle ve plan yaz." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(await screen.findByText("TR")).toBeTruthy();
     expect(screen.queryByText("English compact suggestion")).toBeNull();
@@ -202,7 +202,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "Write a clear plan." },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     expect(
       await screen.findByText(
@@ -239,7 +239,7 @@ describe("Optimizer page", () => {
     fireEvent.change(screen.getByLabelText("Original Prompt"), {
       target: { value: "ok" },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /Analyze cost/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
 
     const inputCostNode = await screen.findByText(/input cost$/);
     expect(inputCostNode.textContent).toMatch(/\$1\.70e-7\s+input cost/);

--- a/web/app/components/Sidebar.test.tsx
+++ b/web/app/components/Sidebar.test.tsx
@@ -82,4 +82,25 @@ describe("Sidebar", () => {
     expect(firstLink?.getAttribute("aria-label")).toBe("Compiler");
     expect(firstLink?.getAttribute("href")).toBe("/");
   });
+
+  test("renders outbound links for repo, CLI, VS Code, and MCP", () => {
+    render(<Sidebar />);
+
+    expect(screen.getByLabelText("GitHub repo").getAttribute("href")).toBe(
+      "https://github.com/madara88645/Compiler",
+    );
+    expect(screen.getByLabelText("CLI install").getAttribute("href")).toContain("docs/cli.md");
+    expect(screen.getByLabelText("VS Code extension").getAttribute("href")).toContain(
+      "madara88645.promptc-vscode",
+    );
+    expect(screen.getByLabelText("MCP setup").getAttribute("href")).toContain(
+      "integrations/mcp-server/README.md",
+    );
+
+    for (const label of ["GitHub repo", "CLI install", "VS Code extension", "MCP setup"]) {
+      const external = screen.getByLabelText(label);
+      expect(external.getAttribute("target")).toBe("_blank");
+      expect(external.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  });
 });

--- a/web/app/components/Sidebar.test.tsx
+++ b/web/app/components/Sidebar.test.tsx
@@ -27,4 +27,52 @@ describe("Sidebar", () => {
     expect(link.getAttribute("href")).toBe("/agent-packs");
     expect(link.getAttribute("aria-current")).toBe("page");
   });
+
+  test("renders a visible text label under every icon", () => {
+    render(<Sidebar />);
+
+    const labels = [
+      "Compiler",
+      "Optimizer",
+      "Offline",
+      "Benchmark",
+      "PR Safety",
+      "Agent Packs",
+      "Agent Generator",
+      "Skills Generator",
+    ];
+
+    for (const label of labels) {
+      // getByLabelText matches the link's aria-label; getAllByText also
+      // matches the visible <span> rendered under the icon.
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("groups nav items into labeled sections with separators between them", () => {
+    render(<Sidebar />);
+
+    const groups = screen.getAllByRole("group");
+    const groupLabels = groups.map((group) => group.getAttribute("aria-label"));
+
+    expect(groupLabels).toEqual([
+      "Compile",
+      "Prove",
+      "Ship agent assets",
+      "Repo checks",
+    ]);
+
+    // One separator between each pair of groups.
+    const separators = screen.getAllByRole("separator");
+    expect(separators).toHaveLength(groups.length - 1);
+  });
+
+  test("keeps Compiler as the first item in the primary Compile group", () => {
+    render(<Sidebar />);
+
+    const compileGroup = screen.getByRole("group", { name: "Compile" });
+    const firstLink = compileGroup.querySelector("a");
+    expect(firstLink?.getAttribute("aria-label")).toBe("Compiler");
+    expect(firstLink?.getAttribute("href")).toBe("/");
+  });
 });

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -4,15 +4,39 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Code2, Sparkles, WifiOff, Swords, Bot, Zap, FolderArchive, ShieldCheck, type LucideIcon } from "lucide-react";
 
-const navItems: { name: string; path: string; Icon: LucideIcon }[] = [
-    { name: "Compiler",          path: "/",                 Icon: Code2    },
-    { name: "Optimizer",         path: "/optimizer",        Icon: Sparkles },
-    { name: "Offline",           path: "/offline",          Icon: WifiOff  },
-    { name: "Benchmark",         path: "/benchmark",        Icon: Swords   },
-    { name: "PR Safety",         path: "/pr-safety",        Icon: ShieldCheck },
-    { name: "Agent Packs",       path: "/agent-packs",      Icon: FolderArchive },
-    { name: "Agent Generator",   path: "/agent-generator",  Icon: Bot      },
-    { name: "Skills Generator",  path: "/skills-generator", Icon: Zap      },
+type NavItem = { name: string; path: string; Icon: LucideIcon };
+type NavGroup = { label: string; items: NavItem[] };
+
+// Compiler is intentionally first: it is the primary, always-on entry point.
+const navGroups: NavGroup[] = [
+    {
+        label: "Compile",
+        items: [
+            { name: "Compiler",  path: "/",         Icon: Code2    },
+            { name: "Optimizer", path: "/optimizer", Icon: Sparkles },
+            { name: "Offline",   path: "/offline",   Icon: WifiOff  },
+        ],
+    },
+    {
+        label: "Prove",
+        items: [
+            { name: "Benchmark", path: "/benchmark", Icon: Swords },
+        ],
+    },
+    {
+        label: "Ship agent assets",
+        items: [
+            { name: "Agent Packs",      path: "/agent-packs",      Icon: FolderArchive },
+            { name: "Agent Generator",  path: "/agent-generator",  Icon: Bot           },
+            { name: "Skills Generator", path: "/skills-generator", Icon: Zap           },
+        ],
+    },
+    {
+        label: "Repo checks",
+        items: [
+            { name: "PR Safety", path: "/pr-safety", Icon: ShieldCheck },
+        ],
+    },
 ];
 
 const accentBarMap: Record<string, string> = {
@@ -41,41 +65,66 @@ export default function Sidebar() {
     const pathname = usePathname();
 
     return (
-        <div className="w-16 md:w-20 h-screen bg-black/20 border-r border-white/5 flex flex-col items-center py-6 gap-6 backdrop-blur-md z-50">
-            <div className="h-10 w-10 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center font-bold text-white shadow-lg shadow-blue-500/20 mb-4">
+        <div className="w-16 md:w-24 h-screen bg-black/20 border-r border-white/5 flex flex-col items-center py-6 gap-1 backdrop-blur-md z-50 overflow-y-auto">
+            <div className="h-10 w-10 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center font-bold text-white shadow-lg shadow-blue-500/20 mb-4 shrink-0">
                 P
             </div>
 
-            {navItems.map((item) => {
-                const isActive = pathname === item.path;
-                const accentBar = accentBarMap[item.path] ?? "bg-blue-500";
-                const accentRing = accentRingMap[item.path] ?? "ring-white/20";
+            {navGroups.map((group, groupIndex) => (
+                <div key={group.label} className="w-full flex flex-col items-center">
+                    {groupIndex > 0 && (
+                        <div
+                            role="separator"
+                            aria-orientation="horizontal"
+                            className="w-8 h-px bg-white/10 my-3 shrink-0"
+                        />
+                    )}
 
-                return (
-                    <Link
-                        key={item.path}
-                        href={item.path}
-                        className={`w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-300 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
-                            isActive
-                                ? `bg-white/[0.08] text-white shadow-lg shadow-white/5 ring-1 ${accentRing}`
-                                : "text-zinc-500 hover:text-white hover:bg-white/5"
-                        }`}
-                        aria-label={item.name}
-                        aria-current={isActive ? "page" : undefined}
+                    <div
+                        role="group"
+                        aria-label={group.label}
+                        className="flex flex-col items-center gap-2 w-full"
                     >
-                        <item.Icon size={20} strokeWidth={1.75} aria-hidden="true" />
+                        {group.items.map((item) => {
+                            const isActive = pathname === item.path;
+                            const accentBar = accentBarMap[item.path] ?? "bg-blue-500";
+                            const accentRing = accentRingMap[item.path] ?? "ring-white/20";
 
-                        {isActive && (
-                            <div className={`animate-slide-in absolute left-[-2px] top-2 bottom-2 w-1 ${accentBar} rounded-full`} />
-                        )}
+                            return (
+                                <Link
+                                    key={item.path}
+                                    href={item.path}
+                                    className={`w-12 md:w-16 py-2 rounded-xl flex flex-col items-center justify-center gap-1 transition-all duration-300 relative group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                                        isActive
+                                            ? `bg-white/[0.08] text-white shadow-lg shadow-white/5 ring-1 ${accentRing}`
+                                            : "text-zinc-500 hover:text-white hover:bg-white/5"
+                                    }`}
+                                    aria-label={item.name}
+                                    aria-current={isActive ? "page" : undefined}
+                                >
+                                    <item.Icon size={20} strokeWidth={1.75} aria-hidden="true" />
 
-                        {/* Tooltip */}
-                        <div className="absolute left-14 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
-                            {item.name}
-                        </div>
-                    </Link>
-                );
-            })}
+                                    <span
+                                        className="hidden md:block text-[9px] leading-none font-medium tracking-tight text-center truncate max-w-full"
+                                        aria-hidden="true"
+                                    >
+                                        {item.name}
+                                    </span>
+
+                                    {isActive && (
+                                        <div className={`animate-slide-in absolute left-[-2px] top-2 bottom-2 w-1 ${accentBar} rounded-full`} />
+                                    )}
+
+                                    {/* Tooltip */}
+                                    <div className="absolute left-full ml-2 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                                        {item.name}
+                                    </div>
+                                </Link>
+                            );
+                        })}
+                    </div>
+                </div>
+            ))}
         </div>
     );
 }

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { Code2, Sparkles, WifiOff, Swords, Bot, Zap, FolderArchive, ShieldCheck,
 
 const navItems: { name: string; path: string; Icon: LucideIcon }[] = [
     { name: "Compiler",          path: "/",                 Icon: Code2    },
-    { name: "Optimizer",         path: "/optimizer",        Icon: Sparkles },
+    { name: "Token Optimizer",   path: "/optimizer",        Icon: Sparkles },
     { name: "Offline",           path: "/offline",          Icon: WifiOff  },
     { name: "Benchmark",         path: "/benchmark",        Icon: Swords   },
     { name: "PR Safety",         path: "/pr-safety",        Icon: ShieldCheck },

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Code2, Sparkles, Swords, Bot, Zap, FolderArchive, ShieldCheck, type LucideIcon } from "lucide-react";
+import { Code2, Sparkles, Swords, Bot, Zap, FolderArchive, ShieldCheck, Github, Terminal, Blocks, Plug, type LucideIcon } from "lucide-react";
 
 type NavItem = { name: string; path: string; Icon: LucideIcon };
 type NavGroup = { label: string; items: NavItem[] };
@@ -35,6 +35,29 @@ const navGroups: NavGroup[] = [
         items: [
             { name: "PR Safety", path: "/pr-safety", Icon: ShieldCheck },
         ],
+    },
+];
+
+const outboundLinks: { name: string; href: string; Icon: LucideIcon }[] = [
+    {
+        name: "GitHub repo",
+        href: "https://github.com/madara88645/Compiler",
+        Icon: Github,
+    },
+    {
+        name: "CLI install",
+        href: "https://github.com/madara88645/Compiler/blob/main/docs/cli.md",
+        Icon: Terminal,
+    },
+    {
+        name: "VS Code extension",
+        href: "https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode",
+        Icon: Blocks,
+    },
+    {
+        name: "MCP setup",
+        href: "https://github.com/madara88645/Compiler/blob/main/integrations/mcp-server/README.md",
+        Icon: Plug,
     },
 ];
 
@@ -122,6 +145,28 @@ export default function Sidebar() {
                     </div>
                 </div>
             ))}
+
+            <div
+                className="mt-auto flex flex-col items-center gap-3 border-t border-white/5 pt-4 w-full"
+                aria-label="Use it in your editor or repo"
+            >
+                {outboundLinks.map((item) => (
+                    <a
+                        key={item.href}
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-300 relative group text-zinc-500 hover:text-white hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        aria-label={item.name}
+                    >
+                        <item.Icon size={18} strokeWidth={1.75} aria-hidden="true" />
+
+                        <div className="absolute left-full ml-2 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
+                            {item.name}
+                        </div>
+                    </a>
+                ))}
+            </div>
         </div>
     );
 }

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -304,7 +304,7 @@ export default function OptimizerPage() {
                         </div>
                     </div>
                     <InfoButton
-                        title="Prompt Optimizer"
+                        title="Token Optimizer"
                         description="Shortens prompts while keeping intent, constraints, variables, and safety details visible. Estimates OpenRouter cost and compares language efficiency."
                     />
                 </div>
@@ -353,12 +353,12 @@ export default function OptimizerPage() {
                         onClick={handleOptimize}
                         disabled={loading || !input.trim()}
                         aria-busy={loading}
-                        title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
+                        title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}
                         className="w-full rounded-lg bg-emerald-600 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-emerald-950/30 transition-colors hover:bg-emerald-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 sm:w-auto"
                     >
                         {loading ? "Analyzing..." : (
                             <>
-                                Analyze cost
+                                Optimize & estimate cost
                                 <kbd className="ml-2 hidden rounded border border-white/20 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] opacity-60 md:inline-block">
                                     Ctrl/Cmd Enter
                                 </kbd>
@@ -486,10 +486,10 @@ export default function OptimizerPage() {
                                     onClick={handleOptimize}
                                     disabled={loading || !input.trim()}
                                     aria-busy={loading}
-                                    title={!input.trim() ? "Enter a prompt first to analyze cost" : "Analyze cost"}
+                                    title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}
                                     className="rounded-lg bg-emerald-600/20 border border-emerald-500/30 px-5 py-2 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-600/30 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
                                 >
-                                    {loading ? "Analyzing..." : "Analyze cost"}
+                                    {loading ? "Analyzing..." : "Optimize & estimate cost"}
                                 </button>
                                 {!input.trim() && (
                                     <button


### PR DESCRIPTION
Integrates the 3 Sidebar.tsx cluster PRs. All three rewrote/edited the same nav structure and conflicted with each other + with main (which removed the Offline nav item via #971).

Resolutions (human-reviewed):
- **#958 grouping** vs main: took the grouped structure, dropped the Offline item (folded into the heuristics toggle on main) and its WifiOff import.
- **#956 outbound links**: reapplied its outboundLinks section + test on top of the grouped nav by hand (it was authored against the old flat navItems).
- **#960 optimizer naming**: applied the 'Optimizer' -> 'Token Optimizer' sidebar label; its optimizer/page.tsx changes merged clean. Also updated the compile<->optimizer handoff tests (#976, landed via C) that still clicked the old 'Analyze cost' CTA #960 renamed.

Verification: web 212 tests pass, lint 0 errors, production build succeeds.

Supersedes #958 #956 #960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)