### PR TITLE
Fix duplicate React keys in RAG search results

### DIFF
--- a/web/app/components/__tests__/RagSearchPanel.test.tsx
+++ b/web/app/components/__tests__/RagSearchPanel.test.tsx
@@ -91,6 +91,29 @@ describe("RagSearchPanel", () => {
     expect(onInsertContext).toHaveBeenCalledWith("[Source: src/auth.ts]\nHandle session creation");
   });
 
+  it("renders every chunk distinctly when multiple results share the same path", () => {
+    // The backend returns chunk-level rows, so one uploaded doc split into
+    // several chunks can produce multiple results with an identical `path`.
+    // Keys must stay unique per row or React will drop/mis-render cards.
+    render(
+      <RagSearchPanel
+        query="auth flow"
+        setQuery={vi.fn()}
+        searching={false}
+        results={[
+          { path: "src/auth.ts", snippet: "Handle session creation", score: 0.81 },
+          { path: "src/auth.ts", snippet: "Refresh tokens on expiry", score: 0.74 },
+        ]}
+        onRunSearch={vi.fn()}
+        onInsertContext={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Handle session creation")).toBeTruthy();
+    expect(screen.getByText("Refresh tokens on expiry")).toBeTruthy();
+    expect(screen.getAllByText("src/auth.ts").length).toBe(2);
+  });
+
   it("shows a clear no-results state when a query returns nothing", () => {
     render(
       <RagSearchPanel

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -84,8 +84,8 @@ export default function RagSearchPanel({
                     </div>
                 )}
 
-                {results.map((result) => (
-                    <div key={result.path} className="group flex flex-col gap-1.5 p-3 bg-white/5 rounded-xl border border-white/5 hover:border-white/10 transition-all hover:bg-white/[0.07]">
+                {results.map((result, index) => (
+                    <div key={`${result.path}-${index}`} className="group flex flex-col gap-1.5 p-3 bg-white/5 rounded-xl border border-white/5 hover:border-white/10 transition-all hover:bg-white/[0.07]">
                         <div className="flex justify-between items-center gap-2">
                             <span className="text-[10px] text-zinc-500 font-mono truncate max-w-[180px] bg-black/20 px-1.5 py-0.5 rounded">{result.path}</span>
                             <span className="text-[10px] text-green-400/80 font-mono bg-green-500/10 px-1.5 py-0.5 rounded">{formatSearchScore(result)}</span>


### PR DESCRIPTION
## Summary
- RAG search returns chunk-level rows, so a single uploaded document split into multiple chunks can produce several results sharing the same `path` (see `api/routes/rag.py:130-140`).
- `RagSearchPanel` keyed each result card by `result.path` alone, so React collided/dropped cards for same-path chunks — hitting the most common first-session RAG flow (search one uploaded doc).
- Fix: key each card by `${result.path}-${index}` so every chunk row renders distinctly, even when paths repeat.

## Test plan
- [x] Extended `web/app/components/__tests__/RagSearchPanel.test.tsx` with a case rendering two results sharing the same path, asserting both snippets render and the path label appears twice.
- [x] `cd web && npm run test` — 213/213 passing (41 test files).
- [x] `cd web && npm run build` — succeeds.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>