### PR TITLE
Humanize export errors and add retry in ExportPanel

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -11,9 +11,13 @@ const { push } = vi.hoisted(() => ({
   push: vi.fn(),
 }));
 
-vi.mock("@/config", () => ({
-  apiFetch,
-}));
+vi.mock("@/config", async () => {
+  const actual = await vi.importActual<typeof import("@/config")>("@/config");
+  return {
+    ...actual,
+    apiFetch,
+  };
+});
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
@@ -224,5 +228,33 @@ describe("Agent ExportPanel", () => {
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(anchors[anchors.length - 1].download).toBe("claude-subagent-export.zip");
+  });
+
+  test("shows a friendly message for a failed export and retries via the retry button", async () => {
+    apiFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
+    );
+    expect(alert).not.toHaveTextContent("Failed to fetch");
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        python_code: "print('hello')",
+        yaml_config: null,
+        code: "print('hello')",
+        files: [],
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /retry export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("print('hello')")).toBeInTheDocument();
   });
 });

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { apiFetch } from "@/config";
+import { apiFetch, describeRequestError } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
 
 const AGENT_PACKS_HANDOFF_KEY = "promptc_agent_pack_goal";
@@ -170,7 +170,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
       const data: ExportResult = await res.json();
       setCache((prev) => ({ ...prev, [nextFormat]: data }));
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Export failed");
+      setError(describeRequestError(e, { fallback: "Export failed." }));
     } finally {
       setLoading(false);
     }
@@ -322,8 +322,18 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 Generating {activeTarget.label} export...
               </div>
             ) : error ? (
-              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                {error}
+              <div
+                className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300 flex flex-col items-start gap-2"
+                role="alert"
+              >
+                <p>{error}</p>
+                <button
+                  type="button"
+                  onClick={() => void fetchExport(target, outputMode)}
+                  className="rounded-lg border border-red-400/30 bg-red-500/20 px-3 py-1.5 text-[11px] font-medium text-red-100 transition-colors hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                >
+                  Retry export
+                </button>
               </div>
             ) : currentContent ? (
               <div className="relative group/code">

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -7,9 +7,13 @@ const { apiFetch } = vi.hoisted(() => ({
   apiFetch: vi.fn(),
 }));
 
-vi.mock("@/config", () => ({
-  apiFetch,
-}));
+vi.mock("@/config", async () => {
+  const actual = await vi.importActual<typeof import("@/config")>("@/config");
+  return {
+    ...actual,
+    apiFetch,
+  };
+});
 
 describe("Skill ExportPanel", () => {
   beforeEach(() => {
@@ -205,5 +209,33 @@ describe("Skill ExportPanel", () => {
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(anchors[anchors.length - 1].download).toBe("claude-mcp-tool-stub-export.zip");
+  });
+
+  test("shows a friendly message for a failed export and retries via the retry button", async () => {
+    apiFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
+    );
+    expect(alert).not.toHaveTextContent("Failed to fetch");
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        python_code: "def tool(): pass",
+        json_config: '{"name":"tool"}',
+        code: "def tool(): pass",
+        files: [],
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /retry export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('{"name":"tool"}')).toBeInTheDocument();
   });
 });

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { apiFetch } from "@/config";
+import { apiFetch, describeRequestError } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
 
 type SkillTarget = "claude-tool" | "claude-mcp-tool" | "langchain-tool";
@@ -154,7 +154,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
         setSelectedFilePath(files[0].path);
       }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Export failed");
+      setError(describeRequestError(e, { fallback: "Export failed." }));
     } finally {
       setLoading(false);
     }
@@ -298,8 +298,18 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 Generating {activeTarget.label} export...
               </div>
             ) : error ? (
-              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                {error}
+              <div
+                className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300 flex flex-col items-start gap-2"
+                role="alert"
+              >
+                <p>{error}</p>
+                <button
+                  type="button"
+                  onClick={() => void fetchExport(target, outputMode)}
+                  className="rounded-lg border border-red-400/30 bg-red-500/20 px-3 py-1.5 text-[11px] font-medium text-red-100 transition-colors hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                >
+                  Retry export
+                </button>
               </div>
             ) : currentContent ? (
               <div className="relative group/code">


### PR DESCRIPTION
## Summary
- Both the agent-generator and skills-generator ExportPanels rendered the raw fetch/catch error message (e.g. `Failed to fetch`) with no way to recover, unlike the rest of the app which already uses `describeRequestError`.
- Format the caught export error with `describeRequestError` (`web/config.ts`) so users see a friendly, actionable message instead of raw browser errors.
- Add a "Retry export" button inside the error box in both panels that re-calls the existing `fetchExport(target, outputMode)`, reusing the current cache/state — no change to caching semantics.

## Test plan
- [x] `cd web && npm run test` — 41 test files / 214 tests pass, including new friendly-error-message + retry-button coverage in both `ExportPanel.test.tsx` files
- [x] `cd web && npm run build` — production build succeeds

Scope note: only touched the error-display/fetch-catch regions in both `ExportPanel.tsx` files; no clipboard-copy call sites, `app/agent_packs_*.py`, or `cli/commands/agent_packs.py` were modified.