### PR TITLE
fix(web): trap focus and support Escape in SecurityAlert modal

### DIFF
--- a/web/app/components/SecurityAlert.test.tsx
+++ b/web/app/components/SecurityAlert.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import SecurityAlert from "./SecurityAlert";
+import type { SecurityFinding } from "../../lib/api/types";
+
+const findings: SecurityFinding[] = [
+    { type: "openai_key", original: "sk-live-abc123", masked: "sk-live-***" },
+];
+
+describe("SecurityAlert", () => {
+    test("calls onCancel when Escape is pressed", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        fireEvent.keyDown(document, { key: "Escape" });
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test("calls onCancel when the backdrop is clicked", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        const dialog = screen.getByRole("dialog");
+        // The backdrop is the dialog's parent element.
+        fireEvent.click(dialog.parentElement as HTMLElement);
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not call onCancel when clicking inside the dialog", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        fireEvent.click(screen.getByRole("dialog"));
+
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    test("keeps Tab focus contained within the modal", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        const cancelButton = screen.getByRole("button", { name: "Cancel" });
+        const stripButton = screen.getByRole("button", { name: /Strip Secrets & Proceed/i });
+
+        stripButton.focus();
+        expect(document.activeElement).toBe(stripButton);
+
+        fireEvent.keyDown(document, { key: "Tab" });
+        expect(document.activeElement).toBe(cancelButton);
+
+        fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+        expect(document.activeElement).toBe(stripButton);
+    });
+});

--- a/web/app/components/SecurityAlert.tsx
+++ b/web/app/components/SecurityAlert.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { ShieldAlert } from "lucide-react";
 import type { SecurityFinding } from "../../lib/api/types";
 
@@ -12,6 +12,9 @@ type SecurityAlertProps = {
     onCancel: () => void;
 };
 
+const FOCUSABLE_SELECTOR =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 export default function SecurityAlert({
     findings,
     redactedText,
@@ -19,6 +22,44 @@ export default function SecurityAlert({
     onProceedOriginal,
     onCancel,
 }: SecurityAlertProps) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                onCancel();
+                return;
+            }
+
+            if (event.key !== "Tab" || !dialogRef.current) {
+                return;
+            }
+
+            const focusable = Array.from(
+                dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+            );
+            if (focusable.length === 0) {
+                return;
+            }
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const active = document.activeElement;
+
+            if (event.shiftKey) {
+                if (active === first || !dialogRef.current.contains(active)) {
+                    event.preventDefault();
+                    last.focus();
+                }
+            } else if (active === last || !dialogRef.current.contains(active)) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [onCancel]);
 
     const findingsSummary = useMemo(() => {
         // Keys match the backend security scanner types in app/heuristics/security.py
@@ -52,8 +93,16 @@ export default function SecurityAlert({
     }, [findings]);
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fade-in">
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fade-in"
+            onClick={(event) => {
+                if (event.target === event.currentTarget) {
+                    onCancel();
+                }
+            }}
+        >
             <div
+                ref={dialogRef}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="security-alert-title"


### PR DESCRIPTION
## Summary
- The security findings modal (`SecurityAlert.tsx`) renders `role=dialog aria-modal` with `autoFocus`, but had no Escape-key handler and no focus trap, so Tab could walk focus out into the obscured page behind it.
- Add a keydown effect that calls `onCancel` on Escape.
- Add a minimal first/last-focusable-element Tab loop (no new dependencies) so Tab/Shift+Tab stay contained within the modal.
- Add backdrop-click-to-cancel (clicking the dimmed overlay outside the dialog calls `onCancel`; clicks inside the dialog do not).
- `autoFocus` on the "Strip Secrets & Proceed" button is unchanged.

## Test plan
- [x] `cd web && npm run test` (216 tests pass, including 4 new `SecurityAlert.test.tsx` cases: Escape closes, backdrop click closes, click-inside does not close, Tab/Shift+Tab stay contained)
- [x] `cd web && npm run build`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>