### PR TITLE
fix(web): guard Benchmark against double submission

### DIFF
--- a/web/app/benchmark/page.test.tsx
+++ b/web/app/benchmark/page.test.tsx
@@ -226,4 +226,75 @@ describe("Benchmark page", () => {
     expect(screen.getByText("COMPILED PROMPT")).toBeTruthy();
     expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
+
+  it("ignores a second click while a benchmark run is already in flight", async () => {
+    let resolveRequest: (value: unknown) => void = () => {};
+    apiJsonMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    render(<BenchmarkPage />);
+
+    fireEvent.change(screen.getByLabelText("Benchmark prompt input"), {
+      target: { value: "Explain rate limiting." },
+    });
+
+    const runButton = screen.getAllByRole("button", { name: /Run Benchmark/i })[0];
+    fireEvent.click(runButton);
+    fireEvent.click(runButton);
+    fireEvent.click(runButton);
+
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRequest({
+        raw_output: "Raw answer",
+        compiled_output: "Compiled answer",
+        metrics: {
+          safety: { raw: 6, compiled: 9 },
+          clarity: { raw: 5, compiled: 9 },
+          conciseness: { raw: 5, compiled: 8 },
+        },
+        processing_ms: 4321,
+        winner: "compiled",
+        improvement_score: 35,
+      });
+    });
+
+    expect(await screen.findByText("Benchmark complete (4321ms)")).toBeTruthy();
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger a second run when Cmd+Enter repeats from a held key", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      raw_output: "Raw answer",
+      compiled_output: "Compiled answer",
+      metrics: {
+        safety: { raw: 6, compiled: 9 },
+        clarity: { raw: 5, compiled: 9 },
+        conciseness: { raw: 5, compiled: 8 },
+      },
+      processing_ms: 4321,
+      winner: "compiled",
+      improvement_score: 35,
+    });
+
+    render(<BenchmarkPage />);
+
+    const textarea = screen.getByLabelText("Benchmark prompt input");
+    fireEvent.change(textarea, {
+      target: { value: "Explain rate limiting." },
+    });
+
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true, repeat: true });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true, repeat: true });
+
+    expect(apiJsonMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true, repeat: false });
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(1));
+  });
 });

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Legend,
   PolarAngleAxis,
@@ -136,6 +136,8 @@ export default function BenchmarkPage() {
   const [status, setStatus] = useState("Ready");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  const isRunningRef = useRef(false);
+
   const selectedModelMeta = useMemo(
     () => (selectedModel === "mock" ? null : getBenchmarkModelById(selectedModel)),
     [selectedModel],
@@ -169,9 +171,10 @@ export default function BenchmarkPage() {
   }, [prompt]);
 
   const handleBenchmark = useCallback(async () => {
-    if (!prompt.trim()) {
+    if (!prompt.trim() || isRunningRef.current) {
       return;
     }
+    isRunningRef.current = true;
 
     setLoading(true);
     setBenchmarkResult(null);
@@ -216,6 +219,7 @@ export default function BenchmarkPage() {
       setErrorMessage(buildBenchmarkErrorMessage(error));
     } finally {
       setLoading(false);
+      isRunningRef.current = false;
     }
   }, [generateMockResult, prompt, selectedModel, selectedModelMeta]);
 
@@ -359,6 +363,7 @@ export default function BenchmarkPage() {
                   window.localStorage.setItem("promptc_benchmark_prompt", event.target.value);
                 }}
                 onKeyDown={(event) => {
+                  if (event.repeat) return;
                   if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
                     event.preventDefault();
                     if (!loading && prompt.trim()) {


### PR DESCRIPTION
## Summary
- Holding Cmd+Enter (or double-clicking Run Benchmark) on the Benchmark page had no guard, so it could fire parallel runs of the most expensive endpoint in the app (two LLM calls per run).
- Add an `isRunningRef` guard in `handleBenchmark` (set at start, cleared in `finally`, early-return if already set), mirroring the existing pattern in `web/app/pr-safety/page.tsx`'s `isAnalyzingRef`.
- Add `if (event.repeat) return;` to the prompt textarea's `onKeyDown`, matching the pattern already used in `web/app/agent-generator/page.tsx`.
- No UI changes — purely defensive.

## Scope
- Only touched `handleBenchmark` (submit handler) and the textarea `onKeyDown` in `web/app/benchmark/page.tsx`. Did not touch the results-row layout region (~lines 445-467), which is being edited concurrently in another branch.

## Test plan
- [x] `cd web && npm run test` — 41 files / 214 tests pass, including 2 new tests covering double-click and held-key-repeat guards
- [x] `cd web && npm run build` — succeeds