### PR TITLE
fix(optimizer): local-heuristics retry no longer re-fires the failed cloud call

### DIFF
--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -3,9 +3,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import OptimizerPage from "../optimizer/page";
 import { apiJson } from "@/config";
+import { showError } from "../lib/showError";
 
-vi.mock("@/config", () => ({
-  apiJson: vi.fn(),
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    apiJson: vi.fn(),
+  };
+});
+
+vi.mock("../lib/showError", () => ({
+  showError: vi.fn(),
 }));
 
 const routerPushMock = vi.fn();
@@ -21,10 +30,12 @@ vi.mock("../components/InfoButton", () => ({
 }));
 
 const apiJsonMock = vi.mocked(apiJson);
+const showErrorMock = vi.mocked(showError);
 
 describe("Optimizer page", () => {
   beforeEach(() => {
     apiJsonMock.mockReset();
+    showErrorMock.mockReset();
     routerPushMock.mockReset();
     localStorage.clear();
     Object.defineProperty(navigator, "clipboard", {
@@ -326,5 +337,29 @@ describe("Optimizer page", () => {
       "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
     );
     expect(routerPushMock).toHaveBeenCalledWith("/");
+  });
+
+  it("actually falls back to local heuristics — not a retry of the failed cloud call — when the recovery button is clicked", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("Provider is missing an API key."));
+
+    render(<OptimizerPage />);
+
+    fireEvent.change(screen.getByLabelText("Original Prompt"), {
+      target: { value: "Please can you kindly summarize this verbose prompt for me, thank you." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
+
+    expect(await screen.findByText("Cloud Optimizer Alert")).toBeTruthy();
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Local Heuristics (Offline)" }));
+
+    // The fallback must run the offline heuristic path directly, not re-issue the
+    // cloud request that just failed (previously a setTimeout-after-setState bug
+    // meant handleOptimize closed over the stale "openrouter" provider state).
+    expect(await screen.findByText("Offline Local Heuristic compression active.")).toBeTruthy();
+    expect(screen.getByText("No cloud API key required for this mode.")).toBeTruthy();
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Cloud Optimizer Alert")).toBeNull();
   });
 });

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Sparkles } from "lucide-react";
-import { apiJson } from "@/config";
+import { apiJson, describeRequestError } from "@/config";
 import { showError } from "../lib/showError";
 
 import InfoButton from "../components/InfoButton";
@@ -113,13 +113,6 @@ function formatProviderName(provider: string): string {
     return provider || "Unknown";
 }
 
-function getErrorMessage(error: unknown): string {
-    if (error instanceof Error && error.message.trim()) {
-        return error.message;
-    }
-    return String(error);
-}
-
 function isCloudOptimizerUnavailable(message: string | null): boolean {
     if (!message) {
         return false;
@@ -205,13 +198,15 @@ export default function OptimizerPage() {
         englishVariant.trim().length > 0 &&
         englishVariant.trim() !== output.trim();
 
-    const handleOptimize = async () => {
+    const handleOptimize = async (overrideProvider?: string, overrideModel?: string) => {
         if (!input.trim()) return;
+        const activeProvider = overrideProvider ?? provider;
+        const activeModel = overrideModel ?? model;
         setLoading(true);
         setOptimizationError(null);
         setResult(null);
 
-        if (provider === "local") {
+        if (activeProvider === "local") {
             // Simulate premium calculation time
             await new Promise((resolve) => setTimeout(resolve, 600));
             const compressed = runLocalOfflineCompression(input);
@@ -260,14 +255,16 @@ export default function OptimizerPage() {
                 body: JSON.stringify({
                     text: input,
                     max_tokens: maxTokens,
-                    provider: provider,
-                    model: model,
+                    provider: activeProvider,
+                    model: activeModel,
                 }),
             });
             setResult(normalizeOptimizeResponse(data));
         } catch (error: unknown) {
             showError(error);
-            setOptimizationError(getErrorMessage(error));
+            setOptimizationError(
+                describeRequestError(error, { fallback: "Failed to optimize prompt." }),
+            );
         } finally {
             setLoading(false);
         }
@@ -350,7 +347,7 @@ export default function OptimizerPage() {
 
                     <button
                         type="button"
-                        onClick={handleOptimize}
+                        onClick={() => void handleOptimize()}
                         disabled={loading || !input.trim()}
                         aria-busy={loading}
                         title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}
@@ -386,10 +383,7 @@ export default function OptimizerPage() {
                                 setProvider("local");
                                 setModel("offline");
                                 setOptimizationError(null);
-                                // Queue the optimize operation instantly
-                                setTimeout(() => {
-                                    void handleOptimize();
-                                }, 50);
+                                void handleOptimize("local", "offline");
                             }}
                             className="w-full sm:w-auto shrink-0 rounded-lg bg-emerald-600/20 border border-emerald-500/40 px-4 py-2 text-xs font-bold text-emerald-200 transition-all hover:bg-emerald-600/30 active:scale-95"
                         >
@@ -484,7 +478,7 @@ export default function OptimizerPage() {
                                 <div className="flex flex-col items-center gap-2">
                                 <button
                                     type="button"
-                                    onClick={handleOptimize}
+                                    onClick={() => void handleOptimize()}
                                     disabled={loading || !input.trim()}
                                     aria-busy={loading}
                                     title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}


### PR DESCRIPTION
## Summary
- The Optimizer's error-banner "Switch to Local Heuristics (Offline)" button called `setProvider("local")` and then `setTimeout(() => handleOptimize(), 50)`, but `handleOptimize` closed over the render's `provider` state from before the state update, so the retry silently re-issued the exact cloud request that had just failed instead of running the offline fallback.
- `handleOptimize` now takes optional `(overrideProvider, overrideModel)` args (falling back to current state when omitted, so the main "Optimize & estimate cost" buttons and the Ctrl/Cmd+Enter shortcut keep working unchanged), and the recovery button calls `handleOptimize("local", "offline")` directly instead of relying on the setState + setTimeout race.
- Non-local optimize failures now route through `describeRequestError` (from `web/config.ts`) instead of surfacing a raw `error.message`, matching the pattern used elsewhere in the app (agent-packs, skills-generator, etc.).

## Test plan
- [x] `cd web && npm run test` — 41 files / 213 tests pass, including a new regression test asserting the recovery button runs the offline heuristic path (not another cloud call) and the cloud-error banner clears.
- [x] `cd web && npm run build` — Next.js production build succeeds.