### PR TITLE
fix(web): stop clipboard-copy buttons claiming success on failure

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { toast } from "sonner";
 import { ArrowRight, Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
+import { copyToClipboard } from "../../lib/copyToClipboard";
 
 const AGENT_PACKS_HANDOFF_KEY = "promptc_agent_pack_goal";
 
@@ -200,13 +200,12 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     void fetchExport(target, nextMode);
   };
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (!currentContent) return;
-    navigator.clipboard.writeText(currentContent).then(() => {
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    const success = await copyToClipboard(currentContent);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   const handleAgentPacksHandoff = () => {

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { toast } from "sonner";
-
 import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Bot } from "lucide-react";
@@ -9,6 +7,7 @@ import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import type { AgentGeneratorResponse, GitHubRepoContextPayload } from "@/lib/api/types";
 import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
 import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
@@ -134,13 +133,12 @@ export default function AgentGenerator() {
     }
   };
 
-  const copyToClipboard = () => {
-    if (result) {
-      navigator.clipboard.writeText(result.content);
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+  const handleCopyToClipboard = async () => {
+    if (!result) return;
+    const success = await copyToClipboard(result.content);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -408,7 +406,7 @@ export default function AgentGenerator() {
 
                   <button
                     type="button"
-                    onClick={copyToClipboard}
+                    onClick={handleCopyToClipboard}
                     className="absolute bottom-6 right-6 bg-green-600 hover:bg-green-500 text-white p-3 rounded-xl shadow-lg shadow-green-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
                     title="Copy to Clipboard"
                     aria-label="Copy Markdown"

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { toast } from "sonner";
-
 import { useEffect, useMemo, useState } from "react";
 import { Bot, Copy, Download, FileCode2, FolderArchive, Loader2, ShieldCheck, Sparkles, X } from "lucide-react";
 
 import { apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
 import InfoButton from "../components/InfoButton";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import FileTree from "./components/FileTree";
 import InstallChecklist from "./components/InstallChecklist";
 import { buildInstallChecklist } from "./installChecklist";
@@ -143,16 +142,16 @@ export default function AgentPacksPage() {
 
   const handleCopyCurrent = async () => {
     if (!currentFile) return;
-    await navigator.clipboard.writeText(currentFile.content);
-    toast.success("Copied to clipboard");
+    const success = await copyToClipboard(currentFile.content);
+    if (!success) return;
     setCopiedState("single");
     setTimeout(() => setCopiedState(null), 1800);
   };
 
   const handleCopyAll = async () => {
     if (!manifest) return;
-    await navigator.clipboard.writeText(bundleFiles(manifest.files));
-    toast.success("Copied to clipboard");
+    const success = await copyToClipboard(bundleFiles(manifest.files));
+    if (!success) return;
     setCopiedState("all");
     setTimeout(() => setCopiedState(null), 1800);
   };

--- a/web/app/components/CopyButton.tsx
+++ b/web/app/components/CopyButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { toast } from "sonner";
+import { copyToClipboard } from "../lib/copyToClipboard";
 
 interface CopyButtonProps {
   text: string;
@@ -18,10 +18,10 @@ export default function CopyButton({
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(text);
+  const handleCopy = async () => {
+    const success = await copyToClipboard(text);
+    if (!success) return;
     setCopied(true);
-    toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 2000);
   };
 

--- a/web/app/lib/copyToClipboard.test.ts
+++ b/web/app/lib/copyToClipboard.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import { copyToClipboard } from "./copyToClipboard";
+
+describe("copyToClipboard", () => {
+  beforeEach(() => {
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves true and shows a success toast when writeText succeeds", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    const result = await copyToClipboard("hello world");
+
+    expect(result).toBe(true);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello world");
+    expect(toast.success).toHaveBeenCalledWith("Copied to clipboard");
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("resolves false and shows a failure toast when writeText rejects (e.g. unfocused tab)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+
+    const result = await copyToClipboard("hello world");
+
+    expect(result).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith("Copy failed — select the text manually");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("resolves false when navigator.clipboard is unavailable (non-secure context)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const result = await copyToClipboard("hello world");
+
+    expect(result).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith("Copy failed — select the text manually");
+  });
+
+  it("supports custom success/failure messages", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    await copyToClipboard("md", { successMessage: "Copied report as Markdown" });
+
+    expect(toast.success).toHaveBeenCalledWith("Copied report as Markdown");
+  });
+});

--- a/web/app/lib/copyToClipboard.ts
+++ b/web/app/lib/copyToClipboard.ts
@@ -1,0 +1,36 @@
+import { toast } from "sonner";
+
+interface CopyToClipboardOptions {
+  /** Toast message shown when the copy succeeds. */
+  successMessage?: string;
+  /** Toast message shown when the copy fails (e.g. unfocused tab, non-HTTPS context). */
+  failureMessage?: string;
+}
+
+/**
+ * Copies text to the clipboard and centralizes the success/failure toast.
+ *
+ * `navigator.clipboard.writeText` rejects in several real-world situations
+ * (unfocused tab, non-HTTPS/insecure context, permission denied), so callers
+ * must not assume the copy succeeded just because they called this function.
+ * Only treat the copy as successful — e.g. flipping a "Copied!" checkmark
+ * state — when this resolves to `true`.
+ */
+export async function copyToClipboard(
+  text: string,
+  options: CopyToClipboardOptions = {},
+): Promise<boolean> {
+  const {
+    successMessage = "Copied to clipboard",
+    failureMessage = "Copy failed — select the text manually",
+  } = options;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(successMessage);
+    return true;
+  } catch {
+    toast.error(failureMessage);
+    return false;
+  }
+}

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Sparkles } from "lucide-react";
 import { apiJson } from "@/config";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 
 import InfoButton from "../components/InfoButton";
 
@@ -281,7 +282,7 @@ export default function OptimizerPage() {
 
     const copyText = (text: string) => {
         if (!text) return;
-        void navigator.clipboard?.writeText(text).catch(() => {});
+        void copyToClipboard(text);
     };
 
     return (

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -2,11 +2,11 @@
 
 import { useRef, useState } from "react";
 import { ShieldCheck } from "lucide-react";
-import { toast } from "sonner";
 
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import { showError } from "../lib/showError";
 import { downloadFile } from "../lib/downloadFile";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import InfoButton from "../components/InfoButton";
 import GeneratorErrorState from "../components/GeneratorErrorState";
 import { reportToMarkdown } from "./markdown";
@@ -159,10 +159,12 @@ export default function PrSafetyPage() {
     setLastError(null);
   };
 
-  const copyMarkdown = () => {
+  const copyMarkdown = async () => {
     if (!report) return;
-    void navigator.clipboard.writeText(reportToMarkdown(report));
-    toast.success("Copied report as Markdown");
+    const success = await copyToClipboard(reportToMarkdown(report), {
+      successMessage: "Copied report as Markdown",
+    });
+    if (!success) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { toast } from "sonner";
 import { Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { apiFetch } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
+import { copyToClipboard } from "../../lib/copyToClipboard";
 
 type SkillTarget = "claude-tool" | "claude-mcp-tool" | "langchain-tool";
 type OutputMode = "python" | "json" | "files";
@@ -179,13 +179,12 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
     setOutputMode(nextMode);
   };
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (!currentContent) return;
-    navigator.clipboard.writeText(currentContent).then(() => {
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    const success = await copyToClipboard(currentContent);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   const handleDownloadFile = () => {

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { toast } from "sonner";
-
 import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Zap } from "lucide-react";
@@ -9,6 +7,7 @@ import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import type { GitHubRepoContextPayload, SkillGeneratorResponse } from "@/lib/api/types";
 import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import InfoButton from "../components/InfoButton";
 import ContextManager from "../components/ContextManager";
 import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
@@ -127,13 +126,12 @@ export default function SkillsGenerator() {
     }
   };
 
-  const copyToClipboard = () => {
-    if (result) {
-      navigator.clipboard.writeText(result.content);
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+  const handleCopyToClipboard = async () => {
+    if (!result) return;
+    const success = await copyToClipboard(result.content);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -381,7 +379,7 @@ export default function SkillsGenerator() {
 
                   <button
                     type="button"
-                    onClick={copyToClipboard}
+                    onClick={handleCopyToClipboard}
                     className="absolute bottom-6 right-6 bg-yellow-600 hover:bg-yellow-500 text-white p-3 rounded-xl shadow-lg shadow-yellow-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500"
                     title="Copy to Clipboard"
                     aria-label="Copy Markdown"


### PR DESCRIPTION
## Summary
- `navigator.clipboard.writeText` rejects on unfocused tabs and non-HTTPS/insecure contexts, but several "Copy" buttons showed a success toast/checkmark unconditionally with no `.catch`.
- Add `web/app/lib/copyToClipboard.ts`, a shared helper that awaits the write, shows a success toast on success or `"Copy failed — select the text manually"` on failure, and resolves to `true`/`false` so callers only flip the "Copied!" checkmark state on an actual success.
- Route every clipboard-copy call site through it: `CopyButton`, `pr-safety`, `agent-generator`, `skills-generator`, `agent-packs`, `optimizer`, and the clipboard-copy paths in both `agent-generator`/`skills-generator` `ExportPanel.tsx` components (their unrelated error-catch/retry-button regions were left untouched).
- Existing `sr-only` / `aria-live` "Copied to clipboard" announcements are preserved — they still fire on real success.

## Test plan
- [x] `cd web && npm run test` — 42 files / 216 tests pass (added `web/app/lib/copyToClipboard.test.ts` covering success, rejection, and missing-`navigator.clipboard` cases)
- [x] `cd web && npm run build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)