### PR TITLE
fix(web): make benchmark results row responsive on mobile

### DIFF
--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -444,7 +444,7 @@ export default function BenchmarkPage() {
                     to measure your prompt.
                   </div>
                 )}
-                <div className="flex h-[40%] min-h-[300px] border-b border-white/5">
+                <div className="flex min-h-[420px] flex-col border-b border-white/5 md:h-[40%] md:min-h-[300px] md:flex-row">
                   <div className="relative flex flex-1 items-center justify-center p-4">
                     <h3 className="absolute left-4 top-4 text-xs font-semibold uppercase text-zinc-500">
                       Performance Radar
@@ -466,7 +466,7 @@ export default function BenchmarkPage() {
                     </div>
                   </div>
 
-                  <div className="flex w-[300px] flex-col items-center justify-center gap-4 border-l border-white/5 bg-black/10 p-6">
+                  <div className="flex w-full flex-col items-center justify-center gap-4 border-t border-white/5 bg-black/10 p-6 md:w-[300px] md:border-l md:border-t-0">
                     <div className="space-y-1 text-center">
                       <div className="font-mono text-xs uppercase text-zinc-500">Winner</div>
                       <div
@@ -489,7 +489,7 @@ export default function BenchmarkPage() {
                   </div>
                 </div>
 
-                <div className="flex min-h-0 flex-1 flex-col bg-black/20">
+                <div className="flex min-h-[160px] flex-1 flex-col bg-black/20 md:min-h-0">
                   <div className="flex-1 overflow-hidden p-4">
                     <DiffViewer oldText={benchmarkResult.raw_output} newText={benchmarkResult.compiled_output} />
                   </div>


### PR DESCRIPTION
## Summary
- The benchmark results row (radar chart + winner column) used a fixed `w-[300px]` winner column and no responsive breakpoints, causing it to get crushed/overflow around 375px width — right at the page's payoff moment.
- Stack the radar chart and winner column vertically below `md` (`flex-col md:flex-row`), let the winner column go full-width on mobile (`w-full md:w-[300px]`), and flip the separator from a left border to a top border on mobile (`border-t md:border-l md:border-t-0`).
- Give the mobile results row and the DiffViewer wrapper below it explicit min-heights (`min-h-[420px]` on the row, `min-h-[160px]` on the DiffViewer container) so neither collapses when stacked. Desktop layout is unchanged (`md:h-[40%] md:min-h-[300px]`, `md:min-h-0`).

## Test plan
- [x] `cd web && npm run build` — succeeds
- [x] `npx vitest run app/benchmark/page.test.tsx app/__tests__/page-benchmark-cta.test.tsx` — 9/9 passed
- [x] Reviewed resulting class list for 375px width: results row stacks (radar full width, then winner column full width below with a top border), DiffViewer keeps a 160px floor

Scope note: only the results-row region (~lines 445-467) plus the DiffViewer wrapper below it were touched. Submit handler, `isRunningRef`, and textarea `onKeyDown` logic were left untouched (owned by a concurrent change).