### PR TITLE
fix(web): show persistent inline error with retry in QualityCoach

### DIFF
--- a/web/app/components/QualityCoach.tsx
+++ b/web/app/components/QualityCoach.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { apiJson } from "@/config";
 import { showError } from "../lib/showError";
+import GeneratorErrorState from "./GeneratorErrorState";
 
 type ValidationResponse = {
     score: number;
@@ -16,7 +17,6 @@ type ValidationResponse = {
 
 type QualityCoachProps = {
     prompt: string;
-    onUpdatePrompt: (newPrompt: string) => void;
 };
 
 const SCORE_LABELS: Record<string, { title: string; help: string }> = {
@@ -52,11 +52,13 @@ function labelHelp(key: string): string {
 export default function QualityCoach({ prompt }: QualityCoachProps) {
     const [analyzing, setAnalyzing] = useState(false);
     const [report, setReport] = useState<ValidationResponse | null>(null);
+    const [error, setError] = useState<unknown>(null);
 
 
     const handleAnalyze = async () => {
         if (!prompt.trim()) return;
         setAnalyzing(true);
+        setError(null);
         try {
             const data = await apiJson<ValidationResponse>("/validate", {
                 method: "POST",
@@ -66,6 +68,7 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
             setReport(data);
         } catch (e) {
             showError(e);
+            setError(e);
         } finally {
             setAnalyzing(false);
         }
@@ -102,7 +105,15 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                 </div>
             </div>
 
-            {!report && (
+            {error ? (
+                <GeneratorErrorState
+                    error={error}
+                    onRetry={() => void handleAnalyze()}
+                    title="Quality analysis failed"
+                    retryLabel="Retry analysis"
+                    reassurance="Your prompt hasn't changed. Try again — if it keeps failing, your connection or the quality checker service may be down."
+                />
+            ) : !report ? (
                 <div className="flex-1 flex flex-col items-center justify-center text-zinc-500 gap-4 opacity-70">
                     <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center text-3xl mb-2">
                         🛡️
@@ -124,12 +135,12 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                         )}
                     </button>
                 </div>
-            )}
+            ) : null}
 
 
 
             {/* Analysis Report */}
-            {report && (
+            {!error && report && (
                 <div className="space-y-8 animate-fade-in pb-10">
                     {/* Category Scores */}
                     <p className="text-xs text-zinc-400">

--- a/web/app/components/__tests__/QualityCoach.test.tsx
+++ b/web/app/components/__tests__/QualityCoach.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import QualityCoach from "../QualityCoach";
+import { apiJson } from "@/config";
+
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    apiJson: vi.fn(),
+  };
+});
+
+vi.mock("../../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+const apiJsonMock = vi.mocked(apiJson);
+
+const validationResponse = {
+  score: 82,
+  category_scores: { clarity: 90, specificity: 70 },
+  strengths: ["Clear goal"],
+  weaknesses: [],
+  suggestions: [],
+  summary: "Looks solid.",
+};
+
+describe("QualityCoach", () => {
+  beforeEach(() => {
+    apiJsonMock.mockReset();
+  });
+
+  it("shows an inline error card with a retry button when analysis fails", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("Backend unreachable"));
+
+    render(<QualityCoach prompt="Write a summary of this document" />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Run quality analysis" })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByText("Quality analysis failed")).toBeTruthy();
+    expect(screen.getByText("Backend unreachable")).toBeTruthy();
+
+    // The pristine empty state must not still be shown alongside the error.
+    expect(
+      screen.queryByText("Run analysis to detect potential improvements and safety issues."),
+    ).toBeNull();
+
+    const retryButton = screen.getByRole("button", { name: "Retry analysis" });
+    expect(retryButton).toBeTruthy();
+
+    apiJsonMock.mockResolvedValueOnce(validationResponse);
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+    expect(screen.getByText("82/100")).toBeTruthy();
+  });
+
+  it("clears a previous error once a new run starts", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("Backend unreachable"));
+
+    render(<QualityCoach prompt="Write a summary of this document" />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Run quality analysis" })[0]);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+
+    apiJsonMock.mockResolvedValueOnce(validationResponse);
+    fireEvent.click(screen.getByRole("button", { name: "Run quality analysis" }));
+
+    // The error card disappears immediately once a new run is kicked off.
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByText("82/100")).toBeTruthy();
+    });
+  });
+});

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -664,7 +664,7 @@ export default function Home() {
                 >
                   {activeTab === "quality" && (
                     <div className="absolute inset-0 bg-transparent z-20 animate-fade-in">
-                      <QualityCoach prompt={prompt} onUpdatePrompt={setPrompt} />
+                      <QualityCoach prompt={prompt} />
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- QualityCoach's `/validate` failures only fired a transient toast (`showError`), then left the panel on its pristine empty state — during a backend outage, the "Run Analysis" button looked like it silently did nothing.
- Add an `error` state to `QualityCoach`, set via `describeRequestError` (through the existing `GeneratorErrorState` component) on failure and cleared at the start of every new run.
- On failure, render an inline error card with a "Retry analysis" button, reusing `GeneratorErrorState` for visual consistency with `skills-generator`, `agent-generator`, and `pr-safety`.
- Fix the declared-but-ignored `onUpdatePrompt` prop: it was dead wiring left over from a previously removed Autofix feature (see `412c786a`, "Remove Autofix") — the component never called it. Removed it from `QualityCoachProps` and from the only call site (`web/app/page.tsx`), since there's no live feature that needs it and restoring one would be out of scope here.

## Test plan
- [x] `cd web && npm run test` — 42 files / 214 tests passed, including a new `app/components/__tests__/QualityCoach.test.tsx` covering the inline error card, the retry button (success after retry), and that a new run clears the previous error.
- [x] `cd web && npm run build` — compiles and typechecks successfully.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>