### PR TITLE
integrate: D-cluster trust/friction fixes (#983-#990)

### DIFF
--- a/web/app/__tests__/optimizer-page.test.tsx
+++ b/web/app/__tests__/optimizer-page.test.tsx
@@ -3,9 +3,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import OptimizerPage from "../optimizer/page";
 import { apiJson } from "@/config";
+import { showError } from "../lib/showError";
 
-vi.mock("@/config", () => ({
-  apiJson: vi.fn(),
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    apiJson: vi.fn(),
+  };
+});
+
+vi.mock("../lib/showError", () => ({
+  showError: vi.fn(),
 }));
 
 const routerPushMock = vi.fn();
@@ -21,10 +30,12 @@ vi.mock("../components/InfoButton", () => ({
 }));
 
 const apiJsonMock = vi.mocked(apiJson);
+const showErrorMock = vi.mocked(showError);
 
 describe("Optimizer page", () => {
   beforeEach(() => {
     apiJsonMock.mockReset();
+    showErrorMock.mockReset();
     routerPushMock.mockReset();
     localStorage.clear();
     Object.defineProperty(navigator, "clipboard", {
@@ -326,5 +337,29 @@ describe("Optimizer page", () => {
       "PDF'i ozetle. Junior gelistirici icin uygulama plani yaz.",
     );
     expect(routerPushMock).toHaveBeenCalledWith("/");
+  });
+
+  it("actually falls back to local heuristics — not a retry of the failed cloud call — when the recovery button is clicked", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("Provider is missing an API key."));
+
+    render(<OptimizerPage />);
+
+    fireEvent.change(screen.getByLabelText("Original Prompt"), {
+      target: { value: "Please can you kindly summarize this verbose prompt for me, thank you." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /Optimize & estimate cost/i })[0]);
+
+    expect(await screen.findByText("Cloud Optimizer Alert")).toBeTruthy();
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Local Heuristics (Offline)" }));
+
+    // The fallback must run the offline heuristic path directly, not re-issue the
+    // cloud request that just failed (previously a setTimeout-after-setState bug
+    // meant handleOptimize closed over the stale "openrouter" provider state).
+    expect(await screen.findByText("Offline Local Heuristic compression active.")).toBeTruthy();
+    expect(screen.getByText("No cloud API key required for this mode.")).toBeTruthy();
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Cloud Optimizer Alert")).toBeNull();
   });
 });

--- a/web/app/agent-generator/components/ExportPanel.test.tsx
+++ b/web/app/agent-generator/components/ExportPanel.test.tsx
@@ -11,9 +11,13 @@ const { push } = vi.hoisted(() => ({
   push: vi.fn(),
 }));
 
-vi.mock("@/config", () => ({
-  apiFetch,
-}));
+vi.mock("@/config", async () => {
+  const actual = await vi.importActual<typeof import("@/config")>("@/config");
+  return {
+    ...actual,
+    apiFetch,
+  };
+});
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
@@ -224,5 +228,33 @@ describe("Agent ExportPanel", () => {
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(anchors[anchors.length - 1].download).toBe("claude-subagent-export.zip");
+  });
+
+  test("shows a friendly message for a failed export and retries via the retry button", async () => {
+    apiFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    render(<ExportPanel systemPrompt={"# Agent\n\n## Role\nTest"} isMultiAgent={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
+    );
+    expect(alert).not.toHaveTextContent("Failed to fetch");
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        python_code: "print('hello')",
+        yaml_config: null,
+        code: "print('hello')",
+        files: [],
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /retry export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("print('hello')")).toBeInTheDocument();
   });
 });

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { apiFetch } from "@/config";
+import { apiFetch, describeRequestError } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
 
 const AGENT_PACKS_HANDOFF_KEY = "promptc_agent_pack_goal";
@@ -170,7 +170,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
       const data: ExportResult = await res.json();
       setCache((prev) => ({ ...prev, [nextFormat]: data }));
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Export failed");
+      setError(describeRequestError(e, { fallback: "Export failed." }));
     } finally {
       setLoading(false);
     }
@@ -322,8 +322,18 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                 Generating {activeTarget.label} export...
               </div>
             ) : error ? (
-              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                {error}
+              <div
+                className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300 flex flex-col items-start gap-2"
+                role="alert"
+              >
+                <p>{error}</p>
+                <button
+                  type="button"
+                  onClick={() => void fetchExport(target, outputMode)}
+                  className="rounded-lg border border-red-400/30 bg-red-500/20 px-3 py-1.5 text-[11px] font-medium text-red-100 transition-colors hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                >
+                  Retry export
+                </button>
               </div>
             ) : currentContent ? (
               <div className="relative group/code">

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { toast } from "sonner";
 import { ArrowRight, Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
+import { copyToClipboard } from "../../lib/copyToClipboard";
 
 const AGENT_PACKS_HANDOFF_KEY = "promptc_agent_pack_goal";
 
@@ -200,13 +200,12 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     void fetchExport(target, nextMode);
   };
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (!currentContent) return;
-    navigator.clipboard.writeText(currentContent).then(() => {
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    const success = await copyToClipboard(currentContent);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   const handleAgentPacksHandoff = () => {

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { toast } from "sonner";
-
 import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Bot } from "lucide-react";
@@ -9,6 +7,7 @@ import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import type { AgentGeneratorResponse, GitHubRepoContextPayload } from "@/lib/api/types";
 import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import ContextManager from "../components/ContextManager";
 import InfoButton from "../components/InfoButton";
 import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
@@ -134,13 +133,12 @@ export default function AgentGenerator() {
     }
   };
 
-  const copyToClipboard = () => {
-    if (result) {
-      navigator.clipboard.writeText(result.content);
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+  const handleCopyToClipboard = async () => {
+    if (!result) return;
+    const success = await copyToClipboard(result.content);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -408,7 +406,7 @@ export default function AgentGenerator() {
 
                   <button
                     type="button"
-                    onClick={copyToClipboard}
+                    onClick={handleCopyToClipboard}
                     className="absolute bottom-6 right-6 bg-green-600 hover:bg-green-500 text-white p-3 rounded-xl shadow-lg shadow-green-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
                     title="Copy to Clipboard"
                     aria-label="Copy Markdown"

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { toast } from "sonner";
-
 import { useEffect, useMemo, useState } from "react";
 import { Bot, Copy, Download, FileCode2, FolderArchive, Loader2, ShieldCheck, Sparkles, X } from "lucide-react";
 
 import { apiJson, buildGeneratorApiHeaders, describeRequestError } from "@/config";
 import InfoButton from "../components/InfoButton";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import FileTree from "./components/FileTree";
 import InstallChecklist from "./components/InstallChecklist";
 import { buildInstallChecklist } from "./installChecklist";
@@ -143,16 +142,16 @@ export default function AgentPacksPage() {
 
   const handleCopyCurrent = async () => {
     if (!currentFile) return;
-    await navigator.clipboard.writeText(currentFile.content);
-    toast.success("Copied to clipboard");
+    const success = await copyToClipboard(currentFile.content);
+    if (!success) return;
     setCopiedState("single");
     setTimeout(() => setCopiedState(null), 1800);
   };
 
   const handleCopyAll = async () => {
     if (!manifest) return;
-    await navigator.clipboard.writeText(bundleFiles(manifest.files));
-    toast.success("Copied to clipboard");
+    const success = await copyToClipboard(bundleFiles(manifest.files));
+    if (!success) return;
     setCopiedState("all");
     setTimeout(() => setCopiedState(null), 1800);
   };

--- a/web/app/benchmark/page.test.tsx
+++ b/web/app/benchmark/page.test.tsx
@@ -226,4 +226,75 @@ describe("Benchmark page", () => {
     expect(screen.getByText("COMPILED PROMPT")).toBeTruthy();
     expect(apiJsonMock).toHaveBeenCalledTimes(2);
   });
+
+  it("ignores a second click while a benchmark run is already in flight", async () => {
+    let resolveRequest: (value: unknown) => void = () => {};
+    apiJsonMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    render(<BenchmarkPage />);
+
+    fireEvent.change(screen.getByLabelText("Benchmark prompt input"), {
+      target: { value: "Explain rate limiting." },
+    });
+
+    const runButton = screen.getAllByRole("button", { name: /Run Benchmark/i })[0];
+    fireEvent.click(runButton);
+    fireEvent.click(runButton);
+    fireEvent.click(runButton);
+
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRequest({
+        raw_output: "Raw answer",
+        compiled_output: "Compiled answer",
+        metrics: {
+          safety: { raw: 6, compiled: 9 },
+          clarity: { raw: 5, compiled: 9 },
+          conciseness: { raw: 5, compiled: 8 },
+        },
+        processing_ms: 4321,
+        winner: "compiled",
+        improvement_score: 35,
+      });
+    });
+
+    expect(await screen.findByText("Benchmark complete (4321ms)")).toBeTruthy();
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger a second run when Cmd+Enter repeats from a held key", async () => {
+    apiJsonMock.mockResolvedValueOnce({
+      raw_output: "Raw answer",
+      compiled_output: "Compiled answer",
+      metrics: {
+        safety: { raw: 6, compiled: 9 },
+        clarity: { raw: 5, compiled: 9 },
+        conciseness: { raw: 5, compiled: 8 },
+      },
+      processing_ms: 4321,
+      winner: "compiled",
+      improvement_score: 35,
+    });
+
+    render(<BenchmarkPage />);
+
+    const textarea = screen.getByLabelText("Benchmark prompt input");
+    fireEvent.change(textarea, {
+      target: { value: "Explain rate limiting." },
+    });
+
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true, repeat: true });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true, repeat: true });
+
+    expect(apiJsonMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true, repeat: false });
+
+    await waitFor(() => expect(apiJsonMock).toHaveBeenCalledTimes(1));
+  });
 });

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Legend,
   PolarAngleAxis,
@@ -136,6 +136,8 @@ export default function BenchmarkPage() {
   const [status, setStatus] = useState("Ready");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  const isRunningRef = useRef(false);
+
   const selectedModelMeta = useMemo(
     () => (selectedModel === "mock" ? null : getBenchmarkModelById(selectedModel)),
     [selectedModel],
@@ -169,9 +171,10 @@ export default function BenchmarkPage() {
   }, [prompt]);
 
   const handleBenchmark = useCallback(async () => {
-    if (!prompt.trim()) {
+    if (!prompt.trim() || isRunningRef.current) {
       return;
     }
+    isRunningRef.current = true;
 
     setLoading(true);
     setBenchmarkResult(null);
@@ -216,6 +219,7 @@ export default function BenchmarkPage() {
       setErrorMessage(buildBenchmarkErrorMessage(error));
     } finally {
       setLoading(false);
+      isRunningRef.current = false;
     }
   }, [generateMockResult, prompt, selectedModel, selectedModelMeta]);
 
@@ -359,6 +363,7 @@ export default function BenchmarkPage() {
                   window.localStorage.setItem("promptc_benchmark_prompt", event.target.value);
                 }}
                 onKeyDown={(event) => {
+                  if (event.repeat) return;
                   if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
                     event.preventDefault();
                     if (!loading && prompt.trim()) {

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -444,7 +444,7 @@ export default function BenchmarkPage() {
                     to measure your prompt.
                   </div>
                 )}
-                <div className="flex h-[40%] min-h-[300px] border-b border-white/5">
+                <div className="flex min-h-[420px] flex-col border-b border-white/5 md:h-[40%] md:min-h-[300px] md:flex-row">
                   <div className="relative flex flex-1 items-center justify-center p-4">
                     <h3 className="absolute left-4 top-4 text-xs font-semibold uppercase text-zinc-500">
                       Performance Radar
@@ -466,7 +466,7 @@ export default function BenchmarkPage() {
                     </div>
                   </div>
 
-                  <div className="flex w-[300px] flex-col items-center justify-center gap-4 border-l border-white/5 bg-black/10 p-6">
+                  <div className="flex w-full flex-col items-center justify-center gap-4 border-t border-white/5 bg-black/10 p-6 md:w-[300px] md:border-l md:border-t-0">
                     <div className="space-y-1 text-center">
                       <div className="font-mono text-xs uppercase text-zinc-500">Winner</div>
                       <div
@@ -489,7 +489,7 @@ export default function BenchmarkPage() {
                   </div>
                 </div>
 
-                <div className="flex min-h-0 flex-1 flex-col bg-black/20">
+                <div className="flex min-h-[160px] flex-1 flex-col bg-black/20 md:min-h-0">
                   <div className="flex-1 overflow-hidden p-4">
                     <DiffViewer oldText={benchmarkResult.raw_output} newText={benchmarkResult.compiled_output} />
                   </div>

--- a/web/app/components/CopyButton.tsx
+++ b/web/app/components/CopyButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { toast } from "sonner";
+import { copyToClipboard } from "../lib/copyToClipboard";
 
 interface CopyButtonProps {
   text: string;
@@ -18,10 +18,10 @@ export default function CopyButton({
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(text);
+  const handleCopy = async () => {
+    const success = await copyToClipboard(text);
+    if (!success) return;
     setCopied(true);
-    toast.success("Copied to clipboard");
     setTimeout(() => setCopied(false), 2000);
   };
 

--- a/web/app/components/QualityCoach.tsx
+++ b/web/app/components/QualityCoach.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { apiJson } from "@/config";
 import { showError } from "../lib/showError";
+import GeneratorErrorState from "./GeneratorErrorState";
 
 type ValidationResponse = {
     score: number;
@@ -16,7 +17,6 @@ type ValidationResponse = {
 
 type QualityCoachProps = {
     prompt: string;
-    onUpdatePrompt: (newPrompt: string) => void;
 };
 
 const SCORE_LABELS: Record<string, { title: string; help: string }> = {
@@ -52,11 +52,13 @@ function labelHelp(key: string): string {
 export default function QualityCoach({ prompt }: QualityCoachProps) {
     const [analyzing, setAnalyzing] = useState(false);
     const [report, setReport] = useState<ValidationResponse | null>(null);
+    const [error, setError] = useState<unknown>(null);
 
 
     const handleAnalyze = async () => {
         if (!prompt.trim()) return;
         setAnalyzing(true);
+        setError(null);
         try {
             const data = await apiJson<ValidationResponse>("/validate", {
                 method: "POST",
@@ -66,6 +68,7 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
             setReport(data);
         } catch (e) {
             showError(e);
+            setError(e);
         } finally {
             setAnalyzing(false);
         }
@@ -102,7 +105,15 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                 </div>
             </div>
 
-            {!report && (
+            {error ? (
+                <GeneratorErrorState
+                    error={error}
+                    onRetry={() => void handleAnalyze()}
+                    title="Quality analysis failed"
+                    retryLabel="Retry analysis"
+                    reassurance="Your prompt hasn't changed. Try again — if it keeps failing, your connection or the quality checker service may be down."
+                />
+            ) : !report ? (
                 <div className="flex-1 flex flex-col items-center justify-center text-zinc-500 gap-4 opacity-70">
                     <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center text-3xl mb-2">
                         🛡️
@@ -124,12 +135,12 @@ export default function QualityCoach({ prompt }: QualityCoachProps) {
                         )}
                     </button>
                 </div>
-            )}
+            ) : null}
 
 
 
             {/* Analysis Report */}
-            {report && (
+            {!error && report && (
                 <div className="space-y-8 animate-fade-in pb-10">
                     {/* Category Scores */}
                     <p className="text-xs text-zinc-400">

--- a/web/app/components/SecurityAlert.test.tsx
+++ b/web/app/components/SecurityAlert.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import SecurityAlert from "./SecurityAlert";
+import type { SecurityFinding } from "../../lib/api/types";
+
+const findings: SecurityFinding[] = [
+    { type: "openai_key", original: "sk-live-abc123", masked: "sk-live-***" },
+];
+
+describe("SecurityAlert", () => {
+    test("calls onCancel when Escape is pressed", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        fireEvent.keyDown(document, { key: "Escape" });
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test("calls onCancel when the backdrop is clicked", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        const dialog = screen.getByRole("dialog");
+        // The backdrop is the dialog's parent element.
+        fireEvent.click(dialog.parentElement as HTMLElement);
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not call onCancel when clicking inside the dialog", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        fireEvent.click(screen.getByRole("dialog"));
+
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    test("keeps Tab focus contained within the modal", () => {
+        const onCancel = vi.fn();
+        render(
+            <SecurityAlert
+                findings={findings}
+                redactedText="redacted preview"
+                onProceedRedacted={vi.fn()}
+                onProceedOriginal={vi.fn()}
+                onCancel={onCancel}
+            />
+        );
+
+        const cancelButton = screen.getByRole("button", { name: "Cancel" });
+        const stripButton = screen.getByRole("button", { name: /Strip Secrets & Proceed/i });
+
+        stripButton.focus();
+        expect(document.activeElement).toBe(stripButton);
+
+        fireEvent.keyDown(document, { key: "Tab" });
+        expect(document.activeElement).toBe(cancelButton);
+
+        fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+        expect(document.activeElement).toBe(stripButton);
+    });
+});

--- a/web/app/components/SecurityAlert.tsx
+++ b/web/app/components/SecurityAlert.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { ShieldAlert } from "lucide-react";
 import type { SecurityFinding } from "../../lib/api/types";
 
@@ -12,6 +12,9 @@ type SecurityAlertProps = {
     onCancel: () => void;
 };
 
+const FOCUSABLE_SELECTOR =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 export default function SecurityAlert({
     findings,
     redactedText,
@@ -19,6 +22,44 @@ export default function SecurityAlert({
     onProceedOriginal,
     onCancel,
 }: SecurityAlertProps) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                onCancel();
+                return;
+            }
+
+            if (event.key !== "Tab" || !dialogRef.current) {
+                return;
+            }
+
+            const focusable = Array.from(
+                dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+            );
+            if (focusable.length === 0) {
+                return;
+            }
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const active = document.activeElement;
+
+            if (event.shiftKey) {
+                if (active === first || !dialogRef.current.contains(active)) {
+                    event.preventDefault();
+                    last.focus();
+                }
+            } else if (active === last || !dialogRef.current.contains(active)) {
+                event.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [onCancel]);
 
     const findingsSummary = useMemo(() => {
         // Keys match the backend security scanner types in app/heuristics/security.py
@@ -52,8 +93,16 @@ export default function SecurityAlert({
     }, [findings]);
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fade-in">
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fade-in"
+            onClick={(event) => {
+                if (event.target === event.currentTarget) {
+                    onCancel();
+                }
+            }}
+        >
             <div
+                ref={dialogRef}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="security-alert-title"

--- a/web/app/components/__tests__/QualityCoach.test.tsx
+++ b/web/app/components/__tests__/QualityCoach.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import QualityCoach from "../QualityCoach";
+import { apiJson } from "@/config";
+
+vi.mock("@/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/config")>();
+  return {
+    ...actual,
+    apiJson: vi.fn(),
+  };
+});
+
+vi.mock("../../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+const apiJsonMock = vi.mocked(apiJson);
+
+const validationResponse = {
+  score: 82,
+  category_scores: { clarity: 90, specificity: 70 },
+  strengths: ["Clear goal"],
+  weaknesses: [],
+  suggestions: [],
+  summary: "Looks solid.",
+};
+
+describe("QualityCoach", () => {
+  beforeEach(() => {
+    apiJsonMock.mockReset();
+  });
+
+  it("shows an inline error card with a retry button when analysis fails", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("Backend unreachable"));
+
+    render(<QualityCoach prompt="Write a summary of this document" />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Run quality analysis" })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByText("Quality analysis failed")).toBeTruthy();
+    expect(screen.getByText("Backend unreachable")).toBeTruthy();
+
+    // The pristine empty state must not still be shown alongside the error.
+    expect(
+      screen.queryByText("Run analysis to detect potential improvements and safety issues."),
+    ).toBeNull();
+
+    const retryButton = screen.getByRole("button", { name: "Retry analysis" });
+    expect(retryButton).toBeTruthy();
+
+    apiJsonMock.mockResolvedValueOnce(validationResponse);
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+    expect(screen.getByText("82/100")).toBeTruthy();
+  });
+
+  it("clears a previous error once a new run starts", async () => {
+    apiJsonMock.mockRejectedValueOnce(new Error("Backend unreachable"));
+
+    render(<QualityCoach prompt="Write a summary of this document" />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Run quality analysis" })[0]);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+
+    apiJsonMock.mockResolvedValueOnce(validationResponse);
+    fireEvent.click(screen.getByRole("button", { name: "Run quality analysis" }));
+
+    // The error card disappears immediately once a new run is kicked off.
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByText("82/100")).toBeTruthy();
+    });
+  });
+});

--- a/web/app/components/__tests__/RagSearchPanel.test.tsx
+++ b/web/app/components/__tests__/RagSearchPanel.test.tsx
@@ -91,6 +91,29 @@ describe("RagSearchPanel", () => {
     expect(onInsertContext).toHaveBeenCalledWith("[Source: src/auth.ts]\nHandle session creation");
   });
 
+  it("renders every chunk distinctly when multiple results share the same path", () => {
+    // The backend returns chunk-level rows, so one uploaded doc split into
+    // several chunks can produce multiple results with an identical `path`.
+    // Keys must stay unique per row or React will drop/mis-render cards.
+    render(
+      <RagSearchPanel
+        query="auth flow"
+        setQuery={vi.fn()}
+        searching={false}
+        results={[
+          { path: "src/auth.ts", snippet: "Handle session creation", score: 0.81 },
+          { path: "src/auth.ts", snippet: "Refresh tokens on expiry", score: 0.74 },
+        ]}
+        onRunSearch={vi.fn()}
+        onInsertContext={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Handle session creation")).toBeTruthy();
+    expect(screen.getByText("Refresh tokens on expiry")).toBeTruthy();
+    expect(screen.getAllByText("src/auth.ts").length).toBe(2);
+  });
+
   it("shows a clear no-results state when a query returns nothing", () => {
     render(
       <RagSearchPanel

--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -84,8 +84,8 @@ export default function RagSearchPanel({
                     </div>
                 )}
 
-                {results.map((result) => (
-                    <div key={result.path} className="group flex flex-col gap-1.5 p-3 bg-white/5 rounded-xl border border-white/5 hover:border-white/10 transition-all hover:bg-white/[0.07]">
+                {results.map((result, index) => (
+                    <div key={`${result.path}-${index}`} className="group flex flex-col gap-1.5 p-3 bg-white/5 rounded-xl border border-white/5 hover:border-white/10 transition-all hover:bg-white/[0.07]">
                         <div className="flex justify-between items-center gap-2">
                             <span className="text-[10px] text-zinc-500 font-mono truncate max-w-[180px] bg-black/20 px-1.5 py-0.5 rounded">{result.path}</span>
                             <span className="text-[10px] text-green-400/80 font-mono bg-green-500/10 px-1.5 py-0.5 rounded">{formatSearchScore(result)}</span>

--- a/web/app/lib/copyToClipboard.test.ts
+++ b/web/app/lib/copyToClipboard.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import { copyToClipboard } from "./copyToClipboard";
+
+describe("copyToClipboard", () => {
+  beforeEach(() => {
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves true and shows a success toast when writeText succeeds", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    const result = await copyToClipboard("hello world");
+
+    expect(result).toBe(true);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello world");
+    expect(toast.success).toHaveBeenCalledWith("Copied to clipboard");
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("resolves false and shows a failure toast when writeText rejects (e.g. unfocused tab)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+
+    const result = await copyToClipboard("hello world");
+
+    expect(result).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith("Copy failed — select the text manually");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("resolves false when navigator.clipboard is unavailable (non-secure context)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const result = await copyToClipboard("hello world");
+
+    expect(result).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith("Copy failed — select the text manually");
+  });
+
+  it("supports custom success/failure messages", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    await copyToClipboard("md", { successMessage: "Copied report as Markdown" });
+
+    expect(toast.success).toHaveBeenCalledWith("Copied report as Markdown");
+  });
+});

--- a/web/app/lib/copyToClipboard.ts
+++ b/web/app/lib/copyToClipboard.ts
@@ -1,0 +1,36 @@
+import { toast } from "sonner";
+
+interface CopyToClipboardOptions {
+  /** Toast message shown when the copy succeeds. */
+  successMessage?: string;
+  /** Toast message shown when the copy fails (e.g. unfocused tab, non-HTTPS context). */
+  failureMessage?: string;
+}
+
+/**
+ * Copies text to the clipboard and centralizes the success/failure toast.
+ *
+ * `navigator.clipboard.writeText` rejects in several real-world situations
+ * (unfocused tab, non-HTTPS/insecure context, permission denied), so callers
+ * must not assume the copy succeeded just because they called this function.
+ * Only treat the copy as successful — e.g. flipping a "Copied!" checkmark
+ * state — when this resolves to `true`.
+ */
+export async function copyToClipboard(
+  text: string,
+  options: CopyToClipboardOptions = {},
+): Promise<boolean> {
+  const {
+    successMessage = "Copied to clipboard",
+    failureMessage = "Copy failed — select the text manually",
+  } = options;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(successMessage);
+    return true;
+  } catch {
+    toast.error(failureMessage);
+    return false;
+  }
+}

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Sparkles } from "lucide-react";
-import { apiJson } from "@/config";
+import { apiJson, describeRequestError } from "@/config";
 import { showError } from "../lib/showError";
 
 import InfoButton from "../components/InfoButton";
@@ -113,13 +113,6 @@ function formatProviderName(provider: string): string {
     return provider || "Unknown";
 }
 
-function getErrorMessage(error: unknown): string {
-    if (error instanceof Error && error.message.trim()) {
-        return error.message;
-    }
-    return String(error);
-}
-
 function isCloudOptimizerUnavailable(message: string | null): boolean {
     if (!message) {
         return false;
@@ -205,13 +198,15 @@ export default function OptimizerPage() {
         englishVariant.trim().length > 0 &&
         englishVariant.trim() !== output.trim();
 
-    const handleOptimize = async () => {
+    const handleOptimize = async (overrideProvider?: string, overrideModel?: string) => {
         if (!input.trim()) return;
+        const activeProvider = overrideProvider ?? provider;
+        const activeModel = overrideModel ?? model;
         setLoading(true);
         setOptimizationError(null);
         setResult(null);
 
-        if (provider === "local") {
+        if (activeProvider === "local") {
             // Simulate premium calculation time
             await new Promise((resolve) => setTimeout(resolve, 600));
             const compressed = runLocalOfflineCompression(input);
@@ -260,14 +255,16 @@ export default function OptimizerPage() {
                 body: JSON.stringify({
                     text: input,
                     max_tokens: maxTokens,
-                    provider: provider,
-                    model: model,
+                    provider: activeProvider,
+                    model: activeModel,
                 }),
             });
             setResult(normalizeOptimizeResponse(data));
         } catch (error: unknown) {
             showError(error);
-            setOptimizationError(getErrorMessage(error));
+            setOptimizationError(
+                describeRequestError(error, { fallback: "Failed to optimize prompt." }),
+            );
         } finally {
             setLoading(false);
         }
@@ -350,7 +347,7 @@ export default function OptimizerPage() {
 
                     <button
                         type="button"
-                        onClick={handleOptimize}
+                        onClick={() => void handleOptimize()}
                         disabled={loading || !input.trim()}
                         aria-busy={loading}
                         title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}
@@ -386,10 +383,7 @@ export default function OptimizerPage() {
                                 setProvider("local");
                                 setModel("offline");
                                 setOptimizationError(null);
-                                // Queue the optimize operation instantly
-                                setTimeout(() => {
-                                    void handleOptimize();
-                                }, 50);
+                                void handleOptimize("local", "offline");
                             }}
                             className="w-full sm:w-auto shrink-0 rounded-lg bg-emerald-600/20 border border-emerald-500/40 px-4 py-2 text-xs font-bold text-emerald-200 transition-all hover:bg-emerald-600/30 active:scale-95"
                         >
@@ -484,7 +478,7 @@ export default function OptimizerPage() {
                                 <div className="flex flex-col items-center gap-2">
                                 <button
                                     type="button"
-                                    onClick={handleOptimize}
+                                    onClick={() => void handleOptimize()}
                                     disabled={loading || !input.trim()}
                                     aria-busy={loading}
                                     title={!input.trim() ? "Enter a prompt first to optimize & estimate cost" : "Optimize & estimate cost"}

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Sparkles } from "lucide-react";
 import { apiJson } from "@/config";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 
 import InfoButton from "../components/InfoButton";
 
@@ -281,7 +282,7 @@ export default function OptimizerPage() {
 
     const copyText = (text: string) => {
         if (!text) return;
-        void navigator.clipboard?.writeText(text).catch(() => {});
+        void copyToClipboard(text);
     };
 
     return (

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -664,7 +664,7 @@ export default function Home() {
                 >
                   {activeTab === "quality" && (
                     <div className="absolute inset-0 bg-transparent z-20 animate-fade-in">
-                      <QualityCoach prompt={prompt} onUpdatePrompt={setPrompt} />
+                      <QualityCoach prompt={prompt} />
                     </div>
                   )}
                 </div>

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -2,11 +2,11 @@
 
 import { useRef, useState } from "react";
 import { ShieldCheck } from "lucide-react";
-import { toast } from "sonner";
 
 import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import { showError } from "../lib/showError";
 import { downloadFile } from "../lib/downloadFile";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import InfoButton from "../components/InfoButton";
 import GeneratorErrorState from "../components/GeneratorErrorState";
 import { reportToMarkdown } from "./markdown";
@@ -159,10 +159,12 @@ export default function PrSafetyPage() {
     setLastError(null);
   };
 
-  const copyMarkdown = () => {
+  const copyMarkdown = async () => {
     if (!report) return;
-    void navigator.clipboard.writeText(reportToMarkdown(report));
-    toast.success("Copied report as Markdown");
+    const success = await copyToClipboard(reportToMarkdown(report), {
+      successMessage: "Copied report as Markdown",
+    });
+    if (!success) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/web/app/skills-generator/components/ExportPanel.test.tsx
+++ b/web/app/skills-generator/components/ExportPanel.test.tsx
@@ -7,9 +7,13 @@ const { apiFetch } = vi.hoisted(() => ({
   apiFetch: vi.fn(),
 }));
 
-vi.mock("@/config", () => ({
-  apiFetch,
-}));
+vi.mock("@/config", async () => {
+  const actual = await vi.importActual<typeof import("@/config")>("@/config");
+  return {
+    ...actual,
+    apiFetch,
+  };
+});
 
 describe("Skill ExportPanel", () => {
   beforeEach(() => {
@@ -205,5 +209,33 @@ describe("Skill ExportPanel", () => {
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(anchors[anchors.length - 1].download).toBe("claude-mcp-tool-stub-export.zip");
+  });
+
+  test("shows a friendly message for a failed export and retries via the retry button", async () => {
+    apiFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    render(<SkillExportPanel skillDefinition={"# Tool\n\n## Name\nweb_search"} />);
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "The service is temporarily unavailable or still waking up. Please retry in a few seconds.",
+    );
+    expect(alert).not.toHaveTextContent("Failed to fetch");
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        python_code: "def tool(): pass",
+        json_config: '{"name":"tool"}',
+        code: "def tool(): pass",
+        files: [],
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /retry export/i }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('{"name":"tool"}')).toBeInTheDocument();
   });
 });

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { apiFetch } from "@/config";
+import { apiFetch, describeRequestError } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
 
 type SkillTarget = "claude-tool" | "claude-mcp-tool" | "langchain-tool";
@@ -154,7 +154,7 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
         setSelectedFilePath(files[0].path);
       }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Export failed");
+      setError(describeRequestError(e, { fallback: "Export failed." }));
     } finally {
       setLoading(false);
     }
@@ -298,8 +298,18 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
                 Generating {activeTarget.label} export...
               </div>
             ) : error ? (
-              <div className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300">
-                {error}
+              <div
+                className="p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-300 flex flex-col items-start gap-2"
+                role="alert"
+              >
+                <p>{error}</p>
+                <button
+                  type="button"
+                  onClick={() => void fetchExport(target, outputMode)}
+                  className="rounded-lg border border-red-400/30 bg-red-500/20 px-3 py-1.5 text-[11px] font-medium text-red-100 transition-colors hover:bg-red-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                >
+                  Retry export
+                </button>
               </div>
             ) : currentContent ? (
               <div className="relative group/code">

--- a/web/app/skills-generator/components/ExportPanel.tsx
+++ b/web/app/skills-generator/components/ExportPanel.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { toast } from "sonner";
 import { Download, FolderArchive } from "lucide-react";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { apiFetch } from "@/config";
 import { buildPackZip } from "../../lib/packZip";
+import { copyToClipboard } from "../../lib/copyToClipboard";
 
 type SkillTarget = "claude-tool" | "claude-mcp-tool" | "langchain-tool";
 type OutputMode = "python" | "json" | "files";
@@ -179,13 +179,12 @@ export default function SkillExportPanel({ skillDefinition }: ExportPanelProps) 
     setOutputMode(nextMode);
   };
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (!currentContent) return;
-    navigator.clipboard.writeText(currentContent).then(() => {
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    const success = await copyToClipboard(currentContent);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   const handleDownloadFile = () => {

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { toast } from "sonner";
-
 import { useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Zap } from "lucide-react";
@@ -9,6 +7,7 @@ import { apiJson, buildGeneratorApiHeaders } from "@/config";
 import type { GitHubRepoContextPayload, SkillGeneratorResponse } from "@/lib/api/types";
 import { withTimeout } from "@/lib/promise/withTimeout";
 import { showError } from "../lib/showError";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import InfoButton from "../components/InfoButton";
 import ContextManager from "../components/ContextManager";
 import RepoContextPreviewCard from "../components/RepoContextPreviewCard";
@@ -127,13 +126,12 @@ export default function SkillsGenerator() {
     }
   };
 
-  const copyToClipboard = () => {
-    if (result) {
-      navigator.clipboard.writeText(result.content);
-      toast.success("Copied to clipboard");
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+  const handleCopyToClipboard = async () => {
+    if (!result) return;
+    const success = await copyToClipboard(result.content);
+    if (!success) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -381,7 +379,7 @@ export default function SkillsGenerator() {
 
                   <button
                     type="button"
-                    onClick={copyToClipboard}
+                    onClick={handleCopyToClipboard}
                     className="absolute bottom-6 right-6 bg-yellow-600 hover:bg-yellow-500 text-white p-3 rounded-xl shadow-lg shadow-yellow-500/20 transition-all hover:scale-105 active:scale-95 z-20 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500"
                     title="Copy to Clipboard"
                     aria-label="Copy Markdown"


### PR DESCRIPTION
Integration of the 8 D-cluster PRs (trust & friction polish). Notably: **all 8 merged git-clean, including the overlapping ones** — but git-clean needed semantic verification (the B lesson), so I confirmed the overlaps cohere rather than double-up.

## Included
- #983 fix duplicate React keys in RAG search results
- #984 humanize export errors + retry in ExportPanels
- #985 focus-trap + Escape in SecurityAlert modal
- #986 guard Benchmark against double submission
- #987 optimizer local-heuristics retry no longer re-fires the failed cloud call
- #988 stop clipboard-copy buttons claiming success on failure (shared copyToClipboard, 10 files)
- #989 benchmark results row responsive on mobile
- #990 persistent inline error + retry in QualityCoach

## Overlap verification (git merged clean; confirmed coherent)
- **ExportPanels (#984 + #988):** orthogonal — #984 wraps the export *fetch* error/retry, #988 swaps the *copy* handler to the shared helper. Both present, no double-wrap.
- **optimizer/page.tsx (#987 + #988):** #987's local-retry + #988's copyToClipboard both present.
- **benchmark/page.tsx (#986 + #989):** #986's double-submit guard + #989's responsive layout both present.

## Verification
- Web: 44 files / 228 tests pass. Lint 0 errors. Production build succeeds.

Supersedes #983 #984 #985 #986 #987 #988 #989 #990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)