### PR TITLE
fix(web): remove the redundant AI MODE status pill

### DIFF
--- a/web/app/__tests__/page-heuristics-toggle.test.tsx
+++ b/web/app/__tests__/page-heuristics-toggle.test.tsx
@@ -48,22 +48,22 @@ describe("Heuristics-only engine toggle", () => {
     });
   });
 
-  it("defaults to the LLM-backed engine and shows AI MODE", () => {
+  it("defaults to the LLM-backed engine", () => {
     render(<Home />);
 
     const toggle = screen.getByRole("switch", { name: "Heuristics-only engine OFF" });
     expect(toggle.getAttribute("aria-checked")).toBe("false");
-    expect(screen.getByText("AI MODE")).toBeTruthy();
+    expect(screen.getByText("LLM-backed engine")).toBeTruthy();
   });
 
-  it("switches to the heuristic engine and stops claiming AI MODE", () => {
+  it("switches to the heuristic engine", () => {
     render(<Home />);
 
     const toggle = screen.getByRole("switch", { name: "Heuristics-only engine OFF" });
     fireEvent.click(toggle);
 
     expect(screen.getByRole("switch", { name: "Heuristics-only engine ON" })).toBeTruthy();
-    expect(screen.getByText("HEURISTIC MODE")).toBeTruthy();
+    expect(screen.getByText("Heuristics only (no LLM)")).toBeTruthy();
     expect(screen.queryByText("AI MODE")).toBeNull();
   });
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -342,21 +342,6 @@ export default function Home() {
               </span>
             </button>
 
-            <div
-              className={`px-3 py-1.5 rounded-full text-xs font-medium border flex items-center gap-2 transition-all duration-300 ${
-                heuristicsOnly
-                  ? "bg-zinc-800/50 border-zinc-700 text-zinc-400"
-                  : "bg-green-500/10 border-green-500/30 text-green-400"
-              }`}
-            >
-              <div
-                className={`w-1.5 h-1.5 rounded-full ${
-                  heuristicsOnly ? "bg-zinc-500" : "bg-green-400 animate-pulse"
-                }`}
-              />
-              {heuristicsOnly ? "HEURISTIC MODE" : "AI MODE"}
-            </div>
-
             <div className="flex items-center gap-2">
               <div className="min-w-0 rounded-lg border border-white/5 bg-black/30 px-3 py-1.5 text-center font-mono text-xs text-zinc-300 sm:min-w-[88px]">
                 {status}


### PR DESCRIPTION
Removes the engine-state pill (AI MODE / HEURISTIC MODE) that duplicated the No-LLM toggle sitting right beside it — the toggle already shows 'LLM-backed engine' vs 'Heuristics only (no LLM)'. Heuristics-toggle tests updated to assert the toggle's own state text. Web 228 tests pass, lint 0 errors, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)