### PR TITLE
fix(pr-safety): harden git_context subprocess calls (T43)

### DIFF
--- a/app/pr_safety/git_context.py
+++ b/app/pr_safety/git_context.py
@@ -7,9 +7,17 @@ network access, no GitHub API — only the local repository state.
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 _CANDIDATE_BASE_REFS = ("origin/main", "origin/master", "main", "master")
+
+# Fail fast instead of hanging: cap every git call, and never let git block on
+# an interactive credential prompt (e.g. a ref that triggers an authenticated
+# fetch). Windows runners decode with the ANSI codepage under ``text=True``, so
+# force UTF-8 with lossy replacement to avoid UnicodeDecodeError on odd bytes.
+_GIT_TIMEOUT_SECONDS = 30
+_GIT_ENV = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
 
 
 class GitContextError(RuntimeError):
@@ -23,10 +31,18 @@ def _run_git(args: list[str]) -> str:
             ["git", *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_SECONDS,
+            env=_GIT_ENV,
             check=False,
         )
     except FileNotFoundError as exc:  # git not installed
         raise GitContextError("git executable not found on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GitContextError(
+            f"git {' '.join(args)} timed out after {_GIT_TIMEOUT_SECONDS}s"
+        ) from exc
 
     if result.returncode != 0:
         message = result.stderr.strip() or result.stdout.strip() or "unknown error"
@@ -41,10 +57,18 @@ def _ref_exists(ref: str) -> bool:
             ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_SECONDS,
+            env=_GIT_ENV,
             check=True,
         )
     except FileNotFoundError as exc:
         raise GitContextError("git executable not found on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GitContextError(
+            f"git rev-parse {ref} timed out after {_GIT_TIMEOUT_SECONDS}s"
+        ) from exc
     except subprocess.CalledProcessError:
         return False
     return True

--- a/tests/test_agent_packs_api.py
+++ b/tests/test_agent_packs_api.py
@@ -140,9 +140,7 @@ def test_agent_packs_download_multi_file_pack_returns_nonempty_zip():
         )
 
         client = TestClient(app)
-        response = client.post(
-            "/agent-packs/claude/download", json=_github_reviewer_payload()
-        )
+        response = client.post("/agent-packs/claude/download", json=_github_reviewer_payload())
 
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("application/zip")
@@ -161,7 +159,9 @@ def test_agent_packs_download_multi_file_pack_returns_nonempty_zip():
         assert all(archive.read(name) for name in names)
 
         mcp_config = json.loads(archive.read(".mcp.json"))
-        assert mcp_config["mcpServers"]["github"]["headers"]["Authorization"] == "Bearer ${GITHUB_PAT}"
+        assert (
+            mcp_config["mcpServers"]["github"]["headers"]["Authorization"] == "Bearer ${GITHUB_PAT}"
+        )
 
         hooks_config = json.loads(archive.read(".claude/hooks.example.json"))
         assert hooks_config["hooks"]["PostToolUse"][0]["matcher"] == "Edit|Write"

--- a/tests/test_compiler_pipeline_helpers.py
+++ b/tests/test_compiler_pipeline_helpers.py
@@ -181,9 +181,7 @@ def test_optimize_ir_keeps_distinct_goals():
 def test_optimize_ir_injects_english_domain_baseline_for_coding():
     ir = _make_ir(domain="coding", language="en", constraints=["Keep it concise."])
     result = optimize_ir(ir)
-    assert any(
-        "type hints, docstrings" in c for c in result.constraints
-    ), result.constraints
+    assert any("type hints, docstrings" in c for c in result.constraints), result.constraints
 
 
 def test_optimize_ir_injects_turkish_domain_baseline_for_security():

--- a/tests/test_compiler_pure_helpers.py
+++ b/tests/test_compiler_pure_helpers.py
@@ -105,9 +105,7 @@ def test_optimize_ir_injects_domain_baseline_constraint_when_missing():
 
 
 def test_optimize_ir_does_not_duplicate_existing_baseline_constraint():
-    existing = (
-        "En az ayrıcalık ilkesini uygula, tüm girdileri doğrula, denetim olaylarını kaydet"
-    )
+    existing = "En az ayrıcalık ilkesini uygula, tüm girdileri doğrula, denetim olaylarını kaydet"
     ir = _make_ir(language="tr", domain="security", constraints=[existing])
     out = optimize_ir(ir)
     assert out.constraints == [existing]

--- a/tests/test_emitters_policy_reasons.py
+++ b/tests/test_emitters_policy_reasons.py
@@ -41,7 +41,9 @@ def test_non_string_reason_entries_are_skipped():
 
 
 def test_no_reasons_but_human_approval_required_falls_back_to_risk_level():
-    ir = IRv2(metadata={}, policy=PolicyV2(execution_mode="human_approval_required", risk_level="high"))
+    ir = IRv2(
+        metadata={}, policy=PolicyV2(execution_mode="human_approval_required", risk_level="high")
+    )
     assert _policy_reason_phrases_v2(ir) == ["high risk policy"]
 
 

--- a/tests/test_heuristics_extractors_new.py
+++ b/tests/test_heuristics_extractors_new.py
@@ -99,9 +99,7 @@ def test_generate_clarify_questions_unknown_term_is_ignored():
 
 def test_generate_clarify_questions_known_term_returns_its_question():
     questions = generate_clarify_questions(["optimize"])
-    assert questions == [
-        "Which metric or aspect should be optimized? (performance, cost, memory?)"
-    ]
+    assert questions == ["Which metric or aspect should be optimized? (performance, cost, memory?)"]
 
 
 def test_generate_clarify_questions_deduplicates_and_caps_at_five():


### PR DESCRIPTION
Adds encoding='utf-8'/errors='replace', a 30s timeout, and GIT_TERMINAL_PROMPT=0 to the two subprocess.run calls in app/pr_safety/git_context.py. Prevents Windows codepage decode errors, indefinite hangs on credential prompts, and maps timeouts to a clean GitContextError. pr_safety/git_context tests pass (92), ruff v0.1.14 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)