### PR TITLE
fix(web): remove sidebar horizontal scroll from overflowing tooltips

### DIFF
--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -85,7 +85,7 @@ export default function Sidebar() {
     const pathname = usePathname();
 
     return (
-        <div className="w-16 md:w-24 h-screen bg-black/20 border-r border-white/5 flex flex-col items-center py-6 gap-1 backdrop-blur-md z-50 overflow-y-auto">
+        <div className="w-16 md:w-24 h-screen bg-black/20 border-r border-white/5 flex flex-col items-center py-6 gap-1 backdrop-blur-md z-50 overflow-y-auto overflow-x-hidden">
             <div className="h-10 w-10 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center font-bold text-white shadow-lg shadow-blue-500/20 mb-4 shrink-0">
                 P
             </div>
@@ -134,11 +134,6 @@ export default function Sidebar() {
                                     {isActive && (
                                         <div className={`animate-slide-in absolute left-[-2px] top-2 bottom-2 w-1 ${accentBar} rounded-full`} />
                                     )}
-
-                                    {/* Tooltip */}
-                                    <div className="absolute left-full ml-2 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
-                                        {item.name}
-                                    </div>
                                 </Link>
                             );
                         })}
@@ -160,10 +155,6 @@ export default function Sidebar() {
                         aria-label={item.name}
                     >
                         <item.Icon size={18} strokeWidth={1.75} aria-hidden="true" />
-
-                        <div className="absolute left-full ml-2 bg-zinc-900 border border-white/10 px-2 py-1 rounded text-xs text-zinc-200 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50">
-                            {item.name}
-                        </div>
                     </a>
                 ))}
             </div>


### PR DESCRIPTION
The sidebar showed a stray horizontal scrollbar and content spilled past the rail. Cause: hover tooltips positioned `absolute left-full` extended past the rail's right edge, and since the sidebar is a vertical scroll container (`overflow-y-auto`), CSS promoted `overflow-x` to auto → horizontal scrollbar (measured scrollWidth 95 vs clientWidth 63).

Fix: drop the tooltips (redundant — nav items already show visible text labels on md+; outbound links keep aria-labels + clear icons) and add `overflow-x-hidden`.

Verified live: no horizontal scroll at 375px (mobile) or 1280px (desktop); nav labels still render; active indicator intact. Web 228 tests pass, lint 0 errors, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)