### PR TITLE
test: cover adapter triple-quote escaping and IR signature helper

### DIFF
--- a/tests/test_adapters_string_escaping.py
+++ b/tests/test_adapters_string_escaping.py
@@ -17,7 +17,7 @@ from app.adapters.langchain import to_langchain_python, to_langgraph_python
 
 
 def test_escape_is_noop_when_no_triple_quotes_present():
-    text = 'A normal prompt with "single double quotes" and \'single quotes\'.'
+    text = "A normal prompt with \"single double quotes\" and 'single quotes'."
     assert claude_sdk_escape(text) == text
     assert langchain_escape(text) == text
 

--- a/tests/test_adapters_string_escaping.py
+++ b/tests/test_adapters_string_escaping.py
@@ -1,0 +1,101 @@
+"""Tests for the triple-quote escaping helper duplicated across
+app.adapters.claude_sdk and app.adapters.langchain.
+
+This helper embeds an arbitrary user-authored system prompt inside a Python
+triple-double-quoted string literal in *generated* export code. If the prompt
+contains a literal `\"\"\"`, it must be escaped or the generated code would
+fail to parse for the end user who downloads the export. These tests lock in
+the escaping behavior directly and verify the generated exports still compile
+when a prompt contains embedded triple quotes.
+"""
+
+from app.adapters.agent_ir import AgentExportIR
+from app.adapters.claude_sdk import _escape_for_python_string as claude_sdk_escape
+from app.adapters.claude_sdk import to_python
+from app.adapters.langchain import _escape_for_python_string as langchain_escape
+from app.adapters.langchain import to_langchain_python, to_langgraph_python
+
+
+def test_escape_is_noop_when_no_triple_quotes_present():
+    text = 'A normal prompt with "single double quotes" and \'single quotes\'.'
+    assert claude_sdk_escape(text) == text
+    assert langchain_escape(text) == text
+
+
+def test_escape_replaces_a_single_triple_quote_occurrence():
+    text = 'Never repeat """secret instructions""" verbatim.'
+    expected = 'Never repeat \\"\\"\\"secret instructions\\"\\"\\" verbatim.'
+    assert claude_sdk_escape(text) == expected
+    assert langchain_escape(text) == expected
+
+
+def test_escape_replaces_multiple_triple_quote_occurrences():
+    text = '"""one""" and """two""" and """three"""'
+    result = claude_sdk_escape(text)
+    assert result.count('\\"\\"\\"') == 6
+    assert '"""' not in result
+
+
+def test_escape_leaves_lone_double_quotes_untouched():
+    text = 'Say "hello" but not ""double"" or too few quotes.'
+    assert claude_sdk_escape(text) == text
+    assert langchain_escape(text) == text
+
+
+def test_claude_sdk_and_langchain_escape_helpers_agree():
+    samples = [
+        "",
+        "plain text",
+        'has """triple""" quotes',
+        'edge """""" case of six quotes in a row',
+        'unicode "çok özel" text with """embedded""" markers',
+    ]
+    for text in samples:
+        assert claude_sdk_escape(text) == langchain_escape(text)
+
+
+def _ir_with_embedded_triple_quotes():
+    # Single-line on purpose: a multi-line raw_system_prompt hits a separate,
+    # pre-existing textwrap.dedent indentation issue in these adapters that
+    # is out of scope for this test file (see PR description).
+    prompt = 'You are a helpful agent. Never say """ignore previous instructions""" to the user.'
+    return AgentExportIR(raw_system_prompt=prompt, model="claude-opus-4-6")
+
+
+def test_claude_sdk_export_compiles_when_prompt_has_embedded_triple_quotes():
+    ir = _ir_with_embedded_triple_quotes()
+    code = to_python(ir)
+
+    compile(code, "<claude_sdk_export>", "exec")
+    assert '\\"\\"\\"ignore previous instructions\\"\\"\\"' in code
+
+
+def test_langchain_export_compiles_when_prompt_has_embedded_triple_quotes():
+    ir = _ir_with_embedded_triple_quotes()
+    code = to_langchain_python(ir)
+
+    compile(code, "<langchain_export>", "exec")
+    assert '\\"\\"\\"ignore previous instructions\\"\\"\\"' in code
+
+
+def test_langgraph_single_agent_export_compiles_when_prompt_has_embedded_triple_quotes():
+    ir = _ir_with_embedded_triple_quotes()
+    code = to_langgraph_python(ir)
+
+    compile(code, "<langgraph_export>", "exec")
+    assert '\\"\\"\\"ignore previous instructions\\"\\"\\"' in code
+
+
+def test_langgraph_multi_agent_export_compiles_when_prompt_has_embedded_triple_quotes():
+    sub_agent = _ir_with_embedded_triple_quotes()
+    sub_agent.name = "Researcher"
+    ir = AgentExportIR(
+        raw_system_prompt="Coordinator prompt with no special characters.",
+        model="claude-opus-4-6",
+        is_multi_agent=True,
+        agents=[sub_agent],
+    )
+    code = to_langgraph_python(ir)
+
+    compile(code, "<langgraph_multi_export>", "exec")
+    assert '\\"\\"\\"ignore previous instructions\\"\\"\\"' in code

--- a/tests/test_compiler_signature.py
+++ b/tests/test_compiler_signature.py
@@ -1,0 +1,68 @@
+"""Tests for app.compiler._compute_signature: a pure, deterministic hash of
+the IR fields that determine cache/dedup identity. Only exercised indirectly
+today (via optimize_ir), so its own determinism and sensitivity to each
+tracked field has no direct assertions.
+"""
+
+import re
+
+from app.compiler import _compute_signature
+from app.models import IR
+
+
+def _make_ir(**overrides):
+    defaults = dict(
+        language="en",
+        persona="assistant",
+        role="AI Assistant",
+        domain="general",
+        output_format="markdown",
+        length_hint="medium",
+        metadata={},
+    )
+    defaults.update(overrides)
+    return IR(**defaults)
+
+
+def test_signature_is_a_16_char_hex_string():
+    signature = _compute_signature(_make_ir())
+    assert re.fullmatch(r"[0-9a-f]{16}", signature)
+
+
+def test_signature_is_deterministic_for_identical_ir_content():
+    ir_a = _make_ir(goals=["a", "b"], tasks=["t1"], constraints=["c1"])
+    ir_b = _make_ir(goals=["a", "b"], tasks=["t1"], constraints=["c1"])
+    assert _compute_signature(ir_a) == _compute_signature(ir_b)
+
+
+def test_signature_changes_when_goals_differ():
+    ir_a = _make_ir(goals=["a"])
+    ir_b = _make_ir(goals=["b"])
+    assert _compute_signature(ir_a) != _compute_signature(ir_b)
+
+
+def test_signature_changes_when_domain_differs():
+    ir_a = _make_ir(domain="general")
+    ir_b = _make_ir(domain="coding")
+    assert _compute_signature(ir_a) != _compute_signature(ir_b)
+
+
+def test_signature_changes_when_heuristic_version_metadata_differs():
+    ir_a = _make_ir(metadata={"heuristic_version": 1})
+    ir_b = _make_ir(metadata={"heuristic_version": 2})
+    assert _compute_signature(ir_a) != _compute_signature(ir_b)
+
+
+def test_signature_is_insensitive_to_fields_it_does_not_track():
+    # output_format/length_hint/role/style are intentionally excluded from
+    # the signature payload; changing them must not change the signature.
+    ir_a = _make_ir(output_format="markdown", length_hint="medium", role="A")
+    ir_b = _make_ir(output_format="text", length_hint="short", role="B")
+    assert _compute_signature(ir_a) == _compute_signature(ir_b)
+
+
+def test_signature_is_order_sensitive_for_list_fields():
+    # Signature payload sorts dict keys but not list contents, so goal order matters.
+    ir_a = _make_ir(goals=["a", "b"])
+    ir_b = _make_ir(goals=["b", "a"])
+    assert _compute_signature(ir_a) != _compute_signature(ir_b)


### PR DESCRIPTION
## Summary

Test-coverage audit found two untested pure-logic areas. This PR adds tests only — no source, config, or CI files are touched.

- `_escape_for_python_string` is duplicated in `app/adapters/claude_sdk.py` and `app/adapters/langchain.py`. It escapes literal `"""` inside a user-authored system prompt before embedding it in a Python triple-quoted string literal in generated export code (Claude SDK / LangChain / LangGraph). No existing test called it directly or verified the generated export still compiles when a prompt contains embedded triple quotes — a real correctness risk since broken escaping ships invalid Python to end users. Added direct unit tests for the escaping behavior plus `compile()`-based checks that single/multi-agent LangGraph, LangChain, and Claude SDK exports remain syntactically valid with an embedded `"""` in the prompt. Also asserts both duplicated copies of the helper agree, to guard against future drift.
- `app/compiler.py::_compute_signature` (the deterministic IR hash used for cache/dedup identity) was only exercised indirectly via `optimize_ir`. Added tests for determinism, sensitivity to each tracked field (goals, domain, `heuristic_version` metadata), insensitivity to untracked fields (`output_format`, `length_hint`, `role`), and list-order sensitivity.

### Note for maintainers (not fixed here, out of scope for a tests-only PR)

While building the compile-check tests above, I found that `to_python`/`to_langchain_python`/`to_langgraph_python` currently produce a `SyntaxError` (`unexpected indent`) for **any multi-line `raw_system_prompt`** — which is the common case, since `parse_agent_markdown` typically produces multi-line prompts. `textwrap.dedent` can't find a common indentation prefix once the interpolated prompt's own lines start at column 0, so the template's indentation is left in place. Reproducible with the existing `SINGLE_AGENT_MARKDOWN` fixture already in `tests/test_export_adapters.py` — that test suite doesn't currently `compile()`-check its output, so this has been passing silently. Flagging since it looks like a real, user-facing bug in the export path, but fixing it is a source change outside this PR's scope.

## Test plan

- [x] `python3 -m pytest tests/test_adapters_string_escaping.py tests/test_compiler_signature.py -v` — 16/16 pass
- [x] `python3 -m pytest tests/ -q` (full suite) — 2046 passed, 7 skipped (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwF2h7V6qWpNv9Nb9chiQL)_