### PR TITLE
test(web): guard agent generator empty system_prompt on HTTP 200

### DIFF
--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -154,6 +154,36 @@ describe("Agent Generator page", () => {
     expect(classes).not.toContain("md:min-h-0");
   });
 
+  it.each([
+    ["empty", { system_prompt: "" }],
+    ["missing", {}],
+  ] as const)(
+    "shows an error when generation succeeds but system_prompt is %s",
+    async (_label, payload) => {
+      apiJsonMock.mockResolvedValueOnce({
+        example_code_requested: false,
+        example_code_present: false,
+        example_code_warning: null,
+        ...payload,
+      });
+
+      render(<AgentGeneratorPage />);
+
+      fireEvent.change(screen.getByLabelText("Agent Description"), {
+        target: { value: "Build a code review agent." },
+      });
+      fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
+
+      expect(await screen.findByText("Agent generation failed")).toBeTruthy();
+      expect(
+        screen.getByText("The generator returned an empty or missing system prompt. Try generating again."),
+      ).toBeTruthy();
+      expect(screen.queryByText("System Prompt")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Copy Markdown" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Retry generation" })).toBeTruthy();
+    },
+  );
+
   it("shows a retryable error in the output panel when generation fails", async () => {
     apiJsonMock.mockRejectedValueOnce(new Error("The service is temporarily unavailable."));
 

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -27,6 +27,13 @@ type AgentGenerationView = {
   exampleCodeWarning: string | null;
 };
 
+const EMPTY_SYSTEM_PROMPT_MESSAGE =
+  "The generator returned an empty or missing system prompt. Try generating again.";
+
+function hasNonemptySystemPrompt(response: AgentGeneratorResponse): boolean {
+  return typeof response.system_prompt === "string" && response.system_prompt.trim().length > 0;
+}
+
 function toAgentGenerationView(
   response: AgentGeneratorResponse,
   multiAgent: boolean,
@@ -114,6 +121,10 @@ export default function AgentGenerator() {
           ...(repoContext && !repoContextDirty ? { repo_context: repoContext } : {}),
         }),
       });
+
+      if (!hasNonemptySystemPrompt(data)) {
+        throw new Error(EMPTY_SYSTEM_PROMPT_MESSAGE);
+      }
 
       const nextResult = toAgentGenerationView(data, multiAgent);
       setResult(nextResult);


### PR DESCRIPTION
## Summary
- Add a frontend guard so Agent Generator treats HTTP 200 responses with a missing or empty `system_prompt` as a failure instead of showing a blank success panel.
- Extend `page.test.tsx` with parameterized coverage for empty and missing `system_prompt` payloads, asserting the retryable error state (not the success UI).

Fixes #1009

## Test plan
- [x] `cd web && npm run test -- app/agent-generator/page.test.tsx` (10/10 passed)
- [ ] Manual: trigger generate with a mocked/proxied empty `system_prompt` response and confirm the error panel appears with retry


Made with [Cursor](https://cursor.com)