### PR TITLE
docs: sync offline route metadata after redirect

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -306,7 +306,8 @@ cd web && npm run build
 | Skill Generator | http://localhost:3000/skills-generator |
 | Benchmark | http://localhost:3000/benchmark |
 | Token Optimizer | http://localhost:3000/optimizer |
-| Offline / heuristics | http://localhost:3000/offline |
+
+`/offline` redirects to `/` (main Compiler). Use the **Heuristics only (no LLM)** toggle on the main page instead of a separate offline surface.
 
 ---
 

--- a/web/app/offline/layout.tsx
+++ b/web/app/offline/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Offline Compiler — Prompt Compiler",
   description:
-    "A fast, local-only prompt compiler that uses deterministic heuristics instead of an LLM — secure, instant, no API keys.",
+    "This route redirects to the main Compiler page. Use the Heuristics only (no LLM) engine toggle there to run the deterministic heuristic pipeline without a cloud LLM call.",
 };
 
 export default function OfflineLayout({

--- a/web/app/route-metadata.test.ts
+++ b/web/app/route-metadata.test.ts
@@ -37,7 +37,7 @@ const ROUTE_CASES: RouteMetadataCase[] = [
   {
     title: "Offline Compiler — Prompt Compiler",
     metadata: offlineMetadata,
-    descriptionFragment: "local-only prompt compiler",
+    descriptionFragment: "redirects to the main Compiler",
   },
   {
     title: "Token Optimizer — Prompt Compiler",


### PR DESCRIPTION
## Summary
- Update `/offline` layout metadata to describe the redirect to the main Compiler page and the **Heuristics only (no LLM)** toggle instead of claiming a separate local-only product
- Document in `AGENTS.md` that `/offline` redirects to `/` rather than listing it as a standalone page
- Align `route-metadata.test.ts` expectations with the new metadata fragment

Fixes #1003

## Test plan
- [x] `cd web && npm run test -- app/route-metadata.test.ts`
- [x] `cd web && npm run test -- app/__tests__/offline-page-redirect.test.tsx`


Made with [Cursor](https://cursor.com)