### PR TITLE
perf: keep benchmark work off event loop

### DIFF
--- a/app/routers/benchmark.py
+++ b/app/routers/benchmark.py
@@ -20,6 +20,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
+import anyio
 from fastapi import APIRouter, Depends, HTTPException
 
 from api.auth import rate_limit_by_ip, enforce_benchmark_daily_cap
@@ -155,6 +156,12 @@ def _generate_llm_output(prompt: str, model: str) -> str:
         json_mode=False,
         model_override=model,
     )
+
+
+def _compile_benchmark_prompt(text: str) -> str:
+    """Compile the prompt outside the event loop for benchmark requests."""
+    ir_v2 = compile_text_v2(text)
+    return emit_expanded_prompt_v2(ir_v2, diagnostics=True)
 
 
 # ---------------------------------------------------------------------------
@@ -303,30 +310,38 @@ async def benchmark_run(
 
     t0 = time.time()
 
+    # The worker client uses synchronous HTTP. Keep that work off the async
+    # server loop so one slow benchmark cannot stall unrelated API requests.
+    # The ordered pipeline is deliberate: the benchmark contract still makes
+    # exactly two model generations, then judges those concrete outputs.
+
     # --- Step A: Generate with raw prompt ---------------------------------
     try:
-        raw_output = _generate_llm_output(req.text, req.model)
+        raw_output = await anyio.to_thread.run_sync(_generate_llm_output, req.text, req.model)
     except Exception as exc:
         logger.exception("Benchmark raw model request failed")
         raise HTTPException(status_code=502, detail="Benchmark model request failed") from exc
 
     # --- Step B: Compile the prompt ---------------------------------------
     try:
-        ir_v2 = compile_text_v2(req.text)
-        compiled_prompt = emit_expanded_prompt_v2(ir_v2, diagnostics=True)
+        compiled_prompt = await anyio.to_thread.run_sync(_compile_benchmark_prompt, req.text)
     except Exception as exc:
         logger.exception("Benchmark compilation failed")
         raise HTTPException(status_code=500, detail="Benchmark compilation failed") from exc
 
     # --- Step C: Generate with compiled prompt ----------------------------
     try:
-        compiled_output = _generate_llm_output(compiled_prompt, req.model)
+        compiled_output = await anyio.to_thread.run_sync(
+            _generate_llm_output, compiled_prompt, req.model
+        )
     except Exception as exc:
         logger.exception("Benchmark compiled model request failed")
         raise HTTPException(status_code=502, detail="Benchmark model request failed") from exc
 
     # --- Step D: Judge — LLM first, heuristic fallback --------------------
-    judge_result = _judge_with_llm(req.text, raw_output, compiled_output)
+    judge_result = await anyio.to_thread.run_sync(
+        _judge_with_llm, req.text, raw_output, compiled_output
+    )
     if judge_result is None:
         judge_result = _heuristic_judge(raw_output, compiled_output)
 

--- a/tests/test_benchmark_api.py
+++ b/tests/test_benchmark_api.py
@@ -66,8 +66,9 @@ def test_benchmark_run_endpoint(client):
     mock_raw = "Here is a basic answer about Python."
     mock_improved = "# Python Overview\n\n- Python is a high-level language\n- It supports OOP\n\n```python\nprint('hello')\n```"
 
-    with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
-        "app.routers.benchmark._judge_with_llm", return_value=None
+    with (
+        patch("app.routers.benchmark._generate_llm_output") as mock_llm,
+        patch("app.routers.benchmark._judge_with_llm", return_value=None),
     ):
         # First call returns raw, second returns improved
         mock_llm.side_effect = [mock_raw, mock_improved]
@@ -105,8 +106,9 @@ def test_benchmark_run_uses_selected_model_for_both_generations(client):
     """The requested benchmark model should be used for raw and compiled generations."""
     selected_model = "openai/gpt-oss-20b"
 
-    with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
-        "app.routers.benchmark._judge_with_llm", return_value=None
+    with (
+        patch("app.routers.benchmark._generate_llm_output") as mock_llm,
+        patch("app.routers.benchmark._judge_with_llm", return_value=None),
     ):
         mock_llm.side_effect = ["raw output", "compiled output"]
 
@@ -121,10 +123,65 @@ def test_benchmark_run_uses_selected_model_for_both_generations(client):
     assert mock_llm.call_args_list[1].args[1] == selected_model
 
 
+def test_benchmark_run_offloads_blocking_steps(client):
+    """The async endpoint must not run synchronous provider work on the event loop."""
+    from unittest.mock import AsyncMock
+
+    import app.routers.benchmark as benchmark_mod
+
+    generation_results = iter(["raw output", "compiled output"])
+
+    async def run_sync(func, *args, **kwargs):
+        if func is benchmark_mod._generate_llm_output:
+            return next(generation_results)
+        if func is benchmark_mod._compile_benchmark_prompt:
+            return "compiled prompt"
+        if func is benchmark_mod._judge_with_llm:
+            return {
+                "a_safety": 8,
+                "a_clarity": 7,
+                "a_conciseness": 8,
+                "b_safety": 9,
+                "b_clarity": 9,
+                "b_conciseness": 9,
+                "winner": "B",
+            }
+        return func(*args, **kwargs)
+
+    with patch(
+        "app.routers.benchmark.anyio.to_thread.run_sync",
+        new_callable=AsyncMock,
+        side_effect=run_sync,
+    ) as run_sync:
+        response = client.post(
+            "/benchmark/run",
+            json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
+        )
+
+    assert response.status_code == 200
+    benchmark_calls = [
+        call.args[0]
+        for call in run_sync.call_args_list
+        if call.args[0]
+        in {
+            benchmark_mod._generate_llm_output,
+            benchmark_mod._compile_benchmark_prompt,
+            benchmark_mod._judge_with_llm,
+        }
+    ]
+    assert benchmark_calls == [
+        benchmark_mod._generate_llm_output,
+        benchmark_mod._compile_benchmark_prompt,
+        benchmark_mod._generate_llm_output,
+        benchmark_mod._judge_with_llm,
+    ]
+
+
 def test_benchmark_run_short_prompt_with_valid_model(client):
     """A short prompt with a supported model should still succeed."""
-    with patch("app.routers.benchmark._generate_llm_output") as mock_llm, patch(
-        "app.routers.benchmark._judge_with_llm", return_value=None
+    with (
+        patch("app.routers.benchmark._generate_llm_output") as mock_llm,
+        patch("app.routers.benchmark._judge_with_llm", return_value=None),
     ):
         mock_llm.return_value = "mock output"
 
@@ -167,10 +224,13 @@ def test_benchmark_request_rejects_blank_text(client):
 
 def test_benchmark_provider_failure_returns_safe_error(client):
     """Provider/model failures should return a safe upstream error instead of a mock result."""
-    with patch(
-        "app.routers.benchmark._generate_llm_output",
-        side_effect=RuntimeError("provider exploded"),
-    ), patch("app.routers.benchmark._judge_with_llm", return_value=None):
+    with (
+        patch(
+            "app.routers.benchmark._generate_llm_output",
+            side_effect=RuntimeError("provider exploded"),
+        ),
+        patch("app.routers.benchmark._judge_with_llm", return_value=None),
+    ):
         response = client.post(
             "/benchmark/run",
             json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},
@@ -207,10 +267,13 @@ def test_benchmark_run_succeeds_when_judge_response_is_malformed(client):
     fake_hybrid = MagicMock()
     fake_hybrid.worker = fake_worker
 
-    with patch(
-        "app.routers.benchmark._generate_llm_output",
-        side_effect=["raw output", "compiled output"],
-    ), patch("api.main.hybrid_compiler", fake_hybrid):
+    with (
+        patch(
+            "app.routers.benchmark._generate_llm_output",
+            side_effect=["raw output", "compiled output"],
+        ),
+        patch("api.main.hybrid_compiler", fake_hybrid),
+    ):
         response = client.post(
             "/benchmark/run",
             json={"text": "Explain Python", "model": "openai/gpt-oss-20b"},

--- a/web/app/benchmark/run/route.ts
+++ b/web/app/benchmark/run/route.ts
@@ -1,7 +1,7 @@
 import { proxyBackendRequest } from "@/lib/server/backendProxy";
 
 export async function POST(request: Request): Promise<Response> {
-  return proxyBackendRequest(request, "/benchmark/run", {
-    retryNetworkErrors: true,
-  });
+  // A benchmark run makes paid upstream LLM calls. Retrying a failed POST can
+  // leave the original work running while starting a duplicate benchmark.
+  return proxyBackendRequest(request, "/benchmark/run");
 }

--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -214,13 +214,6 @@ describe("Next backend proxy route wiring", () => {
       expectedUrl: "http://127.0.0.1:8080/repo-context/github",
     },
     {
-      name: "benchmark run",
-      handler: benchmarkRunRoute,
-      requestUrl: "http://localhost:3000/benchmark/run",
-      requestBody: { model: "gpt-4" },
-      expectedUrl: "http://127.0.0.1:8080/benchmark/run",
-    },
-    {
       name: "optimize",
       handler: optimizeRoute,
       requestUrl: "http://localhost:3000/optimize",
@@ -272,6 +265,25 @@ describe("Next backend proxy route wiring", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(expectedUrl);
     await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("does not retry a benchmark run after a transient backend connection failure", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("fetch failed"));
+
+    const response = await benchmarkRunRoute(
+      new Request("http://localhost:3000/benchmark/run", {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-4" }),
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:8080/benchmark/run");
+    expect(response.status).toBe(502);
   });
 
   it.each<RouteCase>([


### PR DESCRIPTION
## What changed
- Run synchronous benchmark provider, compilation, and judge work outside FastAPI's event loop.
- Stop retrying `/benchmark/run` proxy POSTs so a timeout or connection failure cannot start duplicate paid LLM benchmarks.
- Add regression coverage for both guarantees.

## Why
The async endpoint called synchronous LLM work directly, which could block unrelated requests. The proxy also retried this non-idempotent request while the original upstream work could still continue.

## Validation
- `pytest tests/test_benchmark_api.py tests/test_benchmark_dow_protection.py tests/test_public_endpoints_keyless.py -q` (22 passed)
- CI smoke Python suite (84 passed)
- `npm run test -- app/proxy-routes.test.ts` (29 passed)
- `npm run test:contracts` (59 passed)
- `npm run test` (236 passed; unrelated localhost live-test connection warnings)
- `npm run lint` (0 errors; 2 pre-existing unrelated warnings)
- `npm run build` (passed)