### PR TITLE
test: add unit coverage for untested heuristics, scheduling, and IR parsing helpers

### DIFF
--- a/tests/test_agent_ir_inference_gap.py
+++ b/tests/test_agent_ir_inference_gap.py
@@ -1,0 +1,132 @@
+"""Direct unit coverage for app.adapters.agent_ir keyword-inference helpers.
+
+These pure functions seed the tool permissions, MCP servers, hook
+suggestions, CI automation intent, and CLAUDE.md memory outline written into
+generated agent-pack exports. They take already-lowercased combined text
+(see `_build_ir`'s `combined_text = "...".lower()`) and are otherwise
+untested in isolation — a bug here silently over- or under-grants tool
+access in exported agent packs.
+"""
+
+from app.adapters.agent_ir import (
+    _infer_allowed_tools,
+    _infer_ci_automation_intent,
+    _infer_hook_suggestions,
+    _infer_mcp_servers,
+    _infer_memory_outline,
+)
+
+
+class TestInferAllowedTools:
+    def test_base_tools_always_present(self) -> None:
+        tools = _infer_allowed_tools("a generic assistant with no special needs")
+        assert {"Read", "Edit", "Write", "Glob", "Grep"}.issubset(set(tools))
+        assert "Bash" not in tools
+        assert "WebSearch" not in tools
+
+    def test_code_keyword_adds_bash(self) -> None:
+        tools = _infer_allowed_tools("helps debug python code")
+        assert "Bash" in tools
+
+    def test_research_keyword_adds_web_tools(self) -> None:
+        tools = _infer_allowed_tools("does web research and cites sources")
+        assert "WebSearch" in tools
+        assert "WebFetch" in tools
+
+    def test_github_keyword_adds_bash(self) -> None:
+        tools = _infer_allowed_tools("reviews github pull request diffs")
+        assert "Bash" in tools
+
+    def test_result_is_sorted_and_deduped(self) -> None:
+        tools = _infer_allowed_tools("code code code react react")
+        assert tools == sorted(set(tools))
+
+
+class TestInferHookSuggestions:
+    def test_default_suggestions_always_present(self) -> None:
+        suggestions = _infer_hook_suggestions("a plain assistant")
+        assert len(suggestions) == 2
+        assert any("secrets" in s for s in suggestions)
+
+    def test_frontend_keyword_adds_lint_hook(self) -> None:
+        suggestions = _infer_hook_suggestions("builds react ui components")
+        assert any("frontend lint" in s.lower() for s in suggestions)
+
+    def test_deploy_keyword_adds_confirmation_hook(self) -> None:
+        suggestions = _infer_hook_suggestions("handles ci deploy pipelines")
+        assert any("confirmation" in s.lower() for s in suggestions)
+
+    def test_no_extra_keywords_yields_only_defaults(self) -> None:
+        assert len(_infer_hook_suggestions("writes poetry")) == 2
+
+
+class TestInferMcpServers:
+    def test_no_keywords_returns_empty(self) -> None:
+        assert _infer_mcp_servers("a general assistant") == []
+
+    def test_single_keyword_maps_to_server(self) -> None:
+        assert _infer_mcp_servers("posts updates to slack") == ["slack"]
+
+    def test_multiple_keywords_preserve_mapping_order(self) -> None:
+        result = _infer_mcp_servers("tracks github issues and jira tickets")
+        assert result == ["github", "jira"]
+
+    def test_unmatched_keyword_is_ignored(self) -> None:
+        assert _infer_mcp_servers("uses linear and trello") == []
+
+
+class TestInferCiAutomationIntent:
+    def test_no_keywords_returns_empty(self) -> None:
+        assert _infer_ci_automation_intent("writes documentation") == []
+
+    def test_review_keyword(self) -> None:
+        assert _infer_ci_automation_intent("reviews every pull request") == ["review"]
+
+    def test_implementation_keyword(self) -> None:
+        assert _infer_ci_automation_intent("implements the requested feature") == [
+            "implementation"
+        ]
+
+    def test_autofix_keyword(self) -> None:
+        assert _infer_ci_automation_intent("fix failing test automatically") == [
+            "autofix"
+        ]
+
+    def test_all_three_intents_combine_in_order(self) -> None:
+        text = "review pull requests, implement new features, and autofix flaky tests"
+        assert _infer_ci_automation_intent(text) == [
+            "review",
+            "implementation",
+            "autofix",
+        ]
+
+
+class TestInferMemoryOutline:
+    def test_name_only(self) -> None:
+        outline = _infer_memory_outline(name="Reviewer", role="", goals=[], constraints=[])
+        assert outline == ["Agent name: Reviewer"]
+
+    def test_role_is_included_when_present(self) -> None:
+        outline = _infer_memory_outline(
+            name="Reviewer", role="Code reviewer", goals=[], constraints=[]
+        )
+        assert "Primary role: Code reviewer" in outline
+
+    def test_goals_and_constraints_are_capped_at_three(self) -> None:
+        goals = [f"goal-{i}" for i in range(5)]
+        constraints = [f"constraint-{i}" for i in range(5)]
+        outline = _infer_memory_outline(
+            name="A", role="", goals=goals, constraints=constraints
+        )
+        goal_lines = [line for line in outline if line.startswith("Goal:")]
+        constraint_lines = [line for line in outline if line.startswith("Constraint:")]
+        assert goal_lines == ["Goal: goal-0", "Goal: goal-1", "Goal: goal-2"]
+        assert constraint_lines == [
+            "Constraint: constraint-0",
+            "Constraint: constraint-1",
+            "Constraint: constraint-2",
+        ]
+
+    def test_empty_goals_and_constraints_produce_no_extra_lines(self) -> None:
+        outline = _infer_memory_outline(name="A", role="", goals=[], constraints=[])
+        assert outline == ["Agent name: A"]

--- a/tests/test_agent_ir_inference_gap.py
+++ b/tests/test_agent_ir_inference_gap.py
@@ -83,14 +83,10 @@ class TestInferCiAutomationIntent:
         assert _infer_ci_automation_intent("reviews every pull request") == ["review"]
 
     def test_implementation_keyword(self) -> None:
-        assert _infer_ci_automation_intent("implements the requested feature") == [
-            "implementation"
-        ]
+        assert _infer_ci_automation_intent("implements the requested feature") == ["implementation"]
 
     def test_autofix_keyword(self) -> None:
-        assert _infer_ci_automation_intent("fix failing test automatically") == [
-            "autofix"
-        ]
+        assert _infer_ci_automation_intent("fix failing test automatically") == ["autofix"]
 
     def test_all_three_intents_combine_in_order(self) -> None:
         text = "review pull requests, implement new features, and autofix flaky tests"
@@ -115,9 +111,7 @@ class TestInferMemoryOutline:
     def test_goals_and_constraints_are_capped_at_three(self) -> None:
         goals = [f"goal-{i}" for i in range(5)]
         constraints = [f"constraint-{i}" for i in range(5)]
-        outline = _infer_memory_outline(
-            name="A", role="", goals=goals, constraints=constraints
-        )
+        outline = _infer_memory_outline(name="A", role="", goals=goals, constraints=constraints)
         goal_lines = [line for line in outline if line.startswith("Goal:")]
         constraint_lines = [line for line in outline if line.startswith("Constraint:")]
         assert goal_lines == ["Goal: goal-0", "Goal: goal-1", "Goal: goal-2"]

--- a/tests/test_emitters_scheduling_helpers_gap.py
+++ b/tests/test_emitters_scheduling_helpers_gap.py
@@ -1,0 +1,80 @@
+"""Direct unit coverage for app.emitters._step_mode and _scheduled_modes.
+
+These are the low-level primitives behind the "Working approach" section
+suppression rule documented in test_emitters_scheduling.py — that section
+must render only when explore/decide/verify was actually scheduled. The
+existing tests exercise that rule end-to-end through emit_expanded_prompt_v2;
+these tests pin the two small pure helpers directly, including edge cases
+the integration tests don't reach (steps without a scheduling attribute,
+an IR with no steps at all, and profile-only scheduling).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.emitters import _scheduled_modes, _step_mode
+from app.models_v2 import IRv2, StepScheduling, StepV2
+
+
+def _profile(explore: bool = False, decide: bool = False, verify: bool = False) -> dict:
+    return {
+        "modes": {
+            "explore": {"scheduled": explore},
+            "decide": {"scheduled": decide},
+            "verify": {"scheduled": verify},
+        }
+    }
+
+
+class TestStepMode:
+    def test_returns_mode_when_scheduling_present(self) -> None:
+        step = StepV2(type="task", text="x", scheduling=StepScheduling(mode="explore"))
+        assert _step_mode(step) == "explore"
+
+    def test_returns_none_when_scheduling_attribute_missing(self) -> None:
+        step = SimpleNamespace(type="task", text="x")
+        assert _step_mode(step) is None
+
+    def test_returns_none_when_scheduling_is_none(self) -> None:
+        step = StepV2(type="task", text="x", scheduling=None)
+        assert _step_mode(step) is None
+
+    def test_returns_none_when_mode_attribute_missing_on_scheduling(self) -> None:
+        step = SimpleNamespace(scheduling=SimpleNamespace())
+        assert _step_mode(step) is None
+
+
+class TestScheduledModes:
+    def test_no_steps_no_profile_returns_empty(self) -> None:
+        ir = IRv2(steps=[], metadata={})
+        assert _scheduled_modes(ir) == []
+
+    def test_execute_only_step_is_not_surfaced(self) -> None:
+        ir = IRv2(
+            steps=[StepV2(type="task", text="x", scheduling=StepScheduling(mode="execute"))],
+            metadata={},
+        )
+        assert _scheduled_modes(ir) == []
+
+    def test_explore_step_is_surfaced(self) -> None:
+        ir = IRv2(
+            steps=[StepV2(type="task", text="x", scheduling=StepScheduling(mode="explore"))],
+            metadata={},
+        )
+        assert _scheduled_modes(ir) == ["explore"]
+
+    def test_profile_only_verify_is_surfaced_without_any_step(self) -> None:
+        ir = IRv2(steps=[], metadata={"uncertainty_profile": _profile(verify=True)})
+        assert _scheduled_modes(ir) == ["verify"]
+
+    def test_missing_steps_attribute_is_tolerated(self) -> None:
+        ir = SimpleNamespace(metadata={})
+        assert _scheduled_modes(ir) == []
+
+    def test_combines_step_modes_and_profile_modes_without_duplicates(self) -> None:
+        ir = IRv2(
+            steps=[StepV2(type="task", text="x", scheduling=StepScheduling(mode="explore"))],
+            metadata={"uncertainty_profile": _profile(explore=True, decide=True)},
+        )
+        assert set(_scheduled_modes(ir)) == {"explore", "decide"}

--- a/tests/test_heuristics_parsing_gap.py
+++ b/tests/test_heuristics_parsing_gap.py
@@ -85,14 +85,10 @@ class TestExtractComparisonItems:
 
 class TestDetectFrontendDownloadFeature:
     def test_full_match_returns_true(self) -> None:
-        assert detect_frontend_download_feature(
-            "Add a download button to the dashboard"
-        )
+        assert detect_frontend_download_feature("Add a download button to the dashboard")
 
     def test_missing_action_word_returns_false(self) -> None:
-        assert not detect_frontend_download_feature(
-            "Add a button to the dashboard"
-        )
+        assert not detect_frontend_download_feature("Add a button to the dashboard")
 
     def test_missing_add_verb_returns_false(self) -> None:
         assert not detect_frontend_download_feature(
@@ -103,6 +99,4 @@ class TestDetectFrontendDownloadFeature:
         assert not detect_frontend_download_feature("Add a download feature")
 
     def test_export_synonym_matches(self) -> None:
-        assert detect_frontend_download_feature(
-            "Let users export data from the browser page"
-        )
+        assert detect_frontend_download_feature("Let users export data from the browser page")

--- a/tests/test_heuristics_parsing_gap.py
+++ b/tests/test_heuristics_parsing_gap.py
@@ -1,0 +1,108 @@
+"""Direct unit coverage for heuristics text-parsing helpers that previously
+had no dedicated tests: extract_variant_count, detect_summary,
+extract_comparison_items (additional cases beyond the existing Turkish-form
+regression test), and detect_frontend_download_feature.
+
+These are pure, deterministic string/regex functions that feed directly into
+compiled-output heuristics (variant count, summary bullet count, comparison
+item extraction, frontend feature detection) — a bug here silently changes
+what gets compiled for the end user.
+"""
+
+from app.heuristics import (
+    detect_frontend_download_feature,
+    detect_summary,
+    extract_comparison_items,
+    extract_variant_count,
+)
+
+
+class TestExtractVariantCount:
+    def test_no_keyword_defaults_to_one(self) -> None:
+        assert extract_variant_count("Write a poem about the ocean") == 1
+
+    def test_keyword_without_number_defaults_to_three(self) -> None:
+        assert extract_variant_count("Give me some variants of this logo") == 3
+
+    def test_keyword_with_number_in_range(self) -> None:
+        assert extract_variant_count("Give me 5 options for the headline") == 5
+
+    def test_number_below_two_clamps_to_two(self) -> None:
+        assert extract_variant_count("1 alternatif ver") == 2
+
+    def test_number_above_ten_clamps_to_ten(self) -> None:
+        assert extract_variant_count("15 variants please") == 10
+
+    def test_case_insensitive_keyword_and_number(self) -> None:
+        assert extract_variant_count("SEÇENEK: 4 seçenek istiyorum") == 4
+
+
+class TestDetectSummary:
+    def test_no_keyword(self) -> None:
+        assert detect_summary("Explain how quantum computing works") == (False, None)
+
+    def test_keyword_without_bullet_count(self) -> None:
+        assert detect_summary("Please summarize this article") == (True, None)
+
+    def test_keyword_with_bullet_count(self) -> None:
+        assert detect_summary("Give me a 5 bullet summary") == (True, 5)
+
+    def test_keyword_with_points_count_case_insensitive(self) -> None:
+        assert detect_summary("SUMMARIZE this in 10 points") == (True, 10)
+
+    def test_turkish_keyword_with_madde_count(self) -> None:
+        assert detect_summary("3 madde ile özetle") == (True, 3)
+
+
+class TestExtractComparisonItems:
+    def test_no_comparison_keyword_returns_empty(self) -> None:
+        assert extract_comparison_items("Write a blog post about coffee") == []
+
+    def test_vs_pattern_splits_two_items(self) -> None:
+        assert extract_comparison_items("React vs Vue") == ["react", "vue"]
+
+    def test_vs_pattern_splits_three_items(self) -> None:
+        assert extract_comparison_items("React vs Vue vs Svelte") == [
+            "react",
+            "vue",
+            "svelte",
+        ]
+
+    def test_compare_keyword_with_comma_separated_items(self) -> None:
+        assert extract_comparison_items("react, vue compare") == ["react", "vue"]
+
+    def test_single_item_before_compare_yields_empty(self) -> None:
+        assert extract_comparison_items("react compare") == []
+
+    def test_duplicate_items_are_deduped(self) -> None:
+        assert extract_comparison_items("react vs react") == ["react"]
+
+    def test_long_items_are_truncated_to_forty_chars(self) -> None:
+        long_name = "a" * 50
+        result = extract_comparison_items(f"{long_name} vs short")
+        assert result[0] == long_name[:40]
+
+
+class TestDetectFrontendDownloadFeature:
+    def test_full_match_returns_true(self) -> None:
+        assert detect_frontend_download_feature(
+            "Add a download button to the dashboard"
+        )
+
+    def test_missing_action_word_returns_false(self) -> None:
+        assert not detect_frontend_download_feature(
+            "Add a button to the dashboard"
+        )
+
+    def test_missing_add_verb_returns_false(self) -> None:
+        assert not detect_frontend_download_feature(
+            "The download button on the dashboard is broken"
+        )
+
+    def test_missing_surface_word_returns_false(self) -> None:
+        assert not detect_frontend_download_feature("Add a download feature")
+
+    def test_export_synonym_matches(self) -> None:
+        assert detect_frontend_download_feature(
+            "Let users export data from the browser page"
+        )

--- a/tests/test_skill_ir_parsing_gap.py
+++ b/tests/test_skill_ir_parsing_gap.py
@@ -1,0 +1,103 @@
+"""Direct unit coverage for app.adapters.skill_ir markdown-section parsers
+that previously had no dedicated tests: _parse_purpose_block, _parse_bullet_list,
+and _parse_examples. These feed the Skill export IR directly from user-authored
+markdown — malformed or empty sections must degrade gracefully rather than
+producing garbled exports.
+"""
+
+from app.adapters.skill_ir import (
+    SkillExample,
+    _parse_bullet_list,
+    _parse_examples,
+    _parse_purpose_block,
+)
+
+
+class TestParsePurposeBlock:
+    def test_empty_text_returns_empty_tuple(self) -> None:
+        assert _parse_purpose_block("") == ("", "")
+
+    def test_legacy_single_block_is_kept_as_purpose(self) -> None:
+        purpose, when = _parse_purpose_block("Summarizes long documents into bullets.")
+        assert purpose == "Summarizes long documents into bullets."
+        assert when == ""
+
+    def test_what_and_when_labels_are_split(self) -> None:
+        text = "**What:** Summarizes text.\n**When to use:** Long documents."
+        purpose, when = _parse_purpose_block(text)
+        assert purpose == "Summarizes text."
+        assert when == "Long documents."
+
+    def test_multiline_what_block_is_joined(self) -> None:
+        text = "**What:** Summarizes text\nacross multiple lines."
+        purpose, when = _parse_purpose_block(text)
+        assert purpose == "Summarizes text across multiple lines."
+        assert when == ""
+
+    def test_only_when_label_leaves_purpose_empty(self) -> None:
+        text = "**When to use:** For long documents."
+        purpose, when = _parse_purpose_block(text)
+        assert purpose == ""
+        assert when == "For long documents."
+
+    def test_strips_markdown_code_fence(self) -> None:
+        text = "```\n**What:** Fenced purpose.\n```"
+        purpose, when = _parse_purpose_block(text)
+        assert purpose == "Fenced purpose."
+
+
+class TestParseBulletList:
+    def test_no_bullets_returns_empty(self) -> None:
+        assert _parse_bullet_list("Just a plain sentence.") == []
+
+    def test_dash_bullets(self) -> None:
+        text = "- first\n- second\n- third"
+        assert _parse_bullet_list(text) == ["first", "second", "third"]
+
+    def test_star_bullets(self) -> None:
+        text = "* alpha\n* beta"
+        assert _parse_bullet_list(text) == ["alpha", "beta"]
+
+    def test_mixed_bullet_markers(self) -> None:
+        text = "- one\n* two"
+        assert _parse_bullet_list(text) == ["one", "two"]
+
+    def test_non_bullet_lines_are_skipped(self) -> None:
+        text = "Intro line\n- real bullet\nanother stray line"
+        assert _parse_bullet_list(text) == ["real bullet"]
+
+    def test_empty_bullet_is_skipped(self) -> None:
+        text = "- \n- content"
+        assert _parse_bullet_list(text) == ["content"]
+
+
+class TestParseExamples:
+    def test_no_examples_returns_empty(self) -> None:
+        assert _parse_examples("Nothing to see here.") == []
+
+    def test_arrow_form_is_parsed(self) -> None:
+        text = "Input: hello → Output: world"
+        examples = _parse_examples(text)
+        assert examples == [SkillExample(input="hello", output="world")]
+
+    def test_ascii_arrow_form_is_parsed(self) -> None:
+        text = "Input: 2+2 -> Output: 4"
+        examples = _parse_examples(text)
+        assert examples == [SkillExample(input="2+2", output="4")]
+
+    def test_bulleted_example_strips_marker(self) -> None:
+        text = "- Input: `foo` → Output: `bar`"
+        examples = _parse_examples(text)
+        assert examples == [SkillExample(input="foo", output="bar")]
+
+    def test_multiple_examples_are_all_collected(self) -> None:
+        text = "Input: a → Output: 1\nInput: b → Output: 2"
+        examples = _parse_examples(text)
+        assert examples == [
+            SkillExample(input="a", output="1"),
+            SkillExample(input="b", output="2"),
+        ]
+
+    def test_malformed_line_without_output_is_skipped(self) -> None:
+        text = "Input: only input, no output marker"
+        assert _parse_examples(text) == []


### PR DESCRIPTION
## Summary

Adds direct unit tests for pure, deterministic functions that previously had zero dedicated test coverage. All are core compiler logic — text heuristics, plan-scheduling primitives, and export-IR parsers — where a silent bug would corrupt compiled output or generated agent-pack/skill exports without any test catching it.

- `app/heuristics/__init__.py`: `extract_variant_count`, `detect_summary`, `extract_comparison_items` (additional edge cases beyond the existing Turkish-form test), `detect_frontend_download_feature`
- `app/emitters.py`: `_step_mode`, `_scheduled_modes` — the primitives behind the documented "Working approach" section suppression rule
- `app/adapters/agent_ir.py`: `_infer_allowed_tools`, `_infer_mcp_servers`, `_infer_ci_automation_intent`, `_infer_hook_suggestions`, `_infer_memory_outline`
- `app/adapters/skill_ir.py`: `_parse_purpose_block`, `_parse_bullet_list`, `_parse_examples`

No source, config, lockfile, or CI files were modified — this PR only adds new test files.

## Test plan

- [x] `python3 -m pytest tests/test_heuristics_parsing_gap.py tests/test_emitters_scheduling_helpers_gap.py tests/test_agent_ir_inference_gap.py tests/test_skill_ir_parsing_gap.py -v` — 73 passed
- [x] `python3 -m pytest tests/ -q` (full suite) — 2119 passed, 7 skipped, 0 failed (baseline was 2046 passed, 7 skipped before this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RVdekn9dyFJVKacG1MU69m)_