### PR TITLE
🎨 Palette: Add tooltips to icon-only sidebar links

### DIFF
--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -120,6 +120,7 @@ export default function Sidebar() {
                                             : "text-zinc-500 hover:text-white hover:bg-white/5"
                                     }`}
                                     aria-label={item.name}
+                                    title={item.name}
                                     aria-current={isActive ? "page" : undefined}
                                 >
                                     <item.Icon size={20} strokeWidth={1.75} aria-hidden="true" />
@@ -153,6 +154,7 @@ export default function Sidebar() {
                         rel="noopener noreferrer"
                         className="w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-300 relative group text-zinc-500 hover:text-white hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                         aria-label={item.name}
+                                    title={item.name}
                     >
                         <item.Icon size={18} strokeWidth={1.75} aria-hidden="true" />
                     </a>


### PR DESCRIPTION
💡 What: Added native `title` tooltips to the Sidebar navigation links and outbound resource links.
🎯 Why: The bottom outbound links (like CLI, VS Code extension) are icon-only and lack visible text labels, making their purpose ambiguous until clicked. The main navigation links are also icon-only on mobile devices. Adding tooltips ensures users always know what each icon represents.
📸 Before/After: Hovering over the outbound links now displays a native browser tooltip with the link name.
♿ Accessibility: The `title` attribute reinforces the existing `aria-label` providing consistent accessible names while adding visual context for sighted users who rely on mice.

---
*PR created automatically by Jules for task [3640543753340154644](https://jules.google.com/task/3640543753340154644) started by @madara88645*