### PR TITLE
feat: issue scout batch — tests and ignore-path impl (#1035, #1036, #1037, #1038, #1039)

### DIFF
--- a/cli/commands/json_tools.py
+++ b/cli/commands/json_tools.py
@@ -107,6 +107,48 @@ def json_path(
         typer.echo(json.dumps(cur, ensure_ascii=False))
 
 
+def _parse_path_segments(path: str) -> list[str | int]:
+    """Parse a dot-separated path with optional [N] bracket indexes into segments."""
+    token_re = re.compile(r"([A-Za-z0-9_\-]+)|\[(\d+)\]")
+    segments: list[str | int] = []
+    for dot_part in [p for p in path.split(".") if p]:
+        idx = 0
+        while idx < len(dot_part):
+            m = token_re.match(dot_part, idx)
+            if not m:
+                break
+            if m.group(1):
+                segments.append(m.group(1))
+            else:
+                segments.append(int(m.group(2)))
+            idx = m.end()
+    return segments
+
+
+def _delete_paths(obj: Any, paths: list[str]) -> None:
+    """Delete each path from *obj* in-place, silently skipping missing paths."""
+    for path in paths:
+        segments = _parse_path_segments(path)
+        if not segments:
+            continue
+        cur = obj
+        for seg in segments[:-1]:
+            if isinstance(seg, str) and isinstance(cur, dict) and seg in cur:
+                cur = cur[seg]
+            elif isinstance(seg, int) and isinstance(cur, list) and 0 <= seg < len(cur):
+                cur = cur[seg]
+            else:
+                cur = None
+                break
+        if cur is None:
+            continue
+        last = segments[-1]
+        if isinstance(last, str) and isinstance(cur, dict):
+            cur.pop(last, None)
+        elif isinstance(last, int) and isinstance(cur, list) and 0 <= last < len(cur):
+            del cur[last]
+
+
 @app.command("diff")
 def json_diff(
     a: Path = typer.Argument(..., help="First JSON file"),
@@ -138,8 +180,8 @@ def json_diff(
 
     # Optionally delete ignored paths
     if ignore_path:
-        # (Simplified path deletion logic for brevity)
-        pass
+        _delete_paths(ja, ignore_path)
+        _delete_paths(jb, ignore_path)
 
     if brief:
         if ja == jb:

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -82,3 +82,62 @@ def test_batch_command(tmp_path: Path):
     assert code == 0
     assert (out_dir / "x.json").exists()
     assert (out_dir / "y.json").exists()
+
+
+def test_diff_ignore_path_nested_key(tmp_path: Path):
+    """--ignore-path should suppress differences in a nested dict key."""
+    a = {"name": "alpha", "metadata": {"version": 1, "sig": "aaa"}}
+    b = {"name": "alpha", "metadata": {"version": 1, "sig": "bbb"}}
+
+    fa = tmp_path / "a.json"
+    fb = tmp_path / "b.json"
+    fa.write_text(json.dumps(a), encoding="utf-8")
+    fb.write_text(json.dumps(b), encoding="utf-8")
+
+    # Without ignore: diff should show differences
+    code, out, _ = run_cli(["diff", str(fa), str(fb), "--brief"], Path.cwd())
+    assert code == 1, "files differ without ignore-path"
+
+    # With ignore: diff should show no differences (brief exits 0)
+    code, out, _ = run_cli(
+        ["diff", str(fa), str(fb), "--brief", "--ignore-path", "metadata.sig"], Path.cwd()
+    )
+    assert code == 0, f"expected no diff after ignoring metadata.sig: {out}"
+
+
+def test_diff_ignore_path_list_index(tmp_path: Path):
+    """--ignore-path should handle bracket list indexes like steps[0]."""
+    a = {"steps": ["first", "second", "third"]}
+    b = {"steps": ["CHANGED", "second", "third"]}
+
+    fa = tmp_path / "a.json"
+    fb = tmp_path / "b.json"
+    fa.write_text(json.dumps(a), encoding="utf-8")
+    fb.write_text(json.dumps(b), encoding="utf-8")
+
+    # Without ignore: differs
+    code, _, _ = run_cli(["diff", str(fa), str(fb), "--brief"], Path.cwd())
+    assert code == 1
+
+    # With ignore: removing steps[0] from both makes remaining items align
+    code, _, _ = run_cli(
+        ["diff", str(fa), str(fb), "--brief", "--ignore-path", "steps[0]"], Path.cwd()
+    )
+    assert code == 0
+
+
+def test_diff_ignore_path_missing_key_is_silent(tmp_path: Path):
+    """--ignore-path should silently skip paths that don't exist in the JSON."""
+    a = {"name": "alpha"}
+    b = {"name": "alpha"}
+
+    fa = tmp_path / "a.json"
+    fb = tmp_path / "b.json"
+    fa.write_text(json.dumps(a), encoding="utf-8")
+    fb.write_text(json.dumps(b), encoding="utf-8")
+
+    code, _, _ = run_cli(
+        ["diff", str(fa), str(fb), "--brief", "--ignore-path", "nonexistent.deep.path"],
+        Path.cwd(),
+    )
+    assert code == 0

--- a/tests/test_cli_optimize.py
+++ b/tests/test_cli_optimize.py
@@ -1,0 +1,143 @@
+"""Unit tests for CLI evolutionary prompt optimization commands.
+
+Covers: optimize run (with --dry-run), optimize history list, optimize history show.
+All tests use the mock provider or mocked engines — no real LLM calls.
+
+Fixes #1038.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+from typer.testing import CliRunner
+
+from cli.main import app
+
+runner = CliRunner()
+
+
+def _write_prompt_file(tmp_path: Path, content: str = "Summarize a document") -> Path:
+    p = tmp_path / "prompt.txt"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _write_suite_file(tmp_path: Path, prompt_file: str = "prompt.txt") -> Path:
+    suite_data = {
+        "name": "test-suite",
+        "prompt_file": prompt_file,
+        "test_cases": [
+            {
+                "id": "tc-1",
+                "description": "Basic summary check",
+                "input_variables": {"doc": "A short document"},
+                "assertions": [
+                    {"type": "contains", "value": "summary"},
+                ],
+            }
+        ],
+    }
+    p = tmp_path / "suite.yaml"
+    p.write_text(yaml.dump(suite_data), encoding="utf-8")
+    return p
+
+
+def test_optimize_run_dry_run(tmp_path: Path):
+    """--dry-run should estimate cost and exit without running the engine."""
+    prompt = _write_prompt_file(tmp_path)
+    suite = _write_suite_file(tmp_path, prompt_file=str(prompt))
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "run",
+            str(prompt),
+            str(suite),
+            "--dry-run",
+            "--provider",
+            "mock",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Estimated Cost" in result.output or "Dry Run Estimate" in result.output
+
+
+def test_optimize_run_missing_prompt_file(tmp_path: Path):
+    """Should fail gracefully when prompt file does not exist."""
+    suite = _write_suite_file(tmp_path)
+    missing = tmp_path / "nonexistent.txt"
+
+    result = runner.invoke(
+        app,
+        ["optimize", "run", str(missing), str(suite), "--provider", "mock"],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_optimize_run_missing_suite_file(tmp_path: Path):
+    """Should fail gracefully when suite file does not exist."""
+    prompt = _write_prompt_file(tmp_path)
+    missing = tmp_path / "nonexistent.yaml"
+
+    result = runner.invoke(
+        app,
+        ["optimize", "run", str(prompt), str(missing), "--provider", "mock"],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_optimize_history_list_empty(tmp_path: Path):
+    """history list should print an empty-state message when no history exists."""
+    with patch("app.optimizer.history.HistoryManager") as MockHM:
+        mock_manager = MagicMock()
+        mock_manager.list_runs.return_value = []
+        MockHM.return_value = mock_manager
+
+        result = runner.invoke(app, ["optimize", "history", "list"])
+
+    assert result.exit_code == 0
+    assert "no history" in result.output.lower() or "History" in result.output
+
+
+def test_optimize_history_list_with_runs(tmp_path: Path):
+    """history list should display runs in a table."""
+    with patch("app.optimizer.history.HistoryManager") as MockHM:
+        mock_manager = MagicMock()
+        mock_manager.list_runs.return_value = [
+            {
+                "id": "abc12345-6789-0000-0000-000000000000",
+                "date": "2026-07-10",
+                "best_score": 0.85,
+                "model": "mock",
+                "generations": 3,
+            }
+        ]
+        MockHM.return_value = mock_manager
+
+        result = runner.invoke(app, ["optimize", "history", "list"])
+
+    assert result.exit_code == 0
+    assert "abc12345" in result.output
+    assert "0.85" in result.output
+
+
+def test_optimize_history_show_not_found():
+    """history show should fail when the run ID does not exist."""
+    with patch("app.optimizer.history.HistoryManager") as MockHM:
+        mock_manager = MagicMock()
+        mock_manager.load_run.return_value = None
+        mock_manager.list_runs.return_value = []
+        MockHM.return_value = mock_manager
+
+        result = runner.invoke(app, ["optimize", "history", "show", "nonexistent"])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()

--- a/web/app/components/DownloadButton.test.tsx
+++ b/web/app/components/DownloadButton.test.tsx
@@ -1,0 +1,90 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DownloadButton from "./DownloadButton";
+
+vi.mock("../lib/downloadFile", () => ({
+  downloadFile: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn() },
+}));
+
+import { downloadFile } from "../lib/downloadFile";
+import { toast } from "sonner";
+
+describe("DownloadButton", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("renders with default label and aria-label", () => {
+    render(<DownloadButton content="hello" filename="test.txt" />);
+    const btn = screen.getByRole("button", { name: "Download test.txt" });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("calls downloadFile and shows toast on click", () => {
+    render(
+      <DownloadButton
+        content="file content"
+        filename="output.md"
+        mimeType="text/markdown"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(downloadFile).toHaveBeenCalledWith(
+      "file content",
+      "output.md",
+      "text/markdown",
+    );
+    expect(toast.success).toHaveBeenCalledWith("Downloaded output.md");
+  });
+
+  it("switches to checkmark icon after click and reverts after 2000ms", () => {
+    render(<DownloadButton content="x" filename="f.txt" />);
+    const btn = screen.getByRole("button");
+
+    // Before click: download icon with sr-only "Download" text
+    expect(screen.getByText("Download")).toBeInTheDocument();
+
+    fireEvent.click(btn);
+
+    // After click: checkmark icon with sr-only "Downloaded!" text
+    expect(screen.getByText("Downloaded!")).toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-label", "Downloaded");
+
+    // After timeout: reverts back
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText("Download")).toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-label", "Download f.txt");
+  });
+
+  it("applies gray variant classes by default", () => {
+    render(<DownloadButton content="x" filename="f.txt" />);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("bg-zinc-700");
+  });
+
+  it("applies default (blue) variant classes when specified", () => {
+    render(<DownloadButton content="x" filename="f.txt" variant="default" />);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("bg-blue-600");
+  });
+
+  it("accepts a custom label", () => {
+    render(<DownloadButton content="x" filename="f.txt" label="Export" />);
+    expect(screen.getByRole("button", { name: "Export f.txt" })).toBeInTheDocument();
+  });
+});

--- a/web/app/components/RepoContextPreviewCard.test.tsx
+++ b/web/app/components/RepoContextPreviewCard.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import RepoContextPreviewCard from "./RepoContextPreviewCard";
+import type { GitHubRepoContextPayload } from "@/lib/api/types";
+
+function makePayload(overrides: Partial<GitHubRepoContextPayload> = {}): GitHubRepoContextPayload {
+  return {
+    repo_full_name: "madara88645/Compiler",
+    default_branch: "main",
+    summary: "A prompt compiler tool.",
+    detected_stack: ["Python", "Next.js"],
+    highlights: ["FastAPI backend", "Vitest test suite"],
+    files_used: ["README.md", "pyproject.toml"],
+    ...overrides,
+  };
+}
+
+describe("RepoContextPreviewCard", () => {
+  it("renders repo name and default branch", () => {
+    render(<RepoContextPreviewCard repoContext={makePayload()} accent="green" />);
+    expect(screen.getByText("madara88645/Compiler")).toBeInTheDocument();
+    expect(screen.getByText("main")).toBeInTheDocument();
+  });
+
+  it("renders summary text", () => {
+    render(<RepoContextPreviewCard repoContext={makePayload()} accent="green" />);
+    expect(screen.getByText("A prompt compiler tool.")).toBeInTheDocument();
+  });
+
+  it("renders detected stack items", () => {
+    render(<RepoContextPreviewCard repoContext={makePayload()} accent="yellow" />);
+    expect(screen.getByText("Python")).toBeInTheDocument();
+    expect(screen.getByText("Next.js")).toBeInTheDocument();
+  });
+
+  it("renders highlights section when non-empty", () => {
+    render(<RepoContextPreviewCard repoContext={makePayload()} accent="green" />);
+    expect(screen.getByText("Highlights")).toBeInTheDocument();
+    expect(screen.getByText("FastAPI backend")).toBeInTheDocument();
+    expect(screen.getByText("Vitest test suite")).toBeInTheDocument();
+  });
+
+  it("renders files used section when non-empty", () => {
+    render(<RepoContextPreviewCard repoContext={makePayload()} accent="green" />);
+    expect(screen.getByText("Files Used")).toBeInTheDocument();
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+    expect(screen.getByText("pyproject.toml")).toBeInTheDocument();
+  });
+
+  it("omits highlights section when empty", () => {
+    render(
+      <RepoContextPreviewCard
+        repoContext={makePayload({ highlights: [] })}
+        accent="green"
+      />,
+    );
+    expect(screen.queryByText("Highlights")).not.toBeInTheDocument();
+  });
+
+  it("omits stack section when empty", () => {
+    render(
+      <RepoContextPreviewCard
+        repoContext={makePayload({ detected_stack: [] })}
+        accent="green"
+      />,
+    );
+    expect(screen.queryByText("Python")).not.toBeInTheDocument();
+  });
+
+  it("omits files used section when empty", () => {
+    render(
+      <RepoContextPreviewCard
+        repoContext={makePayload({ files_used: [] })}
+        accent="green"
+      />,
+    );
+    expect(screen.queryByText("Files Used")).not.toBeInTheDocument();
+  });
+
+  it("omits branch badge when default_branch is falsy", () => {
+    render(
+      <RepoContextPreviewCard
+        repoContext={makePayload({ default_branch: "" })}
+        accent="yellow"
+      />,
+    );
+    expect(screen.queryByText("main")).not.toBeInTheDocument();
+  });
+
+  it("applies green accent classes", () => {
+    const { container } = render(
+      <RepoContextPreviewCard repoContext={makePayload()} accent="green" />,
+    );
+    expect(container.firstElementChild?.className).toContain("ring-green-500/20");
+  });
+
+  it("applies yellow accent classes", () => {
+    const { container } = render(
+      <RepoContextPreviewCard repoContext={makePayload()} accent="yellow" />,
+    );
+    expect(container.firstElementChild?.className).toContain("ring-yellow-500/20");
+  });
+});

--- a/web/app/hooks/__tests__/useCompiler.test.tsx
+++ b/web/app/hooks/__tests__/useCompiler.test.tsx
@@ -1,0 +1,186 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCompiler } from "../useCompiler";
+import { compilePrompt } from "../../../lib/api/promptc";
+import type { CompileResponse } from "../../../lib/api/types";
+
+vi.mock("../../../lib/api/promptc", () => ({
+  compilePrompt: vi.fn(),
+}));
+
+vi.mock("../../lib/showError", () => ({
+  showError: vi.fn(),
+}));
+
+const compilePromptMock = vi.mocked(compilePrompt);
+
+function makeResponse(overrides: Partial<CompileResponse> = {}): CompileResponse {
+  return {
+    system_prompt: "sys",
+    user_prompt: "usr",
+    plan: "1. step",
+    expanded_prompt: "expanded",
+    ir: { metadata: {} },
+    processing_ms: 42,
+    readiness_markdown: "",
+    ...overrides,
+  };
+}
+
+describe("useCompiler", () => {
+  beforeEach(() => {
+    compilePromptMock.mockReset();
+  });
+
+  it("starts in Ready state with no result", () => {
+    const { result } = renderHook(() => useCompiler());
+    expect(result.current.status).toBe("Ready");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.result).toBeNull();
+    expect(result.current.lastError).toBeNull();
+  });
+
+  it("transitions to Done with result on successful compile", async () => {
+    const response = makeResponse({ processing_ms: 100 });
+    compilePromptMock.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useCompiler());
+
+    await act(async () => {
+      await result.current.runCompile("build a login flow", "conservative");
+    });
+
+    expect(result.current.status).toBe("Done in 100ms");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.result).toEqual(response);
+  });
+
+  it("ignores empty text input", async () => {
+    const { result } = renderHook(() => useCompiler());
+
+    await act(async () => {
+      await result.current.runCompile("   ", "conservative");
+    });
+
+    expect(compilePromptMock).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("Ready");
+  });
+
+  it("sets Error state on compile failure", async () => {
+    const err = new Error("Network failure");
+    compilePromptMock.mockRejectedValue(err);
+
+    const { result } = renderHook(() => useCompiler());
+
+    await act(async () => {
+      await result.current.runCompile("build something", "default");
+    });
+
+    expect(result.current.status).toBe("Error");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.lastError).toBe(err);
+  });
+
+  it("triggers security alert when response is_safe is false", async () => {
+    const response = makeResponse({
+      ir: {
+        metadata: {
+          security: {
+            is_safe: false,
+            findings: [{ type: "pii", original: "123-45-6789", masked: "[SSN]" }],
+            redacted_text: "Use [SSN] for lookup",
+          },
+        },
+      },
+    });
+    compilePromptMock.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useCompiler());
+
+    await act(async () => {
+      await result.current.runCompile("Use 123-45-6789 for lookup", "conservative");
+    });
+
+    expect(result.current.securityFindings).toHaveLength(1);
+    expect(result.current.securityFindings[0].type).toBe("pii");
+    expect(result.current.redactedText).toBe("Use [SSN] for lookup");
+    expect(result.current.status).toBe("Security Alert Detected");
+    // Result should NOT be set when security alert is triggered
+    expect(result.current.result).toBeNull();
+  });
+
+  it("cancelSecurityReview clears findings and resets loading", async () => {
+    const response = makeResponse({
+      ir: {
+        metadata: {
+          security: {
+            is_safe: false,
+            findings: [{ type: "pii", original: "x", masked: "[X]" }],
+            redacted_text: "redacted",
+          },
+        },
+      },
+    });
+    compilePromptMock.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useCompiler());
+
+    await act(async () => {
+      await result.current.runCompile("some text with PII", "conservative");
+    });
+
+    expect(result.current.securityFindings).toHaveLength(1);
+
+    act(() => {
+      result.current.cancelSecurityReview();
+    });
+
+    expect(result.current.securityFindings).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe("Cancelled");
+  });
+
+  it("retry re-runs the last compile call", async () => {
+    const response = makeResponse();
+    compilePromptMock.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useCompiler());
+
+    await act(async () => {
+      await result.current.runCompile("test prompt", "default", false);
+    });
+
+    expect(compilePromptMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.retry();
+    });
+
+    expect(compilePromptMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("sets heuristics-only status when useLlm is false", async () => {
+    let resolvePromise: (v: CompileResponse) => void;
+    const pendingPromise = new Promise<CompileResponse>((resolve) => {
+      resolvePromise = resolve;
+    });
+    compilePromptMock.mockReturnValue(pendingPromise);
+
+    const { result } = renderHook(() => useCompiler());
+
+    act(() => {
+      void result.current.runCompile("test prompt", "conservative", false);
+    });
+
+    // While in-flight, status should reflect heuristics-only mode
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+
+    // Resolve to clean up
+    await act(async () => {
+      resolvePromise!(makeResponse());
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Batch delivery for 5 issue-scout candidates. All tests green (frontend 261/261, backend targeted suites green).

### Changes

#### Test coverage (Fixes #1035, #1036, #1037, #1038)

| Issue | Component | File |
|---|---|---|
| #1035 | DownloadButton | `web/app/components/DownloadButton.test.tsx` |
| #1036 | RepoContextPreviewCard | `web/app/components/RepoContextPreviewCard.test.tsx` |
| #1037 | useCompiler hook | `web/app/hooks/__tests__/useCompiler.test.tsx` |
| #1038 | CLI optimize commands | `tests/test_cli_optimize.py` |

#### Feature (Fixes #1039)

- **CLI diff `--ignore-path` implementation**: The `--ignore-path` option in `promptc diff` was declared but not implemented (placeholder `pass`). Now parses dot-separated keys and `[N]` bracket indexes, deletes matched paths from both JSON objects before diffing.
- Tests added in `tests/test_cli_extras.py` covering nested keys, list indexes, and missing paths.

## Verification

- `cd web && npm run test`: 48 files, 261 tests passed
- `.venv/bin/pytest tests/test_cli_optimize.py tests/test_cli_extras.py -v`: 12 tests passed