### PR TITLE
CLI: implement --ignore-path deletion logic for json diff command

### DIFF
--- a/cli/commands/json_tools.py
+++ b/cli/commands/json_tools.py
@@ -16,6 +16,47 @@ from rich import print
 
 from cli.commands._base import app
 
+_PATH_TOKEN_RE = re.compile(r"([A-Za-z0-9_\-]+)|\[(\d+)\]")
+
+
+def _parse_path_segments(path: str) -> list[str | int]:
+    """Parse dot/list path syntax into segments (shared by json-path and diff --ignore-path)."""
+    segments: list[str | int] = []
+    for dot_part in [p for p in path.split(".") if p]:
+        idx = 0
+        while idx < len(dot_part):
+            m = _PATH_TOKEN_RE.match(dot_part, idx)
+            if not m:
+                return segments
+            if m.group(1):
+                segments.append(m.group(1))
+            else:
+                segments.append(int(m.group(2)))
+            idx = m.end()
+    return segments
+
+
+def _delete_at_path(root: Any, segments: list[str | int]) -> None:
+    """Delete a value at path segments; no-op when path is missing."""
+    if not segments:
+        return
+
+    if len(segments) == 1:
+        seg = segments[0]
+        if isinstance(seg, str) and isinstance(root, dict):
+            root.pop(seg, None)
+        elif isinstance(seg, int) and isinstance(root, list) and 0 <= seg < len(root):
+            del root[seg]
+        return
+
+    head, *tail = segments
+    if isinstance(head, str):
+        if isinstance(root, dict) and head in root:
+            _delete_at_path(root[head], tail)
+    elif isinstance(head, int):
+        if isinstance(root, list) and 0 <= head < len(root):
+            _delete_at_path(root[head], tail)
+
 
 @app.command("json-path")
 def json_path(
@@ -40,23 +81,13 @@ def json_path(
         typer.secho(f"Read error: {e}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=2)
 
-    token_re = re.compile(r"([A-Za-z0-9_\-]+)|\[(\d+)\]")
-    segments: list[str | int] = []
-    for dot_part in [p for p in path.split(".") if p]:
-        idx = 0
-        while idx < len(dot_part):
-            m = token_re.match(dot_part, idx)
-            if not m:
-                if default is not None:
-                    typer.echo(default)
-                    raise typer.Exit(code=0)
-                typer.secho("<not-found>", fg=typer.colors.YELLOW)
-                raise typer.Exit(code=1)
-            if m.group(1):
-                segments.append(m.group(1))
-            else:
-                segments.append(int(m.group(2)))
-            idx = m.end()
+    segments = _parse_path_segments(path)
+    if not segments and path.strip():
+        if default is not None:
+            typer.echo(default)
+            raise typer.Exit(code=0)
+        typer.secho("<not-found>", fg=typer.colors.YELLOW)
+        raise typer.Exit(code=1)
 
     cur: Any = data
     for seg in segments:
@@ -136,10 +167,12 @@ def json_diff(
         typer.secho(f"Read error: {e}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=2)
 
-    # Optionally delete ignored paths
     if ignore_path:
-        # (Simplified path deletion logic for brevity)
-        pass
+        for p in ignore_path:
+            segments = _parse_path_segments(p)
+            if segments:
+                _delete_at_path(ja, segments)
+                _delete_at_path(jb, segments)
 
     if brief:
         if ja == jb:

--- a/tests/test_cli_extras.py
+++ b/tests/test_cli_extras.py
@@ -82,3 +82,75 @@ def test_batch_command(tmp_path: Path):
     assert code == 0
     assert (out_dir / "x.json").exists()
     assert (out_dir / "y.json").exists()
+
+
+def test_diff_ignore_path_nested(tmp_path: Path):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text(
+        json.dumps({"metadata": {"ir_signature": "sig-a", "version": 1}, "value": 10}),
+        encoding="utf-8",
+    )
+    b.write_text(
+        json.dumps({"metadata": {"ir_signature": "sig-b", "version": 1}, "value": 10}),
+        encoding="utf-8",
+    )
+
+    code, out, _ = run_cli(["diff", str(a), str(b), "--brief"], Path.cwd())
+    assert code == 1
+
+    code, out, _ = run_cli(
+        ["diff", str(a), str(b), "--brief", "--ignore-path", "metadata.ir_signature"],
+        Path.cwd(),
+    )
+    assert code == 0
+    assert out == ""
+
+
+def test_diff_ignore_path_list_index(tmp_path: Path):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text(
+        json.dumps({"steps": [{"id": 1, "note": "alpha"}, {"id": 2}]}),
+        encoding="utf-8",
+    )
+    b.write_text(
+        json.dumps({"steps": [{"id": 1, "note": "beta"}, {"id": 2}]}),
+        encoding="utf-8",
+    )
+
+    code, out, _ = run_cli(
+        ["diff", str(a), str(b), "--brief", "--ignore-path", "steps[0].note"],
+        Path.cwd(),
+    )
+    assert code == 0
+    assert out == ""
+
+
+def test_diff_ignore_path_multiple(tmp_path: Path):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    a.write_text(
+        json.dumps({"metadata": {"ir_signature": "a"}, "timestamp": "t1", "same": True}),
+        encoding="utf-8",
+    )
+    b.write_text(
+        json.dumps({"metadata": {"ir_signature": "b"}, "timestamp": "t2", "same": True}),
+        encoding="utf-8",
+    )
+
+    code, out, _ = run_cli(
+        [
+            "diff",
+            str(a),
+            str(b),
+            "--brief",
+            "--ignore-path",
+            "metadata.ir_signature",
+            "--ignore-path",
+            "timestamp",
+        ],
+        Path.cwd(),
+    )
+    assert code == 0
+    assert out == ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1039

Implements `--ignore-path` for the `diff` CLI command: parses dot/bracket path segments, deletes specified fields from both JSON inputs before comparison, and adds nested/list index test coverage.

**Tests:** 6 passed (`pytest tests/test_cli_extras.py -v`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

