### PR TITLE
Sync offline route metadata and runbook after /offline redirect

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -306,7 +306,8 @@ cd web && npm run build
 | Skill Generator | http://localhost:3000/skills-generator |
 | Benchmark | http://localhost:3000/benchmark |
 | Token Optimizer | http://localhost:3000/optimizer |
-| Offline / heuristics | http://localhost:3000/offline |
+
+`/offline` redirects to `/` (main Compiler). Use the **Heuristics only (no LLM)** toggle on the main page instead of a separate offline surface.
 
 ---
 

--- a/web/app/offline/layout.tsx
+++ b/web/app/offline/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Offline Compiler — Prompt Compiler",
   description:
-    "A fast, local-only prompt compiler that uses deterministic heuristics instead of an LLM — secure, instant, no API keys.",
+    "This route redirects to the main Compiler page. Use the Heuristics only (no LLM) engine toggle there to run the deterministic heuristic pipeline without a cloud LLM call.",
 };
 
 export default function OfflineLayout({

--- a/web/app/route-metadata.test.ts
+++ b/web/app/route-metadata.test.ts
@@ -37,7 +37,7 @@ const ROUTE_CASES: RouteMetadataCase[] = [
   {
     title: "Offline Compiler — Prompt Compiler",
     metadata: offlineMetadata,
-    descriptionFragment: "local-only prompt compiler",
+    descriptionFragment: "redirects to the main Compiler",
   },
   {
     title: "Token Optimizer — Prompt Compiler",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1003

Updates offline layout metadata, AGENTS.md runbook, and route-metadata contract test to reflect that `/offline` redirects to the main Compiler page with the heuristics toggle — no longer described as a separate local-only product.

**Tests:** 8 passed (`npm run test -- app/route-metadata.test.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

