### PR TITLE
Components: add unit tests for DownloadButton client component

### DIFF
--- a/web/app/components/DownloadButton.test.tsx
+++ b/web/app/components/DownloadButton.test.tsx
@@ -1,0 +1,73 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { downloadFileMock } = vi.hoisted(() => ({
+  downloadFileMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../lib/downloadFile", () => ({
+  downloadFile: downloadFileMock,
+}));
+
+import { toast } from "sonner";
+import DownloadButton from "./DownloadButton";
+
+const CHECKMARK_SELECTOR = "polyline[points='20 6 9 17 4 12']";
+
+describe("DownloadButton", () => {
+  beforeEach(() => {
+    downloadFileMock.mockClear();
+    vi.mocked(toast.success).mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls downloadFile and shows a success toast when clicked", () => {
+    render(
+      <DownloadButton
+        content="file content"
+        filename="report.txt"
+        mimeType="text/plain"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download report.txt" }));
+
+    expect(downloadFileMock).toHaveBeenCalledWith("file content", "report.txt", "text/plain");
+    expect(toast.success).toHaveBeenCalledWith("Downloaded report.txt");
+  });
+
+  it("shows the checkmark icon and updated aria attributes after click, then reverts after the timeout", async () => {
+    render(
+      <DownloadButton content="data" filename="output.md" mimeType="text/markdown" />,
+    );
+
+    const button = screen.getByRole("button", { name: "Download output.md" });
+    expect(button).toHaveAttribute("aria-label", "Download output.md");
+    expect(button).toHaveAttribute("aria-live", "polite");
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeNull();
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-label", "Downloaded");
+    expect(button).toHaveAttribute("title", "Downloaded!");
+    expect(screen.getByText("Downloaded!")).toBeInTheDocument();
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(button).toHaveAttribute("aria-label", "Download output.md");
+    expect(button).toHaveAttribute("title", "Download (output.md)");
+    expect(screen.getByText("Download")).toBeInTheDocument();
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds unit tests for DownloadButton covering click handler, downloadFile mock, toast, and checkmark icon timeout revert.

**Tests:** 2 passed (DownloadButton.test.tsx)

Fixes #1035
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

