### PR TITLE
Components: add unit tests for CopyButton component

### DIFF
--- a/web/app/components/__tests__/CopyButton.test.tsx
+++ b/web/app/components/__tests__/CopyButton.test.tsx
@@ -1,0 +1,82 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { copyToClipboardMock } = vi.hoisted(() => ({
+  copyToClipboardMock: vi.fn(),
+}));
+
+vi.mock("../../lib/copyToClipboard", () => ({
+  copyToClipboard: copyToClipboardMock,
+}));
+
+import CopyButton from "../CopyButton";
+
+const CHECKMARK_SELECTOR = "polyline[points='20 6 9 17 4 12']";
+
+async function clickAndFlush(button: HTMLElement) {
+  fireEvent.click(button);
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("CopyButton", () => {
+  beforeEach(() => {
+    copyToClipboardMock.mockReset();
+    copyToClipboardMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls copyToClipboard when clicked", async () => {
+    render(<CopyButton text="hello world" />);
+
+    await clickAndFlush(screen.getByRole("button", { name: "Copy to Clipboard" }));
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith("hello world");
+  });
+
+  it("shows the checkmark icon and updated aria attributes after a successful copy, then reverts after the timeout", async () => {
+    vi.useFakeTimers();
+
+    render(<CopyButton text="payload" label="Copy output" />);
+
+    const button = screen.getByRole("button", { name: "Copy output" });
+    expect(button).toHaveAttribute("aria-label", "Copy output");
+    expect(button).toHaveAttribute("aria-live", "polite");
+    expect(button).toHaveAttribute("title", "Copy output");
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeNull();
+
+    await clickAndFlush(button);
+
+    expect(button).toHaveAttribute("aria-label", "Copied");
+    expect(button).toHaveAttribute("title", "Copied!");
+    expect(screen.getByText("Copied!")).toBeInTheDocument();
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(button).toHaveAttribute("aria-label", "Copy output");
+    expect(button).toHaveAttribute("title", "Copy output");
+    expect(screen.getByText("Copy output")).toBeInTheDocument();
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeNull();
+  });
+
+  it("does not change icon or aria attributes when copyToClipboard fails", async () => {
+    copyToClipboardMock.mockResolvedValue(false);
+
+    render(<CopyButton text="blocked" />);
+
+    const button = screen.getByRole("button", { name: "Copy to Clipboard" });
+    await clickAndFlush(button);
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith("blocked");
+    expect(button).toHaveAttribute("aria-label", "Copy to Clipboard");
+    expect(button).toHaveAttribute("title", "Copy to Clipboard");
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds unit tests for CopyButton covering clipboard integration, icon transitions, aria attributes, and timeout revert.

**Tests:** 3 passed (CopyButton.test.tsx)

Fixes #1025
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

