### PR TITLE
Add PR Safety Next proxy to proxy-routes.test.ts retry matrix

### DIFF
--- a/web/app/proxy-routes.test.ts
+++ b/web/app/proxy-routes.test.ts
@@ -16,6 +16,7 @@ import { POST as skillsExportRoute } from "./skills-generator/export/route";
 import { POST as ragUploadRoute } from "./rag/upload/route";
 import { POST as ragIngestRoute } from "./rag/ingest/route";
 import { POST as repoContextGithubRoute } from "./repo-context/github/route";
+import { POST as prSafetyReportRoute } from "./pr-safety/report/route";
 
 type RouteCase = {
   name: string;
@@ -241,6 +242,17 @@ describe("Next backend proxy route wiring", () => {
       requestBody: { type: "code" },
       expectedUrl: "http://127.0.0.1:8080/skills-generator/export",
     },
+    {
+      name: "PR Safety report",
+      handler: prSafetyReportRoute,
+      requestUrl: "http://localhost:3000/pr-safety/report",
+      requestBody: {
+        title: "feat: add login flow",
+        description: "Add session-based login endpoints for the API.",
+        changed_files: ["api/routes/auth.py", "tests/test_auth.py"],
+      },
+      expectedUrl: "http://127.0.0.1:8080/pr-safety/report",
+    },
   ])("retries $name requests after a transient backend connection failure", async ({
     handler,
     requestUrl,
@@ -434,6 +446,17 @@ describe("Next backend proxy route wiring", () => {
       requestUrl: "http://localhost:3000/skills-generator/export",
       requestBody: { type: "code" },
       expectedUrl: "https://api.memo.dev/skills-generator/export",
+    },
+    {
+      name: "PR Safety report",
+      handler: prSafetyReportRoute,
+      requestUrl: "http://localhost:3000/pr-safety/report",
+      requestBody: {
+        title: "feat: add login flow",
+        description: "Add session-based login endpoints for the API.",
+        changed_files: ["api/routes/auth.py", "tests/test_auth.py"],
+      },
+      expectedUrl: "https://api.memo.dev/pr-safety/report",
     },
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds PR Safety report proxy to the existing retry/success matrix in `proxy-routes.test.ts`.

**Tests:** 31 passed (`npm run test -- app/proxy-routes.test.ts`)

Fixes #1004
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

