### PR TITLE
Agent Generator: empty/malformed system_prompt success response test

### DIFF
--- a/web/app/agent-generator/page.test.tsx
+++ b/web/app/agent-generator/page.test.tsx
@@ -154,6 +154,36 @@ describe("Agent Generator page", () => {
     expect(classes).not.toContain("md:min-h-0");
   });
 
+  it.each([
+    ["empty", { system_prompt: "" }],
+    ["missing", {}],
+  ] as const)(
+    "shows an error when generation succeeds but system_prompt is %s",
+    async (_label, payload) => {
+      apiJsonMock.mockResolvedValueOnce({
+        example_code_requested: false,
+        example_code_present: false,
+        example_code_warning: null,
+        ...payload,
+      });
+
+      render(<AgentGeneratorPage />);
+
+      fireEvent.change(screen.getByLabelText("Agent Description"), {
+        target: { value: "Build a code review agent." },
+      });
+      fireEvent.click(screen.getAllByTitle("Generate Agent")[0]!);
+
+      expect(await screen.findByText("Agent generation failed")).toBeTruthy();
+      expect(
+        screen.getByText("The generator returned an empty or missing system prompt. Try generating again."),
+      ).toBeTruthy();
+      expect(screen.queryByText("System Prompt")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Copy Markdown" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Retry generation" })).toBeTruthy();
+    },
+  );
+
   it("shows a retryable error in the output panel when generation fails", async () => {
     apiJsonMock.mockRejectedValueOnce(new Error("The service is temporarily unavailable."));
 

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -27,6 +27,13 @@ type AgentGenerationView = {
   exampleCodeWarning: string | null;
 };
 
+const EMPTY_SYSTEM_PROMPT_MESSAGE =
+  "The generator returned an empty or missing system prompt. Try generating again.";
+
+function hasNonemptySystemPrompt(response: AgentGeneratorResponse): boolean {
+  return typeof response.system_prompt === "string" && response.system_prompt.trim().length > 0;
+}
+
 function toAgentGenerationView(
   response: AgentGeneratorResponse,
   multiAgent: boolean,
@@ -114,6 +121,10 @@ export default function AgentGenerator() {
           ...(repoContext && !repoContextDirty ? { repo_context: repoContext } : {}),
         }),
       });
+
+      if (!hasNonemptySystemPrompt(data)) {
+        throw new Error(EMPTY_SYSTEM_PROMPT_MESSAGE);
+      }
 
       const nextResult = toAgentGenerationView(data, multiAgent);
       setResult(nextResult);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validates agent generator API responses before rendering success panel. Rejects HTTP 200 with missing/empty `system_prompt` and shows error UI with retry.

**Tests:** 10 passed (agent-generator page tests)

Fixes #1009
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

