### PR TITLE
PR Safety page: malformed API response regression test

### DIFF
--- a/web/app/pr-safety/page.test.tsx
+++ b/web/app/pr-safety/page.test.tsx
@@ -247,4 +247,21 @@ describe("PR Safety page", () => {
 
     await waitFor(() => expect(showError).toHaveBeenCalledTimes(1));
   });
+
+  test("shows an error instead of crashing when the response is malformed", async () => {
+    apiJson.mockResolvedValueOnce({ unexpected: "shape" } as never);
+
+    render(<PrSafetyPage />);
+
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole("button", { name: /analyze pr/i }));
+
+    expect(await screen.findByText("PR Safety analysis failed")).toBeTruthy();
+    expect(
+      screen.getByText("PR Safety returned an unexpected response. Try again or check your PR details."),
+    ).toBeTruthy();
+    expect(screen.queryByText("Analyzing PR...")).toBeNull();
+    expect(screen.queryByTestId("pr-verdict")).toBeNull();
+    expect(showError).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -30,6 +30,71 @@ const DOT_CLASSES: Record<Tone, string> = {
   zinc: "bg-zinc-400",
 };
 
+const MALFORMED_RESPONSE_MESSAGE =
+  "PR Safety returned an unexpected response. Try again or check your PR details.";
+
+const VALID_VERDICTS = new Set<Verdict>(["merge", "hold", "split", "rebase"]);
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+// Validate the response against the existing PrSafetyReport/UI contract so a
+// malformed body becomes a clean error instead of silently skipping the report.
+function isValidPrSafetyReport(data: unknown): data is PrSafetyReport {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+  const report = data as Record<string, unknown>;
+  if (typeof report.verdict !== "string" || !VALID_VERDICTS.has(report.verdict as Verdict)) {
+    return false;
+  }
+  const changedFiles = report.changed_files;
+  if (!changedFiles || typeof changedFiles !== "object") {
+    return false;
+  }
+  const changed = changedFiles as Record<string, unknown>;
+  if (typeof changed.total !== "number" || !Number.isFinite(changed.total)) {
+    return false;
+  }
+  if (!Array.isArray(changed.groups)) {
+    return false;
+  }
+  const riskyAreas = report.risky_areas;
+  if (!riskyAreas || typeof riskyAreas !== "object" || typeof (riskyAreas as { status?: unknown }).status !== "string") {
+    return false;
+  }
+  if (!Array.isArray((riskyAreas as { hits?: unknown }).hits)) {
+    return false;
+  }
+  const testCoverage = report.test_coverage;
+  if (!testCoverage || typeof testCoverage !== "object" || typeof (testCoverage as { status?: unknown }).status !== "string") {
+    return false;
+  }
+  if (!Array.isArray((testCoverage as { gaps?: unknown }).gaps)) {
+    return false;
+  }
+  const branchFreshness = report.branch_freshness;
+  if (
+    !branchFreshness ||
+    typeof branchFreshness !== "object" ||
+    typeof (branchFreshness as { status?: unknown }).status !== "string" ||
+    !isStringArray((branchFreshness as { notes?: unknown }).notes)
+  ) {
+    return false;
+  }
+  const scopeMatch = report.scope_match;
+  if (
+    !scopeMatch ||
+    typeof scopeMatch !== "object" ||
+    typeof (scopeMatch as { status?: unknown }).status !== "string" ||
+    !isStringArray((scopeMatch as { notes?: unknown }).notes)
+  ) {
+    return false;
+  }
+  return isStringArray(report.recommendations);
+}
+
 const VERDICT_VIEW: Record<Verdict, { label: string; tone: Tone; hint: string }> = {
   merge: { label: "Merge", tone: "green", hint: "No blocking safety signals detected" },
   hold: { label: "Hold", tone: "amber", hint: "Address the flagged signals before merging" },
@@ -140,6 +205,9 @@ export default function PrSafetyPage() {
         headers: buildGeneratorApiHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(body),
       });
+      if (!isValidPrSafetyReport(data)) {
+        throw new Error(MALFORMED_RESPONSE_MESSAGE);
+      }
       setReport(data);
     } catch (e: unknown) {
       showError(e);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `isValidPrSafetyReport()` validator and regression test for malformed success shapes like `{ unexpected: "shape" }`.

**Tests:** 10 passed (pr-safety page tests)

Fixes #1008
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0297d5f-d534-4eea-bd96-372a089c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

