### PR TITLE
test: cover untested adapter/heuristic pure functions

### DIFF
--- a/tests/test_agent_ir_inference.py
+++ b/tests/test_agent_ir_inference.py
@@ -1,0 +1,78 @@
+from app.adapters.agent_ir import (
+    _infer_hook_suggestions,
+    _infer_mcp_servers,
+    _infer_ci_automation_intent,
+    _infer_memory_outline,
+)
+
+
+def test_infer_hook_suggestions_baseline_only():
+    suggestions = _infer_hook_suggestions("a simple backend service")
+    assert suggestions == [
+        "Block reads of .env and secrets before tool execution.",
+        "Run targeted tests or lint checks after code edits.",
+    ]
+
+
+def test_infer_hook_suggestions_frontend_keyword():
+    suggestions = _infer_hook_suggestions("react frontend dashboard")
+    assert "Run frontend lint/build hooks after editing TSX or CSS." in suggestions
+
+
+def test_infer_hook_suggestions_deploy_keyword():
+    suggestions = _infer_hook_suggestions("automate the ci deploy pipeline")
+    assert "Require human confirmation before git push or deploy commands." in suggestions
+
+
+def test_infer_hook_suggestions_both_keywords():
+    suggestions = _infer_hook_suggestions("react ui with ci release automation")
+    assert len(suggestions) == 4
+
+
+def test_infer_mcp_servers_matches_known_keywords():
+    assert _infer_mcp_servers("integrates with github and slack") == ["github", "slack"]
+
+
+def test_infer_mcp_servers_no_match():
+    assert _infer_mcp_servers("a plain text agent") == []
+
+
+def test_infer_mcp_servers_preserves_mapping_order():
+    assert _infer_mcp_servers("notion figma sentry jira") == ["figma", "notion", "jira", "sentry"]
+
+
+def test_infer_ci_automation_intent_review():
+    assert _infer_ci_automation_intent("review every pull request") == ["review"]
+
+
+def test_infer_ci_automation_intent_all_categories():
+    text = "review pr, implement feature, autofix flaky bug"
+    assert _infer_ci_automation_intent(text) == ["review", "implementation", "autofix"]
+
+
+def test_infer_ci_automation_intent_no_match():
+    assert _infer_ci_automation_intent("a passive summary tool") == []
+
+
+def test_infer_memory_outline_minimal():
+    outline = _infer_memory_outline(name="Agent", role="", goals=[], constraints=[])
+    assert outline == ["Agent name: Agent"]
+
+
+def test_infer_memory_outline_truncates_goals_and_constraints_to_three():
+    outline = _infer_memory_outline(
+        name="Agent",
+        role="Reviewer",
+        goals=["g1", "g2", "g3", "g4"],
+        constraints=["c1", "c2", "c3", "c4"],
+    )
+    assert outline == [
+        "Agent name: Agent",
+        "Primary role: Reviewer",
+        "Goal: g1",
+        "Goal: g2",
+        "Goal: g3",
+        "Constraint: c1",
+        "Constraint: c2",
+        "Constraint: c3",
+    ]

--- a/tests/test_claude_code_mcp_and_workflow_helpers.py
+++ b/tests/test_claude_code_mcp_and_workflow_helpers.py
@@ -1,0 +1,30 @@
+import json
+
+from app.adapters.claude_code import _mcp_client_config, _workflow_scalar
+
+
+def test_mcp_client_config_shape():
+    config = json.loads(_mcp_client_config("my_tool"))
+    assert config == {
+        "mcpServers": {
+            "my_tool": {"command": "python", "args": ["server.py"]},
+        }
+    }
+
+
+def test_mcp_client_config_uses_given_tool_name_as_key():
+    config = json.loads(_mcp_client_config("weather_lookup"))
+    assert "weather_lookup" in config["mcpServers"]
+    assert "my_tool" not in config["mcpServers"]
+
+
+def test_workflow_scalar_collapses_whitespace():
+    assert _workflow_scalar("line one\n  line two\ttabbed") == "line one line two tabbed"
+
+
+def test_workflow_scalar_escapes_github_actions_expression_syntax():
+    assert _workflow_scalar("Use ${{ secrets.TOKEN }}") == "Use $ {{ secrets.TOKEN }}"
+
+
+def test_workflow_scalar_empty_string():
+    assert _workflow_scalar("") == ""

--- a/tests/test_compiler_plugin_metadata.py
+++ b/tests/test_compiler_plugin_metadata.py
@@ -1,0 +1,30 @@
+from app.compiler import _ensure_plugin_metadata
+
+
+def test_ensure_plugin_metadata_creates_default_when_missing():
+    md = {}
+    entry = _ensure_plugin_metadata(md)
+    assert entry == {"applied": [], "errors": []}
+    assert md["plugins"] is entry
+
+
+def test_ensure_plugin_metadata_creates_default_when_not_a_dict():
+    md = {"plugins": "not-a-dict"}
+    entry = _ensure_plugin_metadata(md)
+    assert entry == {"applied": [], "errors": []}
+    assert md["plugins"] is entry
+
+
+def test_ensure_plugin_metadata_fills_missing_keys_on_existing_dict():
+    existing = {"applied": ["safety"]}
+    md = {"plugins": existing}
+    entry = _ensure_plugin_metadata(md)
+    assert entry is existing
+    assert entry == {"applied": ["safety"], "errors": []}
+
+
+def test_ensure_plugin_metadata_preserves_existing_values():
+    existing = {"applied": ["safety"], "errors": ["boom"]}
+    md = {"plugins": existing}
+    entry = _ensure_plugin_metadata(md)
+    assert entry == {"applied": ["safety"], "errors": ["boom"]}

--- a/tests/test_emitters_domain_suggestions.py
+++ b/tests/test_emitters_domain_suggestions.py
@@ -1,0 +1,50 @@
+from app.emitters import _domain_suggestions_v2
+from app.models_v2 import IRv2
+
+
+def _ir_with_suggestions(raw):
+    return IRv2(metadata={"domain_suggestions": raw})
+
+
+def test_domain_suggestions_v2_empty_metadata_returns_empty():
+    assert _domain_suggestions_v2(IRv2()) == []
+
+
+def test_domain_suggestions_v2_non_list_metadata_returns_empty():
+    ir = IRv2(metadata={"domain_suggestions": "not-a-list"})
+    assert _domain_suggestions_v2(ir) == []
+
+
+def test_domain_suggestions_v2_sorts_by_priority_descending():
+    ir = _ir_with_suggestions(
+        [
+            {"text": "low priority item", "priority": 1},
+            {"text": "high priority item", "priority": 5},
+            {"text": "mid priority item", "priority": 3},
+        ]
+    )
+    assert _domain_suggestions_v2(ir) == [
+        "high priority item",
+        "mid priority item",
+        "low priority item",
+    ]
+
+
+def test_domain_suggestions_v2_dedupes_case_insensitively():
+    ir = _ir_with_suggestions(
+        [
+            {"text": "Add tests", "priority": 1},
+            {"text": "add tests", "priority": 2},
+        ]
+    )
+    assert len(_domain_suggestions_v2(ir)) == 1
+
+
+def test_domain_suggestions_v2_respects_limit():
+    ir = _ir_with_suggestions([{"text": f"item {i}", "priority": i} for i in range(5)])
+    assert len(_domain_suggestions_v2(ir, limit=2)) == 2
+
+
+def test_domain_suggestions_v2_skips_non_dict_entries_and_missing_priority():
+    ir = _ir_with_suggestions(["not-a-dict", {"text": "valid entry"}])
+    assert _domain_suggestions_v2(ir) == ["valid entry"]

--- a/tests/test_langchain_yaml_export.py
+++ b/tests/test_langchain_yaml_export.py
@@ -1,0 +1,34 @@
+import yaml
+
+from app.adapters.agent_ir import AgentExportIR
+from app.adapters.langchain import to_langchain_yaml
+
+
+def test_to_langchain_yaml_contains_expected_keys():
+    ir = AgentExportIR(name="Agent", model="claude-opus-4-6", raw_system_prompt="You are helpful.")
+    output = to_langchain_yaml(ir)
+    parsed = yaml.safe_load(output)
+    assert parsed == {
+        "model": "claude-opus-4-6",
+        "system_prompt": "You are helpful.",
+        "input_variables": ["input"],
+        "template": "{input}",
+    }
+
+
+def test_to_langchain_yaml_preserves_unicode_and_multiline_prompt():
+    ir = AgentExportIR(
+        name="Agent",
+        model="claude-opus-4-6",
+        raw_system_prompt="Çözüm üret.\nBirden fazla satır.",
+    )
+    output = to_langchain_yaml(ir)
+    assert "\\u" not in output
+    parsed = yaml.safe_load(output)
+    assert parsed["system_prompt"] == "Çözüm üret.\nBirden fazla satır."
+
+
+def test_to_langchain_yaml_is_valid_yaml_roundtrip():
+    ir = AgentExportIR(name="Agent", model="m", raw_system_prompt="")
+    output = to_langchain_yaml(ir)
+    assert yaml.safe_load(output)["system_prompt"] == ""

--- a/tests/test_skill_adapter_python_literal.py
+++ b/tests/test_skill_adapter_python_literal.py
@@ -1,0 +1,33 @@
+from app.adapters.skill_adapter import _python_literal_for
+
+
+def test_python_literal_for_int():
+    assert _python_literal_for("42", "int") == "42"
+
+
+def test_python_literal_for_float():
+    assert _python_literal_for("3.14", "float") == "3.14"
+
+
+def test_python_literal_for_bool_true_variants():
+    assert _python_literal_for("true", "bool") == "True"
+    assert _python_literal_for("yes", "bool") == "True"
+    assert _python_literal_for("1", "bool") == "True"
+
+
+def test_python_literal_for_bool_false():
+    assert _python_literal_for("false", "bool") == "False"
+
+
+def test_python_literal_for_string_is_json_quoted():
+    assert _python_literal_for("hello", "str") == '"hello"'
+
+
+def test_python_literal_for_string_with_special_characters_is_escaped():
+    result = _python_literal_for('has "quotes" and\nnewline', "str")
+    assert result == '"has \\"quotes\\" and\\nnewline"'
+
+
+def test_python_literal_for_non_numeric_int_falls_back_to_string():
+    result = _python_literal_for("not-a-number", "int")
+    assert result == '"not-a-number"'


### PR DESCRIPTION
## Summary
Test-coverage audit found several pure, network-free helper functions in the export adapters and compiler modules with zero existing test coverage. This PR adds unit tests only — no production code, config, or CI was touched.

Covered in this PR:
- `app/adapters/agent_ir.py`: `_infer_hook_suggestions`, `_infer_mcp_servers`, `_infer_ci_automation_intent`, `_infer_memory_outline`
- `app/adapters/langchain.py`: `to_langchain_yaml` (the whole LangChain YAML export path had no test at all)
- `app/adapters/claude_code.py`: `_mcp_client_config`, `_workflow_scalar`
- `app/adapters/skill_adapter.py`: `_python_literal_for`
- `app/compiler.py`: `_ensure_plugin_metadata`
- `app/emitters.py`: `_domain_suggestions_v2`

## Test plan
- [x] `python -m pytest tests/test_agent_ir_inference.py tests/test_langchain_yaml_export.py tests/test_claude_code_mcp_and_workflow_helpers.py tests/test_skill_adapter_python_literal.py tests/test_compiler_plugin_metadata.py tests/test_emitters_domain_suggestions.py -q` — 37 passed
- [x] Full suite `python -m pytest tests/ -q` — 2083 passed, 7 pre-existing skips (unchanged), no regressions

🤖 Generated with automated test-coverage audit tooling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqtRp72iE829msuiHFZQxe)_