### PR TITLE
fix(tests): set USERPROFILE so cli-optimize history tests pass on Windows

### DIFF
--- a/tests/test_cli_optimize.py
+++ b/tests/test_cli_optimize.py
@@ -16,6 +16,9 @@ def _home_env(tmp_path: Path) -> dict[str, str]:
         existing = env.get("PYTHONPATH", "")
         env["PYTHONPATH"] = f"{user_site}{os.pathsep}{existing}" if existing else user_site
     env["HOME"] = str(tmp_path)
+    # Windows: Path.home() resolves via USERPROFILE (not HOME), so history
+    # written under tmp_path/.promptc is only found if USERPROFILE points here too.
+    env["USERPROFILE"] = str(tmp_path)
     env["PYTHONIOENCODING"] = "utf-8"
     return env
 


### PR DESCRIPTION
## Problem
After #1049 merged, `main` went red on the **windows-latest** Full Test matrix (3.10/3.11/3.12):
```
FAILED tests/test_cli_optimize.py::test_optimize_resume_with_mock_provider - Run not found: cli-opt-run-1
FAILED tests/test_cli_optimize.py::test_optimize_history_list_with_mock_provider - assert 'Optimization History' in 'No history found.'
FAILED tests/test_cli_optimize.py::test_optimize_history_show_with_mock_provider - Run not found: cli-opt-run-1
```
The PR-level CI only runs ubuntu, so the windows-only break surfaced only post-merge.

## Root cause
The tests seed run history under `tmp_path/.promptc` and set `HOME=tmp_path`. But `HistoryManager()` defaults to `Path.home()/.promptc`, and on **Windows `Path.home()` resolves via `USERPROFILE`, not `HOME`** — so the CLI read history from the real profile and found nothing.

## Fix
Also set `USERPROFILE=tmp_path` in the test's `_home_env` helper. Test-only, no production change; preserves the #1038 coverage.

## Verification
Local macOS run: `4 passed`. Windows behavior is deterministic per Python's `os.path.expanduser` precedence (USERPROFILE first on nt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)