### PR TITLE
fix(benchmark): handle clipboard write failures

### DIFF
--- a/web/app/components/BenchmarkResults.test.tsx
+++ b/web/app/components/BenchmarkResults.test.tsx
@@ -1,0 +1,91 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import BenchmarkResults, { type BenchmarkData } from "./BenchmarkResults";
+
+const CHECKMARK_SELECTOR = "polyline[points='20 6 9 17 4 12']";
+
+const benchmarkData: BenchmarkData = {
+  raw_output: "Raw benchmark output",
+  compiled_output: "Compiled benchmark output",
+  compiled_prompt: "Compiled prompt",
+  winner: "compiled",
+  improvement_score: 20,
+  metrics: {
+    raw_relevance: 6.5,
+    compiled_relevance: 8.5,
+    raw_clarity: 6.0,
+    compiled_clarity: 8.0,
+  },
+  processing_ms: 120,
+};
+
+function deferredWrite() {
+  let resolve: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve: () => resolve() };
+}
+
+describe("BenchmarkResults", () => {
+  beforeEach(() => {
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+  });
+
+  it("shows the report copied state only after the clipboard write succeeds", async () => {
+    const write = deferredWrite();
+    const writeText = vi.fn().mockReturnValue(write.promise);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<BenchmarkResults data={benchmarkData} />);
+
+    const button = screen.getByRole("button", { name: "Copy report" });
+    fireEvent.click(button);
+
+    expect(button).toHaveTextContent("Copy report");
+    expect(toast.success).not.toHaveBeenCalled();
+
+    await act(async () => {
+      write.resolve();
+      await write.promise;
+    });
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("# Benchmark Report"));
+    expect(toast.success).toHaveBeenCalledWith("Copied report as Markdown");
+    expect(button).toHaveTextContent("Copied!");
+  });
+
+  it.each([
+    ["raw output", "Copy raw output"],
+    ["compiled output", "Copy compiled output"],
+  ])("does not show a copied state when writing the %s is rejected", async (_label, buttonName) => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+
+    render(<BenchmarkResults data={benchmarkData} />);
+
+    const button = screen.getByRole("button", { name: buttonName });
+    fireEvent.click(button);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Copy failed — select the text manually");
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeNull();
+  });
+});

--- a/web/app/components/BenchmarkResults.tsx
+++ b/web/app/components/BenchmarkResults.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { toast } from "sonner";
-
 import { useState, memo } from "react";
 
 import { benchmarkReportToMarkdown } from "./benchmarkMarkdown";
+import { copyToClipboard } from "../lib/copyToClipboard";
 
 export type BenchmarkData = {
     raw_output: string;
@@ -36,11 +35,33 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
     const isCompiledWinner = data.winner === "compiled";
     const isTie = data.winner === "tie";
 
-    const copyReport = () => {
-        navigator.clipboard.writeText(benchmarkReportToMarkdown(data));
-        toast.success("Copied report as Markdown");
-        setCopiedReport(true);
-        setTimeout(() => setCopiedReport(false), 2000);
+    const copyReport = async () => {
+        const copied = await copyToClipboard(benchmarkReportToMarkdown(data), {
+            successMessage: "Copied report as Markdown",
+        });
+
+        if (copied) {
+            setCopiedReport(true);
+            setTimeout(() => setCopiedReport(false), 2000);
+        }
+    };
+
+    const copyRaw = async () => {
+        const copied = await copyToClipboard(data.raw_output);
+
+        if (copied) {
+            setCopiedRaw(true);
+            setTimeout(() => setCopiedRaw(false), 2000);
+        }
+    };
+
+    const copyCompiled = async () => {
+        const copied = await copyToClipboard(data.compiled_output);
+
+        if (copied) {
+            setCopiedCompiled(true);
+            setTimeout(() => setCopiedCompiled(false), 2000);
+        }
     };
 
     const downloadReport = () => {
@@ -172,12 +193,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
                         </div>
                         <button
                             type="button"
-                            onClick={() => {
-                                navigator.clipboard.writeText(data.raw_output);
-                                toast.success("Copied to clipboard");
-                                setCopiedRaw(true);
-                                setTimeout(() => setCopiedRaw(false), 2000);
-                            }}
+                            onClick={copyRaw}
                             className="text-zinc-600 hover:text-zinc-400 transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             title="Copy raw output"
                             aria-label="Copy raw output"
@@ -204,12 +220,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
                         </div>
                         <button
                             type="button"
-                            onClick={() => {
-                                navigator.clipboard.writeText(data.compiled_output);
-                                toast.success("Copied to clipboard");
-                                setCopiedCompiled(true);
-                                setTimeout(() => setCopiedCompiled(false), 2000);
-                            }}
+                            onClick={copyCompiled}
                             className="text-zinc-600 hover:text-zinc-400 transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             title="Copy compiled output"
                             aria-label="Copy compiled output"


### PR DESCRIPTION
Fixes #1065

## Summary
- route benchmark report, raw output, and compiled output copy actions through the shared clipboard helper
- show copied UI state only after clipboard writes succeed
- cover deferred success and rejected clipboard writes for benchmark interactions

## Tests
- `cd web && npm run test -- app/components/BenchmarkResults.test.tsx app/lib/copyToClipboard.test.ts`
- `cd web && npm run lint` (passes with two pre-existing warnings)
- `cd web && npm run build`