### PR TITLE
Fix Python skill identifiers in generated adapters

### DIFF
--- a/app/adapters/claude_code.py
+++ b/app/adapters/claude_code.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import keyword
 import re
 import shlex
 import textwrap
@@ -14,6 +15,19 @@ from .skill_ir import SkillExportIR
 def _slugify(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return slug or "agent"
+
+
+def _to_python_identifier(value: str) -> str:
+    """Convert a skill name to a safe Python identifier."""
+    identifier = re.sub(r"[^a-zA-Z0-9_]+", "_", value).strip("_").lower()
+    identifier = re.sub(r"_+", "_", identifier)
+    if not identifier:
+        return "skill"
+    if identifier[0].isdigit():
+        identifier = f"skill_{identifier}"
+    if keyword.iskeyword(identifier):
+        identifier = f"{identifier}_skill"
+    return identifier
 
 
 def _escape_triple_quotes(text: str) -> str:
@@ -172,6 +186,10 @@ def to_claude_pr_reviewer_pack(ir: AgentExportIR) -> list[dict[str, str]]:
 
 def to_claude_mcp_tool_stub(ir: SkillExportIR) -> list[dict[str, str]]:
     tool_name = ir.name
+    python_name = _to_python_identifier(tool_name)
+    tool_decorator = "@mcp.tool()"
+    if python_name != tool_name:
+        tool_decorator = f"@mcp.tool(name={json.dumps(tool_name)})"
     param_signature = ", ".join(
         f"{param.name}: {param.type if param.type != 'Any' else 'str'}"
         + ("" if param.required else " | None = None")
@@ -184,8 +202,8 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("{tool_name}")
 
 
-@mcp.tool()
-async def {tool_name}({param_signature}) -> str:
+{tool_decorator}
+async def {python_name}({param_signature}) -> str:
     \"\"\"{ir.purpose or f"Execute {tool_name}."}\"\"\"
     raise NotImplementedError("TODO: implement {tool_name}")
 

--- a/app/adapters/skill_adapter.py
+++ b/app/adapters/skill_adapter.py
@@ -10,6 +10,7 @@ Supported targets:
 from __future__ import annotations
 
 import json
+import keyword
 import re
 
 from .skill_ir import SkillExample, SkillExportIR, SkillParam
@@ -30,6 +31,19 @@ def _to_kebab(snake: str) -> str:
 
 def _to_title(snake: str) -> str:
     return " ".join(_capitalize_words(snake))
+
+
+def _to_python_identifier(value: str) -> str:
+    """Convert a skill name to a safe Python identifier."""
+    identifier = re.sub(r"[^a-zA-Z0-9_]+", "_", value).strip("_").lower()
+    identifier = re.sub(r"_+", "_", identifier)
+    if not identifier:
+        return "skill"
+    if identifier[0].isdigit():
+        identifier = f"skill_{identifier}"
+    if keyword.iskeyword(identifier):
+        identifier = f"{identifier}_skill"
+    return identifier
 
 
 def _example_value_for(param: SkillParam, examples: list[SkillExample]) -> str | None:
@@ -233,8 +247,8 @@ def _build_docstring(ir: SkillExportIR) -> str:
 
 def to_langchain_tool(ir: SkillExportIR) -> str:
     """Return a LangChain @tool Python definition for this skill."""
-    pascal_name = _to_pascal(ir.name)
-    func_name = ir.name
+    func_name = _to_python_identifier(ir.name)
+    pascal_name = _to_pascal(func_name)
 
     if ir.params:
         example_map = _resolve_example_map(ir.params, ir.examples)
@@ -247,7 +261,12 @@ def to_langchain_tool(ir: SkillExportIR) -> str:
         schema_arg = ""
         sig_params = ""
 
-    decorator = f"@tool({schema_arg})" if schema_arg else "@tool"
+    if func_name == ir.name:
+        decorator = f"@tool({schema_arg})" if schema_arg else "@tool"
+    elif schema_arg:
+        decorator = f"@tool({json.dumps(ir.name)}, {schema_arg})"
+    else:
+        decorator = f"@tool({json.dumps(ir.name)})"
 
     parts = [
         "from langchain.tools import tool",

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -4,6 +4,7 @@ tests/test_export_adapters.py — Tests for the Export Adapter layer.
 Covers IR extraction, code generation, and API endpoints for both
 agent and skill exports.
 """
+
 from __future__ import annotations
 
 import json
@@ -26,7 +27,7 @@ from app.adapters.claude_sdk import to_python, to_yaml
 from app.adapters.langchain import to_langchain_python, to_langgraph_python
 from app.adapters.mcp_servers import render_mcp_json
 from app.adapters.skill_adapter import to_agent_skill, to_claude_tool_use, to_langchain_tool
-from app.adapters.skill_ir import SkillExportIR, parse_skill_markdown
+from app.adapters.skill_ir import SkillExportIR, SkillParam, parse_skill_markdown
 
 
 # ---------------------------------------------------------------------------
@@ -399,6 +400,75 @@ def test_claude_mcp_tool_stub_includes_client_config():
     assert "Claude Code" in readme_file["content"]
     assert "Claude Desktop" in readme_file["content"]
     assert ".mcp.json" in readme_file["content"]
+
+
+@pytest.mark.parametrize(
+    ("skill_name", "python_name"),
+    [("web-search", "web_search"), ("web search", "web_search")],
+)
+def test_generated_python_normalizes_non_identifier_skill_names(skill_name, python_name):
+    ir = SkillExportIR(name=skill_name, purpose="Search the web.")
+
+    mcp_server = next(
+        item["content"] for item in to_claude_mcp_tool_stub(ir) if item["path"] == "server.py"
+    )
+    langchain_tool = to_langchain_tool(ir)
+
+    compile(mcp_server, "<mcp_tool_stub>", "exec")
+    compile(langchain_tool, "<langchain_tool>", "exec")
+    assert f'FastMCP("{skill_name}")' in mcp_server
+    assert f'@mcp.tool(name="{skill_name}")' in mcp_server
+    assert f"async def {python_name}() -> str:" in mcp_server
+    assert f'@tool("{skill_name}")' in langchain_tool
+    assert f"def {python_name}() -> str:" in langchain_tool
+
+
+@pytest.mark.parametrize("skill_name", ["web-search", "web search"])
+def test_langchain_tool_normalizes_input_model_name_for_non_identifier_skill_names(skill_name):
+    ir = SkillExportIR(
+        name=skill_name,
+        purpose="Search the web.",
+        params=[SkillParam(name="query", type="str", description="Search query")],
+    )
+
+    langchain_tool = to_langchain_tool(ir)
+
+    assert "class WebSearchInput(BaseModel):" in langchain_tool
+    assert f'@tool("{skill_name}", args_schema=WebSearchInput)' in langchain_tool
+    compile(langchain_tool, "<langchain_tool_with_input_model>", "exec")
+
+
+@pytest.mark.parametrize(
+    ("skill_name", "python_name", "input_model_name"),
+    [
+        ("123-search", "skill_123_search", "Skill123SearchInput"),
+        ("class", "class_skill", "ClassSkillInput"),
+        ("async", "async_skill", "AsyncSkillInput"),
+        ("!!!", "skill", "SkillInput"),
+    ],
+)
+def test_generated_python_normalizes_numeric_keyword_and_punctuation_skill_names(
+    skill_name, python_name, input_model_name
+):
+    ir = SkillExportIR(
+        name=skill_name,
+        purpose="Search the web.",
+        params=[SkillParam(name="query", type="str", description="Search query")],
+    )
+
+    mcp_server = next(
+        item["content"] for item in to_claude_mcp_tool_stub(ir) if item["path"] == "server.py"
+    )
+    langchain_tool = to_langchain_tool(ir)
+
+    compile(mcp_server, "<mcp_tool_stub>", "exec")
+    compile(langchain_tool, "<langchain_tool>", "exec")
+    assert f'FastMCP("{skill_name}")' in mcp_server
+    assert f'@mcp.tool(name="{skill_name}")' in mcp_server
+    assert f"async def {python_name}(query: str) -> str:" in mcp_server
+    assert f"class {input_model_name}(BaseModel):" in langchain_tool
+    assert f'@tool("{skill_name}", args_schema={input_model_name})' in langchain_tool
+    assert f"def {python_name}(query: str) -> str:" in langchain_tool
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1066

## Summary
- normalize generated Python function and input-model identifiers for hyphenated and spaced skill names
- preserve the original human-facing tool name in MCP and LangChain exports
- add syntax-compilation regressions for hyphenated and spaced names

## Tests
- `/Users/mehmetozel/Developer/personal/Compiler/.venv/bin/python -m pytest tests/test_export_adapters.py tests/test_skill_adapter.py -q`
- `/Users/mehmetozel/Developer/personal/Compiler/.venv/bin/ruff check app/adapters/claude_code.py app/adapters/skill_adapter.py tests/test_export_adapters.py`
- `/Users/mehmetozel/Developer/personal/Compiler/.venv/bin/ruff format --check app/adapters/claude_code.py app/adapters/skill_adapter.py tests/test_export_adapters.py`