### PR TITLE
🎨 Palette: Add right padding to textareas with Clear buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Padding for absolutely positioned buttons
+**Learning:** When adding conditionally rendered, absolutely positioned buttons (like 'Clear') over textareas or inputs, failing to add right padding to the underlying input will cause user text to flow underneath and be obscured by the button.
+**Action:** Always add sufficient right padding (e.g., `pr-14`) to textareas/inputs that contain absolutely positioned overlay elements to ensure the content remains readable.

--- a/web/app/agent-generator/page.tsx
+++ b/web/app/agent-generator/page.tsx
@@ -288,7 +288,7 @@ export default function AgentGenerator() {
                 id="agent-description"
                 aria-labelledby="agent-description-label"
                 aria-describedby="agent-description-help"
-                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-[220px]"
+                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 pr-14 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-green-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'I need an agent that reviews React code for performance bottlenecks' or 'A creative writer for sci-fi stories'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}

--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -306,7 +306,7 @@ export default function AgentPacksPage() {
                 aria-label="Agent Pack Goal"
                 value={request.goal}
                 onChange={(event) => handleFieldChange("goal", event.target.value)}
-                className="min-h-36 rounded-2xl border border-white/10 bg-black/20 p-4 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
+                className="min-h-36 rounded-2xl border border-white/10 bg-black/20 p-4 pr-14 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
                 placeholder="e.g. Review PRs for prompt leakage, unsafe settings, and missing regression tests."
               />
 

--- a/web/app/benchmark/page.tsx
+++ b/web/app/benchmark/page.tsx
@@ -355,7 +355,7 @@ export default function BenchmarkPage() {
                 id="benchmark-prompt"
                 aria-labelledby="benchmark-prompt-label"
                 aria-describedby="benchmark-prompt-help"
-                className="h-full min-h-[160px] w-full resize-none rounded-xl border border-white/10 bg-black/30 p-4 font-mono text-sm leading-relaxed text-zinc-300 shadow-inner transition-all placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
+                className="h-full min-h-[160px] w-full resize-none rounded-xl border border-white/10 bg-black/30 p-4 pr-14 font-mono text-sm leading-relaxed text-zinc-300 shadow-inner transition-all placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-amber-500/50"
                 placeholder={"Enter a prompt to benchmark...\n\ne.g. 'Write a Python script to scrape data'"}
                 value={prompt}
                 onChange={(event) => {

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -417,7 +417,7 @@ export default function OptimizerPage() {
                                 }
                             }}
                             placeholder="Paste a verbose prompt here..."
-                            className="h-full min-h-72 w-full resize-none bg-transparent font-mono text-sm leading-relaxed text-zinc-200 outline-none placeholder:text-zinc-500"
+                            className="h-full min-h-72 w-full resize-none bg-transparent pr-14 font-mono text-sm leading-relaxed text-zinc-200 outline-none placeholder:text-zinc-500"
                         />
                         {input && (
                             <button

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -373,7 +373,7 @@ export default function Home() {
                   id="prompt-input"
                   aria-labelledby="prompt-input-label"
                   aria-describedby="prompt-input-help"
-                  className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 sm:min-h-44 md:min-h-0"
+                  className="min-h-36 w-full flex-1 resize-none rounded-2xl border border-white/10 bg-black/20 p-5 pr-14 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500/50 sm:min-h-44 md:min-h-0"
                   placeholder="Paste a vague task, bug report, spec, or workflow request... e.g. 'Turn this GitHub issue into a safe implementation brief'"
                   value={prompt}
                   onChange={(e) => { stopTypewriter(); setPrompt(e.target.value); }}

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -295,7 +295,7 @@ export default function PrSafetyPage() {
                 id="pr-description"
                 aria-labelledby="pr-description-label"
                 aria-describedby="pr-description-help"
-                className="min-h-20 w-full resize-none rounded-xl border border-white/10 bg-black/20 p-3 text-sm leading-relaxed text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-rose-500/50"
+                className="min-h-20 w-full resize-none rounded-xl border border-white/10 bg-black/20 p-3 pr-14 text-sm leading-relaxed text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-rose-500/50"
                 placeholder="What does this PR do? Paste the PR body here."
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -324,7 +324,7 @@ export default function PrSafetyPage() {
                 id="pr-changed-files"
                 aria-labelledby="pr-changed-files-label"
                 aria-describedby="pr-changed-files-help"
-                className="min-h-32 w-full resize-none rounded-xl border border-white/10 bg-black/20 p-3 font-mono text-xs leading-relaxed text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-rose-500/50"
+                className="min-h-32 w-full resize-none rounded-xl border border-white/10 bg-black/20 p-3 pr-14 font-mono text-xs leading-relaxed text-zinc-200 transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-rose-500/50"
                 placeholder={"app/auth/login.py\napi/routes/auth.py\ntests/test_auth.py"}
                 value={changedFilesText}
                 onChange={(e) => setChangedFilesText(e.target.value)}

--- a/web/app/skills-generator/page.tsx
+++ b/web/app/skills-generator/page.tsx
@@ -271,7 +271,7 @@ export default function SkillsGenerator() {
                 id="skill-description"
                 aria-labelledby="skill-description-label"
                 aria-describedby="skill-description-help"
-                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-[220px]"
+                className="min-h-36 w-full resize-none rounded-2xl border border-white/10 bg-black/20 p-5 pr-14 font-mono text-sm leading-relaxed text-zinc-200 shadow-inner transition-all placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-yellow-500/50 sm:min-h-44 md:min-h-[220px]"
                 placeholder="e.g., 'A skill that parses JSON and validates schemas' or 'Fetch and summarize web pages'"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}


### PR DESCRIPTION
💡 What: Added `pr-14` (right padding) to `textarea` elements that contain absolutely positioned "Clear" buttons.
🎯 Why: Prevents long lines of text from overflowing and becoming obscured beneath the "Clear" button, ensuring the entire input is always readable.
📸 Before/After: Visual verification attached in PR artifacts.
♿ Accessibility: Ensures text content remains visible and legible without the user having to blindly arrow-key through hidden text.

---
*PR created automatically by Jules for task [4531933046386820984](https://jules.google.com/task/4531933046386820984) started by @madara88645*