### PR TITLE
test: add coverage for domain_expert secret scanner and psycholinguist thresholds

### DIFF
--- a/tests/heuristics/test_domain_expert_pure_helpers.py
+++ b/tests/heuristics/test_domain_expert_pure_helpers.py
@@ -1,0 +1,180 @@
+"""Direct unit tests for DomainHandler's pure, regex/AST-based helpers.
+
+These helpers (`_scan_for_secrets`, `_analyze_python_ast`) were previously only
+exercised indirectly through full-pipeline `compile_text()` calls, which never
+asserted on their specific branch/edge-case behavior. `_scan_for_secrets` in
+particular is a security-relevant hardcoded-secret detector and had zero
+coverage of any kind before this file.
+"""
+
+import re
+
+from app.heuristics.handlers.domain_expert import DomainAnalysis, DomainHandler
+
+
+def _new_analysis():
+    return DomainAnalysis(detected_domain="coding")
+
+
+# -----------------------------------------------------------------------------
+# _scan_for_secrets
+# -----------------------------------------------------------------------------
+
+
+def test_scan_for_secrets_no_match_leaves_analysis_untouched():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._scan_for_secrets("just a normal prompt about writing a function", analysis)
+
+    assert analysis.suggestions == []
+    assert analysis.diagnostics == []
+
+
+def test_scan_for_secrets_detects_generic_api_key_assignment():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._scan_for_secrets('api_key = "sk_test_1234567890abcdefghij"', analysis)
+
+    assert len(analysis.suggestions) == 1
+    assert analysis.suggestions[0].category == "security"
+    assert analysis.suggestions[0].priority == 90
+    assert len(analysis.diagnostics) == 1
+    assert analysis.diagnostics[0].severity == "warning"
+    assert analysis.diagnostics[0].category == "security"
+
+
+def test_scan_for_secrets_detects_openai_style_key():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+    fake_key = "sk-" + "a" * 48
+
+    handler._scan_for_secrets(f"use this key: {fake_key}", analysis)
+
+    assert len(analysis.suggestions) == 1
+
+
+def test_scan_for_secrets_detects_github_token():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+    fake_token = "ghp_" + "a" * 36
+
+    handler._scan_for_secrets(f"token={fake_token}", analysis)
+
+    assert len(analysis.suggestions) == 1
+
+
+def test_scan_for_secrets_detects_credentials_in_url():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._scan_for_secrets(
+        "connect to https://admin:password123@internal.example.com/db", analysis
+    )
+
+    assert len(analysis.suggestions) == 1
+
+
+def test_scan_for_secrets_short_value_does_not_match_generic_pattern():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    # Fewer than 20 chars after the assignment must not trigger the generic pattern.
+    handler._scan_for_secrets('api_key = "short"', analysis)
+
+    assert analysis.suggestions == []
+    assert analysis.diagnostics == []
+
+
+def test_scan_for_secrets_respects_additional_patterns():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+    custom_pattern = re.compile(r"CUSTOM-SECRET-\d+")
+
+    handler._scan_for_secrets(
+        "value is CUSTOM-SECRET-42", analysis, additional_patterns=[custom_pattern]
+    )
+
+    assert len(analysis.suggestions) == 1
+
+
+# -----------------------------------------------------------------------------
+# _analyze_python_ast
+# -----------------------------------------------------------------------------
+
+
+def test_analyze_python_ast_flags_missing_return_and_arg_hints():
+    handler = DomainHandler()
+    text = """```python
+def add(a, b):
+    return a + b
+```"""
+
+    suggestions, diagnostics = handler._analyze_python_ast(text)
+
+    messages = [d.message for d in diagnostics]
+    assert any("add" in m and "return type hint" in m for m in messages)
+    assert any("'a'" in m and "missing type hint" in m for m in messages)
+    assert any("'b'" in m and "missing type hint" in m for m in messages)
+    assert suggestions == []
+
+
+def test_analyze_python_ast_skips_init_return_hint_and_self():
+    handler = DomainHandler()
+    text = """```python
+class Foo:
+    def __init__(self, value):
+        self.value = value
+```"""
+
+    suggestions, diagnostics = handler._analyze_python_ast(text)
+
+    messages = [d.message for d in diagnostics]
+    assert not any("__init__" in m and "return type hint" in m for m in messages)
+    assert not any("'self'" in m for m in messages)
+    assert any("'value'" in m for m in messages)
+
+
+def test_analyze_python_ast_fully_typed_function_has_no_diagnostics():
+    handler = DomainHandler()
+    text = """```python
+def add(a: int, b: int) -> int:
+    return a + b
+```"""
+
+    suggestions, diagnostics = handler._analyze_python_ast(text)
+
+    assert diagnostics == []
+
+
+def test_analyze_python_ast_falls_back_to_bare_code_without_fence():
+    handler = DomainHandler()
+    text = "def greet(name):\n    return f'hi {name}'"
+
+    suggestions, diagnostics = handler._analyze_python_ast(text)
+
+    messages = [d.message for d in diagnostics]
+    assert any("greet" in m for m in messages)
+
+
+def test_analyze_python_ast_ignores_plain_prose_without_code_markers():
+    handler = DomainHandler()
+    text = "Please help me plan a birthday party for my friend."
+
+    suggestions, diagnostics = handler._analyze_python_ast(text)
+
+    assert suggestions == []
+    assert diagnostics == []
+
+
+def test_analyze_python_ast_swallows_syntax_errors_gracefully():
+    handler = DomainHandler()
+    text = """```python
+def broken(:
+```"""
+
+    suggestions, diagnostics = handler._analyze_python_ast(text)
+
+    assert suggestions == []
+    assert diagnostics == []

--- a/tests/heuristics/test_psycholinguist_cognitive_load_ambiguity.py
+++ b/tests/heuristics/test_psycholinguist_cognitive_load_ambiguity.py
@@ -99,9 +99,7 @@ def test_cognitive_load_empty_text_defaults_to_single_sentence_zero_density():
 
 
 def test_detect_ambiguity_no_vague_terms():
-    result = detect_ambiguity(
-        "Write a Python function that reverses a string using recursion."
-    )
+    result = detect_ambiguity("Write a Python function that reverses a string using recursion.")
 
     assert result.is_ambiguous is False
     assert result.ambiguous_terms == []

--- a/tests/heuristics/test_psycholinguist_cognitive_load_ambiguity.py
+++ b/tests/heuristics/test_psycholinguist_cognitive_load_ambiguity.py
@@ -1,0 +1,151 @@
+"""Direct unit tests for the pure idea-density and ambiguity-detection helpers
+in `app.heuristics.handlers.psycholinguist`.
+
+Previously these were only exercised transitively through
+`PsycholinguistHandler.handle()`, and no existing test asserted on
+`idea_density` / `is_high_load` / `is_low_load` or on ambiguity diagnostics
+directly, leaving the threshold boundaries untested.
+"""
+
+from app.heuristics.handlers.psycholinguist import (
+    calculate_cognitive_load,
+    detect_ambiguity,
+)
+
+
+# -----------------------------------------------------------------------------
+# calculate_cognitive_load
+# -----------------------------------------------------------------------------
+
+
+def test_cognitive_load_high_density_single_sentence():
+    text = (
+        "analyze compute process transform validate execute optimize calculate "
+        "integrate synthesize evaluate configure implement monitor deploy "
+        "refactor document review test build"
+    )
+
+    result = calculate_cognitive_load(text)
+
+    assert result.idea_density > 15
+    assert result.is_high_load is True
+    assert result.is_low_load is False
+    assert result.suggestion == "Break this down into sub-tasks for clarity."
+
+
+def test_cognitive_load_low_density_multiple_sentences():
+    text = "Hi. Ok. Go."
+
+    result = calculate_cognitive_load(text)
+
+    assert result.idea_density == 0
+    assert result.is_low_load is True
+    assert result.is_high_load is False
+    assert result.suggestion == "Consider summarizing to focus the request."
+
+
+def test_cognitive_load_moderate_density_has_no_suggestion():
+    text = "The quick brown fox jumps over lazy dog today morning."
+
+    result = calculate_cognitive_load(text)
+
+    assert 3 <= result.idea_density <= 15
+    assert result.is_high_load is False
+    assert result.is_low_load is False
+    assert result.suggestion is None
+
+
+def test_cognitive_load_exact_threshold_is_not_high_load():
+    # Exactly 15 words of 4+ chars in a single sentence -> density == 15,
+    # which must NOT trip the `> 15` high-load branch.
+    words = [
+        "alpha",
+        "beta",
+        "gamma",
+        "delta",
+        "epsilon",
+        "zeta",
+        "theta",
+        "iota",
+        "kappa",
+        "lambda",
+        "sigma",
+        "omega",
+        "value",
+        "index",
+        "logic",
+    ]
+    text = " ".join(words)
+    assert len(words) == 15
+
+    result = calculate_cognitive_load(text)
+
+    assert result.idea_density == 15
+    assert result.is_high_load is False
+
+
+def test_cognitive_load_empty_text_defaults_to_single_sentence_zero_density():
+    result = calculate_cognitive_load("")
+
+    assert result.idea_density == 0
+    assert result.is_high_load is False
+    assert result.is_low_load is False
+    assert result.suggestion is None
+
+
+# -----------------------------------------------------------------------------
+# detect_ambiguity
+# -----------------------------------------------------------------------------
+
+
+def test_detect_ambiguity_no_vague_terms():
+    result = detect_ambiguity(
+        "Write a Python function that reverses a string using recursion."
+    )
+
+    assert result.is_ambiguous is False
+    assert result.ambiguous_terms == []
+    assert result.suggestions == []
+
+
+def test_detect_ambiguity_fix_it_pattern():
+    result = detect_ambiguity("Please fix it for me.")
+
+    assert result.is_ambiguous is True
+    assert "fix_it" in result.ambiguous_terms
+
+
+def test_detect_ambiguity_better_pattern():
+    result = detect_ambiguity("Please make it better.")
+
+    assert result.is_ambiguous is True
+    assert "better" in result.ambiguous_terms
+
+
+def test_detect_ambiguity_clean_up_pattern():
+    result = detect_ambiguity("Let's clean up this code.")
+
+    assert result.is_ambiguous is True
+    assert "clean_up" in result.ambiguous_terms
+
+
+def test_detect_ambiguity_stuff_pattern():
+    result = detect_ambiguity("There is some stuff to consider.")
+
+    assert result.is_ambiguous is True
+    assert "stuff" in result.ambiguous_terms
+
+
+def test_detect_ambiguity_multiple_patterns_detected_together():
+    result = detect_ambiguity("Please fix it and clean up the stuff, make it better.")
+
+    assert result.is_ambiguous is True
+    assert set(result.ambiguous_terms) == {"fix_it", "clean_up", "stuff", "better"}
+    assert len(result.suggestions) == 4
+
+
+def test_detect_ambiguity_is_case_insensitive():
+    result = detect_ambiguity("FIX IT NOW")
+
+    assert result.is_ambiguous is True
+    assert "fix_it" in result.ambiguous_terms


### PR DESCRIPTION
## Summary
Adds unit tests for pure heuristic helpers that had zero or only indirect test coverage. No source files were modified — only new test files were added.

- `DomainHandler._scan_for_secrets` (`app/heuristics/handlers/domain_expert.py`) — the hardcoded API-key/token/URL-credential regex scanner had **zero test coverage of any kind** before this PR, despite being security-relevant (it drives the "secrets detected" diagnostic/suggestion). New tests cover: no-match baseline, generic `api_key = "..."` assignment pattern, OpenAI-style `sk-` keys, GitHub `ghp_` tokens, credentials embedded in a URL, a too-short value that must NOT match, and the `additional_patterns` extension point.
- `DomainHandler._analyze_python_ast` (same file) — AST-based missing-type-hint detector, previously only reached indirectly through full-pipeline compiles. New tests cover: missing return/arg type hints, the `__init__`/`self` exclusion rules, a fully-typed function producing no diagnostics, the fenceless "looks like code" fallback path, plain prose being ignored, and malformed code being swallowed without raising.
- `calculate_cognitive_load` / `detect_ambiguity` (`app/heuristics/handlers/psycholinguist.py`) — idea-density and vague-term heuristics were only exercised transitively via `PsycholinguistHandler.handle()`, with no test ever asserting on `idea_density`, `is_high_load`, `is_low_load`, or ambiguity diagnostics directly. New tests cover the high/low-load thresholds (including the `> 15` boundary at exactly 15), an empty-text edge case, each of the four ambiguous-term patterns individually, multiple patterns detected together, and case-insensitivity.

## Test plan
- [x] `python -m pytest tests/heuristics/test_domain_expert_pure_helpers.py tests/heuristics/test_psycholinguist_cognitive_load_ambiguity.py -q` — 25 passed
- [x] `python -m pytest tests/ -q` (full suite) — 2254 passed, 7 skipped (pre-existing skips, unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_014AiFqkxXo2kjpXYBo9NS4G)_