### PR TITLE
test: cover token_optimizer markdown pass and emitters policy-v2 formatters

### DIFF
--- a/tests/test_emitters_is_conservative_mode.py
+++ b/tests/test_emitters_is_conservative_mode.py
@@ -1,0 +1,41 @@
+"""Unit tests for app.emitters._is_conservative_mode.
+
+Reached indirectly today via emit_expanded_prompt/emit_plan tests that force
+PROMPT_COMPILER_MODE through a fixture, but the function itself (explicit
+override vs. env var vs. default) had no direct test.
+"""
+
+from __future__ import annotations
+
+from app.emitters import _is_conservative_mode
+
+
+class TestIsConservativeMode:
+    def test_explicit_true_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "default")
+        assert _is_conservative_mode(True) is True
+
+    def test_explicit_false_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+        assert _is_conservative_mode(False) is False
+
+    def test_env_var_conservative_is_conservative(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+        assert _is_conservative_mode(None) is True
+
+    def test_env_var_default_is_not_conservative(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "default")
+        assert _is_conservative_mode(None) is False
+
+    def test_env_var_is_case_and_whitespace_insensitive(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "  DEFAULT  ")
+        assert _is_conservative_mode(None) is False
+
+    def test_missing_env_var_defaults_to_conservative(self, monkeypatch):
+        monkeypatch.delenv("PROMPT_COMPILER_MODE", raising=False)
+        assert _is_conservative_mode(None) is True
+
+    def test_unrecognized_env_var_value_is_conservative(self, monkeypatch):
+        # Only the literal "default" opts out of conservative mode.
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "aggressive")
+        assert _is_conservative_mode(None) is True

--- a/tests/test_emitters_policy_v2_formatting.py
+++ b/tests/test_emitters_policy_v2_formatting.py
@@ -1,0 +1,154 @@
+"""Unit tests for the IRv2 policy-header formatting helpers in app.emitters.
+
+_policy_summary_text_v2, _top_constraints_text_v2, _policy_check_lines_v2,
+_is_benign_policy_v2, and _emit_policy_header_v2 are pure string/bool
+formatters reached transitively via emit_expanded_prompt_v2 /
+emit_system_prompt_v2 tests, but had no direct unit test pinning their
+branches in isolation.
+"""
+
+from __future__ import annotations
+
+from app.emitters import (
+    _emit_policy_header_v2,
+    _is_benign_policy_v2,
+    _policy_check_lines_v2,
+    _policy_summary_text_v2,
+    _top_constraints_text_v2,
+)
+from app.models_v2 import ConstraintV2, IRv2, PolicyV2
+
+
+class TestTopConstraintsTextV2:
+    def test_empty_list_returns_empty_string(self):
+        assert _top_constraints_text_v2([]) == ""
+
+    def test_sorts_by_priority_descending(self):
+        cons = [
+            ConstraintV2(text="low", priority=10),
+            ConstraintV2(text="high", priority=90),
+            ConstraintV2(text="mid", priority=50),
+        ]
+        assert _top_constraints_text_v2(cons) == "high | mid | low"
+
+    def test_respects_limit(self):
+        cons = [ConstraintV2(text=f"c{i}", priority=i) for i in range(5)]
+        assert _top_constraints_text_v2(cons, limit=2) == "c4 | c3"
+
+    def test_schema_enforcement_id_renders_as_bracketed_label(self):
+        cons = [ConstraintV2(id="schema_enforcement", text="ignored text", priority=100)]
+        assert _top_constraints_text_v2(cons) == "[JSON Schema Enforced]"
+
+
+class TestPolicySummaryTextV2:
+    def test_includes_risk_and_execution_by_default(self):
+        ir = IRv2()
+        assert _policy_summary_text_v2(ir) == "risk=low; execution=advice_only"
+
+    def test_includes_domains_forbidden_tools_and_sanitization_when_present(self):
+        ir = IRv2(
+            policy=PolicyV2(
+                risk_level="high",
+                execution_mode="human_approval_required",
+                risk_domains=["finance", "health"],
+                forbidden_tools=["shell", "network"],
+                sanitization_rules=["strip_pii"],
+            )
+        )
+        assert _policy_summary_text_v2(ir) == (
+            "risk=high; execution=human_approval_required; "
+            "domains=finance,health; forbidden_tools=shell,network; "
+            "sanitization=strip_pii"
+        )
+
+    def test_truncates_lists_to_first_five_entries(self):
+        ir = IRv2(policy=PolicyV2(risk_domains=[f"d{i}" for i in range(8)]))
+        assert "domains=d0,d1,d2,d3,d4" in _policy_summary_text_v2(ir)
+        assert "d5" not in _policy_summary_text_v2(ir)
+
+    def test_omits_data_sensitivity_when_public(self):
+        ir = IRv2(policy=PolicyV2(data_sensitivity="public"))
+        assert "data=" not in _policy_summary_text_v2(ir)
+
+    def test_includes_data_sensitivity_when_non_public(self):
+        ir = IRv2(policy=PolicyV2(data_sensitivity="confidential"))
+        assert "data=confidential" in _policy_summary_text_v2(ir)
+
+
+class TestPolicyCheckLinesV2:
+    def test_returns_empty_for_fully_benign_policy(self):
+        ir = IRv2(policy=PolicyV2())
+        assert _policy_check_lines_v2(ir) == []
+
+    def test_approval_required_line_uses_reason_phrases(self):
+        ir = IRv2(
+            policy=PolicyV2(execution_mode="human_approval_required"),
+            metadata={"policy_reasons": ["debug_request"]},
+        )
+        lines = _policy_check_lines_v2(ir)
+        assert lines[0] == "Approval required because debugging or code execution context."
+
+    def test_non_approval_mode_with_reasons_uses_policy_trigger_line(self):
+        ir = IRv2(
+            policy=PolicyV2(execution_mode="auto_ok", forbidden_tools=["shell"]),
+            metadata={"policy_reasons": ["debug_request"]},
+        )
+        lines = _policy_check_lines_v2(ir)
+        assert lines[0] == "Policy trigger: debugging or code execution context."
+
+    def test_forbidden_tools_line_truncates_to_five(self):
+        ir = IRv2(policy=PolicyV2(forbidden_tools=[f"t{i}" for i in range(8)]))
+        lines = _policy_check_lines_v2(ir)
+        assert lines[-1] == "Do not use: t0, t1, t2, t3, t4."
+
+    def test_sanitization_rules_line_present(self):
+        ir = IRv2(policy=PolicyV2(sanitization_rules=["strip_pii", "mask_emails"]))
+        lines = _policy_check_lines_v2(ir)
+        assert "Apply sanitization: strip_pii, mask_emails." in lines
+
+    def test_data_sensitivity_line_present_when_non_public(self):
+        ir = IRv2(policy=PolicyV2(data_sensitivity="restricted"))
+        lines = _policy_check_lines_v2(ir)
+        assert lines == ["Data sensitivity: restricted."]
+
+
+class TestIsBenignPolicyV2:
+    def test_auto_ok_low_risk_public_policy_is_benign(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="auto_ok", risk_level="low"))
+        assert _is_benign_policy_v2(ir) is True
+
+    def test_non_auto_ok_execution_mode_is_not_benign(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="human_approval_required"))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_elevated_risk_level_is_not_benign(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="auto_ok", risk_level="medium"))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_non_public_data_sensitivity_is_not_benign(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="auto_ok", data_sensitivity="confidential"))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_any_risk_domain_is_not_benign(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="auto_ok", risk_domains=["finance"]))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_any_forbidden_tool_is_not_benign(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="auto_ok", forbidden_tools=["shell"]))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_any_sanitization_rule_is_not_benign(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="auto_ok", sanitization_rules=["strip_pii"]))
+        assert _is_benign_policy_v2(ir) is False
+
+
+class TestEmitPolicyHeaderV2:
+    def test_benign_policy_yields_no_header(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="auto_ok", risk_level="low"))
+        assert _emit_policy_header_v2(ir) == []
+
+    def test_non_benign_policy_yields_prefixed_summary_line(self):
+        ir = IRv2(policy=PolicyV2(execution_mode="human_approval_required", risk_level="high"))
+        assert _emit_policy_header_v2(ir) == [
+            "Policy: risk=high; execution=human_approval_required"
+        ]

--- a/tests/test_token_optimizer_markdown_pass.py
+++ b/tests/test_token_optimizer_markdown_pass.py
@@ -1,0 +1,107 @@
+"""Unit tests for app.token_optimizer's internal markdown-compaction pass.
+
+_optimize_once and _optimize_markdown_text are only exercised indirectly today
+through optimize_text() in test_token_optimizer.py, so their level-dependent
+branches (blank-line collapsing, duplicate-line removal, list-marker
+de-indentation) aren't pinned in isolation.
+"""
+
+from __future__ import annotations
+
+from app.token_optimizer import _optimize_markdown_text, _optimize_once
+
+
+class TestOptimizeMarkdownTextLevel1:
+    def test_collapses_consecutive_blank_lines_into_one(self):
+        text = "line one\n\n\n\nline two"
+        assert _optimize_markdown_text(text, level=1) == "line one\n\nline two"
+
+    def test_trims_trailing_whitespace_on_each_line(self):
+        text = "line one   \nline two\t"
+        assert _optimize_markdown_text(text, level=1) == "line one\nline two"
+
+    def test_collapses_internal_runs_of_spaces(self):
+        text = "a    b   c"
+        assert _optimize_markdown_text(text, level=1) == "a b c"
+
+    def test_collapses_internal_runs_of_tabs(self):
+        text = "a\t\tb"
+        assert _optimize_markdown_text(text, level=1) == "a b"
+
+    def test_removes_exact_duplicate_consecutive_lines(self):
+        text = "repeat me\nrepeat me\nkeep me"
+        assert _optimize_markdown_text(text, level=1) == "repeat me\nkeep me"
+
+    def test_does_not_dedupe_duplicate_blank_lines(self):
+        # Blank-line collapsing is handled by the separate is_blank branch,
+        # not the duplicate-consecutive-line check (which skips blanks).
+        text = "a\n\n\nb"
+        assert _optimize_markdown_text(text, level=1) == "a\n\nb"
+
+    def test_preserves_single_blank_line_between_paragraphs(self):
+        text = "para one\n\npara two"
+        assert _optimize_markdown_text(text, level=1) == "para one\n\npara two"
+
+
+class TestOptimizeMarkdownTextLevel2:
+    def test_removes_all_blank_lines(self):
+        text = "line one\n\n\nline two\n\nline three"
+        assert _optimize_markdown_text(text, level=2) == "line one\nline two\nline three"
+
+    def test_still_collapses_spaces_and_dedupes_lines(self):
+        text = "a   b\na   b\n\nc"
+        assert _optimize_markdown_text(text, level=2) == "a b\nc"
+
+
+class TestOptimizeMarkdownTextLevel3:
+    def test_strips_indentation_before_list_markers(self):
+        # Indentation of 4+ spaces is treated as an indented code block and left
+        # untouched (see TestOptimizeMarkdownTextPreservesStructure), so this only
+        # exercises the 1-3 space case that _LIST_RE de-indents at level 3.
+        text = "  - item one\n   * item two"
+        assert _optimize_markdown_text(text, level=3) == "- item one\n* item two"
+
+    def test_normalizes_internal_spacing_within_list_item_text(self):
+        text = "- item  with   many    spaces"
+        assert _optimize_markdown_text(text, level=1) == "- item with many spaces"
+
+
+class TestOptimizeMarkdownTextPreservesStructure:
+    def test_leaves_four_space_indented_code_content_untouched(self):
+        # Trailing whitespace is still trimmed (every line is rstripped before
+        # the indented-code passthrough check), but internal spacing and the
+        # leading indentation itself are preserved verbatim.
+        text = "    def  foo():   \n        pass   "
+        result = _optimize_markdown_text(text, level=3)
+        assert result == "    def  foo():\n        pass"
+
+    def test_leaves_tab_indented_code_content_untouched(self):
+        text = "\tvalue   =   1   "
+        assert _optimize_markdown_text(text, level=1) == "\tvalue   =   1"
+
+    def test_leaves_table_rows_untouched(self):
+        text = "| a   | b |\n| --- | - |"
+        assert _optimize_markdown_text(text, level=3) == "| a   | b |\n| --- | - |"
+
+
+class TestOptimizeOnce:
+    def test_preserves_fenced_code_block_verbatim(self):
+        text = "Intro line\n\n\n```python\ndef  foo():\n    pass\n```\n\nOutro   line"
+        result = _optimize_once(text, level=1)
+        assert "def  foo():\n    pass" in result
+
+    def test_optimizes_text_outside_fences(self):
+        text = "a    b\n\n\n```\ncode   stays\n```"
+        result = _optimize_once(text, level=1)
+        assert result.startswith("a b\n")
+        assert "code   stays" in result
+
+    def test_normalizes_crlf_to_lf(self):
+        text = "line one\r\nline two"
+        result = _optimize_once(text, level=1)
+        assert "\r" not in result
+
+    def test_inserts_missing_newline_before_glued_fence(self):
+        text = "Intro```python\nx = 1\n```"
+        result = _optimize_once(text, level=1)
+        assert "Intro\n```python" in result


### PR DESCRIPTION
## Summary

Test-coverage audit across 5 repos found two clusters of pure, deterministic helpers in this repo that were only exercised **indirectly** (through the public functions that call them), leaving their own level/branch behavior unpinned:

- `app/token_optimizer.py` — `_optimize_once` and `_optimize_markdown_text` (the markdown-compaction pass: blank-line collapsing by level, duplicate-line removal, whitespace normalization, list-marker de-indentation, fenced-code preservation). Previously only reached via `optimize_text()` in `tests/test_token_optimizer.py`.
- `app/emitters.py` — the IRv2 policy-header formatters `_policy_summary_text_v2`, `_top_constraints_text_v2`, `_policy_check_lines_v2`, `_is_benign_policy_v2`, `_emit_policy_header_v2`. Previously only reached transitively via `emit_expanded_prompt_v2`/`emit_system_prompt_v2` tests (a sibling function, `_policy_reason_phrases_v2`, already had its own direct test file — this fills in the rest of the same formatter family).
- `app/emitters.py` — `_is_conservative_mode`'s explicit-override vs. env-var vs. default precedence, previously only forced via a `monkeypatch` fixture in `tests/test_conservative_mode.py` rather than tested directly.

## Changes

- `tests/test_token_optimizer_markdown_pass.py` — level 1/2/3 blank-line and spacing behavior, duplicate-line removal, list-marker de-indentation, indented-code/table passthrough, and `_optimize_once`'s fence-preservation + CRLF normalization + fence-boundary-gluing fix.
- `tests/test_emitters_policy_v2_formatting.py` — constraint sorting/truncation/schema-enforcement label, policy summary field composition and 5-item truncation, approval/trigger/forbidden-tools/sanitization/data-sensitivity check lines, benign-policy detection, and the final header emission gate.
- `tests/test_emitters_is_conservative_mode.py` — explicit `True`/`False` override precedence over the env var, env var case/whitespace handling, and the conservative-by-default fallback.

Test-only change: no source, config, `.env`, lockfile, or CI files touched.

## Test plan

- [x] `python -m pytest tests/test_token_optimizer_markdown_pass.py tests/test_emitters_policy_v2_formatting.py tests/test_emitters_is_conservative_mode.py -v` — 49 passed
- [x] `python -m pytest tests/ -q` (full suite) — 2386 passed, 7 skipped (pre-existing), no regressions

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_0198AUUe1qNh1BU8skn6J7cJ)_