### PR TITLE
🎨 Palette: Add tooltip for disabled Analyze PR button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-02-13 - Add padding to prevent text overlap with absolutely positioned buttons
 **Learning:** When textareas or inputs have absolutely positioned interactive elements (like a "Clear" button) floating over them, users can experience friction if long text flows underneath the button, making it unreadable or unclickable.
 **Action:** Always ensure the underlying text input has sufficient right padding (e.g., `pr-14` in Tailwind) so the text wraps naturally without overlapping the absolutely positioned elements on the right side.
+## 2024-05-28 - Explain Disabled Button States
+**Learning:** When a main action button is disabled (like a submit or analyze button) due to form validation, users can be confused about what exactly they need to do to proceed. Adding a `title` attribute that explains the specific missing requirements helps them quickly correct the form.
+**Action:** When a form submission or action button is disabled due to missing inputs or incomplete state (e.g., `disabled={!canSubmit}`), improve UX and accessibility by adding a dynamic `title` attribute to the button explaining exactly what inputs are missing to enable it.

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -372,6 +372,7 @@ export default function PrSafetyPage() {
               onClick={handleAnalyze}
               disabled={!canSubmit}
               aria-busy={loading}
+              title={!canSubmit ? "Enter PR title, description, and changed files first to analyze" : "Analyze PR"}
               className="w-full rounded-xl bg-gradient-to-r from-rose-600 to-orange-600 px-4 py-3 text-sm font-bold text-white shadow-lg shadow-rose-500/20 transition-all hover:from-rose-500 hover:to-orange-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               {loading ? <span className="animate-pulse">Analyzing PR...</span> : "Analyze PR"}


### PR DESCRIPTION
💡 What: Added a title attribute to the 'Analyze PR' button in the PR Safety tool.
🎯 Why: To explain why the button is disabled when the form is incomplete, reducing friction and matching the UX pattern established in other generative tools in the app.
📸 Before/After: Visual verified.
♿ Accessibility: Screen readers and hover states now correctly communicate the missing prerequisites when the button is inactive.

---
*PR created automatically by Jules for task [10344481236553452715](https://jules.google.com/task/10344481236553452715) started by @madara88645*