### PR TITLE
test: add unit tests for repo-inspect parsers, upload naming, and heuristics helpers

### DIFF
--- a/tests/optimizer/test_language_costs_gap.py
+++ b/tests/optimizer/test_language_costs_gap.py
@@ -1,0 +1,65 @@
+from app.optimizer.language_costs import (
+    DEFAULT_OPENROUTER_MODEL,
+    count_estimated_tokens,
+    get_openrouter_rates,
+)
+
+
+# --------------------------------------------------------------------------
+# count_estimated_tokens
+# --------------------------------------------------------------------------
+
+
+def test_count_estimated_tokens_empty_string_is_zero():
+    assert count_estimated_tokens("") == 0
+
+
+def test_count_estimated_tokens_returns_positive_count_for_text():
+    assert count_estimated_tokens("hello world, this is a short prompt") > 0
+
+
+def test_count_estimated_tokens_scales_with_input_length():
+    short = count_estimated_tokens("hello")
+    long = count_estimated_tokens("hello " * 50)
+    assert long > short
+
+
+# --------------------------------------------------------------------------
+# get_openrouter_rates
+# --------------------------------------------------------------------------
+
+
+def test_get_openrouter_rates_exact_match_returns_configured_rates_with_no_warnings():
+    input_rate, output_rate, warnings = get_openrouter_rates("openai/gpt-oss-20b")
+    assert input_rate == 0.075
+    assert output_rate == 0.30
+    assert warnings == []
+
+
+def test_get_openrouter_rates_blank_model_falls_back_to_default():
+    input_rate, output_rate, warnings = get_openrouter_rates("")
+    default_input, default_output, default_warnings = get_openrouter_rates(
+        DEFAULT_OPENROUTER_MODEL
+    )
+    assert (input_rate, output_rate, warnings) == (default_input, default_output, default_warnings)
+
+
+def test_get_openrouter_rates_strips_whitespace_before_matching():
+    input_rate, output_rate, warnings = get_openrouter_rates("  openai/gpt-oss-20b  ")
+    assert (input_rate, output_rate) == (0.075, 0.30)
+    assert warnings == []
+
+
+def test_get_openrouter_rates_prefix_match_for_unlisted_variant():
+    # "openai/gpt-oss-20b-preview" isn't a configured key, but should match
+    # the longest configured prefix, "openai/gpt-oss-20b".
+    input_rate, output_rate, warnings = get_openrouter_rates("openai/gpt-oss-20b-preview")
+    assert (input_rate, output_rate) == (0.075, 0.30)
+    assert warnings == []
+
+
+def test_get_openrouter_rates_unknown_model_returns_zero_cost_with_warning():
+    input_rate, output_rate, warnings = get_openrouter_rates("totally/unknown-model")
+    assert (input_rate, output_rate) == (0.0, 0.0)
+    assert len(warnings) == 1
+    assert "totally/unknown-model" in warnings[0]

--- a/tests/test_emit_user_prompt_v2_gap.py
+++ b/tests/test_emit_user_prompt_v2_gap.py
@@ -1,0 +1,73 @@
+from app.emitters import emit_user_prompt_v2
+from app.models_v2 import IRv2
+
+
+def _ir(**overrides) -> IRv2:
+    return IRv2(**overrides)
+
+
+def test_emit_user_prompt_v2_empty_ir_returns_empty_string():
+    assert emit_user_prompt_v2(_ir()) == ""
+
+
+def test_emit_user_prompt_v2_includes_goals_section():
+    ir = _ir(goals=["Ship the feature", "Keep it simple"])
+    out = emit_user_prompt_v2(ir)
+    assert "Goals:" in out
+    assert "- Ship the feature" in out
+    assert "- Keep it simple" in out
+
+
+def test_emit_user_prompt_v2_includes_tasks_section():
+    ir = _ir(tasks=["Write tests", "Open a PR"])
+    out = emit_user_prompt_v2(ir)
+    assert "Tasks:" in out
+    assert "- Write tests" in out
+    assert "- Open a PR" in out
+
+
+def test_emit_user_prompt_v2_includes_inputs_as_key_value_lines():
+    ir = _ir(inputs={"repo": "compiler", "branch": "main"})
+    out = emit_user_prompt_v2(ir)
+    assert "Inputs:" in out
+    assert "- repo: compiler" in out
+    assert "- branch: main" in out
+
+
+def test_emit_user_prompt_v2_includes_tools_section():
+    ir = _ir(tools=["pytest", "ruff"])
+    out = emit_user_prompt_v2(ir)
+    assert "Tools:" in out
+    assert "- pytest" in out
+    assert "- ruff" in out
+
+
+def test_emit_user_prompt_v2_includes_examples_fenced_by_dashes():
+    ir = _ir(examples=["print('hi')"])
+    out = emit_user_prompt_v2(ir)
+    assert "Examples:" in out
+    assert "---\nprint('hi')\n---" in out
+
+
+def test_emit_user_prompt_v2_preserves_section_order():
+    ir = _ir(
+        goals=["g1"],
+        tasks=["t1"],
+        inputs={"k": "v"},
+        tools=["tool1"],
+        examples=["ex1"],
+    )
+    out = emit_user_prompt_v2(ir)
+    sections = ["Goals:", "Tasks:", "Inputs:", "Tools:", "Examples:"]
+    positions = [out.index(section) for section in sections]
+    assert positions == sorted(positions)
+
+
+def test_emit_user_prompt_v2_omits_sections_with_no_data():
+    ir = _ir(goals=["only goal"])
+    out = emit_user_prompt_v2(ir)
+    assert "Goals:" in out
+    assert "Tasks:" not in out
+    assert "Inputs:" not in out
+    assert "Tools:" not in out
+    assert "Examples:" not in out

--- a/tests/test_heuristics_recency_style_tone_gap.py
+++ b/tests/test_heuristics_recency_style_tone_gap.py
@@ -1,0 +1,63 @@
+from app.heuristics import detect_recency, extract_style_tone
+
+
+# --------------------------------------------------------------------------
+# detect_recency
+# --------------------------------------------------------------------------
+
+
+def test_detect_recency_true_for_today_keyword():
+    assert detect_recency("What happened in the news today?") is True
+
+
+def test_detect_recency_true_for_latest_keyword():
+    assert detect_recency("Give me the latest release notes.") is True
+
+
+def test_detect_recency_true_is_case_insensitive():
+    assert detect_recency("BREAKING update on the merger") is True
+
+
+def test_detect_recency_false_when_no_temporal_keyword_present():
+    assert detect_recency("Write a function that reverses a string.") is False
+
+
+def test_detect_recency_false_for_empty_string():
+    assert detect_recency("") is False
+
+
+# --------------------------------------------------------------------------
+# extract_style_tone
+# --------------------------------------------------------------------------
+
+
+def test_extract_style_tone_detects_style_keywords():
+    style, tone = extract_style_tone("Please write this in a structured, academic style.")
+    assert "structured" in style
+    assert "academic" in style
+    assert tone == []
+
+
+def test_extract_style_tone_detects_tone_keywords():
+    style, tone = extract_style_tone("Keep the tone friendly and objective.")
+    assert "friendly" in tone
+    assert "objective" in tone
+    assert style == []
+
+
+def test_extract_style_tone_detects_turkish_keywords():
+    style, tone = extract_style_tone("Resmi ve samimi bir dille yaz.")
+    assert "resmi" in style
+    assert "samimi" in tone
+
+
+def test_extract_style_tone_returns_empty_lists_when_no_keywords_match():
+    style, tone = extract_style_tone("Summarize the attached document.")
+    assert style == []
+    assert tone == []
+
+
+def test_extract_style_tone_is_case_insensitive():
+    style, tone = extract_style_tone("Use a CONCISE and FORMAL voice.")
+    assert "concise" in style
+    assert "formal" in tone

--- a/tests/test_rag_uploads_naming_gap.py
+++ b/tests/test_rag_uploads_naming_gap.py
@@ -1,0 +1,82 @@
+from app.rag.uploads import build_storage_name, normalize_display_name
+
+
+# --------------------------------------------------------------------------
+# normalize_display_name
+# --------------------------------------------------------------------------
+
+
+def test_normalize_display_name_strips_directory_components():
+    assert normalize_display_name("/etc/passwd") == "passwd"
+    assert normalize_display_name("some/dir/notes.txt") == "notes.txt"
+
+
+def test_normalize_display_name_trims_whitespace():
+    assert normalize_display_name("  report.pdf  ") == "report.pdf"
+
+
+def test_normalize_display_name_none_falls_back_to_default():
+    assert normalize_display_name(None) == "upload.txt"
+
+
+def test_normalize_display_name_empty_string_falls_back_to_default():
+    assert normalize_display_name("") == "upload.txt"
+    assert normalize_display_name("   ") == "upload.txt"
+
+
+def test_normalize_display_name_dot_and_dotdot_fall_back_to_default():
+    assert normalize_display_name(".") == "upload.txt"
+    assert normalize_display_name("..") == "upload.txt"
+
+
+# --------------------------------------------------------------------------
+# build_storage_name
+# --------------------------------------------------------------------------
+
+
+def test_build_storage_name_preserves_extension_and_appends_digest():
+    name = build_storage_name("notes.txt", "hello world")
+    assert name.startswith("notes-")
+    assert name.endswith(".txt")
+
+
+def test_build_storage_name_is_deterministic_for_same_content():
+    first = build_storage_name("notes.txt", "same content")
+    second = build_storage_name("notes.txt", "same content")
+    assert first == second
+
+
+def test_build_storage_name_differs_for_different_content():
+    first = build_storage_name("notes.txt", "content a")
+    second = build_storage_name("notes.txt", "content b")
+    assert first != second
+
+
+def test_build_storage_name_sanitizes_invalid_filename_characters():
+    name = build_storage_name('weird<>:"name.txt', "x")
+    assert "<" not in name
+    assert ">" not in name
+    assert ":" not in name
+    assert '"' not in name
+
+
+def test_build_storage_name_defaults_extension_when_missing():
+    name = build_storage_name("README", "x")
+    assert name.endswith(".txt")
+    assert name.startswith("README-")
+
+
+def test_build_storage_name_truncates_long_extension():
+    long_suffix = "." + ("a" * 40)
+    name = build_storage_name(f"file{long_suffix}", "x")
+    # suffix is capped to the first 16 characters (including the leading dot)
+    ext = name.rsplit("-", 1)[-1]
+    assert ext.count(".") >= 1
+    assert len(ext.split(".", 1)[-1]) <= 16 - 1
+
+
+def test_build_storage_name_blank_stem_falls_back_to_upload():
+    # sanitizing "???.txt" leaves a stem of only underscores, which strips to
+    # empty and must fall back to "upload".
+    name = build_storage_name("???.txt", "x")
+    assert name.split("-", 1)[0] == "upload"

--- a/tests/test_repo_inspect_parsers_gap.py
+++ b/tests/test_repo_inspect_parsers_gap.py
@@ -1,0 +1,135 @@
+from app.repo_inspect.detect import (
+    detect_stacks,
+    parse_makefile_targets,
+    parse_package_json_scripts,
+)
+
+
+# --------------------------------------------------------------------------
+# parse_package_json_scripts
+# --------------------------------------------------------------------------
+
+
+def test_parse_package_json_scripts_maps_known_aliases():
+    content = '{"scripts": {"test": "vitest run", "build": "next build", "start": "next start"}}'
+    cmds = parse_package_json_scripts(content, source="web/package.json")
+
+    by_name = {c.name: c.command for c in cmds}
+    assert by_name["test"] == "npm run test"
+    assert by_name["build"] == "npm run build"
+    # "start" aliases to canonical "dev"
+    assert by_name["dev"] == "npm run start"
+    assert all(c.source == "web/package.json" for c in cmds)
+
+
+def test_parse_package_json_scripts_ignores_unknown_script_names():
+    content = '{"scripts": {"deploy": "vercel --prod"}}'
+    assert parse_package_json_scripts(content, source="package.json") == []
+
+
+def test_parse_package_json_scripts_invalid_json_returns_empty_list():
+    assert parse_package_json_scripts("not json {{{", source="package.json") == []
+
+
+def test_parse_package_json_scripts_missing_scripts_key_returns_empty_list():
+    assert parse_package_json_scripts("{}", source="package.json") == []
+
+
+def test_parse_package_json_scripts_non_dict_scripts_value_returns_empty_list():
+    content = '{"scripts": ["test"]}'
+    assert parse_package_json_scripts(content, source="package.json") == []
+
+
+# --------------------------------------------------------------------------
+# parse_makefile_targets
+# --------------------------------------------------------------------------
+
+
+def test_parse_makefile_targets_uses_tab_indented_recipe_line():
+    content = "test:\n\tpython -m pytest tests/ -q\n"
+    cmds = parse_makefile_targets(content, source="Makefile")
+
+    assert len(cmds) == 1
+    assert cmds[0].name == "test"
+    assert cmds[0].command == "python -m pytest tests/ -q"
+    assert cmds[0].source == "Makefile"
+
+
+def test_parse_makefile_targets_falls_back_to_make_target_without_recipe():
+    content = "build:\nlint:\n\tflake8 .\n"
+    cmds = parse_makefile_targets(content, source="Makefile")
+
+    by_name = {c.name: c.command for c in cmds}
+    assert by_name["build"] == "make build"
+    assert by_name["lint"] == "flake8 ."
+
+
+def test_parse_makefile_targets_ignores_unaliased_target_names():
+    content = "deploy:\n\techo shipping\n"
+    assert parse_makefile_targets(content, source="Makefile") == []
+
+
+def test_parse_makefile_targets_ignores_variable_assignments():
+    # "CC:=gcc" looks target-like but the `(?!=)` guard should exclude it.
+    content = "CC:=gcc\ntest:\n\tgo test ./...\n"
+    cmds = parse_makefile_targets(content, source="Makefile")
+    assert [c.name for c in cmds] == ["test"]
+
+
+def test_parse_makefile_targets_stops_recipe_search_at_next_non_indented_line():
+    # No tab-indented recipe immediately follows "build:", so it should fall
+    # back to "make build" rather than picking up "lint"'s recipe.
+    content = "build:\nlint:\n\tflake8 .\n"
+    cmds = parse_makefile_targets(content, source="Makefile")
+    by_name = {c.name: c.command for c in cmds}
+    assert by_name["build"] == "make build"
+
+
+def test_parse_makefile_targets_empty_content_returns_empty_list():
+    assert parse_makefile_targets("", source="Makefile") == []
+
+
+# --------------------------------------------------------------------------
+# detect_stacks
+# --------------------------------------------------------------------------
+
+
+def test_detect_stacks_groups_frameworks_by_language():
+    files = {
+        "package.json": '{"dependencies": {"react": "18.0.0", "next": "14.0.0"}}',
+        "requirements.txt": "django==5.0\n",
+    }
+    stacks = detect_stacks(files)
+
+    by_language = {s.language: set(s.frameworks) for s in stacks}
+    assert by_language["javascript"] == {"react", "next"}
+    assert by_language["python"] == {"django"}
+
+
+def test_detect_stacks_ignores_unrecognized_manifest_files():
+    files = {"README.md": "next react django flask"}
+    assert detect_stacks(files) == []
+
+
+def test_detect_stacks_no_files_returns_empty_list():
+    assert detect_stacks({}) == []
+
+
+def test_detect_stacks_merges_multiple_manifests_of_same_language():
+    files = {
+        "requirements.txt": "flask==3.0\n",
+        "pyproject.toml": '[project]\ndependencies = ["fastapi"]\n',
+    }
+    stacks = detect_stacks(files)
+    assert len(stacks) == 1
+    assert stacks[0].language == "python"
+    assert set(stacks[0].frameworks) == {"flask", "fastapi"}
+
+
+def test_detect_stacks_returns_sorted_by_language():
+    files = {
+        "go.mod": "module example.com/x\n",
+        "package.json": "{}",
+    }
+    stacks = detect_stacks(files)
+    assert [s.language for s in stacks] == ["go", "javascript"]


### PR DESCRIPTION
## Summary

A repo-wide test coverage audit found this codebase generally well-tested, but a handful of pure/utility functions were only ever exercised indirectly through higher-level integration tests, with no direct unit coverage isolating their edge cases. This PR adds direct tests for those functions — no source, config, or CI files were touched.

- `app/repo_inspect/detect.py` — `parse_package_json_scripts`, `parse_makefile_targets`, `detect_stacks` (previously only exercised via `derive_repo_context`)
- `app/rag/uploads.py` — `normalize_display_name`, `build_storage_name` (filename sanitization/digest naming, untested)
- `app/emitters.py` — `emit_user_prompt_v2` (zero prior test references)
- `app/heuristics/__init__.py` — `detect_recency`, `extract_style_tone` (zero prior test references)
- `app/optimizer/language_costs.py` — `count_estimated_tokens`, `get_openrouter_rates` (exact-match, prefix-match, and unknown-model branches)

## Test plan

- [x] `python -m pytest tests/test_repo_inspect_parsers_gap.py tests/test_rag_uploads_naming_gap.py tests/test_emit_user_prompt_v2_gap.py tests/test_heuristics_recency_style_tone_gap.py tests/optimizer/test_language_costs_gap.py -q` — 54 passed
- [x] `python -m pytest tests/ -q` — 2391 passed, 7 skipped (same skip count as before this change; no regressions)

🤖 Generated with automated test-coverage audit

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hipyt4LCnwweNHktH7rTdx)_