### PR TITLE
docs: fix 'All rights reserved' vs Apache-2.0 contradiction

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,9 +470,9 @@ docs/           Product, pattern, and workflow docs
 
 ## License
 
-Copyright © 2026 Mehmet Özel. All rights reserved.
+Licensed under the [Apache License 2.0](LICENSE) — free to use, self-host, and modify.
 
-Licensed under the [Apache License 2.0](LICENSE).
+Copyright © 2026 Mehmet Özel.
 
 For managed/hosted service inquiries: [mehmet.ozel2701@gmail.com](mailto:mehmet.ozel2701@gmail.com)
 


### PR DESCRIPTION
Portfolio/trust polish: the License section read 'All rights reserved' immediately above 'Licensed under the Apache License 2.0', which signals proprietary and undercuts the actual open license. Reworded to lead with the Apache-2.0 grant. Docs-only.