### PR TITLE
docs: add a table of contents to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,9 +470,9 @@ docs/           Product, pattern, and workflow docs
 
 ## License
 
-Copyright © 2026 Mehmet Özel. All rights reserved.
+Licensed under the [Apache License 2.0](LICENSE) — free to use, self-host, and modify.
 
-Licensed under the [Apache License 2.0](LICENSE).
+Copyright © 2026 Mehmet Özel.
 
 For managed/hosted service inquiries: [mehmet.ozel2701@gmail.com](mailto:mehmet.ozel2701@gmail.com)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It also ships a **PR Safety / Merge Readiness Layer**: paste an AI-agent PR and 
 
 Try it now at [prcompiler.com](https://prcompiler.com) — or open [PR Safety](https://prcompiler.com/pr-safety) ([guide](docs/pr-safety.md)) · [VS Code extension](integrations/vscode-extension) · [GitHub artifacts](docs/pattern-library.md)
 
+**Jump to:** [What It Does](#what-it-does) · [Key Features](#key-features) · [Installation](#installation) · [Running the App](#running-the-app) · [How To Use](#how-to-use) · [Project Structure](#project-structure) · [Docs](#docs) · [License](#license)
+
 ---
 
 ## What It Does


### PR DESCRIPTION
Portfolio polish: the README is large (15+ feature sections before Installation), so a hiring manager has to scroll past everything to find how to run it. Added a one-line 'Jump to' TOC right under the intro so readers can navigate to Installation / How To Use / License instantly. Docs-only, no content moved. (Separate from the license-wording PR #1099.)