### PR TITLE
docs: add an animated product-tour GIF to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 It also ships a **PR Safety / Merge Readiness Layer**: paste an AI-agent PR and get a clear verdict — **merge, hold, split, or rebase** — before you merge it.
 
+<p align="center">
+  <img src="docs/images/demo.gif" alt="Animated tour: a vague request is compiled into an expanded prompt, execution plan, and readiness check, ending with a PR Safety verdict" width="100%">
+</p>
+
 Try it now at [prcompiler.com](https://prcompiler.com) — or open [PR Safety](https://prcompiler.com/pr-safety) ([guide](docs/pr-safety.md)) · [VS Code extension](integrations/vscode-extension) · [GitHub artifacts](docs/pattern-library.md)
 
 **Jump to:** [What It Does](#what-it-does) · [Key Features](#key-features) · [Installation](#installation) · [Running the App](#running-the-app) · [How To Use](#how-to-use) · [Project Structure](#project-structure) · [Docs](#docs) · [License](#license)


### PR DESCRIPTION
Adds the missing motion demo flagged by the portfolio review: a **15-second animated product tour** embedded right under the intro (`docs/images/demo.gif`, 5.2 MB, loops).

Scenes: a vague request ("make the login faster somehow??") is typed → **Compile** → three panels spring in (**Expanded Prompt / Execution Plan / Readiness Check** with Risk Level, Execution Mode, Data Sensitivity ticking green) → a **PR Safety** verdict chip (**SPLIT** — "touches auth + billing") → end card with prcompiler.com.

**Transparency:** this is a Remotion-rendered stylized animation (an honest product *tour*, not a screen recording). All terminology is taken from this README; sample values are clearly generic. Rendered at 960×540, reviewed frame-by-frame before export.

Docs-only.