### PR TITLE
test: add unit tests for policy header suppression and agent-output trust gating

### DIFF
--- a/tests/test_agent_packs_trust_gating.py
+++ b/tests/test_agent_packs_trust_gating.py
@@ -1,0 +1,151 @@
+"""Unit tests for the LLM-output trust gates in app/adapters/agent_packs.py.
+
+`_agent_output_is_usable` and `_skill_output_is_usable` decide whether
+LLM-generated markdown is trusted (and thus surfaced to the user) or
+discarded in favor of the request-grounded IR fallback. Getting this wrong
+means either hallucinated content is trusted, or good content is thrown
+away.
+
+Both functions share the same shape of gate:
+1. Reject empty/whitespace-only markdown.
+2. Reject markdown containing known failure/error markers.
+3. Reject a handful of known placeholder/error names.
+4. Otherwise require at least one populated "real content" field on the IR.
+"""
+
+from __future__ import annotations
+
+from app.adapters.agent_packs import (
+    _agent_output_is_usable,
+    _skill_output_is_usable,
+)
+from app.adapters.agent_ir import AgentExportIR
+from app.adapters.skill_ir import SkillExportIR
+
+
+# ---------------------------------------------------------------------------
+# _agent_output_is_usable
+# ---------------------------------------------------------------------------
+
+
+class TestAgentOutputIsUsable:
+    def test_usable_when_markdown_present_and_ir_has_role(self):
+        ir = AgentExportIR(name="Repo Maintainer", role="Maintains the repository")
+        assert _agent_output_is_usable(ir, "# Repo Maintainer\n\nSome content") is True
+
+    def test_usable_when_ir_has_only_goals(self):
+        ir = AgentExportIR(name="Focused Agent", goals=["ship the feature"])
+        assert _agent_output_is_usable(ir, "some markdown") is True
+
+    def test_usable_when_ir_has_only_constraints(self):
+        ir = AgentExportIR(name="Focused Agent", constraints=["no network access"])
+        assert _agent_output_is_usable(ir, "some markdown") is True
+
+    def test_usable_when_ir_has_only_workflows(self):
+        ir = AgentExportIR(name="Focused Agent", workflows=["run tests then deploy"])
+        assert _agent_output_is_usable(ir, "some markdown") is True
+
+    def test_rejects_empty_markdown(self):
+        ir = AgentExportIR(name="Focused Agent", role="Does things")
+        assert _agent_output_is_usable(ir, "") is False
+
+    def test_rejects_whitespace_only_markdown(self):
+        ir = AgentExportIR(name="Focused Agent", role="Does things")
+        assert _agent_output_is_usable(ir, "   \n\t  ") is False
+
+    def test_rejects_none_markdown(self):
+        ir = AgentExportIR(name="Focused Agent", role="Does things")
+        assert _agent_output_is_usable(ir, None) is False
+
+    def test_rejects_failed_to_generate_marker(self):
+        ir = AgentExportIR(name="Focused Agent", role="Does things")
+        assert _agent_output_is_usable(ir, "Failed to generate response") is False
+
+    def test_rejects_failed_to_generate_marker_case_insensitive(self):
+        ir = AgentExportIR(name="Focused Agent", role="Does things")
+        assert _agent_output_is_usable(ir, "FAILED TO GENERATE due to timeout") is False
+
+    def test_rejects_api_key_is_missing_marker(self):
+        ir = AgentExportIR(name="Focused Agent", role="Does things")
+        assert _agent_output_is_usable(ir, "Error: API key is missing") is False
+
+    def test_rejects_default_error_name(self):
+        ir = AgentExportIR(name="Error", role="Does things")
+        assert _agent_output_is_usable(ir, "some markdown") is False
+
+    def test_rejects_default_placeholder_name_ai_agent(self):
+        # AgentExportIR() defaults name to "AI Agent" -- the untouched default
+        # must never be treated as usable, even with real-looking fields.
+        ir = AgentExportIR(role="Does things", goals=["ship it"])
+        assert ir.name == "AI Agent"
+        assert _agent_output_is_usable(ir, "some markdown") is False
+
+    def test_rejects_placeholder_name_case_and_whitespace_insensitive(self):
+        ir = AgentExportIR(name="  ai AGENT  ", role="Does things")
+        assert _agent_output_is_usable(ir, "some markdown") is False
+
+    def test_rejects_when_all_content_fields_empty(self):
+        ir = AgentExportIR(name="Real Name")
+        assert not (ir.role or ir.goals or ir.constraints or ir.workflows)
+        assert _agent_output_is_usable(ir, "some markdown") is False
+
+
+# ---------------------------------------------------------------------------
+# _skill_output_is_usable
+# ---------------------------------------------------------------------------
+
+
+class TestSkillOutputIsUsable:
+    def test_usable_when_markdown_present_and_ir_has_purpose(self):
+        ir = SkillExportIR(name="format_dates", purpose="Formats dates consistently")
+        assert _skill_output_is_usable(ir, "# format_dates\n\nDoes things") is True
+
+    def test_usable_when_ir_has_only_implementation(self):
+        ir = SkillExportIR(name="format_dates", implementation="return date.isoformat()")
+        assert _skill_output_is_usable(ir, "some markdown") is True
+
+    def test_usable_when_ir_has_only_params(self):
+        from app.adapters.skill_ir import SkillParam
+
+        ir = SkillExportIR(name="format_dates", params=[SkillParam(name="value", type="str")])
+        assert _skill_output_is_usable(ir, "some markdown") is True
+
+    def test_rejects_empty_markdown(self):
+        ir = SkillExportIR(name="format_dates", purpose="Formats dates")
+        assert _skill_output_is_usable(ir, "") is False
+
+    def test_rejects_whitespace_only_markdown(self):
+        ir = SkillExportIR(name="format_dates", purpose="Formats dates")
+        assert _skill_output_is_usable(ir, "\n   ") is False
+
+    def test_rejects_none_markdown(self):
+        ir = SkillExportIR(name="format_dates", purpose="Formats dates")
+        assert _skill_output_is_usable(ir, None) is False
+
+    def test_rejects_failed_to_generate_marker(self):
+        ir = SkillExportIR(name="format_dates", purpose="Formats dates")
+        assert _skill_output_is_usable(ir, "failed to generate skill") is False
+
+    def test_rejects_api_key_is_missing_marker(self):
+        ir = SkillExportIR(name="format_dates", purpose="Formats dates")
+        assert _skill_output_is_usable(ir, "API Key is missing, cannot proceed") is False
+
+    def test_rejects_default_error_name(self):
+        ir = SkillExportIR(name="error", purpose="Formats dates")
+        assert _skill_output_is_usable(ir, "some markdown") is False
+
+    def test_rejects_default_placeholder_name_skill_name(self):
+        # SkillExportIR() defaults name to "skill_name" -- must never be
+        # trusted even if purpose/params/implementation look real.
+        ir = SkillExportIR(purpose="Formats dates", implementation="do it")
+        assert ir.name == "skill_name"
+        assert _skill_output_is_usable(ir, "some markdown") is False
+
+    def test_rejects_placeholder_name_case_and_whitespace_insensitive(self):
+        ir = SkillExportIR(name="  SKILL_NAME  ", purpose="Formats dates")
+        assert _skill_output_is_usable(ir, "some markdown") is False
+
+    def test_rejects_when_all_content_fields_empty(self):
+        ir = SkillExportIR(name="real_name")
+        assert not (ir.purpose or ir.params or ir.implementation)
+        assert _skill_output_is_usable(ir, "some markdown") is False

--- a/tests/test_emitters_policy_gating.py
+++ b/tests/test_emitters_policy_gating.py
@@ -1,0 +1,247 @@
+"""Unit tests for policy-gating pure helpers in app/emitters.py.
+
+These functions decide whether risk/policy metadata is surfaced or
+suppressed in the compiled system prompt, and how conservative mode is
+resolved. They are security/policy relevant because a wrong answer here
+means a risky request silently loses its policy warning text.
+
+Covers:
+- _is_conservative_mode: explicit arg wins over env var; env var fallback;
+  default (unset env) behavior.
+- _is_benign_policy_v2: true/false branches for each contributing field.
+- _policy_check_lines_v2: empty-line short circuit, approval-required
+  phrasing, forbidden tools, sanitization rules, data sensitivity.
+- _emit_policy_header_v2: suppressed for benign policy, surfaced
+  otherwise, and empty when the summary text is empty (defensive branch).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.emitters import (
+    _is_conservative_mode,
+    _is_benign_policy_v2,
+    _policy_check_lines_v2,
+    _emit_policy_header_v2,
+)
+from app.models_v2 import IRv2, PolicyV2
+
+
+def _make_ir(policy: PolicyV2 | None = None, metadata: dict | None = None) -> IRv2:
+    return IRv2(policy=policy or PolicyV2(), metadata=metadata or {})
+
+
+# ---------------------------------------------------------------------------
+# _is_conservative_mode
+# ---------------------------------------------------------------------------
+
+
+class TestIsConservativeMode:
+    def test_explicit_true_wins_regardless_of_env(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "default")
+        assert _is_conservative_mode(True) is True
+
+    def test_explicit_false_wins_regardless_of_env(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+        assert _is_conservative_mode(False) is False
+
+    def test_env_conservative_when_arg_is_none(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "conservative")
+        assert _is_conservative_mode(None) is True
+
+    def test_env_default_disables_conservative(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "default")
+        assert _is_conservative_mode(None) is False
+
+    def test_env_default_case_insensitive_and_whitespace_tolerant(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "  DEFAULT  ")
+        assert _is_conservative_mode(None) is False
+
+    def test_missing_env_defaults_to_conservative(self, monkeypatch):
+        monkeypatch.delenv("PROMPT_COMPILER_MODE", raising=False)
+        assert _is_conservative_mode(None) is True
+
+    def test_unrecognized_env_value_is_treated_as_conservative(self, monkeypatch):
+        monkeypatch.setenv("PROMPT_COMPILER_MODE", "some_other_mode")
+        assert _is_conservative_mode(None) is True
+
+
+# ---------------------------------------------------------------------------
+# _is_benign_policy_v2
+# ---------------------------------------------------------------------------
+
+
+class TestIsBenignPolicyV2:
+    def test_default_policy_is_not_benign_because_default_execution_mode_is_advice_only(self):
+        # PolicyV2()'s default execution_mode is "advice_only", not "auto_ok",
+        # so an untouched default policy does NOT count as benign.
+        ir = _make_ir()
+        assert ir.policy.execution_mode == "advice_only"
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_human_approval_required_is_not_benign(self):
+        ir = _make_ir(PolicyV2(execution_mode="human_approval_required"))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_high_risk_level_is_not_benign(self):
+        ir = _make_ir(PolicyV2(risk_level="high"))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_non_public_data_sensitivity_is_not_benign(self):
+        ir = _make_ir(PolicyV2(data_sensitivity="confidential"))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_risk_domains_present_is_not_benign(self):
+        ir = _make_ir(PolicyV2(risk_domains=["medical"]))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_forbidden_tools_present_is_not_benign(self):
+        ir = _make_ir(PolicyV2(forbidden_tools=["shell_exec"]))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_sanitization_rules_present_is_not_benign(self):
+        ir = _make_ir(PolicyV2(sanitization_rules=["strip_pii"]))
+        assert _is_benign_policy_v2(ir) is False
+
+    def test_auto_ok_low_public_no_extras_is_benign(self):
+        ir = _make_ir(
+            PolicyV2(
+                execution_mode="auto_ok",
+                risk_level="low",
+                data_sensitivity="public",
+                risk_domains=[],
+                forbidden_tools=[],
+                sanitization_rules=[],
+            )
+        )
+        assert _is_benign_policy_v2(ir) is True
+
+
+# ---------------------------------------------------------------------------
+# _policy_check_lines_v2
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyCheckLinesV2:
+    def test_benign_policy_produces_no_lines(self):
+        ir = _make_ir()
+        assert _policy_check_lines_v2(ir) == []
+
+    def test_human_approval_required_produces_approval_line(self):
+        ir = _make_ir(
+            PolicyV2(execution_mode="human_approval_required", risk_level="high"),
+            metadata={"policy_reasons": ["debug_request"]},
+        )
+        lines = _policy_check_lines_v2(ir)
+        assert any(line.startswith("Approval required because") for line in lines)
+        assert any("debugging or code execution context" in line for line in lines)
+
+    def test_human_approval_required_without_reasons_falls_back_to_risk_level_phrase(self):
+        ir = _make_ir(PolicyV2(execution_mode="human_approval_required", risk_level="high"))
+        lines = _policy_check_lines_v2(ir)
+        assert lines[0] == "Approval required because high risk policy."
+
+    def test_forbidden_tools_present_produces_do_not_use_line(self):
+        ir = _make_ir(PolicyV2(forbidden_tools=["shell_exec", "network_call"]))
+        lines = _policy_check_lines_v2(ir)
+        assert any(line.startswith("Do not use: shell_exec, network_call") for line in lines)
+
+    def test_forbidden_tools_absent_produces_no_do_not_use_line(self):
+        ir = _make_ir(PolicyV2(execution_mode="human_approval_required"))
+        lines = _policy_check_lines_v2(ir)
+        assert not any(line.startswith("Do not use:") for line in lines)
+
+    def test_sanitization_required_produces_sanitize_line(self):
+        ir = _make_ir(PolicyV2(sanitization_rules=["strip_pii", "mask_emails"]))
+        lines = _policy_check_lines_v2(ir)
+        assert any(
+            line.startswith("Apply sanitization: strip_pii, mask_emails") for line in lines
+        )
+
+    def test_sanitization_not_required_produces_no_sanitize_line(self):
+        ir = _make_ir(PolicyV2(execution_mode="human_approval_required"))
+        lines = _policy_check_lines_v2(ir)
+        assert not any(line.startswith("Apply sanitization:") for line in lines)
+
+    def test_non_public_data_sensitivity_produces_data_sensitivity_line(self):
+        ir = _make_ir(PolicyV2(data_sensitivity="confidential"))
+        lines = _policy_check_lines_v2(ir)
+        assert "Data sensitivity: confidential." in lines
+
+    def test_forbidden_tools_list_is_truncated_to_five(self):
+        tools = [f"tool{i}" for i in range(8)]
+        ir = _make_ir(PolicyV2(forbidden_tools=tools))
+        lines = _policy_check_lines_v2(ir)
+        do_not_use_line = next(line for line in lines if line.startswith("Do not use:"))
+        assert ", ".join(tools[:5]) in do_not_use_line
+        assert "tool6" not in do_not_use_line
+
+    def test_non_approval_with_reasons_uses_policy_trigger_phrasing(self):
+        ir = _make_ir(
+            PolicyV2(execution_mode="advice_only", forbidden_tools=["shell_exec"]),
+            metadata={"policy_reasons": ["overlapping_risk_domains"]},
+        )
+        lines = _policy_check_lines_v2(ir)
+        assert any(line.startswith("Policy trigger: overlapping risk domains") for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# _emit_policy_header_v2
+# ---------------------------------------------------------------------------
+
+
+class TestEmitPolicyHeaderV2:
+    def test_benign_policy_suppresses_header(self):
+        ir = _make_ir(
+            PolicyV2(
+                execution_mode="auto_ok",
+                risk_level="low",
+                data_sensitivity="public",
+                risk_domains=[],
+                forbidden_tools=[],
+                sanitization_rules=[],
+            )
+        )
+        assert _emit_policy_header_v2(ir) == []
+
+    def test_untouched_default_policy_surfaces_header(self):
+        # Default execution_mode is "advice_only" (not benign's "auto_ok"),
+        # so a completely default policy still surfaces a header line.
+        ir = _make_ir()
+        header = _emit_policy_header_v2(ir)
+        assert header == ["Policy: risk=low; execution=advice_only"]
+
+    def test_non_benign_policy_surfaces_header(self):
+        ir = _make_ir(PolicyV2(execution_mode="human_approval_required", risk_level="high"))
+        header = _emit_policy_header_v2(ir)
+        assert len(header) == 1
+        assert header[0].startswith("Policy: ")
+        assert "risk=high" in header[0]
+        assert "execution=human_approval_required" in header[0]
+
+    def test_header_includes_forbidden_tools_and_sanitization(self):
+        ir = _make_ir(
+            PolicyV2(
+                risk_level="medium",
+                forbidden_tools=["shell_exec"],
+                sanitization_rules=["strip_pii"],
+            )
+        )
+        header = _emit_policy_header_v2(ir)
+        assert header
+        assert "forbidden_tools=shell_exec" in header[0]
+        assert "sanitization=strip_pii" in header[0]
+
+    def test_header_includes_risk_domains_and_data_sensitivity(self):
+        ir = _make_ir(
+            PolicyV2(
+                risk_level="high",
+                risk_domains=["medical", "legal"],
+                data_sensitivity="confidential",
+            )
+        )
+        header = _emit_policy_header_v2(ir)
+        assert header
+        assert "domains=medical,legal" in header[0]
+        assert "data=confidential" in header[0]


### PR DESCRIPTION
## Summary
- Test-coverage audit found several pure, security/policy-relevant functions in `app/emitters.py` and `app/adapters/agent_packs.py` with zero direct unit tests: conservative-mode resolution, benign-vs-non-benign policy classification, policy-check line generation, policy-header suppression, and agent/skill output trust gating.
- Adds two new pytest files covering these functions' branches. No source, config, or lockfile changes.

## What's covered
- `tests/test_emitters_policy_gating.py`: `_is_conservative_mode` (explicit arg vs `PROMPT_COMPILER_MODE` env fallback vs default), `_is_benign_policy_v2` (each of the six contributing conditions), `_policy_check_lines_v2` (approval/policy-trigger phrasing, forbidden-tools + sanitization lines, truncation), `_emit_policy_header_v2` (suppressed vs surfaced).
- `tests/test_agent_packs_trust_gating.py`: `_agent_output_is_usable` / `_skill_output_is_usable` — empty/None/whitespace rejection, error-marker rejection, placeholder/default-name rejection, populated-content requirement.

## Test plan
- [x] `python -m pytest tests/test_emitters_policy_gating.py tests/test_agent_packs_trust_gating.py -q` → 56 passed
- [x] Full suite `python -m pytest tests/ -q` → 2393 passed, 7 skipped (pre-existing skips, unrelated)
- [x] Only new test files added; no existing files modified

---
_Generated by [Claude Code](https://claude.ai/code/session_019J89sBtBq4hkpdGLAsoY3n)_