### PR TITLE
fix(packaging): ship only application packages in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["api*", "app*", "cli*", "integrations*"]
 exclude = ["tests*", "docs*", "examples*", "prcompiler.egg-info*"]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Why
`prcompiler` has never been published to PyPI, and the pending trusted publisher expires soon. Before the first release, the built distribution was over-broad: flat-layout package discovery pulled in `scripts/` (14 dev/debug scripts) and a stray `web/node_modules/flatted/python/flatted.py`, shipping top-level `scripts` and `web` packages. Generic top-level names like `scripts` risk import-name collisions in an installed environment.

## What
Restrict `[tool.setuptools.packages.find]` to the real application packages via an allowlist (allowlist over blocklist so future stray directories can't leak in):

```toml
include = ["api*", "app*", "cli*", "integrations*"]
```

## Verification
Local `python -m build`, before vs after:

| | before | after |
|---|---|---|
| top-level packages | api, app, cli, integrations, **scripts, web** | api, app, cli, integrations |
| wheel file count | 207 | 192 |
| scripts / web / node_modules entries | 15 | 0 |
| `promptc` entry point (`cli.main:app`) | present | present |
| `twine check` (sdist + wheel) | — | PASSED |

Packaging metadata only — no dependency, runtime, or code changes. Verified no runtime module imports `scripts` or `web` as a package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)