### PR TITLE
🎨 Palette: Add dynamic tooltip to disabled Analyze PR button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -34,3 +34,6 @@
 ## 2025-02-13 - Add padding to prevent text overlap with absolutely positioned buttons
 **Learning:** When textareas or inputs have absolutely positioned interactive elements (like a "Clear" button) floating over them, users can experience friction if long text flows underneath the button, making it unreadable or unclickable.
 **Action:** Always ensure the underlying text input has sufficient right padding (e.g., `pr-14` in Tailwind) so the text wraps naturally without overlapping the absolutely positioned elements on the right side.
+## 2025-02-13 - Add specific reasons to disabled buttons
+**Learning:** When a main CTA button (like "Analyze PR") is disabled because a form is incomplete, a generic `disabled` state with no explanation causes frustration. Users might not realize which specific input is holding up the submission.
+**Action:** Add a dynamic `title` attribute to disabled CTA buttons that explicitly lists exactly which required fields are missing (e.g., `Missing: Title, Changed Files`) using an array filter/join pattern.

--- a/web/app/pr-safety/page.tsx
+++ b/web/app/pr-safety/page.tsx
@@ -372,6 +372,7 @@ export default function PrSafetyPage() {
               onClick={handleAnalyze}
               disabled={!canSubmit}
               aria-busy={loading}
+              title={!canSubmit && !loading ? `Missing: ${[title.trim().length === 0 ? "Title" : "", description.trim().length === 0 ? "Description" : "", parsedFiles.length === 0 ? "Changed Files" : ""].filter(Boolean).join(", ")}` : undefined}
               className="w-full rounded-xl bg-gradient-to-r from-rose-600 to-orange-600 px-4 py-3 text-sm font-bold text-white shadow-lg shadow-rose-500/20 transition-all hover:from-rose-500 hover:to-orange-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             >
               {loading ? <span className="animate-pulse">Analyzing PR...</span> : "Analyze PR"}


### PR DESCRIPTION
💡 What: Added a dynamic `title` attribute to the disabled "Analyze PR" button that lists exactly which required fields are missing.
🎯 Why: When form submission is disabled, it is not always obvious which inputs are preventing submission, especially in multi-input forms. This tooltip provides clear, actionable feedback.
📸 Before/After: Before, the button was simply disabled with a generic cursor-not-allowed. After, hovering over the disabled button explicitly states "Missing: Title, Changed Files" based on current form state.
♿ Accessibility: Provides explicitly readable state reasons for why the action is unavailable, helping users complete the form.

---
*PR created automatically by Jules for task [16525689934375676670](https://jules.google.com/task/16525689934375676670) started by @madara88645*