### PR TITLE
test(web): cover CopyButton default render and custom label

### DIFF
--- a/web/app/components/__tests__/CopyButton.test.tsx
+++ b/web/app/components/__tests__/CopyButton.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../../lib/copyToClipboard", () => ({
 import CopyButton from "../CopyButton";
 
 const CHECKMARK_SELECTOR = "polyline[points='20 6 9 17 4 12']";
+const COPY_ICON_SELECTOR = "rect[x='8'][y='8']";
 
 async function clickAndFlush(button: HTMLElement) {
   fireEvent.click(button);
@@ -28,6 +29,27 @@ describe("CopyButton", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("renders with default props and correct accessibility attributes", () => {
+    render(<CopyButton text="hello world" />);
+
+    const button = screen.getByRole("button", { name: "Copy to Clipboard" });
+    expect(button).toHaveAttribute("aria-label", "Copy to Clipboard");
+    expect(button).toHaveAttribute("title", "Copy to Clipboard");
+    expect(button).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("Copy to Clipboard")).toBeInTheDocument();
+    expect(button.querySelector(COPY_ICON_SELECTOR)).toBeInTheDocument();
+    expect(button.querySelector(CHECKMARK_SELECTOR)).toBeNull();
+  });
+
+  it("uses custom label if provided", () => {
+    render(<CopyButton text="hello world" label="Copy output" />);
+
+    const button = screen.getByRole("button", { name: "Copy output" });
+    expect(button).toHaveAttribute("aria-label", "Copy output");
+    expect(button).toHaveAttribute("title", "Copy output");
+    expect(screen.getByText("Copy output")).toBeInTheDocument();
   });
 
   it("calls copyToClipboard when clicked", async () => {


### PR DESCRIPTION
## What

Adds two render-level test cases to `web/app/components/__tests__/CopyButton.test.tsx`:

- `renders with default props and correct accessibility attributes` — asserts the default `aria-label`, `title`, `aria-live="polite"`, the screen-reader text, and that the copy icon is rendered while the checkmark is not.
- `uses custom label if provided` — asserts the `label` prop overrides `aria-label`, `title`, and the screen-reader text.

No production code changes. Test file only, +22 lines.

## Why

These two cases came from PR #1027, which was closed without merging. A different, smaller rewrite of `CopyButton.test.tsx` landed on main instead, covering only the click / success-timeout / failure paths. The pure-render and custom-label assertions were never recovered.

Found while auditing and pruning 42 stale git worktrees: the `fix/issue-1025` worktree was the only one holding work that was not already on `main`.

## Notes

The cases were rewritten to match the current test file's idiom — `vi.hoisted` mock, `toHaveAttribute` instead of `getAttribute().toBe()`, and a shared `COPY_ICON_SELECTOR` constant alongside the existing `CHECKMARK_SELECTOR` — rather than copied verbatim from the original branch.

## Verification

- `npx vitest run app/components/__tests__/CopyButton.test.tsx` → 5/5 passed
- `npm run test` (full web suite) → 54 files, 283 tests passed
- `npm run lint` → 0 errors (2 pre-existing warnings in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
