### PR TITLE
fix(web): point Sidebar VS Code link to install docs

### DIFF
--- a/web/app/components/Sidebar.test.tsx
+++ b/web/app/components/Sidebar.test.tsx
@@ -90,8 +90,8 @@ describe("Sidebar", () => {
       "https://github.com/madara88645/Compiler",
     );
     expect(screen.getByLabelText("CLI install").getAttribute("href")).toContain("docs/cli.md");
-    expect(screen.getByLabelText("VS Code extension").getAttribute("href")).toContain(
-      "madara88645.promptc-vscode",
+    expect(screen.getByLabelText("VS Code extension").getAttribute("href")).toBe(
+      "https://github.com/madara88645/Compiler/blob/main/integrations/vscode-extension/README.md#install",
     );
     expect(screen.getByLabelText("MCP setup").getAttribute("href")).toContain(
       "integrations/mcp-server/README.md",

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -51,7 +51,7 @@ const outboundLinks: { name: string; href: string; Icon: LucideIcon }[] = [
     },
     {
         name: "VS Code extension",
-        href: "https://marketplace.visualstudio.com/items?itemName=madara88645.promptc-vscode",
+        href: "https://github.com/madara88645/Compiler/blob/main/integrations/vscode-extension/README.md#install",
         Icon: Blocks,
     },
     {


### PR DESCRIPTION
## Summary
- Point the Sidebar “VS Code extension” outbound link at the GitHub install docs (`integrations/vscode-extension/README.md#install`) instead of the not-yet-live Marketplace listing.
- Update the Sidebar outbound-link test to assert the new docs URL.

Fixes #1134

## Test plan
- [x] `cd web && npm run test -- Sidebar` (6 passed)
- [ ] Manually confirm Sidebar VS Code icon opens the Install section on GitHub


Made with [Cursor](https://cursor.com)