### PR TITLE
a11y: announce compile loading via OutputSkeleton status

### DIFF
--- a/web/app/components/OutputSkeleton.test.tsx
+++ b/web/app/components/OutputSkeleton.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import OutputSkeleton from "./OutputSkeleton";
+
+describe("OutputSkeleton", () => {
+  it("announces compiling as an accessible busy status region", () => {
+    render(<OutputSkeleton />);
+
+    const status = screen.getByRole("status", { name: /compiling/i });
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(status).toHaveAccessibleName("Compiling…");
+    expect(screen.getByText("Compiling…")).toHaveClass("sr-only");
+  });
+});

--- a/web/app/components/OutputSkeleton.tsx
+++ b/web/app/components/OutputSkeleton.tsx
@@ -2,7 +2,13 @@ import { Skeleton, SkeletonBlock } from "./Skeleton";
 
 export default function OutputSkeleton() {
   return (
-    <div className="flex flex-col h-full animate-fade-in">
+    <div
+      className="flex flex-col h-full animate-fade-in"
+      role="status"
+      aria-busy="true"
+      aria-label="Compiling…"
+    >
+      <span className="sr-only">Compiling…</span>
       {/* Tab bar skeleton */}
       <div className="flex gap-2 px-4 pt-4 pb-2 border-b border-white/5">
         {["w-16", "w-20", "w-14", "w-18", "w-22", "w-12", "w-18"].map((w, i) => (


### PR DESCRIPTION
## Summary
- Add `role="status"`, `aria-busy="true"`, and a concise “Compiling…” announcement (`aria-label` + visually hidden text) on `OutputSkeleton` so assistive tech hears compile loading in the output pane.
- Add a focused Vitest covering those accessible attributes without changing the visual layout.

Fixes #1133

## Test plan
- [x] `cd web && npm run test -- OutputSkeleton` (1 passed)
- [x] `npx eslint app/components/OutputSkeleton.tsx app/components/OutputSkeleton.test.tsx`
- [ ] Spot-check Compiler home while compiling: skeleton looks unchanged; screen reader announces loading


Made with [Cursor](https://cursor.com)