### PR TITLE
test: cover repo_inspect parsers and PolicyHandler path/dedup helpers

### DIFF
--- a/tests/test_policy_handler_helpers.py
+++ b/tests/test_policy_handler_helpers.py
@@ -1,0 +1,64 @@
+"""Direct unit tests for PolicyHandler's pure regex/dedup helpers.
+
+test_policy_handler.py exercises these indirectly through compile_text_v2();
+this file calls PolicyHandler._has_explicit_path and PolicyHandler._unique
+directly to pin down edge cases (cloud-path-before-URL-stripping ordering,
+UNC paths, dedup semantics) that aren't individually asserted elsewhere.
+"""
+
+from app.heuristics.handlers.policy import PolicyHandler
+
+
+# --- _has_explicit_path -------------------------------------------------------
+
+
+def test_has_explicit_path_empty_text_is_false():
+    assert PolicyHandler._has_explicit_path("") is False
+
+
+def test_has_explicit_path_detects_windows_path():
+    assert PolicyHandler._has_explicit_path("Open C:\\Users\\me\\notes.txt please") is True
+
+
+def test_has_explicit_path_detects_posix_path():
+    assert PolicyHandler._has_explicit_path("Read /var/log/app/error.log for me") is True
+
+
+def test_has_explicit_path_detects_unc_path():
+    assert PolicyHandler._has_explicit_path(r"Copy from \\fileserver\share\report.docx") is True
+
+
+def test_has_explicit_path_detects_cloud_path_even_inside_a_url_like_string():
+    # Cloud paths (s3://, gs://) are checked BEFORE URL stripping, so they
+    # must be detected even though they share the "scheme://" shape a bare
+    # URL would have (which the plain URL branch would otherwise strip out).
+    assert PolicyHandler._has_explicit_path("Upload the export to s3://my-bucket/out.csv") is True
+    assert PolicyHandler._has_explicit_path("Read from gs://data-bucket/input.json") is True
+
+
+def test_has_explicit_path_ignores_plain_urls():
+    text = "Check https://example.com/docs/page for details."
+    assert PolicyHandler._has_explicit_path(text) is False
+
+
+def test_has_explicit_path_detects_relative_file_reference():
+    assert PolicyHandler._has_explicit_path("Update ./src/utils/helpers.py next") is True
+
+
+def test_has_explicit_path_false_for_plain_prose():
+    assert PolicyHandler._has_explicit_path("Explain how photosynthesis works") is False
+
+
+# --- _unique -------------------------------------------------------------------
+
+
+def test_unique_preserves_first_occurrence_order():
+    assert PolicyHandler._unique(["b", "a", "b", "c", "a"]) == ["b", "a", "c"]
+
+
+def test_unique_strips_whitespace_and_drops_blank_entries():
+    assert PolicyHandler._unique([" x ", "", "   ", "x", "y "]) == ["x", "y"]
+
+
+def test_unique_empty_list_returns_empty_list():
+    assert PolicyHandler._unique([]) == []

--- a/tests/test_repo_inspect_detect_functions.py
+++ b/tests/test_repo_inspect_detect_functions.py
@@ -1,0 +1,118 @@
+"""Direct unit tests for the pure parsing helpers in app.repo_inspect.detect.
+
+test_repo_inspect.py already covers these through derive_repo_context(); this
+file targets parse_package_json_scripts, parse_makefile_targets, and
+detect_stacks directly, including edge cases (malformed input, alias mapping,
+recipe-line boundaries) that aren't reachable/asserted through the
+higher-level integration tests.
+"""
+
+from app.repo_inspect.detect import (
+    detect_stacks,
+    parse_makefile_targets,
+    parse_package_json_scripts,
+)
+from app.repo_inspect.models import DetectedCommand, StackInfo
+
+
+# --- parse_package_json_scripts ---------------------------------------------
+
+
+def test_parse_package_json_scripts_malformed_json_returns_empty():
+    assert parse_package_json_scripts("{not valid json", "package.json") == []
+
+
+def test_parse_package_json_scripts_non_dict_scripts_returns_empty():
+    assert parse_package_json_scripts('{"scripts": ["test"]}', "package.json") == []
+
+
+def test_parse_package_json_scripts_missing_scripts_key_returns_empty():
+    assert parse_package_json_scripts('{"name": "x"}', "package.json") == []
+
+
+def test_parse_package_json_scripts_maps_known_aliases():
+    content = '{"scripts": {"test": "vitest run", "fmt": "prettier --write .", "start": "vite"}}'
+    cmds = parse_package_json_scripts(content, "web/package.json")
+    by_name = {c.name: c for c in cmds}
+    assert by_name["test"] == DetectedCommand(
+        name="test", command="npm run test", source="web/package.json"
+    )
+    # "fmt" aliases to the canonical "format" name.
+    assert by_name["format"].command == "npm run fmt"
+    # "start" aliases to the canonical "dev" name.
+    assert by_name["dev"].command == "npm run start"
+
+
+def test_parse_package_json_scripts_ignores_unknown_script_names():
+    cmds = parse_package_json_scripts('{"scripts": {"deploy": "vercel"}}', "package.json")
+    assert cmds == []
+
+
+# --- parse_makefile_targets --------------------------------------------------
+
+
+def test_parse_makefile_targets_picks_first_tab_indented_recipe_line():
+    content = "test:\n\tpytest -q\n\techo done\nbuild:\n\techo build\n"
+    cmds = parse_makefile_targets(content, "Makefile")
+    by_name = {c.name: c.command for c in cmds}
+    assert by_name["test"] == "pytest -q"
+    assert by_name["build"] == "echo build"
+
+
+def test_parse_makefile_targets_falls_back_to_make_target_when_no_recipe():
+    content = "lint:\nbuild:\n\techo build\n"
+    cmds = parse_makefile_targets(content, "Makefile")
+    by_name = {c.name: c.command for c in cmds}
+    assert by_name["lint"] == "make lint"
+
+
+def test_parse_makefile_targets_stops_scanning_recipe_at_non_indented_line():
+    # A blank/non-tab line right after the target means "no recipe" even
+    # though a tab-indented line exists further down (belongs to another target).
+    content = "lint:\n\ndeploy:\n\techo unrelated\n"
+    cmds = parse_makefile_targets(content, "Makefile")
+    by_name = {c.name: c.command for c in cmds}
+    assert by_name["lint"] == "make lint"
+
+
+def test_parse_makefile_targets_ignores_unaliased_targets():
+    content = "deploy:\n\techo deploy\n"
+    assert parse_makefile_targets(content, "Makefile") == []
+
+
+def test_parse_makefile_targets_ignores_variable_assignments():
+    # "FOO:=bar" looks target-like but the regex explicitly excludes ":=" lines.
+    content = "FOO:=bar\ntest:\n\techo t\n"
+    cmds = parse_makefile_targets(content, "Makefile")
+    assert [c.name for c in cmds] == ["test"]
+
+
+# --- detect_stacks ------------------------------------------------------------
+
+
+def test_detect_stacks_empty_files_returns_empty_list():
+    assert detect_stacks({}) == []
+
+
+def test_detect_stacks_ignores_unrecognized_manifest_names():
+    assert detect_stacks({"README.md": "next react fastapi"}) == []
+
+
+def test_detect_stacks_multiple_languages_sorted_by_language_name():
+    files = {
+        "go.mod": "module example.com/x\n",
+        "package.json": '{"dependencies": {"react": "18.0.0"}}',
+    }
+    stacks = detect_stacks(files)
+    assert [s.language for s in stacks] == ["go", "javascript"]
+    assert stacks[1] == StackInfo(language="javascript", frameworks=("react",))
+
+
+def test_detect_stacks_frameworks_are_sorted_and_deduplicated_per_language():
+    files = {
+        "package.json": '{"dependencies": {"react": "18", "vue": "3"}}',
+        "pom.xml": "<project></project>",
+    }
+    stacks = detect_stacks(files)
+    js_stack = next(s for s in stacks if s.language == "javascript")
+    assert js_stack.frameworks == ("react", "vue")


### PR DESCRIPTION
## Summary
- Adds direct unit tests for `parse_package_json_scripts`, `parse_makefile_targets`, and `detect_stacks` in `app/repo_inspect/detect.py`
- Adds direct unit tests for `PolicyHandler._has_explicit_path` and `PolicyHandler._unique` in `app/heuristics/handlers/policy.py`

These pure, deterministic helpers were previously exercised only indirectly through `test_repo_inspect.py` / `test_policy_handler.py`'s integration-style tests against `derive_repo_context()` / `compile_text_v2()`. Several edge cases had no direct assertion at all: malformed JSON in `package.json`, a non-dict `scripts` block, Makefile recipe-line/target boundary handling, and — notably — the ordering guarantee that cloud paths (`s3://`, `gs://`) are detected *before* the generic URL-stripping step in `_has_explicit_path`.

Only new test files were added; no source, config, or CI files were touched.

## Test plan
- [x] `pytest tests/test_repo_inspect_detect_functions.py tests/test_policy_handler_helpers.py tests/test_repo_inspect.py tests/test_policy_handler.py -q` → 56 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4dLzLwEojcJ43dE9qJ42S)_