### PR TITLE
🎨 Palette: Add explanation to disabled download button

### DIFF
--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -363,7 +363,7 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
                     disabled={!downloadFilename}
                     className="focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-white px-2.5 py-1.5 rounded-lg text-[10px] font-medium flex items-center gap-1.5 border border-white/10 disabled:cursor-not-allowed disabled:opacity-50"
                     aria-label="Download file"
-                    title={downloadFilename ? `Download ${downloadFilename}` : "Download file"}
+                    title={downloadFilename ? `Download ${downloadFilename}` : "Generate an export first to download"}
                   >
                     <Download size={12} aria-hidden="true" />
                     Download


### PR DESCRIPTION
💡 What: Added dynamic title to download button when disabled to explain why it is disabled.
🎯 Why: It wasn't obvious to users why the download button was disabled when there was no filename yet.
📸 Before/After: Visual change in tooltip.
♿ Accessibility: Improves accessibility by explaining the disabled state.

---
*PR created automatically by Jules for task [8532387006087769232](https://jules.google.com/task/8532387006087769232) started by @madara88645*