### PR TITLE
test: cover emit_user_prompt_v2 and batch path-rule helpers

### DIFF
--- a/tests/test_emit_user_prompt_v2_gap.py
+++ b/tests/test_emit_user_prompt_v2_gap.py
@@ -1,0 +1,74 @@
+"""Unit tests for app.emitters.emit_user_prompt_v2.
+
+This pure, deterministic string builder had zero test coverage despite being
+used by api/routes/compile.py (fallback / render_v2_prompts / language-
+mismatch-correction branches) and by the CLI export/transform commands.
+"""
+
+from __future__ import annotations
+
+from app.emitters import emit_user_prompt_v2
+from app.models_v2 import IRv2
+
+
+def test_all_sections_empty_returns_empty_string():
+    ir = IRv2()
+    assert emit_user_prompt_v2(ir) == ""
+
+
+def test_goals_section_renders_bulleted_list():
+    ir = IRv2(goals=["Ship the feature", "Keep it simple"])
+    result = emit_user_prompt_v2(ir)
+    assert result == "Goals:\n- Ship the feature\n- Keep it simple"
+
+
+def test_tasks_section_renders_bulleted_list():
+    ir = IRv2(tasks=["Write the code", "Write the tests"])
+    result = emit_user_prompt_v2(ir)
+    assert result == "Tasks:\n- Write the code\n- Write the tests"
+
+
+def test_inputs_section_renders_key_value_pairs():
+    ir = IRv2(inputs={"language": "python", "framework": "fastapi"})
+    result = emit_user_prompt_v2(ir)
+    assert result == "Inputs:\n- language: python\n- framework: fastapi"
+
+
+def test_tools_section_renders_bulleted_list():
+    ir = IRv2(tools=["search", "python_exec"])
+    result = emit_user_prompt_v2(ir)
+    assert result == "Tools:\n- search\n- python_exec"
+
+
+def test_examples_section_wraps_each_example_in_separators():
+    ir = IRv2(examples=["ex one", "ex two"])
+    result = emit_user_prompt_v2(ir)
+    assert result == "Examples:\n---\nex one\n---\n---\nex two\n---"
+
+
+def test_sections_render_in_fixed_order_and_are_joined_by_newline():
+    ir = IRv2(
+        goals=["g1"],
+        tasks=["t1"],
+        inputs={"k": "v"},
+        tools=["tool1"],
+        examples=["ex1"],
+    )
+    result = emit_user_prompt_v2(ir)
+    assert result == (
+        "Goals:\n- g1\n"
+        "Tasks:\n- t1\n"
+        "Inputs:\n- k: v\n"
+        "Tools:\n- tool1\n"
+        "Examples:\n---\nex1\n---"
+    )
+
+
+def test_only_populated_sections_are_included():
+    ir = IRv2(goals=["only goals"])
+    result = emit_user_prompt_v2(ir)
+    assert "Goals:" in result
+    assert "Tasks:" not in result
+    assert "Inputs:" not in result
+    assert "Tools:" not in result
+    assert "Examples:" not in result

--- a/tests/test_pr_safety_path_rules_batch_gap.py
+++ b/tests/test_pr_safety_path_rules_batch_gap.py
@@ -1,0 +1,83 @@
+"""Unit tests for app.pr_safety.path_rules batch helpers.
+
+normalize_paths / list_test_files / list_source_files_needing_tests are pure,
+deterministic, and used directly by app/pr_safety/analyzer.py and
+app/pr_safety/repo_signals.py, but (unlike their singular/per-file siblings
+in tests/test_pr_safety_path_rules.py) had no direct unit tests of their own.
+"""
+
+from __future__ import annotations
+
+from app.pr_safety.path_rules import (
+    list_source_files_needing_tests,
+    list_test_files,
+    normalize_paths,
+)
+
+
+# --------------------------------------------------------------------------
+# normalize_paths
+# --------------------------------------------------------------------------
+
+
+def test_normalize_paths_converts_backslashes_and_strips_whitespace():
+    assert normalize_paths([" a\\b.py ", "c/d.py"]) == ["a/b.py", "c/d.py"]
+
+
+def test_normalize_paths_drops_empty_entries():
+    assert normalize_paths(["", "   ", "app/compiler.py"]) == ["app/compiler.py"]
+
+
+def test_normalize_paths_deduplicates_while_preserving_first_occurrence_order():
+    assert normalize_paths(["b.py", "a.py", "b.py", "a.py"]) == ["b.py", "a.py"]
+
+
+def test_normalize_paths_deduplicates_across_backslash_and_forward_slash_forms():
+    assert normalize_paths(["a\\b.py", "a/b.py"]) == ["a/b.py"]
+
+
+def test_normalize_paths_empty_input_returns_empty_list():
+    assert normalize_paths([]) == []
+
+
+# --------------------------------------------------------------------------
+# list_test_files
+# --------------------------------------------------------------------------
+
+
+def test_list_test_files_filters_to_only_test_files():
+    paths = ["app/compiler.py", "tests/test_compiler.py", "docs/README.md"]
+    assert list_test_files(paths) == ["tests/test_compiler.py"]
+
+
+def test_list_test_files_returns_empty_list_when_no_test_files_present():
+    assert list_test_files(["app/compiler.py", "docs/README.md"]) == []
+
+
+def test_list_test_files_normalizes_and_deduplicates_input():
+    paths = ["tests\\test_foo.py", "tests/test_foo.py"]
+    assert list_test_files(paths) == ["tests/test_foo.py"]
+
+
+# --------------------------------------------------------------------------
+# list_source_files_needing_tests
+# --------------------------------------------------------------------------
+
+
+def test_list_source_files_needing_tests_filters_to_only_source_files():
+    paths = [
+        "app/compiler.py",
+        "tests/test_compiler.py",
+        "docs/README.md",
+        "config/settings.yaml",
+    ]
+    assert list_source_files_needing_tests(paths) == ["app/compiler.py"]
+
+
+def test_list_source_files_needing_tests_excludes_test_doc_and_config_files():
+    paths = ["tests/test_foo.py", "README.md", "app/config.yaml"]
+    assert list_source_files_needing_tests(paths) == []
+
+
+def test_list_source_files_needing_tests_empty_input_returns_empty_list():
+    assert list_source_files_needing_tests([]) == []


### PR DESCRIPTION
## Summary

Test-coverage audit found two genuine zero-coverage gaps in otherwise well-tested pure/deterministic code:

- `emit_user_prompt_v2` (`app/emitters.py:924`) — a public, exported prompt-string builder used by `api/routes/compile.py` (fallback / `render_v2_prompts` / language-mismatch-correction branches) and by the CLI export/transform commands. It had **zero references anywhere in `tests/`**.
- `normalize_paths`, `list_test_files`, `list_source_files_needing_tests` (`app/pr_safety/path_rules.py`) — only reached indirectly through `analyze_pr`/`analyze_pr_safety`. Their per-file sibling helpers (`normalize_path`, `is_test_file`, etc.) already have direct unit tests in `tests/test_pr_safety_path_rules.py`, but these batch versions did not.

No source, config, CI, or existing test files were modified — only two new test files were added.

## Test plan

- [x] `python -m pytest tests/test_emit_user_prompt_v2_gap.py tests/test_pr_safety_path_rules_batch_gap.py -q` → 19 passed
- [x] `python -m pytest tests/ -q` → 2374 passed, 7 skipped (no regressions)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtetcGyCEx5JLvJxp4djYf)_