### PR TITLE
test: add coverage for pr_safety path-matching helpers

### DIFF
--- a/tests/test_pr_safety_path_rules_helpers.py
+++ b/tests/test_pr_safety_path_rules_helpers.py
@@ -1,0 +1,179 @@
+"""Direct coverage for the pure path-matching helpers in ``app.pr_safety.path_rules``.
+
+``normalize_paths``, ``_matches_any_pattern``, ``list_test_files``, and
+``list_source_files_needing_tests`` back the PR-safety verdict feature but,
+prior to this file, only had indirect coverage through higher-level
+functions (``group_changed_files``, ``detect_risky_areas``, etc.) in
+``tests/test_pr_safety_path_rules.py``. These tests exercise them directly,
+including edge cases (empty/whitespace input, duplicate paths, backslash
+normalization, and empty pattern sets) relevant to path-matching correctness.
+"""
+
+from app.pr_safety.path_rules import (
+    TEST_FILE_PATTERNS,
+    _matches_any_pattern,
+    list_source_files_needing_tests,
+    list_test_files,
+    normalize_paths,
+)
+
+
+# --------------------------------------------------------------------------
+# normalize_paths
+# --------------------------------------------------------------------------
+
+
+def test_normalize_paths_converts_backslashes_and_strips_whitespace():
+    assert normalize_paths(["  app\\foo.py  "]) == ["app/foo.py"]
+
+
+def test_normalize_paths_drops_empty_and_whitespace_only_entries():
+    assert normalize_paths(["", "   ", "app/foo.py"]) == ["app/foo.py"]
+
+
+def test_normalize_paths_deduplicates_after_normalization():
+    # "app\\foo.py" and "app/foo.py" normalize to the same string, so the
+    # second occurrence must be dropped rather than kept as a duplicate.
+    result = normalize_paths(["app\\foo.py", "app/foo.py", "app/bar.py"])
+    assert result == ["app/foo.py", "app/bar.py"]
+
+
+def test_normalize_paths_preserves_first_occurrence_order():
+    result = normalize_paths(["c.py", "a.py", "b.py", "a.py"])
+    assert result == ["c.py", "a.py", "b.py"]
+
+
+def test_normalize_paths_empty_list_returns_empty_list():
+    assert normalize_paths([]) == []
+
+
+def test_normalize_paths_all_whitespace_entries_returns_empty_list():
+    assert normalize_paths(["   ", "\t", ""]) == []
+
+
+# --------------------------------------------------------------------------
+# _matches_any_pattern
+# --------------------------------------------------------------------------
+
+
+def test_matches_any_pattern_true_when_one_pattern_matches():
+    assert _matches_any_pattern("app/foo.py", ("*.md", "*.py")) is True
+
+
+def test_matches_any_pattern_false_when_no_pattern_matches():
+    assert _matches_any_pattern("app/foo.py", ("*.md", "*.txt")) is False
+
+
+def test_matches_any_pattern_false_for_empty_pattern_tuple():
+    assert _matches_any_pattern("app/foo.py", ()) is False
+
+
+def test_matches_any_pattern_is_case_sensitive_on_posix():
+    # fnmatch on POSIX platforms is case-sensitive; a pattern matching
+    # lowercase paths should not match an uppercase variant.
+    assert _matches_any_pattern("APP/FOO.PY", ("*.py",)) is False
+
+
+def test_matches_any_pattern_glob_star_does_not_cross_directories_implicitly():
+    # fnmatch's "*" matches "/" too (unlike shell globbing in some
+    # contexts), so a single-segment wildcard can still match nested paths.
+    assert _matches_any_pattern("a/b/c.py", ("*.py",)) is True
+
+
+def test_matches_any_pattern_stops_after_first_match():
+    # Sanity check the explicit loop short-circuits like any(): matching on
+    # an early pattern still returns True even if later patterns are bogus
+    # fnmatch expressions that would otherwise raise if evaluated eagerly
+    # (fnmatch itself won't raise, but this documents the short-circuit
+    # intent of the loop).
+    assert _matches_any_pattern("README.md", ("README*", "[unclosed")) is True
+
+
+# --------------------------------------------------------------------------
+# list_test_files
+# --------------------------------------------------------------------------
+
+
+def test_list_test_files_filters_to_test_files_only():
+    paths = ["tests/test_a.py", "app/b.py", "app/c_test.go", "docs/readme.md"]
+    assert list_test_files(paths) == ["tests/test_a.py", "app/c_test.go"]
+
+
+def test_list_test_files_normalizes_backslashes_before_filtering():
+    assert list_test_files(["tests\\test_a.py"]) == ["tests/test_a.py"]
+
+
+def test_list_test_files_empty_input_returns_empty_list():
+    assert list_test_files([]) == []
+
+
+def test_list_test_files_no_test_files_present_returns_empty_list():
+    assert list_test_files(["app/foo.py", "docs/readme.md"]) == []
+
+
+def test_list_test_files_deduplicates_via_normalize_paths():
+    result = list_test_files(["tests/test_a.py", "tests\\test_a.py"])
+    assert result == ["tests/test_a.py"]
+
+
+def test_list_test_files_matches_every_declared_test_pattern_family():
+    # Spot-check that at least one representative path per pattern group in
+    # TEST_FILE_PATTERNS is recognized end-to-end through list_test_files.
+    assert TEST_FILE_PATTERNS  # sanity: pattern tuple isn't empty
+    candidates = [
+        "test_foo.py",
+        "foo_test.py",
+        "foo_test.go",
+        "foo.test.ts",
+        "foo.test.tsx",
+        "foo.test.js",
+        "foo.test.jsx",
+        "foo.spec.ts",
+        "foo.spec.tsx",
+        "foo.spec.js",
+        "foo.spec.jsx",
+        "tests/foo.py",
+        "test/foo.py",
+        "__tests__/foo.js",
+        "nested/dir/tests/foo.py",
+    ]
+    result = list_test_files(candidates)
+    assert result == candidates
+
+
+# --------------------------------------------------------------------------
+# list_source_files_needing_tests
+# --------------------------------------------------------------------------
+
+
+def test_list_source_files_needing_tests_filters_to_source_files_only():
+    paths = [
+        "app/foo.py",
+        "tests/test_foo.py",
+        "docs/readme.md",
+        "app/config.yaml",
+        "image.png",
+    ]
+    assert list_source_files_needing_tests(paths) == ["app/foo.py"]
+
+
+def test_list_source_files_needing_tests_excludes_test_files_even_with_source_extension():
+    assert list_source_files_needing_tests(["tests/test_foo.py"]) == []
+
+
+def test_list_source_files_needing_tests_excludes_files_without_known_extension():
+    assert list_source_files_needing_tests(["Makefile", "Dockerfile"]) == []
+
+
+def test_list_source_files_needing_tests_normalizes_and_deduplicates():
+    result = list_source_files_needing_tests(["app\\foo.py", "app/foo.py"])
+    assert result == ["app/foo.py"]
+
+
+def test_list_source_files_needing_tests_empty_input_returns_empty_list():
+    assert list_source_files_needing_tests([]) == []
+
+
+def test_list_source_files_needing_tests_preserves_input_order():
+    paths = ["app/b.py", "app/a.py", "docs/readme.md", "app/c.go"]
+    assert list_source_files_needing_tests(paths) == ["app/b.py", "app/a.py", "app/c.go"]

--- a/tests/test_pr_safety_repo_signals_pattern_matching.py
+++ b/tests/test_pr_safety_repo_signals_pattern_matching.py
@@ -1,0 +1,181 @@
+"""Direct coverage for the private pattern-matching and path-safety helpers
+in ``app.pr_safety.repo_signals``.
+
+``_matches_repo_pattern``, ``_matches_any_repo_pattern``,
+``_matches_ordered_patterns``, and ``_is_safe_relative_path`` are the
+security-adjacent primitives behind CODEOWNERS matching and GitHub Actions
+``paths``/``paths-ignore`` evaluation. Prior to this file they only had
+indirect coverage via ``collect_repo_signals`` integration tests in
+``tests/test_pr_safety_repo_signals.py``. These tests exercise the helpers
+directly, especially path-traversal and anchoring edge cases.
+"""
+
+from app.pr_safety.repo_signals import (
+    _is_safe_relative_path,
+    _matches_any_repo_pattern,
+    _matches_ordered_patterns,
+    _matches_repo_pattern,
+)
+
+
+# --------------------------------------------------------------------------
+# _matches_repo_pattern
+# --------------------------------------------------------------------------
+
+
+def test_matches_repo_pattern_unanchored_star_matches_extension_anywhere():
+    assert _matches_repo_pattern("app/nested/foo.py", "*.py") is True
+
+
+def test_matches_repo_pattern_unanchored_bare_filename_matches_any_depth():
+    # A pattern with no "/" acts like a gitignore basename rule: it matches
+    # the file at any directory depth, not just at the repo root.
+    assert _matches_repo_pattern("app/sub/foo.py", "foo.py") is True
+    assert _matches_repo_pattern("foo.py", "foo.py") is True
+
+
+def test_matches_repo_pattern_leading_slash_anchors_to_root():
+    assert _matches_repo_pattern("app/foo.py", "/app/foo.py") is True
+    assert _matches_repo_pattern("other/app/foo.py", "/app/foo.py") is False
+
+
+def test_matches_repo_pattern_slash_in_middle_anchors_without_leading_slash():
+    # Any "/" in the pattern (other than a purely trailing one) makes the
+    # match anchored to the start of the path, per CODEOWNERS/gitattributes
+    # semantics implemented here.
+    assert _matches_repo_pattern("app/foo.py", "app/*.py") is True
+    assert _matches_repo_pattern("nested/app/foo.py", "app/*.py") is False
+
+
+def test_matches_repo_pattern_single_star_does_not_cross_directory_boundary():
+    assert _matches_repo_pattern("app/sub/foo.py", "app/*.py") is False
+
+
+def test_matches_repo_pattern_double_star_crosses_directory_boundaries():
+    assert _matches_repo_pattern("app/sub/deep/foo.py", "app/**") is True
+    assert _matches_repo_pattern("app/sub/deep/foo.py", "/app/**") is True
+
+
+def test_matches_repo_pattern_trailing_slash_implies_directory_wildcard():
+    assert _matches_repo_pattern("app/foo.py", "app/") is True
+    assert _matches_repo_pattern("app/sub/foo.py", "app/") is True
+    assert _matches_repo_pattern("appendix/foo.py", "app/") is False
+
+
+def test_matches_repo_pattern_question_mark_matches_single_non_slash_char():
+    assert _matches_repo_pattern("app/foo.py", "?pp/foo.py") is True
+    assert _matches_repo_pattern("a/pp/foo.py", "?pp/foo.py") is False
+
+
+def test_matches_repo_pattern_empty_pattern_never_matches():
+    assert _matches_repo_pattern("app/foo.py", "") is False
+
+
+def test_matches_repo_pattern_whitespace_only_pattern_never_matches():
+    assert _matches_repo_pattern("app/foo.py", "   ") is False
+
+
+def test_matches_repo_pattern_normalizes_backslashes_in_pattern():
+    assert _matches_repo_pattern("app/foo.py", "app\\foo.py") is True
+
+
+def test_matches_repo_pattern_is_case_sensitive():
+    assert _matches_repo_pattern("APP/foo.py", "app/foo.py") is False
+
+
+def test_matches_repo_pattern_special_regex_characters_are_escaped():
+    # "." in a glob pattern is literal, not "any character" - a pattern like
+    # "app.py" must not match "appXpy" even though "." is a regex metachar.
+    assert _matches_repo_pattern("appXpy", "app.py") is False
+    assert _matches_repo_pattern("app.py", "app.py") is True
+
+
+# --------------------------------------------------------------------------
+# _matches_any_repo_pattern
+# --------------------------------------------------------------------------
+
+
+def test_matches_any_repo_pattern_true_when_one_pattern_matches():
+    assert _matches_any_repo_pattern("app/foo.py", ["*.md", "*.py"]) is True
+
+
+def test_matches_any_repo_pattern_false_when_none_match():
+    assert _matches_any_repo_pattern("app/foo.py", ["*.md", "*.txt"]) is False
+
+
+def test_matches_any_repo_pattern_empty_pattern_list_is_false():
+    assert _matches_any_repo_pattern("app/foo.py", []) is False
+
+
+# --------------------------------------------------------------------------
+# _matches_ordered_patterns
+# --------------------------------------------------------------------------
+
+
+def test_matches_ordered_patterns_empty_pattern_list_is_not_included():
+    assert _matches_ordered_patterns("app/foo.py", []) is False
+
+
+def test_matches_ordered_patterns_simple_include():
+    assert _matches_ordered_patterns("app/foo.py", ["app/**"]) is True
+    assert _matches_ordered_patterns("web/foo.py", ["app/**"]) is False
+
+
+def test_matches_ordered_patterns_negation_excludes_a_matched_file():
+    patterns = ["app/**", "!app/generated/**"]
+    assert _matches_ordered_patterns("app/generated/x.py", patterns) is False
+    assert _matches_ordered_patterns("app/handwritten/x.py", patterns) is True
+
+
+def test_matches_ordered_patterns_later_pattern_overrides_earlier_one():
+    # Ordering matters: the last matching pattern in the list wins,
+    # mirroring GitHub Actions' paths/paths-ignore evaluation order.
+    reincluded = _matches_ordered_patterns("app/x.py", ["!app/**", "app/**"])
+    assert reincluded is True
+
+    excluded_last = _matches_ordered_patterns("app/x.py", ["app/**", "!app/**"])
+    assert excluded_last is False
+
+
+def test_matches_ordered_patterns_non_matching_negation_has_no_effect():
+    patterns = ["app/**", "!web/**"]
+    assert _matches_ordered_patterns("app/foo.py", patterns) is True
+
+
+# --------------------------------------------------------------------------
+# _is_safe_relative_path
+# --------------------------------------------------------------------------
+
+
+def test_is_safe_relative_path_accepts_ordinary_relative_path():
+    assert _is_safe_relative_path("app/foo.py") is True
+
+
+def test_is_safe_relative_path_rejects_absolute_path():
+    assert _is_safe_relative_path("/etc/passwd") is False
+
+
+def test_is_safe_relative_path_rejects_leading_parent_traversal():
+    assert _is_safe_relative_path("../outside.py") is False
+
+
+def test_is_safe_relative_path_rejects_embedded_parent_traversal():
+    assert _is_safe_relative_path("app/../../etc/passwd") is False
+
+
+def test_is_safe_relative_path_rejects_parent_traversal_at_the_end():
+    assert _is_safe_relative_path("app/..") is False
+
+
+def test_is_safe_relative_path_accepts_dot_current_directory_segment():
+    # A literal "." segment is not a traversal risk; only ".." components
+    # are rejected.
+    assert _is_safe_relative_path("app/./foo.py") is True
+    assert _is_safe_relative_path("./app/foo.py") is True
+
+
+def test_is_safe_relative_path_accepts_filename_containing_dotdot_substring():
+    # ".." must be an exact path *component*, not merely a substring of a
+    # filename - "foo..py" or "..foo" are not traversal attempts.
+    assert _is_safe_relative_path("app/foo..py") is True
+    assert _is_safe_relative_path("app/..foo.py") is True


### PR DESCRIPTION
## What

Adds two new unit test files that give the pure, security-adjacent path-matching helpers behind the PR Safety verdict feature their first **direct** unit test coverage:

- `tests/test_pr_safety_path_rules_helpers.py` — covers `app/pr_safety/path_rules.py`:
  - `normalize_paths` (backslash normalization, whitespace/empty-entry dropping, dedup-after-normalization, order preservation)
  - `_matches_any_pattern` (match/no-match, empty pattern set, case sensitivity, short-circuit behavior)
  - `list_test_files` (filtering, normalization, dedup, one representative case per `TEST_FILE_PATTERNS` family)
  - `list_source_files_needing_tests` (filtering, exclusion of test/doc/config/unknown-extension files, normalization, order preservation)

- `tests/test_pr_safety_repo_signals_pattern_matching.py` — covers `app/pr_safety/repo_signals.py`:
  - `_matches_repo_pattern` (anchored vs. unanchored patterns, `*`/`**`/`?` glob semantics, trailing-slash directory wildcards, empty/whitespace patterns, backslash normalization, case sensitivity, regex-metacharacter escaping)
  - `_matches_any_repo_pattern` (match/no-match/empty list)
  - `_matches_ordered_patterns` (gitignore-style ordered include/exclude evaluation, negation, last-match-wins semantics)
  - `_is_safe_relative_path` (path-traversal guarding: absolute paths, leading/embedded/trailing `..` components, `.`-segment tolerance, filenames that merely *contain* `..` as a substring)

## Why

These functions decide whether a changed file is "safe"/expected for the PR-safety verdict — including CODEOWNERS pattern matching, GitHub Actions `paths`/`paths-ignore` evaluation, and the relative-path traversal guard used before any filesystem read in `repo_signals.py`. Before this PR they only had **indirect** coverage through higher-level functions (`group_changed_files`, `detect_risky_areas`, `collect_repo_signals`) in the existing `tests/test_pr_safety_path_rules.py` and `tests/test_pr_safety_repo_signals.py` files — none of the tests exercised these helpers, or their edge cases (path-traversal variants, pattern anchoring/negation ordering, empty inputs), directly. Given their security-adjacent role, direct coverage of the edge cases makes regressions easier to catch and easier to diagnose when they fail.

## Scope

- New test files only. No source, config, lockfile, or CI files were modified.
- Existing `tests/test_pr_safety_path_rules.py` and `tests/test_pr_safety_repo_signals.py` were left untouched — new files use distinct names to avoid overlap.

## Test plan

- [x] `python -m pytest tests/test_pr_safety_path_rules_helpers.py tests/test_pr_safety_repo_signals_pattern_matching.py -q` → 52 passed
- [x] `python -m pytest tests/ -k pr_safety -q` → 159 passed (full existing pr_safety suite unaffected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DckTZpWdFHp2fivqARUAhi)_