### PR TITLE
fix(test): skip POSIX-only case-sensitivity assertion on Windows

### DIFF
--- a/tests/test_pr_safety_path_rules_helpers.py
+++ b/tests/test_pr_safety_path_rules_helpers.py
@@ -9,6 +9,10 @@ including edge cases (empty/whitespace input, duplicate paths, backslash
 normalization, and empty pattern sets) relevant to path-matching correctness.
 """
 
+import os
+
+import pytest
+
 from app.pr_safety.path_rules import (
     TEST_FILE_PATTERNS,
     _matches_any_pattern,
@@ -68,6 +72,10 @@ def test_matches_any_pattern_false_for_empty_pattern_tuple():
     assert _matches_any_pattern("app/foo.py", ()) is False
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="fnmatch normalises case on Windows, so this POSIX-only behaviour does not hold",
+)
 def test_matches_any_pattern_is_case_sensitive_on_posix():
     # fnmatch on POSIX platforms is case-sensitive; a pattern matching
     # lowercase paths should not match an uppercase variant.


### PR DESCRIPTION
## Problem

`main` is red. `test_matches_any_pattern_is_case_sensitive_on_posix`, added in #1175, fails on all three `windows-latest` legs of the Full Test matrix:

```
>       assert _matches_any_pattern("APP/FOO.PY", ("*.py",)) is False
E       AssertionError: assert True is False
FAILED tests/test_pr_safety_path_rules_helpers.py::test_matches_any_pattern_is_case_sensitive_on_posix
```

`_matches_any_pattern` uses `fnmatch.fnmatch`, which normalises case according to the host OS — case-sensitive on POSIX, case-insensitive on Windows. The assertion is correct on Linux and macOS and cannot hold on Windows.

The test name already says `_on_posix`; it just never had the guard.

## Fix

`@pytest.mark.skipif(os.name == "nt", ...)`, plus the two imports it needs. No production code touched.

## Why it slipped through

#1175's own PR checks did not include the Windows matrix legs — the full `Full Test (windows-latest, 3.10/3.11/3.12)` set only runs on `main`. The PR was green when merged and the failure appeared afterwards.

## Verification

`ruff format` and `ruff check` clean (ruff 0.1.14, the pinned version). Full file passes locally on macOS: `24 passed`.

## Follow-up worth considering separately

`_matches_any_pattern` being platform-dependent is arguably a real inconsistency for path-safety rules — `fnmatch.fnmatchcase` would make it deterministic everywhere. Production runs on Linux so there is no live impact, and changing it is a behaviour decision, not a hotfix. Flagging rather than bundling it here.