### PR TITLE
test: widen timing margin in agent-generation timeout test

### DIFF
--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -100,7 +100,7 @@ def test_worker_client_generate_agent_timeout_returns_quickly():
         client = WorkerClient(api_key="test")
 
     def slow_call_api(*args, **kwargs):
-        time.sleep(0.2)
+        time.sleep(1.0)
         return "# Agent System Prompt"
 
     with patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01), patch.object(
@@ -111,7 +111,12 @@ def test_worker_client_generate_agent_timeout_returns_quickly():
             client.generate_agent("Test Agent")
         elapsed = time.perf_counter() - started_at
 
-    assert elapsed < 0.15
+    # The stub sleeps for 1.0s; the patched hard timeout is 0.01s. Anything
+    # comfortably below the sleep proves the timeout short-circuited the call
+    # rather than waiting it out. The previous budget of 0.15s sat only 0.05s
+    # under the sleep, which a loaded CI runner could exceed on scheduling
+    # alone - it failed on windows-latest at 0.184s.
+    assert elapsed < 0.5
 
 
 def test_worker_client_preserves_repo_context_when_example_code_is_disabled():


### PR DESCRIPTION
## Problem

`test_worker_client_generate_agent_timeout_returns_quickly` is flaky on the `windows-latest` legs of the Full Test matrix. It failed on `main` at `ccf87b0`:

```
>       assert elapsed < 0.15
E       assert 0.18378310000002784 < 0.15
FAILED tests/test_agent_generator.py::test_worker_client_generate_agent_timeout_returns_quickly
```

Re-running the identical job with no code change passed on all three Windows legs, confirming a flake rather than a regression.

## Why it flakes

The stub sleeps **0.2s**, the patched `HARD_TIMEOUT_SECONDS` is **0.01s**, and the assertion budget is **0.15s**. The number that matters is not the 0.14s above the timeout — it is the **0.05s** between the budget and the sleep. That is the entire distance between "the timeout fired" and "the timeout did not fire", and thread scheduling on a loaded CI runner covers it easily.

## Fix

Widen the gap rather than the tolerance:

| | before | after |
|---|---|---|
| stub sleep | 0.2s | 1.0s |
| assertion budget | 0.15s | 0.5s |
| margin to "timeout didn't fire" | 0.05s | 0.5s |

The test still fails if the timeout stops short-circuiting the call — that is the whole point of the assertion, and it is preserved. Simply bumping `0.15` to `0.2` was rejected: that equals the sleep, which would make the assertion vacuous.

## No cost on the happy path

The longer sleep does not slow the suite. `_call_api_with_timeout` deliberately avoids blocking on the worker thread:

```python
finally:
    executor.shutdown(wait=not timed_out, cancel_futures=timed_out)
```

On timeout `wait=False`, so the call returns immediately and the sleeping thread is abandoned rather than joined. Its docstring says as much: *"Run an LLM call with a timeout that does not block on executor shutdown."*

## Verification

Ran the patched test locally against `origin/main`:

```
0.01s call  tests/…::test_worker_client_generate_agent_timeout_returns_quickly
1 passed
```

0.01s measured against a 0.5s budget — a 50x margin, versus the ~1.2x it had at the moment it failed.

**Caveat:** this repo's PR checks do not include the Windows matrix legs (they only run on `main`), so a green run here does not by itself prove the fix on Windows. The argument rests on the margin: the observed failure was 0.184s, and the new budget is 0.5s.