### PR TITLE
test: de-flake agent generation hard-timeout test on Windows CI

### DIFF
--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -1,4 +1,5 @@
 import pytest
+import threading
 import time
 from unittest.mock import MagicMock, patch
 from app.llm_engine.client import WorkerClient
@@ -99,19 +100,29 @@ def test_worker_client_generate_agent_timeout_returns_quickly():
     with patch("app.llm_engine.client.OpenAI"):
         client = WorkerClient(api_key="test")
 
+    # The stub blocks until the test releases it (with a 10s safety net so a bug here can
+    # never hang the suite), so generate_agent() can only return fast if the hard timeout
+    # actually short-circuits the call.
+    release = threading.Event()
+
     def slow_call_api(*args, **kwargs):
-        time.sleep(0.2)
+        release.wait(timeout=10)
         return "# Agent System Prompt"
 
-    with patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01), patch.object(
-        client, "_call_api", side_effect=slow_call_api
-    ):
-        started_at = time.perf_counter()
-        with pytest.raises(RuntimeError, match="Agent generation timed out after 0.01s."):
-            client.generate_agent("Test Agent")
-        elapsed = time.perf_counter() - started_at
+    try:
+        with patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01), patch.object(
+            client, "_call_api", side_effect=slow_call_api
+        ):
+            started_at = time.perf_counter()
+            with pytest.raises(RuntimeError, match="Agent generation timed out after 0.01s."):
+                client.generate_agent("Test Agent")
+            elapsed = time.perf_counter() - started_at
+    finally:
+        release.set()
 
-    assert elapsed < 0.15
+    # Deliberately generous: a loaded CI runner (windows-latest especially) can need a few
+    # hundred ms just to schedule threads, but nowhere near the 10s the stub would block for.
+    assert elapsed < 1.0
 
 
 def test_worker_client_preserves_repo_context_when_example_code_is_disabled():


### PR DESCRIPTION
## Problem

`tests/test_agent_generator.py::test_worker_client_generate_agent_timeout_returns_quickly` is flaky on the `windows-latest` legs of the Full Test matrix.

Observed on `main` at ccf87b0 ([run 30915687229](https://github.com/madara88645/Compiler/actions/runs/30915687229), job *Full Test (windows-latest, 3.11)*):

```
>       assert elapsed < 0.15
E       assert 0.18378310000002784 < 0.15
```

Re-running the same job with no code change passed on all three Windows legs, so this is a flake, not a regression.

The test's intent is right — it proves the hard timeout short-circuits instead of waiting for the full call. The margin is the problem: a 0.2s stub sleep against a 0.15s budget leaves only ~0.14s of scheduling slack, and a loaded Windows runner exceeds that.

## Fix

Widen the gap rather than the tolerance:

- The `_call_api` stub now blocks on a `threading.Event` instead of `time.sleep(0.2)`, with a 10s safety net so a future bug here can never hang the suite.
- The assertion allows `elapsed < 1.0`.

The hard timeout still has to interrupt the call for the test to pass, but there is now ~1s of slack instead of a tenth. Bumping `0.15` to `0.2` was deliberately avoided — that equals the old stub's sleep and would make the assertion nearly meaningless.

The Event is released in a `finally` block so the worker thread does not linger for the full 10s after the assertion completes.

## Verification

- `python -m pytest tests/test_agent_generator.py -q` → 16 passed
- `uvx ruff@0.1.14 format --check` / `check` → clean
- Mutation check: patching `future.result(timeout=timeout_seconds)` to `future.result()` in `app/llm_engine/client.py` makes the test fail with `DID NOT RAISE` after 10.1s, confirming it still catches a genuinely broken timeout.

Note: PR checks do **not** include the Windows matrix legs (those run only on `main`), so a green PR here does not by itself prove the flake is gone — the margin argument and the post-merge `main` run are the real evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)