### PR TITLE
test: close coverage gaps in docx parsing, upload naming, IR validators, cost tracker, handler idempotency

### DIFF
--- a/tests/optimizer/test_costs_unknown_direction_gap.py
+++ b/tests/optimizer/test_costs_unknown_direction_gap.py
@@ -1,0 +1,24 @@
+"""Coverage gap: CostTracker.add_usage raises ValueError for an unknown
+direction (only "input" and "output" are accepted).
+"""
+import pytest
+
+from app.optimizer.costs import CostTracker
+
+
+def test_add_usage_unknown_direction_raises_value_error():
+    tracker = CostTracker()
+
+    with pytest.raises(ValueError, match="Unknown direction: sideways"):
+        tracker.add_usage("gpt-4o", 100, "sideways")
+
+
+def test_add_usage_unknown_direction_does_not_mutate_state():
+    tracker = CostTracker()
+
+    with pytest.raises(ValueError):
+        tracker.add_usage("gpt-4o", 100, "bogus")
+
+    assert tracker.total_input_tokens == 0
+    assert tracker.total_output_tokens == 0
+    assert tracker.total_cost == 0.0

--- a/tests/test_heuristics_handlers_idempotency_gap.py
+++ b/tests/test_heuristics_handlers_idempotency_gap.py
@@ -1,0 +1,70 @@
+"""Coverage gap: FormatEnforcerHandler.handle() and ParadoxResolverHandler.handle()
+both guard against double-inserting the same constraint into ir_v1.constraints
+and ir_v2.constraints. Calling .handle() twice on the same IR should not
+duplicate the injected constraint.
+"""
+from app.heuristics.handlers.format_enforcer import FormatEnforcerHandler
+from app.heuristics.handlers.paradox_resolver import ParadoxResolverHandler
+from app.models import IR
+from app.models_v2 import IRv2
+
+
+def test_format_enforcer_handle_twice_does_not_duplicate_constraint():
+    handler = FormatEnforcerHandler()
+
+    ir_v1 = IR(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        output_format="markdown",
+        length_hint="short",
+    )
+
+    ir_v2 = IRv2(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        metadata={"original_text": "Extract the emails into a JSON file"},
+    )
+
+    handler.handle(ir_v2, ir_v1)
+    handler.handle(ir_v2, ir_v1)
+
+    v1_matches = [c for c in ir_v1.constraints if "No conversational filler" in c]
+    v2_matches = [c for c in ir_v2.constraints if "No conversational filler" in c.text]
+
+    assert len(v1_matches) == 1
+    assert len(v2_matches) == 1
+
+
+def test_paradox_resolver_handle_twice_does_not_duplicate_constraint():
+    handler = ParadoxResolverHandler()
+
+    ir_v1 = IR(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        output_format="markdown",
+        length_hint="short",
+        constraints=["be brief", "be very detailed"],
+    )
+
+    ir_v2 = IRv2(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        metadata={"original_text": "Make it very short but also explain everything in detail"},
+    )
+
+    handler.handle(ir_v2, ir_v1)
+    handler.handle(ir_v2, ir_v1)
+
+    v1_matches = [c for c in ir_v1.constraints if "CONFLICT DETECTED" in c]
+    v2_matches = [c for c in ir_v2.constraints if "CONFLICT DETECTED" in c.text]
+
+    assert len(v1_matches) == 1
+    assert len(v2_matches) == 1

--- a/tests/test_models_ir_validators_gap.py
+++ b/tests/test_models_ir_validators_gap.py
@@ -1,0 +1,82 @@
+"""Coverage gap: app.models.IR field validators (_norm_list, _lang, _fmt,
+_persona, _len). Existing tests only ever construct valid IR instances; these
+tests assert on the ValueError branches and on _norm_list's dedup/stripping
+behavior.
+"""
+import pytest
+
+from app.models import IR
+
+
+def _base_kwargs(**overrides):
+    kwargs = dict(
+        language="en",
+        persona="assistant",
+        role="test",
+        domain="general",
+        output_format="markdown",
+        length_hint="short",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_ir_invalid_language_raises_value_error():
+    with pytest.raises(ValueError, match="language must be one of"):
+        IR(**_base_kwargs(language="fr"))
+
+
+def test_ir_invalid_output_format_raises_value_error():
+    with pytest.raises(ValueError, match="invalid output_format"):
+        IR(**_base_kwargs(output_format="pdf"))
+
+
+def test_ir_invalid_persona_raises_value_error():
+    with pytest.raises(ValueError, match="persona must be one of"):
+        IR(**_base_kwargs(persona="wizard"))
+
+
+def test_ir_invalid_length_hint_raises_value_error():
+    with pytest.raises(ValueError, match="invalid length_hint"):
+        IR(**_base_kwargs(length_hint="epic"))
+
+
+def test_ir_valid_construction_does_not_raise():
+    ir = IR(**_base_kwargs())
+    assert ir.language == "en"
+    assert ir.persona == "assistant"
+    assert ir.output_format == "markdown"
+    assert ir.length_hint == "short"
+
+
+def test_norm_list_dedups_case_insensitively_preserving_first_occurrence():
+    ir = IR(**_base_kwargs(goals=["Learn Python", "learn python", "Learn Python", "Ship code"]))
+    assert ir.goals == ["Learn Python", "Ship code"]
+
+
+def test_norm_list_strips_whitespace_and_drops_empties():
+    ir = IR(**_base_kwargs(tasks=["  write tests  ", "", "   ", "review PR"]))
+    assert ir.tasks == ["write tests", "review PR"]
+
+
+def test_norm_list_accepts_single_string_and_wraps_in_list():
+    ir = IR(**_base_kwargs(constraints="be concise"))
+    assert ir.constraints == ["be concise"]
+
+
+def test_norm_list_none_becomes_empty_list():
+    ir = IR(**_base_kwargs(style=None))
+    assert ir.style == []
+
+
+def test_norm_list_default_empty():
+    ir = IR(**_base_kwargs())
+    assert ir.goals == []
+    assert ir.tasks == []
+    assert ir.constraints == []
+    assert ir.style == []
+    assert ir.tone == []
+    assert ir.steps == []
+    assert ir.examples == []
+    assert ir.banned == []
+    assert ir.tools == []

--- a/tests/test_rag_parsers_docx_gap.py
+++ b/tests/test_rag_parsers_docx_gap.py
@@ -1,0 +1,86 @@
+"""Coverage gap: app.rag.parsers.parse_docx (previously untested).
+
+Builds a real .docx fixture via python-docx (Document with a paragraph and a
+table), then exercises the success path plus the ImportError and generic
+exception fallback branches.
+"""
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from app.rag.parsers import parse_docx, ParseResult
+
+docx = pytest.importorskip("docx", reason="python-docx not installed")
+
+
+def _build_sample_docx(tmp_path):
+    document = docx.Document()
+    document.add_paragraph("Hello from a real docx paragraph.")
+
+    table = document.add_table(rows=2, cols=2)
+    table.rows[0].cells[0].text = "Name"
+    table.rows[0].cells[1].text = "Score"
+    table.rows[1].cells[0].text = "Alice"
+    table.rows[1].cells[1].text = "42"
+
+    docx_path = tmp_path / "sample.docx"
+    document.save(str(docx_path))
+    return docx_path
+
+
+def test_parse_docx_success(tmp_path):
+    docx_path = _build_sample_docx(tmp_path)
+
+    result = parse_docx(docx_path)
+
+    assert isinstance(result, ParseResult)
+    assert "Hello from a real docx paragraph." in result.content
+    assert "[Table]" in result.content
+    assert "Name | Score" in result.content
+    assert "Alice | 42" in result.content
+
+    assert result.metadata["format"] == "docx"
+    assert result.metadata["extension"] == ".docx"
+    assert result.metadata["parser"] == "python-docx"
+    assert result.metadata["paragraph_count"] == 1
+    assert result.metadata["table_count"] == 1
+
+    assert result.word_count == len(result.content.split())
+    assert result.word_count > 0
+
+
+def test_parse_docx_empty_paragraphs_and_no_tables(tmp_path):
+    document = docx.Document()
+    document.add_paragraph("   ")  # whitespace-only paragraph should be skipped
+    document.add_paragraph("Real content here")
+
+    docx_path = tmp_path / "sparse.docx"
+    document.save(str(docx_path))
+
+    result = parse_docx(docx_path)
+
+    assert result.content == "Real content here"
+    assert result.metadata["paragraph_count"] == 1
+    assert result.metadata["table_count"] == 0
+
+
+def test_parse_docx_import_error(tmp_path):
+    docx_path = _build_sample_docx(tmp_path)
+
+    with patch.dict(sys.modules, {"docx": None}):
+        result = parse_docx(docx_path)
+
+    assert result.content == ""
+    assert result.metadata["format"] == "docx"
+    assert "python-docx not installed" in result.metadata["error"]
+
+
+def test_parse_docx_generic_exception(tmp_path):
+    non_existent_path = tmp_path / "does_not_exist.docx"
+
+    result = parse_docx(non_existent_path)
+
+    assert result.content == ""
+    assert result.metadata["format"] == "docx"
+    assert "An internal error occurred during parsing." in result.metadata["error"]

--- a/tests/test_rag_uploads_storage_name_gap.py
+++ b/tests/test_rag_uploads_storage_name_gap.py
@@ -1,0 +1,87 @@
+"""Coverage gap: app.rag.uploads.build_storage_name (previously only exercised
+indirectly through full upload API tests).
+"""
+import hashlib
+
+from app.rag.uploads import build_storage_name
+
+
+def _expected_digest(content: str) -> str:
+    return hashlib.sha1(content.encode("utf-8")).hexdigest()[:10]
+
+
+def test_build_storage_name_normal_name():
+    content = "hello world"
+    result = build_storage_name("notes.txt", content)
+    digest = _expected_digest(content)
+
+    assert result == f"notes-{digest}.txt"
+    assert len(digest) == 10
+
+
+def test_build_storage_name_digest_matches_sha1_of_content():
+    content = "some file content used for hashing"
+    result = build_storage_name("report.md", content)
+
+    digest = hashlib.sha1(content.encode("utf-8")).hexdigest()[:10]
+    assert result == f"report-{digest}.md"
+
+    # Different content must yield a different digest/name.
+    other_result = build_storage_name("report.md", "different content")
+    assert other_result != result
+
+
+def test_build_storage_name_invalid_chars_are_sanitized():
+    content = "content"
+    result = build_storage_name('weird<>:"/\\|?*name.txt', content)
+    digest = _expected_digest(content)
+
+    # Each of the 9 invalid chars (< > : " / \ | ? *) becomes its own underscore.
+    assert result == f"weird_________name-{digest}.txt"
+    assert result.endswith(f"-{digest}.txt")
+
+
+def test_build_storage_name_unicode_chars():
+    content = "content"
+    result = build_storage_name("résumé café.docx", content)
+    digest = _expected_digest(content)
+
+    # Accented letters and the space are collapsed to underscores by the stem sanitizer.
+    assert result == f"r_sum_caf-{digest}.docx"
+
+
+def test_build_storage_name_empty_stem_falls_back_to_upload():
+    content = "content"
+    # A stem made entirely of characters stripped by the stem sanitizer (leaving
+    # nothing but underscores, which are then trimmed by .strip("._")) collapses
+    # to the "upload" fallback.
+    result = build_storage_name("!!!.txt", content)
+    digest = _expected_digest(content)
+
+    assert result == f"upload-{digest}.txt"
+
+
+def test_build_storage_name_missing_suffix_defaults_to_txt():
+    content = "content"
+    result = build_storage_name("no_extension_name", content)
+    digest = _expected_digest(content)
+
+    assert result == f"no_extension_name-{digest}.txt"
+
+
+def test_build_storage_name_empty_display_name_defaults_to_upload():
+    content = "content"
+    result = build_storage_name("", content)
+    digest = _expected_digest(content)
+
+    assert result == f"upload-{digest}.txt"
+
+
+def test_build_storage_name_format_has_stem_digest_suffix():
+    content = "abc123"
+    result = build_storage_name("my-file.PDF", content)
+    digest = _expected_digest(content)
+
+    stem, _, rest = result.rpartition("-")
+    assert stem == "my-file"
+    assert rest == f"{digest}.PDF"


### PR DESCRIPTION
## Summary

Adds new pytest test files only, closing five previously-identified zero/low-coverage gaps in pure, deterministic, non-LLM/non-network logic. No source, config, `.env`, lockfile, or CI workflow files were modified.

### Gaps closed

1. **`app/rag/parsers.py::parse_docx`** — `tests/test_rag_parsers_docx_gap.py`
   Builds real `.docx` fixtures via `docx.Document()` (paragraph + table), and exercises the success path, an empty-paragraph/no-table case, the `ImportError` fallback branch (simulated via `sys.modules` patch), and the generic-exception fallback branch (non-existent file path).

2. **`app/rag/uploads.py::build_storage_name`** — `tests/test_rag_uploads_storage_name_gap.py`
   Direct unit tests for the sanitize + SHA1-digest-suffix behavior: normal name, invalid/unicode characters, empty stem (`"!!!.txt"` → `upload-<digest>.txt`), missing suffix (defaults to `.txt`), empty display name, and verifying the digest matches `hashlib.sha1(content...).hexdigest()[:10]` exactly.

3. **`app/models.py::IR`** field validators (`_norm_list`, `_lang`, `_fmt`, `_persona`, `_len`) — `tests/test_models_ir_validators_gap.py`
   Asserts `ValueError` is raised for invalid `language`, `output_format`, `persona`, and `length_hint` values, plus dedup (case-insensitive, order-preserving), whitespace-stripping/empty-dropping, single-string-to-list coercion, and `None`-to-`[]` behavior of `_norm_list` on fields like `goals`/`tasks`/`constraints`/`style`.

4. **`app/optimizer/costs.py::CostTracker.add_usage`** unknown-direction branch — `tests/optimizer/test_costs_unknown_direction_gap.py`
   Confirms `ValueError(f"Unknown direction: {direction}")` is raised for any direction outside `{"input", "output"}`, and that tracker state is left unmutated.

5. **`app/heuristics/handlers/format_enforcer.py::FormatEnforcerHandler.handle`** and **`app/heuristics/handlers/paradox_resolver.py::ParadoxResolverHandler.handle`** dedup guards — `tests/test_heuristics_handlers_idempotency_gap.py`
   Calls `.handle()` twice on the same `IR`/`IRv2` pair for each handler and asserts the injected constraint appears exactly once in both `ir_v1.constraints` and `ir_v2.constraints`.

All five planned test additions were completed — none were skipped.

### Verification

- Only test files were added; no source, config, `.env`, lockfile, or CI workflow files were touched (verified via `git status --porcelain` before commit — five new untracked files under `tests/`, nothing else).
- `python -m pytest tests/ -q` from repo root: **2570 passed, 7 skipped** (pre-existing skips, unrelated to this change), 0 failed.
- `python-docx` is already a declared project dependency (`pyproject.toml` `docs`/`all` extras) and is installed by CI via `pip install -e .[dev,docs]`; the new docx test additionally guards with `pytest.importorskip("docx")` so it degrades gracefully in environments without the optional extra installed.


---
_Generated by [Claude Code](https://claude.ai/code/session_0165WhUsTuGFsTAHtFUNYXt4)_