### PR TITLE
test: cover _safe_join path-traversal guard and skill_adapter helpers

### DIFF
--- a/integrations/mcp-server/test_repo_write_safe_join_gap.py
+++ b/integrations/mcp-server/test_repo_write_safe_join_gap.py
@@ -1,0 +1,65 @@
+"""Direct unit tests for repo_write._safe_join.
+
+This is the path-traversal guard behind write_pack_files. Before this file,
+it only had one indirect case (via test_repo_write.py::test_rejects_path_escape,
+exercised through write_pack_files). It is security-relevant — it decides
+whether a manifest entry is allowed to write outside the target repo root —
+so it deserves direct coverage of its own branches.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from repo_write import _safe_join
+
+
+def test_nested_relative_path_stays_inside_root(tmp_path: Path):
+    result = _safe_join(str(tmp_path), "a/b/c.txt")
+    assert result == str(tmp_path / "a" / "b" / "c.txt")
+
+
+def test_dot_segment_resolves_back_inside_root(tmp_path: Path):
+    result = _safe_join(str(tmp_path), "sub/../file.txt")
+    assert result == str(tmp_path / "file.txt")
+
+
+def test_empty_relative_path_resolves_to_root(tmp_path: Path):
+    result = _safe_join(str(tmp_path), "")
+    assert result == str(tmp_path)
+
+
+def test_dot_relative_path_resolves_to_root(tmp_path: Path):
+    result = _safe_join(str(tmp_path), ".")
+    assert result == str(tmp_path)
+
+
+def test_simple_parent_escape_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError, match="unsafe path escapes repo root"):
+        _safe_join(str(tmp_path), "../evil.txt")
+
+
+def test_nested_parent_escape_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError):
+        _safe_join(str(tmp_path), "a/../../evil.txt")
+
+
+def test_deeply_nested_parent_escape_is_rejected(tmp_path: Path):
+    with pytest.raises(ValueError):
+        _safe_join(str(tmp_path), "../../../../etc/passwd")
+
+
+def test_absolute_path_outside_root_is_rejected(tmp_path: Path):
+    # os.path.join discards the root when the second argument is absolute,
+    # so this must still be caught by the commonpath check.
+    with pytest.raises(ValueError):
+        _safe_join(str(tmp_path), os.path.join(os.sep, "etc", "passwd"))
+
+
+def test_root_with_trailing_separator_still_matches(tmp_path: Path):
+    root_with_slash = str(tmp_path) + os.sep
+    result = _safe_join(root_with_slash, "file.txt")
+    assert result == str(tmp_path / "file.txt")

--- a/tests/test_skill_adapter_identifier_yaml_gap.py
+++ b/tests/test_skill_adapter_identifier_yaml_gap.py
@@ -1,0 +1,99 @@
+"""Unit tests for skill_adapter's identifier/YAML/truncation helpers.
+
+_to_python_identifier, _to_python_param_identifier, _yaml_safe, and
+_truncate_at_sentence are pure string helpers reached only transitively
+through the adapter's public to_langchain_tool/to_agent_skill tests. None of
+them had a direct test before this file, despite handling edge cases
+(keyword collisions, YAML-reserved words, sentence-boundary truncation) that
+are easy to regress silently.
+"""
+
+from __future__ import annotations
+
+from app.adapters.skill_adapter import (
+    _to_python_identifier,
+    _to_python_param_identifier,
+    _truncate_at_sentence,
+    _yaml_safe,
+)
+
+
+def test_to_python_identifier_normalizes_symbols_and_case():
+    assert _to_python_identifier("My Skill-Name!") == "my_skill_name"
+
+
+def test_to_python_identifier_empty_input_falls_back():
+    assert _to_python_identifier("") == "skill"
+    assert _to_python_identifier("***") == "skill"
+
+
+def test_to_python_identifier_leading_digit_gets_prefixed():
+    assert _to_python_identifier("123start") == "skill_123start"
+
+
+def test_to_python_identifier_keyword_collision_gets_suffixed():
+    assert _to_python_identifier("class") == "class_skill"
+    assert _to_python_identifier("for") == "for_skill"
+
+
+def test_to_python_identifier_collapses_repeated_underscores():
+    assert _to_python_identifier("a___b") == "a_b"
+
+
+def test_to_python_param_identifier_normalizes_symbols():
+    assert _to_python_param_identifier("My Param!") == "My_Param"
+
+
+def test_to_python_param_identifier_empty_input_falls_back():
+    assert _to_python_param_identifier("") == "param"
+    assert _to_python_param_identifier("***") == "param"
+
+
+def test_to_python_param_identifier_leading_digit_gets_prefixed():
+    assert _to_python_param_identifier("123count") == "param_123count"
+
+
+def test_to_python_param_identifier_keyword_collision_gets_suffixed():
+    assert _to_python_param_identifier("class") == "class_"
+
+
+def test_yaml_safe_plain_string_is_unquoted():
+    assert _yaml_safe("a plain description") == "a plain description"
+
+
+def test_yaml_safe_reserved_word_is_quoted():
+    assert _yaml_safe("true") == '"true"'
+    assert _yaml_safe("Null") == '"Null"'
+
+
+def test_yaml_safe_special_char_is_quoted_and_escaped():
+    assert _yaml_safe('has: a colon') == '"has: a colon"'
+    assert _yaml_safe('has "quotes"') == '"has \\"quotes\\""'
+
+
+def test_yaml_safe_strips_newlines_and_carriage_returns():
+    assert _yaml_safe("line one\nline two\r") == "line one line two"
+
+
+def test_truncate_at_sentence_returns_unchanged_when_under_limit():
+    assert _truncate_at_sentence("short text", 50) == "short text"
+
+
+def test_truncate_at_sentence_cuts_at_sentence_boundary():
+    text = "First sentence. Second sentence. Third sentence that is long."
+    result = _truncate_at_sentence(text, 35)
+    assert result == "First sentence. Second sentence."
+
+
+def test_truncate_at_sentence_falls_back_to_word_boundary():
+    text = "wordwordword wordwordword wordwordword wordwordword nopunctuation"
+    result = _truncate_at_sentence(text, 30)
+    assert result.endswith("…")
+    assert "." not in result
+    assert len(result) <= 31
+
+
+def test_truncate_at_sentence_hard_cuts_when_no_spaces():
+    text = "a" * 50
+    result = _truncate_at_sentence(text, 10)
+    assert result == "a" * 10 + "…"


### PR DESCRIPTION
## Summary
- Add direct unit tests for `repo_write._safe_join`, the path-traversal guard behind `write_pack_files` in the MCP bridge. It previously had only one indirect test case (via `test_repo_write.py::test_rejects_path_escape`). Covers: nested relative paths, `.`/empty relative paths, simple/nested/deep `../` escapes, an absolute-path escape attempt, and a root path with a trailing separator.
- Add direct unit tests for four pure `app/adapters/skill_adapter.py` helpers that had zero direct coverage despite being reached only transitively through higher-level adapter tests: `_to_python_identifier`, `_to_python_param_identifier` (symbol stripping, empty-input fallback, leading-digit prefix, Python-keyword collision), `_yaml_safe` (reserved-word quoting, special-character escaping, newline stripping), and `_truncate_at_sentence` (under-limit passthrough, sentence-boundary cut, word-boundary fallback, hard cut with no spaces).

No source files, config, CI, or lockfiles were changed — this is test-only, produced by a scheduled test-coverage audit across the account's repos.

## Test plan
- [x] `python3 -m pytest integrations/mcp-server/test_repo_write_safe_join_gap.py -q` → 9 passed
- [x] `python3 -m pytest tests/test_skill_adapter_identifier_yaml_gap.py -q` → 17 passed
- [x] `python3 -m pytest tests/ integrations/mcp-server/ -q -m "not live" --ignore=integrations/mcp-server/test_server.py` → 2580 passed, 2 skipped (full suite, no regressions; `test_server.py` was already failing to collect before this change due to a pre-existing missing `mcp` package dependency, unrelated to this PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1auQN1mmRbXQknrALjcxj)_