### PR TITLE
test: add direct unit coverage for skill_adapter and agent_ir pure helpers

### DIFF
--- a/tests/test_agent_ir_map_sections.py
+++ b/tests/test_agent_ir_map_sections.py
@@ -1,0 +1,44 @@
+"""Direct unit coverage for app.adapters.agent_ir._map_sections.
+
+`_map_sections` normalises the raw ## header keys parsed out of Agent
+Generator markdown (e.g. "persona", "objective", "tools & capabilities")
+into the canonical IR field names (`role`, `goals`, `tech_stack`, ...) via
+the `_SECTION_ALIASES` table. It is pure dict-remapping with no I/O, but
+was previously only exercised indirectly through `parse_agent_markdown`
+end-to-end tests, so its alias resolution and first-wins collision
+behavior were never asserted directly.
+"""
+
+from app.adapters.agent_ir import _map_sections
+
+
+class TestMapSections:
+    def test_canonical_key_passes_through(self):
+        assert _map_sections({"role": "R content"}) == {"role": "R content"}
+
+    def test_alias_key_maps_to_canonical(self):
+        assert _map_sections({"persona": "P content"}) == {"role": "P content"}
+
+    def test_multiple_distinct_canonicals(self):
+        sections = {"tools": "T1", "constraints": "C1"}
+        assert _map_sections(sections) == {"tech_stack": "T1", "constraints": "C1"}
+
+    def test_unknown_header_is_dropped(self):
+        assert _map_sections({"random_header": "text"}) == {}
+
+    def test_first_alias_wins_when_multiple_map_to_same_canonical(self):
+        # dict preserves insertion order, and _map_sections keeps the first
+        # value seen for a given canonical key.
+        sections = {"goals": "G1", "objective": "G2", "objectives": "G3"}
+        assert _map_sections(sections) == {"goals": "G1"}
+
+    def test_later_alias_wins_if_it_appears_first_in_input(self):
+        sections = {"objective": "G2", "goals": "G1"}
+        assert _map_sections(sections) == {"goals": "G2"}
+
+    def test_empty_sections_returns_empty_dict(self):
+        assert _map_sections({}) == {}
+
+    def test_tech_stack_aliases_all_resolve(self):
+        for alias in ("tech stack", "tech", "technology stack", "tools", "capabilities"):
+            assert _map_sections({alias: "content"}) == {"tech_stack": "content"}

--- a/tests/test_skill_adapter_identifier_helpers.py
+++ b/tests/test_skill_adapter_identifier_helpers.py
@@ -1,0 +1,122 @@
+"""Direct unit coverage for app.adapters.skill_adapter identifier helpers.
+
+`_capitalize_words`, `_to_kebab`, `_to_python_identifier`,
+`_to_python_param_identifier`, and `_needs_keyword_only_params` turn
+arbitrary skill/param names into safe Python identifiers and SKILL.md
+frontmatter names. They are pure string/list transforms with several
+edge cases (empty input, leading digits, Python keyword collisions) that
+were previously only exercised incidentally through end-to-end export
+tests, never asserted directly.
+"""
+
+from app.adapters.skill_adapter import (
+    _capitalize_words,
+    _needs_keyword_only_params,
+    _to_kebab,
+    _to_python_identifier,
+    _to_python_param_identifier,
+)
+from app.adapters.skill_ir import SkillParam
+
+
+class TestCapitalizeWords:
+    def test_splits_and_capitalizes_each_word(self):
+        assert _capitalize_words("hello_world") == ["Hello", "World"]
+
+    def test_single_word(self):
+        assert _capitalize_words("single") == ["Single"]
+
+    def test_lowercases_rest_of_already_mixed_case_word(self):
+        assert _capitalize_words("hELLO_wORLD") == ["Hello", "World"]
+
+    def test_empty_string_yields_single_empty_element(self):
+        assert _capitalize_words("") == [""]
+
+
+class TestToKebab:
+    def test_converts_snake_case_to_kebab_case(self):
+        assert _to_kebab("hello_world") == "hello-world"
+
+    def test_collapses_repeated_underscores(self):
+        assert _to_kebab("hello__world") == "hello-world"
+
+    def test_strips_leading_and_trailing_underscores(self):
+        assert _to_kebab("__hello_world__") == "hello-world"
+
+    def test_lowercases_input(self):
+        assert _to_kebab("HELLO_WORLD") == "hello-world"
+
+    def test_empty_string(self):
+        assert _to_kebab("") == ""
+
+
+class TestToPythonIdentifier:
+    def test_lowercases_and_underscores_non_alnum(self):
+        assert _to_python_identifier("My Skill!") == "my_skill"
+
+    def test_collapses_repeated_separators(self):
+        assert _to_python_identifier("my--skill  name") == "my_skill_name"
+
+    def test_leading_digit_gets_prefixed(self):
+        assert _to_python_identifier("123abc") == "skill_123abc"
+
+    def test_python_keyword_gets_suffixed(self):
+        assert _to_python_identifier("class") == "class_skill"
+
+    def test_empty_input_falls_back_to_skill(self):
+        assert _to_python_identifier("") == "skill"
+
+    def test_only_symbols_falls_back_to_skill(self):
+        assert _to_python_identifier("!!!") == "skill"
+
+    def test_already_valid_identifier_is_unchanged(self):
+        assert _to_python_identifier("get_weather") == "get_weather"
+
+
+class TestToPythonParamIdentifier:
+    def test_replaces_invalid_characters(self):
+        assert _to_python_param_identifier("user-name") == "user_name"
+
+    def test_preserves_case_unlike_skill_identifier(self):
+        assert _to_python_param_identifier("My Param") == "My_Param"
+
+    def test_leading_digit_gets_param_prefix(self):
+        assert _to_python_param_identifier("2fa") == "param_2fa"
+
+    def test_python_keyword_gets_trailing_underscore(self):
+        assert _to_python_param_identifier("class") == "class_"
+
+    def test_empty_input_falls_back_to_param(self):
+        assert _to_python_param_identifier("") == "param"
+
+
+class TestNeedsKeywordOnlyParams:
+    def _param(self, name: str, required: bool) -> SkillParam:
+        return SkillParam(name=name, required=required)
+
+    def test_no_params_does_not_need_keyword_only(self):
+        assert _needs_keyword_only_params([]) is False
+
+    def test_all_required_does_not_need_keyword_only(self):
+        params = [self._param("a", True), self._param("b", True)]
+        assert _needs_keyword_only_params(params) is False
+
+    def test_required_after_optional_needs_keyword_only(self):
+        params = [self._param("a", False), self._param("b", True)]
+        assert _needs_keyword_only_params(params) is True
+
+    def test_optional_after_required_does_not_need_keyword_only(self):
+        params = [self._param("a", True), self._param("b", False)]
+        assert _needs_keyword_only_params(params) is False
+
+    def test_required_after_run_of_optionals_needs_keyword_only(self):
+        params = [
+            self._param("a", False),
+            self._param("b", False),
+            self._param("c", True),
+        ]
+        assert _needs_keyword_only_params(params) is True
+
+    def test_all_optional_does_not_need_keyword_only(self):
+        params = [self._param("a", False), self._param("b", False)]
+        assert _needs_keyword_only_params(params) is False


### PR DESCRIPTION
## Summary

Scheduled test-coverage audit across 5 repos flagged a few pure helper functions in this repo that were only exercised indirectly through end-to-end export tests. This PR adds direct unit tests for them.

## Changes

- `tests/test_skill_adapter_identifier_helpers.py` — direct coverage for `_capitalize_words`, `_to_kebab`, `_to_python_identifier`, `_to_python_param_identifier`, and `_needs_keyword_only_params` in `app/adapters/skill_adapter.py`: empty input, leading digits, Python keyword collisions, and required-after-optional param ordering.
- `tests/test_agent_ir_map_sections.py` — direct coverage for `_map_sections` in `app/adapters/agent_ir.py`: alias-table resolution, unknown headers, and first-alias-wins collision behavior.

No source, config, or CI files were touched — new test files only.

## Testing

- Backend tests: `python -m pytest tests/ -q` — 2579 passed, 7 skipped (pre-existing skips, unrelated to this change), 0 failed (full suite, run locally)
- New tests: 35 new test cases, all passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsaLxayRjXjgaZU4JremPb)_