### PR TITLE
test: add coverage for adapter and heuristics private helpers

### DIFF
--- a/tests/test_agent_ir_pure_helpers.py
+++ b/tests/test_agent_ir_pure_helpers.py
@@ -1,0 +1,51 @@
+"""Direct unit tests for `_map_sections` in app.adapters.agent_ir.
+
+`_map_sections` normalises raw markdown section keys (as parsed from
+`## Header` lines) into a small canonical set using the `_SECTION_ALIASES`
+table, keeping the first canonical match on collision. It was previously
+only exercised indirectly through full `_build_ir` / markdown-to-agent
+conversion tests.
+"""
+
+from app.adapters.agent_ir import _map_sections
+
+
+def test_map_sections_maps_known_alias_to_canonical_key():
+    assert _map_sections({"objective": "Ship the feature"}) == {"goals": "Ship the feature"}
+
+
+def test_map_sections_leaves_already_canonical_keys_unchanged():
+    assert _map_sections({"role": "You are an assistant"}) == {"role": "You are an assistant"}
+
+
+def test_map_sections_drops_unrecognized_keys():
+    assert _map_sections({"random_header": "some content"}) == {}
+
+
+def test_map_sections_first_canonical_wins_on_collision():
+    # "goal" and "objectives" both alias to "goals" — dict preserves insertion
+    # order, so whichever is encountered first should win.
+    sections = {"goal": "first goal text", "objectives": "second goal text"}
+    result = _map_sections(sections)
+    assert result == {"goals": "first goal text"}
+
+
+def test_map_sections_merges_multiple_distinct_aliases_into_shared_canonical():
+    sections = {
+        "rules": "no PII",
+        "limitations": "read-only",
+        "tech": "Python",
+    }
+    result = _map_sections(sections)
+    # "rules" wins over "limitations" for the "constraints" bucket.
+    assert result == {"constraints": "no PII", "tech_stack": "Python"}
+
+
+def test_map_sections_empty_input_returns_empty_dict():
+    assert _map_sections({}) == {}
+
+
+def test_map_sections_case_sensitive_alias_lookup():
+    # The alias table keys are lowercase; an uppercase raw key (as could
+    # theoretically be passed directly) will not match and is dropped.
+    assert _map_sections({"ROLE": "text"}) == {}

--- a/tests/test_agent_packs_helpers_gap.py
+++ b/tests/test_agent_packs_helpers_gap.py
@@ -1,0 +1,95 @@
+"""Direct unit tests for pure string-templating helpers in
+app.adapters.agent_packs that are not covered by
+tests/test_agent_packs_private_helpers.py: `_agent_name`, `_agent_role`,
+and `_pack_specific_workflow`.
+"""
+
+from app.adapters.agent_packs import (
+    AgentPackRequest,
+    _agent_name,
+    _agent_role,
+    _pack_specific_workflow,
+)
+
+
+def _req(pack_type: str, project_type: str = "svc", stack: str = "Python, FastAPI"):
+    return AgentPackRequest(
+        project_type=project_type,
+        stack=stack,
+        goal="Add a health route",
+        pack_type=pack_type,
+    )
+
+
+# --- _agent_name -------------------------------------------------------------
+
+
+def test_agent_name_project_pack_suffix():
+    assert _agent_name(_req("project-pack", project_type="MyApp")) == "MyApp Maintainer"
+
+
+def test_agent_name_subagent_suffix():
+    assert _agent_name(_req("subagent", project_type="MyApp")) == "MyApp Focused Agent"
+
+
+def test_agent_name_pr_reviewer_suffix():
+    assert _agent_name(_req("pr-reviewer", project_type="MyApp")) == "MyApp PR Reviewer"
+
+
+def test_agent_name_mcp_tool_stub_suffix():
+    assert _agent_name(_req("mcp-tool-stub", project_type="MyApp")) == "MyApp Tool"
+
+
+# --- _agent_role ---------------------------------------------------------------
+
+
+def test_agent_role_pr_reviewer_mentions_read_only_and_stack():
+    role = _agent_role(_req("pr-reviewer", project_type="svc", stack="Python, FastAPI"))
+    assert "read-only pull request reviewer for svc" in role
+    assert "Python, FastAPI" in role
+
+
+def test_agent_role_subagent_mentions_focused_and_stack():
+    role = _agent_role(_req("subagent", project_type="svc", stack="Node, Express"))
+    assert "focused Claude Code subagent for svc" in role
+    assert "Node, Express" in role
+
+
+def test_agent_role_project_pack_mentions_maintain_and_stack():
+    role = _agent_role(_req("project-pack", project_type="svc", stack="Go"))
+    assert "maintain svc" in role
+    assert "Go" in role
+
+
+def test_agent_role_mcp_tool_stub_falls_back_to_default_maintainer_role():
+    # mcp-tool-stub is not special-cased, so it falls through to the same
+    # generic "maintain" branch as project-pack.
+    role = _agent_role(_req("mcp-tool-stub", project_type="svc", stack="Rust"))
+    assert "maintain svc" in role
+    assert "Rust" in role
+
+
+# --- _pack_specific_workflow -----------------------------------------------------
+
+
+def test_pack_specific_workflow_pr_reviewer():
+    workflow = _pack_specific_workflow("pr-reviewer")
+    assert "Review the diff" in workflow
+    assert "without editing" in workflow
+
+
+def test_pack_specific_workflow_subagent():
+    workflow = _pack_specific_workflow("subagent")
+    assert "Confirm the requested outcome and boundaries" in workflow
+    assert "smallest evidence-backed" in workflow
+
+
+def test_pack_specific_workflow_project_pack_default():
+    workflow = _pack_specific_workflow("project-pack")
+    assert "implement the smallest scoped change" in workflow
+
+
+def test_pack_specific_workflow_mcp_tool_stub_uses_default_branch():
+    # mcp-tool-stub is not special-cased, so it shares the generic default
+    # workflow text with project-pack.
+    assert _pack_specific_workflow("mcp-tool-stub") == _pack_specific_workflow("project-pack")

--- a/tests/test_claude_code_adapter_pure_helpers.py
+++ b/tests/test_claude_code_adapter_pure_helpers.py
@@ -1,0 +1,97 @@
+"""Direct unit tests for small pure string-sanitization helpers in
+app.adapters.claude_code: `_to_python_identifier`, `_escape_triple_quotes`,
+and `_strip_markdown_fences`.
+
+These were previously only exercised indirectly through the higher-level
+`to_agent_sdk_python` / `to_claude_agent_sdk_multi` export tests.
+"""
+
+from app.adapters.claude_code import (
+    _escape_triple_quotes,
+    _strip_markdown_fences,
+    _to_python_identifier,
+)
+
+
+# --- _to_python_identifier -------------------------------------------------
+
+
+def test_to_python_identifier_simple_name():
+    assert _to_python_identifier("My Skill") == "my_skill"
+
+
+def test_to_python_identifier_replaces_non_alnum_with_underscore():
+    assert _to_python_identifier("fetch-orders!!") == "fetch_orders"
+
+
+def test_to_python_identifier_collapses_repeated_underscores():
+    assert _to_python_identifier("a---b   c") == "a_b_c"
+
+
+def test_to_python_identifier_strips_leading_and_trailing_underscores():
+    assert _to_python_identifier("__hello__") == "hello"
+
+
+def test_to_python_identifier_leading_digit_gets_prefixed():
+    assert _to_python_identifier("123 go") == "skill_123_go"
+
+
+def test_to_python_identifier_python_keyword_collision():
+    assert _to_python_identifier("class") == "class_skill"
+
+
+def test_to_python_identifier_another_keyword_collision():
+    assert _to_python_identifier("import") == "import_skill"
+
+
+def test_to_python_identifier_empty_string_falls_back_to_default():
+    assert _to_python_identifier("") == "skill"
+
+
+def test_to_python_identifier_all_symbols_falls_back_to_default():
+    assert _to_python_identifier("!!!___...") == "skill"
+
+
+# --- _escape_triple_quotes --------------------------------------------------
+
+
+def test_escape_triple_quotes_escapes_all_occurrences():
+    assert (
+        _escape_triple_quotes('He said """hello""" to me')
+        == 'He said \\"\\"\\"hello\\"\\"\\" to me'
+    )
+
+
+def test_escape_triple_quotes_no_triple_quotes_is_noop():
+    assert _escape_triple_quotes("plain text with no fences") == "plain text with no fences"
+
+
+def test_escape_triple_quotes_empty_string():
+    assert _escape_triple_quotes("") == ""
+
+
+# --- _strip_markdown_fences --------------------------------------------------
+
+
+def test_strip_markdown_fences_removes_language_tagged_fence():
+    text = "```python\nprint('hi')\n```"
+    assert _strip_markdown_fences(text) == "print('hi')"
+
+
+def test_strip_markdown_fences_removes_bare_fence():
+    text = "```\nsome content\n```"
+    assert _strip_markdown_fences(text) == "some content"
+
+
+def test_strip_markdown_fences_strips_surrounding_whitespace():
+    text = "   ```\ncontent\n```   "
+    assert _strip_markdown_fences(text) == "content"
+
+
+def test_strip_markdown_fences_no_fences_is_unchanged():
+    assert _strip_markdown_fences("just plain text") == "just plain text"
+
+
+def test_strip_markdown_fences_only_strips_leading_and_trailing_fences():
+    text = "```js\nconst x = '```not a fence```';\n```"
+    assert _strip_markdown_fences(text) == "const x = '```not a fence```';"

--- a/tests/test_domain_expert_snippets_gap.py
+++ b/tests/test_domain_expert_snippets_gap.py
@@ -1,0 +1,129 @@
+"""Direct unit tests for DomainHandler._inject_snippets and
+DomainHandler._hash_id, which were previously only exercised indirectly
+(if at all) through full compile_text() / analyze_domain() pipeline tests.
+
+Follows the pattern established in
+tests/heuristics/test_domain_expert_pure_helpers.py.
+"""
+
+from app.heuristics.handlers.domain_expert import DomainAnalysis, DomainHandler
+
+
+def _new_analysis():
+    return DomainAnalysis(detected_domain="coding")
+
+
+# -----------------------------------------------------------------------------
+# _inject_snippets
+# -----------------------------------------------------------------------------
+
+
+def test_inject_snippets_react_component_with_tailwind_adds_stack_suggestion():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets(
+        "Write a react component using tailwind for styling", analysis
+    )
+
+    assert len(analysis.suggestions) == 1
+    assert analysis.suggestions[0].category == "stack_recommendation"
+    assert analysis.suggestions[0].priority == 70
+
+
+def test_inject_snippets_react_code_with_tailwind_adds_stack_suggestion():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets("Generate react code styled with tailwind", analysis)
+
+    assert len(analysis.suggestions) == 1
+    assert analysis.suggestions[0].category == "stack_recommendation"
+
+
+def test_inject_snippets_react_without_tailwind_adds_nothing():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets("Write a react component please", analysis)
+
+    assert analysis.suggestions == []
+
+
+def test_inject_snippets_react_and_tailwind_without_component_or_code_adds_nothing():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets("I like react and tailwind a lot", analysis)
+
+    assert analysis.suggestions == []
+
+
+def test_inject_snippets_shadcn_keyword_adds_architecture_suggestion():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets("Please use shadcn for the buttons", analysis)
+
+    assert len(analysis.suggestions) == 1
+    assert analysis.suggestions[0].category == "architecture"
+    assert analysis.suggestions[0].priority == 65
+
+
+def test_inject_snippets_ui_component_phrase_adds_architecture_suggestion():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets("Build a reusable ui component for forms", analysis)
+
+    assert len(analysis.suggestions) == 1
+    assert analysis.suggestions[0].category == "architecture"
+
+
+def test_inject_snippets_both_conditions_trigger_two_suggestions():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets(
+        "Write a react component with tailwind and shadcn/ui", analysis
+    )
+
+    assert len(analysis.suggestions) == 2
+    categories = {s.category for s in analysis.suggestions}
+    assert categories == {"stack_recommendation", "architecture"}
+
+
+def test_inject_snippets_no_relevant_keywords_leaves_analysis_untouched():
+    handler = DomainHandler()
+    analysis = _new_analysis()
+
+    handler._inject_snippets("Write a Python function to sort a list", analysis)
+
+    assert analysis.suggestions == []
+
+
+# -----------------------------------------------------------------------------
+# _hash_id
+# -----------------------------------------------------------------------------
+
+
+def test_hash_id_returns_ten_char_hex_prefix():
+    handler = DomainHandler()
+    result = handler._hash_id("hello")
+    assert result == "aaf4c61ddc"
+    assert len(result) == 10
+
+
+def test_hash_id_empty_string():
+    handler = DomainHandler()
+    assert handler._hash_id("") == "da39a3ee5e"
+
+
+def test_hash_id_is_deterministic():
+    handler = DomainHandler()
+    assert handler._hash_id("same input") == handler._hash_id("same input")
+
+
+def test_hash_id_differs_for_different_inputs():
+    handler = DomainHandler()
+    assert handler._hash_id("input one") != handler._hash_id("input two")

--- a/tests/test_skill_adapter_pure_helpers_gap.py
+++ b/tests/test_skill_adapter_pure_helpers_gap.py
@@ -1,0 +1,144 @@
+"""Direct unit tests for pure helpers in app.adapters.skill_adapter that were
+not covered by tests/test_skill_adapter.py: `_needs_keyword_only_params`,
+`_truncate_at_sentence`, `_to_kebab`, `_to_title`, and `_capitalize_words`.
+
+`_to_pascal` (sibling case-conversion helper) is already covered in
+tests/test_skill_adapter.py::test_to_pascal.
+"""
+
+from app.adapters.skill_adapter import (
+    _capitalize_words,
+    _needs_keyword_only_params,
+    _to_kebab,
+    _to_title,
+    _truncate_at_sentence,
+)
+from app.adapters.skill_ir import SkillParam
+
+
+# --- _capitalize_words / _to_kebab / _to_title ------------------------------
+
+
+def test_capitalize_words_splits_and_capitalizes_each_segment():
+    assert _capitalize_words("hello_world") == ["Hello", "World"]
+
+
+def test_capitalize_words_single_segment():
+    assert _capitalize_words("single") == ["Single"]
+
+
+def test_capitalize_words_empty_string_returns_single_empty_segment():
+    assert _capitalize_words("") == [""]
+
+
+def test_to_kebab_converts_underscores_to_hyphens():
+    assert _to_kebab("my_skill_name") == "my-skill-name"
+
+
+def test_to_kebab_collapses_repeated_underscores():
+    assert _to_kebab("a__b___c") == "a-b-c"
+
+
+def test_to_kebab_strips_leading_and_trailing_underscores():
+    assert _to_kebab("__hello_world__") == "hello-world"
+
+
+def test_to_kebab_lowercases_input():
+    assert _to_kebab("My_Skill") == "my-skill"
+
+
+def test_to_title_joins_capitalized_words_with_spaces():
+    assert _to_title("hello_world") == "Hello World"
+
+
+def test_to_title_single_word():
+    assert _to_title("single") == "Single"
+
+
+# --- _needs_keyword_only_params ---------------------------------------------
+
+
+def _param(name: str, required: bool) -> SkillParam:
+    return SkillParam(name=name, type="str", description="", required=required)
+
+
+def test_needs_keyword_only_params_all_required_is_false():
+    params = [_param("a", True), _param("b", True)]
+    assert _needs_keyword_only_params(params) is False
+
+
+def test_needs_keyword_only_params_all_optional_is_false():
+    params = [_param("a", False), _param("b", False)]
+    assert _needs_keyword_only_params(params) is False
+
+
+def test_needs_keyword_only_params_required_after_optional_is_true():
+    params = [_param("a", False), _param("b", True)]
+    assert _needs_keyword_only_params(params) is True
+
+
+def test_needs_keyword_only_params_optional_after_required_is_false():
+    params = [_param("a", True), _param("b", False)]
+    assert _needs_keyword_only_params(params) is False
+
+
+def test_needs_keyword_only_params_empty_list_is_false():
+    assert _needs_keyword_only_params([]) is False
+
+
+def test_needs_keyword_only_params_required_optional_required_is_true():
+    params = [_param("a", True), _param("b", False), _param("c", True)]
+    assert _needs_keyword_only_params(params) is True
+
+
+# --- _truncate_at_sentence ----------------------------------------------------
+
+
+def test_truncate_at_sentence_returns_unchanged_when_within_limit():
+    assert _truncate_at_sentence("short text", 100) == "short text"
+
+
+def test_truncate_at_sentence_returns_unchanged_when_exactly_at_limit():
+    text = "12345"
+    assert _truncate_at_sentence(text, 5) == text
+
+
+def test_truncate_at_sentence_breaks_on_sentence_boundary():
+    text = "This is the first sentence. This is the second sentence that runs long."
+    result = _truncate_at_sentence(text, 40)
+    assert result == "This is the first sentence."
+    assert not result.endswith("…")
+
+
+def test_truncate_at_sentence_falls_back_to_word_boundary_when_no_sentence_break():
+    # No ". "/"! "/"? " within the cut, but there is a word boundary past
+    # max_len // 2, so it should cut at the last space and add an ellipsis.
+    text = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda"
+    result = _truncate_at_sentence(text, 30)
+    assert result.endswith("…")
+    assert not result.endswith(" …")
+
+
+def test_truncate_at_sentence_strips_trailing_punctuation_before_ellipsis():
+    text = "word one, word two, word three, word four is long"
+    result = _truncate_at_sentence(text, 20)
+    # The word boundary falls right after "word two,"; the trailing comma
+    # should be stripped before the ellipsis is appended.
+    assert result == "word one, word two…"
+    assert not result.endswith(",…")
+
+
+def test_truncate_at_sentence_hard_cutoff_when_no_boundary_found():
+    # A single long token with no spaces or sentence punctuation at all.
+    text = "a" * 50
+    result = _truncate_at_sentence(text, 10)
+    assert result == "a" * 10 + "…"
+
+
+def test_truncate_at_sentence_ignores_sentence_break_before_half_max_len():
+    # The only sentence break ("Hi. ") occurs at index 2, well before
+    # max_len // 2 == 15, so it must be ignored in favor of the
+    # word-boundary fallback rather than truncating down to just "Hi.".
+    text = "Hi. " + "word " * 20
+    result = _truncate_at_sentence(text, 30)
+    assert result == "Hi. word word word word word…"


### PR DESCRIPTION
## Summary

Backfills unit test coverage for previously-untested pure functions in `app/adapters/` and `app/heuristics/handlers/`, found during a test-coverage audit across the repo. All are pure input→output transforms (string sanitization, markdown parsing, templating) with no LLM/network calls.

## Changes

New test files only, following the repo's existing `*_pure_helpers`/`*_gap` convention:

- `tests/test_agent_ir_pure_helpers.py` — `app/adapters/agent_ir.py:_map_sections`
- `tests/test_claude_code_adapter_pure_helpers.py` — `app/adapters/claude_code.py:_to_python_identifier`, `_strip_markdown_fences`, `_escape_triple_quotes`
- `tests/test_skill_adapter_pure_helpers_gap.py` — `app/adapters/skill_adapter.py:_needs_keyword_only_params`, `_truncate_at_sentence`, `_to_kebab`, `_to_title`, `_capitalize_words`
- `tests/test_domain_expert_snippets_gap.py` — `app/heuristics/handlers/domain_expert.py:_inject_snippets`, `_hash_id`
- `tests/test_agent_packs_helpers_gap.py` — `app/adapters/agent_packs.py:_agent_name`, `_agent_role`, `_pack_specific_workflow`

No existing source, config, or CI files were modified.

## Test plan

- [x] Targeted run: 380 passed
- [x] Full suite (`python -m pytest tests/ -q`): 2614 passed, 7 skipped (pre-existing, unrelated) in 69.92s


---
_Generated by [Claude Code](https://claude.ai/code/session_01RRMvBsp9X1rNRxRHNFjW7F)_