### PR TITLE
🎨 Palette: [UX improvement] Add dynamic title to Download Pack button

### DIFF
--- a/web/app/agent-packs/page.tsx
+++ b/web/app/agent-packs/page.tsx
@@ -452,6 +452,7 @@ export default function AgentPacksPage() {
                       onClick={handleDownload}
                       disabled={downloading}
                       aria-busy={downloading}
+                      title={downloading ? "Preparing your pack for download..." : "Download Pack"}
                       className="inline-flex items-center gap-2 rounded-xl border border-cyan-400/20 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
                     >
                       <Download size={14} aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added a dynamic `title` attribute to the Download Pack button in Agent Packs.
🎯 Why: When the button is disabled during download preparation, users should have clarity on exactly why it is disabled and what is happening.
📸 Before/After: Before, the button was disabled without an explicit tooltip explaining the state. Now, it shows 'Preparing your pack for download...' on hover when busy.
♿ Accessibility: Improves accessibility by explicitly declaring the disabled state rationale via a dynamic title tooltip.

---
*PR created automatically by Jules for task [6812784381517773866](https://jules.google.com/task/6812784381517773866) started by @madara88645*