### PR TITLE
test: add unit coverage for rag parsers, judge, llm adapter, and repo_inspect

### DIFF
--- a/tests/optimizer/test_judge.py
+++ b/tests/optimizer/test_judge.py
@@ -1,0 +1,102 @@
+"""tests/optimizer/test_judge.py — direct unit tests for app.optimizer.judge.JudgeAgent,
+which had no dedicated test coverage. Uses the default MockExecutor-backed TestRunner
+so no network/LLM calls are involved.
+"""
+
+from pathlib import Path
+
+from app.optimizer.judge import JudgeAgent
+from app.optimizer.models import Candidate
+from app.testing.models import Assertion, TestCase, TestSuite
+
+
+def _candidate(prompt_text: str = "Say hello politely.") -> Candidate:
+    return Candidate(generation=0, prompt_text=prompt_text)
+
+
+def _suite_with_cases(*cases: TestCase) -> TestSuite:
+    return TestSuite(
+        name="judge-suite",
+        prompt_file="unused.txt",
+        test_cases=list(cases),
+    )
+
+
+def test_evaluate_empty_suite_returns_zero_score():
+    judge = JudgeAgent()
+    suite = _suite_with_cases()
+
+    result = judge.evaluate(_candidate(), suite, base_dir=Path("."))
+
+    assert result.score == 0.0
+    assert result.passed_count == 0
+    assert result.failed_count == 0
+    assert result.error_count == 0
+    assert result.avg_latency_ms == 0
+
+
+def test_evaluate_all_cases_pass():
+    # MockExecutor echoes "MOCKED RESPONSE. Prompt info: <prompt>", so an
+    # assertion that the output contains a substring of the compiled prompt
+    # (here, the literal instruction text) will pass deterministically.
+    case = TestCase(
+        id="case-1",
+        assertions=[Assertion(type="contains", value="hello", target="output")],
+    )
+    suite = _suite_with_cases(case)
+    judge = JudgeAgent()
+
+    result = judge.evaluate(_candidate("Please say hello."), suite, base_dir=Path("."))
+
+    assert result.score == 1.0
+    assert result.passed_count == 1
+    assert result.failed_count == 0
+    assert result.error_count == 0
+    assert result.failures == []
+
+
+def test_evaluate_mixed_pass_and_fail_computes_partial_score():
+    passing_case = TestCase(
+        id="pass-case",
+        assertions=[Assertion(type="contains", value="hello", target="output")],
+    )
+    failing_case = TestCase(
+        id="fail-case",
+        assertions=[
+            Assertion(
+                type="contains",
+                value="this-substring-will-never-appear-xyz",
+                target="output",
+                error_message="expected marker missing",
+            )
+        ],
+    )
+    suite = _suite_with_cases(passing_case, failing_case)
+    judge = JudgeAgent()
+
+    result = judge.evaluate(_candidate("Please say hello."), suite, base_dir=Path("."))
+
+    assert result.score == 0.5
+    assert result.passed_count == 1
+    assert result.failed_count == 1
+    assert result.error_count == 0
+    assert len(result.failures) == 1
+    assert "expected marker missing" in result.failures[0]
+
+
+def test_evaluate_all_cases_fail_scores_zero():
+    case = TestCase(
+        id="always-fails",
+        assertions=[
+            Assertion(type="contains", value="not-in-the-mock-response", target="output")
+        ],
+    )
+    suite = _suite_with_cases(case)
+    judge = JudgeAgent()
+
+    result = judge.evaluate(_candidate(), suite, base_dir=Path("."))
+
+    assert result.score == 0.0
+    assert result.passed_count == 0
+    assert result.failed_count == 1
+    assert result.avg_latency_ms >= 0

--- a/tests/optimizer/test_language_costs_gap.py
+++ b/tests/optimizer/test_language_costs_gap.py
@@ -1,0 +1,93 @@
+"""tests/optimizer/test_language_costs_gap.py — direct unit tests for
+app.optimizer.language_costs.count_estimated_tokens and get_openrouter_rates,
+whose branches (empty text, tiktoken-missing fallback, prefix-match pricing,
+unknown-model warning) were only exercised indirectly via estimate_prompt_cost.
+"""
+
+from unittest.mock import patch
+
+from app.optimizer import language_costs
+from app.optimizer.language_costs import (
+    OPENROUTER_RATES,
+    count_estimated_tokens,
+    get_openrouter_rates,
+)
+
+
+# --- count_estimated_tokens ---
+
+
+def test_count_estimated_tokens_empty_string_is_zero():
+    assert count_estimated_tokens("") == 0
+
+
+def test_count_estimated_tokens_none_like_falsy_is_zero():
+    assert count_estimated_tokens(None) == 0  # type: ignore[arg-type]
+
+
+def test_count_estimated_tokens_uses_tiktoken_when_available():
+    text = "hello world, this is a short sentence."
+    tokens = count_estimated_tokens(text)
+
+    assert tokens > 0
+    assert isinstance(tokens, int)
+
+
+def test_count_estimated_tokens_falls_back_when_tiktoken_is_none():
+    with patch.object(language_costs, "tiktoken", None):
+        tokens = count_estimated_tokens("hello world")
+
+    assert tokens > 0
+
+
+def test_count_estimated_tokens_falls_back_on_encoding_exception():
+    with patch.object(language_costs, "tiktoken") as mock_tiktoken:
+        mock_tiktoken.get_encoding.side_effect = RuntimeError("encoding unavailable")
+        tokens = count_estimated_tokens("hello world")
+
+    assert tokens > 0
+
+
+# --- get_openrouter_rates ---
+
+
+def test_get_openrouter_rates_exact_match():
+    input_rate, output_rate, warnings = get_openrouter_rates("openai/gpt-oss-20b")
+
+    assert input_rate == OPENROUTER_RATES["openai/gpt-oss-20b"]["input"]
+    assert output_rate == OPENROUTER_RATES["openai/gpt-oss-20b"]["output"]
+    assert warnings == []
+
+
+def test_get_openrouter_rates_prefix_match_falls_back_to_longest_key():
+    # "openai/gpt-oss-120b-preview" isn't a registered key, but it starts with
+    # the registered "openai/gpt-oss-120b" key, which should win over the
+    # shorter "openai/gpt-oss-20b" prefix candidate.
+    input_rate, output_rate, warnings = get_openrouter_rates("openai/gpt-oss-120b-preview")
+
+    assert input_rate == OPENROUTER_RATES["openai/gpt-oss-120b"]["input"]
+    assert output_rate == OPENROUTER_RATES["openai/gpt-oss-120b"]["output"]
+    assert warnings == []
+
+
+def test_get_openrouter_rates_unknown_model_returns_zero_with_warning():
+    input_rate, output_rate, warnings = get_openrouter_rates("some/totally-unknown-model")
+
+    assert input_rate == 0.0
+    assert output_rate == 0.0
+    assert len(warnings) == 1
+    assert "some/totally-unknown-model" in warnings[0]
+
+
+def test_get_openrouter_rates_empty_model_defaults_to_default_model():
+    input_rate, output_rate, warnings = get_openrouter_rates("")
+
+    assert input_rate == OPENROUTER_RATES[language_costs.DEFAULT_OPENROUTER_MODEL]["input"]
+    assert warnings == []
+
+
+def test_get_openrouter_rates_strips_whitespace():
+    input_rate, output_rate, warnings = get_openrouter_rates("  openai/gpt-oss-20b  ")
+
+    assert input_rate == OPENROUTER_RATES["openai/gpt-oss-20b"]["input"]
+    assert warnings == []

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,96 @@
+"""tests/test_llm_adapter.py — direct unit tests for app.llm.adapter's bidirectional
+Executor <-> LLMProvider adapters, which had no dedicated test coverage. Both classes
+are pure glue/mapping code exercised here with local fake doubles, no network/LLM calls.
+"""
+
+from typing import Any, Dict, Optional
+
+from app.llm.adapter import ExecutorProvider, ProviderExecutor
+from app.llm.base import LLMProvider, LLMResponse, ProviderConfig
+from app.testing.runner import Executor
+
+
+class FakeProvider(LLMProvider):
+    """Records the last call and returns a fixed response."""
+
+    def __init__(self, content: str = "fake response"):
+        super().__init__(ProviderConfig(model="fake-model"))
+        self._content = content
+        self.last_prompt: Optional[str] = None
+        self.last_system_prompt: Optional[str] = None
+
+    def generate(self, prompt: str, system_prompt: Optional[str] = None, **kwargs) -> LLMResponse:
+        self.last_prompt = prompt
+        self.last_system_prompt = system_prompt
+        return LLMResponse(content=self._content)
+
+
+class FakeExecutor(Executor):
+    """Records the last call and returns a fixed string."""
+
+    def __init__(self, output: str = "fake output"):
+        self._output = output
+        self.last_prompt: Optional[str] = None
+        self.last_config: Optional[Dict[str, Any]] = None
+
+    def execute(self, prompt: str, config: Dict[str, Any]) -> str:
+        self.last_prompt = prompt
+        self.last_config = config
+        return self._output
+
+
+# --- ProviderExecutor (LLMProvider used as an Executor) ---
+
+
+def test_provider_executor_delegates_to_provider_and_returns_content():
+    provider = FakeProvider(content="hello from provider")
+    executor = ProviderExecutor(provider)
+
+    result = executor.execute("some prompt", {"model": "irrelevant", "temperature": 0.5})
+
+    assert result == "hello from provider"
+    assert provider.last_prompt == "some prompt"
+    # ProviderExecutor treats the full prompt as the user prompt; no system_prompt is set.
+    assert provider.last_system_prompt is None
+
+
+def test_provider_executor_ignores_extra_config_keys():
+    provider = FakeProvider(content="ok")
+    executor = ProviderExecutor(provider)
+
+    # config dict is currently unused by ProviderExecutor.execute; it should not raise
+    # regardless of what's in it.
+    result = executor.execute("prompt text", {"model": "x", "temperature": 1.0, "extra": "ignored"})
+
+    assert result == "ok"
+
+
+# --- ExecutorProvider (Executor used as an LLMProvider) ---
+
+
+def test_executor_provider_generate_without_system_prompt():
+    fake_executor = FakeExecutor(output="executor said hi")
+    provider = ExecutorProvider(fake_executor)
+
+    response = provider.generate(prompt="just the prompt")
+
+    assert isinstance(response, LLMResponse)
+    assert response.content == "executor said hi"
+    assert fake_executor.last_prompt == "just the prompt"
+    assert fake_executor.last_config == {}
+
+
+def test_executor_provider_generate_concatenates_system_prompt():
+    fake_executor = FakeExecutor(output="combined response")
+    provider = ExecutorProvider(fake_executor)
+
+    response = provider.generate(prompt="user part", system_prompt="system part")
+
+    assert response.content == "combined response"
+    assert fake_executor.last_prompt == "system part\n\nuser part"
+
+
+def test_executor_provider_config_model_is_adapter_placeholder():
+    provider = ExecutorProvider(FakeExecutor())
+
+    assert provider.config.model == "executor-adapter"

--- a/tests/test_rag_parsers_gap.py
+++ b/tests/test_rag_parsers_gap.py
@@ -1,0 +1,214 @@
+"""tests/test_rag_parsers_gap.py — direct unit tests for app.rag.parsers functions
+that had no dedicated test coverage: parse_json, parse_docx, register_parser.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from app.rag.parsers import (
+    ParseResult,
+    PARSERS,
+    can_parse,
+    get_supported_extensions,
+    parse_json,
+    parse_docx,
+    register_parser,
+)
+
+
+# --- parse_json ---
+
+
+def test_parse_json_success_pretty_prints(tmp_path):
+    test_file = tmp_path / "test.json"
+    test_file.write_text('{"b": 2, "a": 1}')
+
+    result = parse_json(test_file)
+
+    assert isinstance(result, ParseResult)
+    assert result.content == '{\n  "b": 2,\n  "a": 1\n}'
+    assert result.metadata["format"] == "json"
+    assert result.metadata["extension"] == ".json"
+    assert result.word_count == len(result.content.split())
+
+
+def test_parse_json_unicode_is_not_escaped(tmp_path):
+    test_file = tmp_path / "unicode.json"
+    test_file.write_text('{"name": "Çağla"}', encoding="utf-8")
+
+    result = parse_json(test_file)
+
+    assert "Çağla" in result.content
+    assert "\\u" not in result.content
+
+
+def test_parse_json_invalid_json_returns_error(tmp_path):
+    test_file = tmp_path / "bad.json"
+    test_file.write_text("{not valid json")
+
+    result = parse_json(test_file)
+
+    assert result.content == ""
+    assert "error" in result.metadata
+
+
+def test_parse_json_file_not_found():
+    from pathlib import Path
+
+    result = parse_json(Path("/nonexistent/path/does-not-exist.json"))
+    assert result.content == ""
+    assert "error" in result.metadata
+
+
+def test_parse_json_empty_object(tmp_path):
+    test_file = tmp_path / "empty.json"
+    test_file.write_text("{}")
+
+    result = parse_json(test_file)
+
+    assert result.content == "{}"
+    assert result.metadata["format"] == "json"
+
+
+# --- parse_docx ---
+
+
+def _make_mock_docx_module(paragraphs, tables):
+    """Build a fake `docx` module whose Document(path) returns an object
+    with .paragraphs (list of objects with .text) and .tables (list of
+    objects with .rows -> list of objects with .cells -> list of objects
+    with .text), mirroring python-docx's real API surface.
+    """
+    mock_doc_instance = MagicMock()
+    mock_doc_instance.paragraphs = [MagicMock(text=p) for p in paragraphs]
+
+    mock_tables = []
+    for table_rows in tables:
+        mock_table = MagicMock()
+        mock_rows = []
+        for row_cells in table_rows:
+            mock_row = MagicMock()
+            mock_row.cells = [MagicMock(text=c) for c in row_cells]
+            mock_rows.append(mock_row)
+        mock_table.rows = mock_rows
+        mock_tables.append(mock_table)
+    mock_doc_instance.tables = mock_tables
+
+    mock_docx_module = MagicMock()
+    mock_docx_module.Document.return_value = mock_doc_instance
+    return mock_docx_module
+
+
+def test_parse_docx_success_paragraphs_and_tables(tmp_path):
+    mock_docx = _make_mock_docx_module(
+        paragraphs=["Hello world", "", "Second paragraph"],
+        tables=[[["A", "B"], ["1", "2"]]],
+    )
+
+    with patch.dict(sys.modules, {"docx": mock_docx}):
+        test_file = tmp_path / "test.docx"
+        test_file.touch()
+
+        result = parse_docx(test_file)
+
+        assert "Hello world" in result.content
+        assert "Second paragraph" in result.content
+        assert "[Table]" in result.content
+        assert "A | B" in result.content
+        assert "1 | 2" in result.content
+        assert result.metadata["format"] == "docx"
+        assert result.metadata["extension"] == ".docx"
+        assert result.metadata["paragraph_count"] == 2  # empty paragraph excluded
+        assert result.metadata["table_count"] == 1
+        assert result.metadata["parser"] == "python-docx"
+        assert result.word_count == len(result.content.split())
+
+
+def test_parse_docx_empty_document(tmp_path):
+    mock_docx = _make_mock_docx_module(paragraphs=[], tables=[])
+
+    with patch.dict(sys.modules, {"docx": mock_docx}):
+        test_file = tmp_path / "empty.docx"
+        test_file.touch()
+
+        result = parse_docx(test_file)
+
+        assert result.content == ""
+        assert result.metadata["paragraph_count"] == 0
+        assert result.metadata["table_count"] == 0
+
+
+def test_parse_docx_import_error(tmp_path):
+    with patch.dict(sys.modules, {"docx": None}):
+        test_file = tmp_path / "test.docx"
+        test_file.touch()
+
+        result = parse_docx(test_file)
+
+        assert result.content == ""
+        assert result.metadata["format"] == "docx"
+        assert "python-docx not installed" in result.metadata["error"]
+
+
+def test_parse_docx_unexpected_exception(tmp_path):
+    mock_docx = MagicMock()
+    mock_docx.Document.side_effect = ValueError("corrupt docx")
+
+    with patch.dict(sys.modules, {"docx": mock_docx}):
+        test_file = tmp_path / "test.docx"
+        test_file.touch()
+
+        result = parse_docx(test_file)
+
+        assert result.content == ""
+        assert result.metadata["format"] == "docx"
+        assert "An internal error occurred during parsing." in result.metadata["error"]
+
+
+# --- register_parser ---
+
+
+def test_register_parser_adds_new_extension():
+    original_parsers = dict(PARSERS)
+    try:
+        custom_parser = MagicMock(return_value=ParseResult(content="custom"))
+        register_parser(".customext", custom_parser)
+
+        assert ".customext" in get_supported_extensions()
+        assert can_parse(__import__("pathlib").Path("file.customext")) is True
+        assert PARSERS[".customext"] is custom_parser
+    finally:
+        PARSERS.clear()
+        PARSERS.update(original_parsers)
+
+
+def test_register_parser_normalizes_extension_case():
+    original_parsers = dict(PARSERS)
+    try:
+        custom_parser = MagicMock()
+        register_parser(".UPPER", custom_parser)
+
+        assert ".upper" in PARSERS
+        assert ".UPPER" not in PARSERS
+    finally:
+        PARSERS.clear()
+        PARSERS.update(original_parsers)
+
+
+def test_register_parser_overrides_existing_extension(tmp_path):
+    original_parsers = dict(PARSERS)
+    try:
+        override_parser = MagicMock(return_value=ParseResult(content="overridden"))
+        register_parser(".txt", override_parser)
+
+        from app.rag.parsers import parse_file
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("original content")
+        result = parse_file(test_file)
+
+        assert result.content == "overridden"
+        override_parser.assert_called_once_with(test_file)
+    finally:
+        PARSERS.clear()
+        PARSERS.update(original_parsers)

--- a/tests/test_repo_inspect_models_gap.py
+++ b/tests/test_repo_inspect_models_gap.py
@@ -1,0 +1,72 @@
+"""tests/test_repo_inspect_models_gap.py — direct unit tests for
+app.repo_inspect.models.RepoContext.command_map / .stack_summary, which had
+no dedicated test coverage. Both are pure derived-property methods over
+plain dataclass instances, no I/O involved.
+"""
+
+from app.repo_inspect.models import DetectedCommand, RepoContext, StackInfo
+
+
+# --- command_map ---
+
+
+def test_command_map_empty_commands_returns_empty_dict():
+    ctx = RepoContext()
+    assert ctx.command_map() == {}
+
+
+def test_command_map_single_command_per_name():
+    ctx = RepoContext(
+        commands=[
+            DetectedCommand(name="test", command="npm run test", source="web/package.json"),
+            DetectedCommand(name="build", command="npm run build", source="web/package.json"),
+        ]
+    )
+
+    assert ctx.command_map() == {
+        "test": "npm run test",
+        "build": "npm run build",
+    }
+
+
+def test_command_map_first_detected_wins_on_duplicate_name():
+    ctx = RepoContext(
+        commands=[
+            DetectedCommand(name="test", command="npm run test", source="web/package.json"),
+            DetectedCommand(name="test", command="pytest tests/ -q", source="Makefile"),
+        ]
+    )
+
+    # setdefault semantics: the first "test" command encountered wins.
+    assert ctx.command_map()["test"] == "npm run test"
+
+
+# --- stack_summary ---
+
+
+def test_stack_summary_empty_stacks_returns_empty_string():
+    ctx = RepoContext()
+    assert ctx.stack_summary() == ""
+
+
+def test_stack_summary_languages_only_no_frameworks():
+    ctx = RepoContext(stacks=[StackInfo(language="python"), StackInfo(language="go")])
+
+    assert ctx.stack_summary() == "go, python"
+
+
+def test_stack_summary_languages_and_frameworks_are_sorted_and_deduped():
+    ctx = RepoContext(
+        stacks=[
+            StackInfo(language="python", frameworks=("fastapi", "pytest")),
+            StackInfo(language="javascript", frameworks=("next", "fastapi")),
+        ]
+    )
+
+    assert ctx.stack_summary() == "javascript, python / fastapi, next, pytest"
+
+
+def test_stack_summary_single_stack_with_single_framework():
+    ctx = RepoContext(stacks=[StackInfo(language="rust", frameworks=("actix",))])
+
+    assert ctx.stack_summary() == "rust / actix"


### PR DESCRIPTION
## Summary

Test-coverage audit across the org's 5 repos found that AI-learn, VibeGraph, AgenticPlace, and CogniGraph have already been through deliberate gap-closing test passes (visible in their git history) and had little safe, non-trivial coverage left to add. Compiler stood out with several genuinely zero-coverage pure-logic modules, so this PR adds direct unit tests for them:

- `app/rag/parsers.py` — `parse_json`, `parse_docx` (mocked `docx` module, matching the existing `parse_pdf` test convention), and `register_parser`
- `app/optimizer/judge.py` — `JudgeAgent.evaluate` (empty suite, all-pass, mixed, all-fail branches), using the default Mock-backed `TestRunner` so no network/LLM calls are involved
- `app/llm/adapter.py` — `ProviderExecutor` and `ExecutorProvider`, the bidirectional Executor↔LLMProvider glue, exercised with local fake doubles
- `app/optimizer/language_costs.py` — `count_estimated_tokens` (empty input, tiktoken-unavailable and encoding-exception fallbacks) and `get_openrouter_rates` (exact match, prefix match, unknown-model warning, whitespace handling) — branches previously only reached indirectly through `estimate_prompt_cost`
- `app/repo_inspect/models.py` — `RepoContext.command_map` and `.stack_summary` derived properties

Only new test files were added — no source, config, `.env`, lockfile, or CI changes.

## Test plan

- [x] `python -m pytest tests/test_rag_parsers_gap.py tests/optimizer/test_judge.py tests/test_llm_adapter.py tests/optimizer/test_language_costs_gap.py tests/test_repo_inspect_models_gap.py -v` — 38 passed
- [x] `python -m pytest tests/ -m "not live" -q` (full suite) — 2582 passed, 2 skipped, 5 deselected, no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx8dNKh13bjvWqHjSGdbn2)_