### PR TITLE
⚡ Bolt: Replace re.sub with split and join for collapsing spaces

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-08-08 - Use built-in str.split and join instead of re.sub for collapsing spaces
 **Learning:** In Python, to optimize collapsing multiple consecutive whitespaces (spaces/tabs) into a single space, using `' '.join(text.split())` is significantly faster (~5-6x) than using a compiled regular expression like `re.sub(r'\s+', ' ', text).strip()`.
 **Action:** Replace `re.sub(r'\s+', ' ', text).strip()` with `' '.join(text.split())` for collapsing spaces in Python strings.
+## 2024-08-11 - Fast path string normalization
+**Learning:** In Python, to optimize collapsing multiple consecutive whitespaces (spaces/tabs/newlines) into a single space, using `' '.join(text.split())` is significantly faster (~5x) than using a compiled regular expression like `re.sub(r'\s+', ' ', text).strip()`. `.split()` automatically handles all whitespace characters and removes leading/trailing empty elements.
+**Action:** Replace `re.sub(r'\s+', ' ', text).strip()` with `' '.join(text.split())` for collapsing spaces in Python strings.

--- a/app/llm_engine/client.py
+++ b/app/llm_engine/client.py
@@ -160,7 +160,8 @@ def _normalize_skill_plain_heading(heading: str) -> str:
     normalized = heading.strip().strip(":").strip("#").strip("[]").strip()
     normalized = normalized.replace("&", " and ")
     normalized = re.sub(r"[^A-Za-z0-9]+", " ", normalized)
-    return re.sub(r"\s+", " ", normalized).strip().lower()
+    # Bolt Optimization: Built-in str.split and join is significantly faster than re.sub for collapsing spaces
+    return " ".join(normalized.split()).lower()
 
 
 def _skill_plain_heading_name(line: str) -> str | None:


### PR DESCRIPTION
💡 What: Replaced `re.sub(r'\s+', ' ', normalized).strip().lower()` with `' '.join(normalized.split()).lower()` in `app/llm_engine/client.py`.
🎯 Why: In Python, using built-in string methods like `.split()` and `.join()` is significantly faster (~5x speedup) than compiling and executing regular expressions to collapse multiple whitespace characters into a single space.
📊 Impact: Faster string normalization when processing skill headings.
🔬 Measurement: Run `make test-backend` to verify functionality remains unchanged.

---
*PR created automatically by Jules for task [7995468400926478143](https://jules.google.com/task/7995468400926478143) started by @madara88645*