### PR TITLE
Reconnect prompt history consumers

### DIFF
--- a/app/history/manager.py
+++ b/app/history/manager.py
@@ -3,7 +3,7 @@ import orjson
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from .models import HistoryEntry
 
 DEFAULT_DB_PATH = os.path.expanduser("~/.promptc_history.db")
@@ -84,6 +84,43 @@ class HistoryManager:
             cur = conn.execute("SELECT * FROM history ORDER BY timestamp DESC LIMIT ?", (limit,))
             rows = cur.fetchall()
             return [self._row_to_entry(row) for row in rows]
+        finally:
+            conn.close()
+
+    def get_recent(self, limit: int = 20) -> List[HistoryEntry]:
+        """Compatibility alias for consumers that call the older query name."""
+        return self.list_recent(limit=limit)
+
+    def search(self, query: str, limit: int = 20) -> List[HistoryEntry]:
+        """Search prompt text, source, and serialized metadata."""
+        escaped_query = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        pattern = f"%{escaped_query}%"
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                """
+                SELECT *
+                FROM history
+                WHERE prompt_text LIKE ? ESCAPE '\\'
+                   OR source LIKE ? ESCAPE '\\'
+                   OR metadata LIKE ? ESCAPE '\\'
+                ORDER BY timestamp DESC
+                LIMIT ?
+                """,
+                (pattern, pattern, pattern, limit),
+            )
+            return [self._row_to_entry(row) for row in cur.fetchall()]
+        finally:
+            conn.close()
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Return aggregate statistics used by the history CLI."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*), MIN(timestamp), MAX(timestamp) FROM history"
+            ).fetchone()
+            return {"total": row[0], "first": row[1], "last": row[2]}
         finally:
             conn.close()
 

--- a/app/history/models.py
+++ b/app/history/models.py
@@ -11,3 +11,7 @@ class HistoryEntry(BaseModel):
     parent_id: Optional[str] = Field(default=None, max_length=100)
     metadata: Dict[str, Any] = Field(default_factory=dict)
     score: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable representation for CLI consumers."""
+        return self.model_dump(mode="json")

--- a/app/quick_edit.py
+++ b/app/quick_edit.py
@@ -12,23 +12,7 @@ from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
 
 from app.favorites import get_favorites_manager
-
-
-def get_history_manager():
-    """Stub for removed history manager."""
-
-    class HistoryManagerStub:
-        def get_by_id(self, *args, **kwargs):
-            return None
-
-        def _save(self):
-            pass
-
-        @property
-        def entries(self):
-            return []
-
-    return HistoryManagerStub()
+from app.history import get_history_manager
 
 
 console = Console()
@@ -86,15 +70,18 @@ class QuickEditor:
 
         info_text = f"[bold cyan]ID:[/bold cyan] {prompt_dict.get('id', 'N/A')}\n"
         info_text += f"[bold cyan]Timestamp:[/bold cyan] {prompt_dict.get('timestamp', 'N/A')}\n"
-        info_text += f"[bold cyan]Domain:[/bold cyan] {prompt_dict.get('domain', 'N/A')}\n"
-        info_text += f"[bold cyan]Language:[/bold cyan] {prompt_dict.get('language', 'N/A')}\n"
+        if source == "history":
+            info_text += f"[bold cyan]Source:[/bold cyan] {prompt_dict.get('source', 'N/A')}\n"
+        else:
+            info_text += f"[bold cyan]Domain:[/bold cyan] {prompt_dict.get('domain', 'N/A')}\n"
+            info_text += f"[bold cyan]Language:[/bold cyan] {prompt_dict.get('language', 'N/A')}\n"
         info_text += f"[bold cyan]Score:[/bold cyan] {prompt_dict.get('score', 0.0)}\n"
 
         console.print(Panel(info_text, title="📋 Current Prompt Info", border_style="cyan"))
 
         console.print("\n[bold yellow]What would you like to edit?[/bold yellow]")
         console.print("1. Prompt text")
-        console.print("2. Domain and Language")
+        console.print("2. Source" if source == "history" else "2. Domain and Language")
         console.print("3. Tags")
 
         choice = Prompt.ask("\n[cyan]Choose option[/cyan]", choices=["1", "2", "3"], default="1")
@@ -117,31 +104,46 @@ class QuickEditor:
                     changes_made = True
 
         elif choice == "2":
-            console.print("\n[bold]Edit Domain and Language:[/bold]")
+            if source == "history":
+                new_source = Prompt.ask(
+                    "[cyan]Source[/cyan]", default=prompt_dict.get("source", "user")
+                )
+                if new_source != prompt_dict.get("source", ""):
+                    prompt_dict["source"] = new_source
+                    changes_made = True
+            else:
+                console.print("\n[bold]Edit Domain and Language:[/bold]")
 
-            new_domain = Prompt.ask(
-                "[cyan]Domain[/cyan]", default=prompt_dict.get("domain", "general")
-            )
-            new_language = Prompt.ask(
-                "[cyan]Language[/cyan]", default=prompt_dict.get("language", "en")
-            )
+                new_domain = Prompt.ask(
+                    "[cyan]Domain[/cyan]", default=prompt_dict.get("domain", "general")
+                )
+                new_language = Prompt.ask(
+                    "[cyan]Language[/cyan]", default=prompt_dict.get("language", "en")
+                )
 
-            if new_domain != prompt_dict.get("domain", ""):
-                prompt_dict["domain"] = new_domain
-                changes_made = True
-            if new_language != prompt_dict.get("language", ""):
-                prompt_dict["language"] = new_language
-                changes_made = True
+                if new_domain != prompt_dict.get("domain", ""):
+                    prompt_dict["domain"] = new_domain
+                    changes_made = True
+                if new_language != prompt_dict.get("language", ""):
+                    prompt_dict["language"] = new_language
+                    changes_made = True
 
         elif choice == "3":
             console.print("\n[bold]Edit Tags:[/bold]")
 
-            current_tags = ", ".join(prompt_dict.get("tags", []))
+            if source == "history":
+                current_tags_list = prompt_dict.get("metadata", {}).get("tags", [])
+            else:
+                current_tags_list = prompt_dict.get("tags", [])
+            current_tags = ", ".join(current_tags_list)
             new_tags_str = Prompt.ask("[cyan]Tags (comma-separated)[/cyan]", default=current_tags)
             new_tags = [tag.strip() for tag in new_tags_str.split(",") if tag.strip()]
 
-            if new_tags != prompt_dict.get("tags", []):
-                prompt_dict["tags"] = new_tags
+            if new_tags != current_tags_list:
+                if source == "history":
+                    prompt_dict.setdefault("metadata", {})["tags"] = new_tags
+                else:
+                    prompt_dict["tags"] = new_tags
                 changes_made = True
 
         if not changes_made:
@@ -149,14 +151,14 @@ class QuickEditor:
             return False
 
         if source == "history":
-            for entry in self.history_manager.entries:
-                if entry.id == prompt_id:
-                    entry.prompt_text = prompt_dict.get("prompt_text", entry.prompt_text)
-                    entry.domain = prompt_dict.get("domain", entry.domain)
-                    entry.language = prompt_dict.get("language", entry.language)
-                    entry.tags = prompt_dict.get("tags", entry.tags)
-                    break
-            self.history_manager._save()
+            entry = self.history_manager.get_by_id(prompt_id)
+            if entry is None:
+                console.print(f"\n[red]❌ Prompt not found:[/red] {prompt_id}\n")
+                return False
+            entry.prompt_text = prompt_dict.get("prompt_text", entry.prompt_text)
+            entry.source = prompt_dict.get("source", entry.source)
+            entry.metadata = prompt_dict.get("metadata", entry.metadata)
+            self.history_manager.save(entry)
         else:
             for entry in self.favorites_manager.entries:
                 if entry.id == prompt_id:

--- a/cli/commands/analytics.py
+++ b/cli/commands/analytics.py
@@ -10,32 +10,9 @@ from rich.panel import Panel
 from rich.table import Table
 
 from app.analytics import AnalyticsManager, create_record_from_ir
-
-# from app.history import get_history_manager
+from app.history import get_history_manager
 from app.compiler import compile_text_v2
 from app.validator import validate_prompt
-
-
-def get_history_manager():
-    """Stub for removed history manager."""
-
-    class HistoryManagerStub:
-        def get_by_domain(self, *args, **kwargs):
-            return []
-
-        def get_recent(self, *args, **kwargs):
-            return []
-
-        def search(self, *args, **kwargs):
-            return []
-
-        def get_by_id(self, *args, **kwargs):
-            return None
-
-        def get_stats(self):
-            return {"total": 0}
-
-    return HistoryManagerStub()
 
 
 analytics_app = typer.Typer(help="Prompt analytics and metrics")
@@ -499,7 +476,7 @@ def analytics_clean(
 @history_app.command("list")
 def history_list(
     limit: int = typer.Option(10, help="Number of entries to show"),
-    domain: Optional[str] = typer.Option(None, help="Filter by domain"),
+    source: Optional[str] = typer.Option(None, help="Filter by entry source"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """
@@ -508,11 +485,9 @@ def history_list(
     console = Console()
     history_mgr = get_history_manager()
 
-    # Get entries
-    if domain:
-        entries = history_mgr.get_by_domain(domain, limit=limit)
-    else:
-        entries = history_mgr.get_recent(limit=limit)
+    entries = history_mgr.get_recent(limit=limit)
+    if source:
+        entries = [entry for entry in entries if entry.source == source]
 
     if not entries:
         console.print("[yellow]No history entries found[/yellow]")
@@ -529,16 +504,15 @@ def history_list(
     console.print(f"\n[bold cyan]Prompt History[/bold cyan] [dim](Last {limit})[/dim]\n")
 
     table = Table(show_header=True)
-    table.add_column("ID", style="dim", width=12)
+    table.add_column("ID", style="dim", width=8)
     table.add_column("Date", style="cyan", width=10)
     table.add_column("Score", justify="right", style="yellow", width=6)
-    table.add_column("Domain", style="magenta", width=12)
-    table.add_column("Lang", width=4)
-    table.add_column("Prompt", style="dim", width=50)
+    table.add_column("Source", style="magenta", width=9)
+    table.add_column("Prompt", style="dim", width=36)
 
     for entry in entries:
         # Format date
-        date_str = entry.timestamp[:10]
+        date_str = entry.timestamp.date().isoformat()
 
         # Truncate prompt
         prompt_preview = entry.prompt_text.replace("\n", " ")[:50]
@@ -546,21 +520,21 @@ def history_list(
             prompt_preview += "..."
 
         # Score color
-        if entry.score >= 80:
+        score = entry.score or 0.0
+        if score >= 80:
             score_style = "green"
-        elif entry.score >= 60:
+        elif score >= 60:
             score_style = "yellow"
         else:
-            score_style = "red" if entry.score > 0 else "dim"
+            score_style = "red" if score > 0 else "dim"
 
-        score_str = f"{entry.score:.1f}" if entry.score > 0 else "—"
+        score_str = f"{score:.1f}" if score > 0 else "—"
 
         table.add_row(
             entry.id[:8],
             date_str,
             f"[{score_style}]{score_str}[/{score_style}]",
-            entry.domain,
-            entry.language.upper(),
+            entry.source,
             prompt_preview,
         )
 
@@ -589,11 +563,11 @@ def history_search(
     table = Table(show_header=True)
     table.add_column("ID", style="dim", width=12)
     table.add_column("Date", style="cyan", width=10)
-    table.add_column("Domain", style="magenta", width=12)
+    table.add_column("Source", style="magenta", width=12)
     table.add_column("Prompt", style="white", width=60)
 
     for entry in entries:
-        date_str = entry.timestamp[:10]
+        date_str = entry.timestamp.date().isoformat()
         prompt_preview = entry.prompt_text.replace("\n", " ")[:60]
         if len(entry.prompt_text) > 60:
             prompt_preview += "..."
@@ -608,7 +582,7 @@ def history_search(
             flags=re.IGNORECASE,
         )
 
-        table.add_row(entry.id[:8], date_str, entry.domain, highlighted)
+        table.add_row(entry.id[:8], date_str, entry.source, highlighted)
 
     console.print(table)
 
@@ -632,12 +606,11 @@ def history_show(entry_id: str = typer.Argument(..., help="Entry ID")):
 
     info = (
         f"[cyan]Date:[/cyan] {entry.timestamp}\n"
-        f"[cyan]Domain:[/cyan] {entry.domain}\n"
-        f"[cyan]Language:[/cyan] {entry.language}\n"
-        f"[cyan]IR Version:[/cyan] {entry.ir_version}\n"
+        f"[cyan]Source:[/cyan] {entry.source}\n"
+        f"[cyan]Parent ID:[/cyan] {entry.parent_id or 'N/A'}\n"
     )
 
-    if entry.score > 0:
+    if entry.score is not None and entry.score > 0:
         score_color = "green" if entry.score >= 80 else "yellow"
         info += f"[cyan]Score:[/cyan] [{score_color}]{entry.score:.1f}[/{score_color}]\n"
 

--- a/tests/test_history_cli.py
+++ b/tests/test_history_cli.py
@@ -1,0 +1,47 @@
+from typer.testing import CliRunner
+
+from app.history import HistoryEntry, HistoryManager
+from cli.main import app
+
+
+runner = CliRunner()
+
+
+def test_history_cli_reads_real_sqlite_store(tmp_path, monkeypatch):
+    manager = HistoryManager(str(tmp_path / "history.db"))
+    manager.save(
+        HistoryEntry(
+            id="optimizer-entry",
+            prompt_text="Explain bounded retry budgets",
+            source="evolution",
+            score=91.0,
+            metadata={"run_id": "run-1"},
+        )
+    )
+    monkeypatch.setattr("cli.commands.analytics.get_history_manager", lambda: manager)
+
+    list_result = runner.invoke(app, ["history", "list"])
+    search_result = runner.invoke(app, ["history", "search", "bounded"])
+    show_result = runner.invoke(app, ["history", "show", "optimizer-entry"])
+    stats_result = runner.invoke(app, ["history", "stats"])
+
+    assert list_result.exit_code == 0, list_result.exception
+    assert search_result.exit_code == 0, search_result.exception
+    assert show_result.exit_code == 0, show_result.exception
+    assert stats_result.exit_code == 0, stats_result.exception
+    assert "Explain bounded retry budgets" in list_result.stdout
+    assert "optimizer-entry" in show_result.stdout
+    assert "evolution" in show_result.stdout
+    assert "Explain bounded retry budgets" in show_result.stdout
+    assert "Total Entries: 1" in stats_result.stdout
+
+
+def test_history_cli_json_serializes_real_entries(tmp_path, monkeypatch):
+    manager = HistoryManager(str(tmp_path / "history.db"))
+    manager.save(HistoryEntry(id="json-entry", prompt_text="JSON history"))
+    monkeypatch.setattr("cli.commands.analytics.get_history_manager", lambda: manager)
+
+    result = runner.invoke(app, ["history", "list", "--json"])
+
+    assert result.exit_code == 0, result.exception
+    assert '"id": "json-entry"' in result.stdout

--- a/tests/test_history_integration.py
+++ b/tests/test_history_integration.py
@@ -1,13 +1,13 @@
-from app.history import get_history_manager, HistoryEntry
-from app.prompt_diff import get_prompt_comparison
+from app.history import HistoryEntry, HistoryManager
+from app.prompt_diff import PromptComparison
 import uuid
 
 
-def test_history_diff_integration():
+def test_history_diff_integration(tmp_path):
     print("Testing History <-> Le Prompt Diff Integration...")
 
     # 1. Seed History
-    history = get_history_manager()
+    history = HistoryManager(str(tmp_path / "history.db"))
     prompt_id = str(uuid.uuid4())
     entry = HistoryEntry(
         id=prompt_id,
@@ -19,7 +19,8 @@ def test_history_diff_integration():
     print(f"Seeded prompt {prompt_id}")
 
     # 2. Use PromptComparison to retrieve it
-    differ = get_prompt_comparison()
+    differ = PromptComparison.__new__(PromptComparison)
+    differ.history = history
     success, text, source = differ.get_prompt_text(prompt_id, source="history")
 
     print(f"Retrieval result: success={success}, text='{text}', source='{source}'")
@@ -42,7 +43,3 @@ def test_history_diff_integration():
     # They are different lines.
 
     print("✅ History Diff integration passed!")
-
-
-if __name__ == "__main__":
-    test_history_diff_integration()

--- a/tests/test_history_manager.py
+++ b/tests/test_history_manager.py
@@ -86,6 +86,42 @@ def test_list_recent(manager):
     assert len(all_recent) == 5
 
 
+def test_search_and_stats_use_the_real_sqlite_store(manager):
+    manager.save(
+        HistoryEntry(
+            id="optimizer-entry",
+            prompt_text="Explain retry budgets clearly",
+            source="evolution",
+            score=87.5,
+            metadata={"run_id": "run-1"},
+        )
+    )
+    manager.save(
+        HistoryEntry(
+            id="user-entry",
+            prompt_text="Draft a release note",
+            source="user",
+        )
+    )
+
+    matches = manager.search("retry", limit=10)
+    stats = manager.get_stats()
+
+    assert [entry.id for entry in matches] == ["optimizer-entry"]
+    assert stats["total"] == 2
+    assert stats["first"] is not None
+    assert stats["last"] is not None
+
+
+def test_history_entry_to_dict_is_cli_serializable():
+    entry = HistoryEntry(id="json-entry", prompt_text="JSON ready")
+
+    payload = entry.to_dict()
+
+    assert payload["id"] == "json-entry"
+    assert isinstance(payload["timestamp"], str)
+
+
 def test_get_history_manager_singleton(monkeypatch, temp_db_path):
     # Mock default arg in __init__ instead of module constant because the
     # module constant is likely already evaluated at import time by Python.

--- a/tests/test_quick_edit_security.py
+++ b/tests/test_quick_edit_security.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 import click
 
+from app.history import HistoryEntry, HistoryManager
 from app.quick_edit import QuickEditor
 
 
@@ -71,20 +72,29 @@ def test_get_quick_editor_singleton():
     assert inst1 is inst2
 
 
-def test_quick_editor_find_prompt():
+def test_quick_editor_find_prompt_reads_real_history_store(tmp_path, monkeypatch):
+    history_manager = HistoryManager(str(tmp_path / "history.db"))
+    history_manager.save(
+        HistoryEntry(
+            id="h1",
+            prompt_text="history text",
+            source="evolution",
+            metadata={"run_id": "run-1"},
+        )
+    )
+
+    monkeypatch.setattr("app.quick_edit.get_history_manager", lambda: history_manager)
     editor = QuickEditor()
-    editor.history_manager = MagicMock()
     editor.favorites_manager = MagicMock()
 
-    h_entry = MockEntry("h1", "history text")
     f_entry = MockEntry("f1", "favorites text")
 
-    editor.history_manager.get_by_id.side_effect = lambda x: h_entry if x == "h1" else None
     editor.favorites_manager.get_by_id.side_effect = lambda x: f_entry if x == "f1" else None
 
     # Find in history
     p, src = editor.find_prompt("h1")
     assert p["prompt_text"] == "history text"
+    assert p["source"] == "evolution"
     assert src == "history"
 
     # Find in favorites
@@ -96,6 +106,23 @@ def test_quick_editor_find_prompt():
     p, src = editor.find_prompt("nonexistent")
     assert p is None
     assert src is None
+
+
+@patch("rich.prompt.Prompt.ask")
+@patch("rich.prompt.Confirm.ask")
+def test_quick_editor_persists_history_text_edit(mock_confirm, mock_ask, tmp_path, monkeypatch):
+    history_manager = HistoryManager(str(tmp_path / "history.db"))
+    history_manager.save(HistoryEntry(id="h1", prompt_text="before"))
+    monkeypatch.setattr("app.quick_edit.get_history_manager", lambda: history_manager)
+
+    editor = QuickEditor()
+    mock_ask.side_effect = ["1"]
+    mock_confirm.return_value = True
+
+    with patch.object(editor, "edit_text_in_editor", return_value="after"):
+        assert editor.edit_prompt("h1") is True
+
+    assert history_manager.get_by_id("h1").prompt_text == "after"
 
 
 @patch("rich.prompt.Prompt.ask")
@@ -118,23 +145,24 @@ def test_edit_prompt_no_changes(mock_confirm, mock_ask):
 
 @patch("rich.prompt.Prompt.ask")
 @patch("rich.prompt.Confirm.ask")
-def test_edit_prompt_text_external_editor(mock_confirm, mock_ask):
+def test_edit_favorite_text_external_editor(mock_confirm, mock_ask):
     editor = QuickEditor()
     editor.history_manager = MagicMock()
     editor.favorites_manager = MagicMock()
 
-    entry = MockEntry("h1", "hello")
-    editor.history_manager.get_by_id.return_value = entry
-    editor.history_manager.entries = [entry]
+    editor.history_manager.get_by_id.return_value = None
+    entry = MockEntry("f1", "hello")
+    editor.favorites_manager.get_by_id.return_value = entry
+    editor.favorites_manager.entries = [entry]
 
     # Choice 1, confirm edit, editor returns new text
     mock_ask.side_effect = ["1"]
     mock_confirm.return_value = True
     with patch.object(editor, "edit_text_in_editor", return_value="hello modified"):
-        res = editor.edit_prompt("h1")
+        res = editor.edit_prompt("f1")
         assert res is True
         assert entry.prompt_text == "hello modified"
-        editor.history_manager._save.assert_called_once()
+        editor.favorites_manager._save.assert_called_once()
 
 
 @patch("rich.prompt.Prompt.ask")
@@ -160,42 +188,39 @@ def test_edit_prompt_text_manual(mock_confirm, mock_ask):
 
 
 @patch("rich.prompt.Prompt.ask")
-def test_edit_prompt_domain_and_language(mock_ask):
+def test_edit_favorite_domain_and_language(mock_ask):
     editor = QuickEditor()
     editor.history_manager = MagicMock()
     editor.favorites_manager = MagicMock()
 
-    entry = MockEntry("h1", "hello", domain="general", language="en")
-    editor.history_manager.get_by_id.return_value = entry
-    editor.history_manager.entries = [entry]
+    editor.history_manager.get_by_id.return_value = None
+    entry = MockEntry("f1", "hello", domain="general", language="en")
+    editor.favorites_manager.get_by_id.return_value = entry
+    editor.favorites_manager.entries = [entry]
 
     # Choice 2, enter new domain and language
     mock_ask.side_effect = ["2", "tech", "tr"]
 
-    res = editor.edit_prompt("h1")
+    res = editor.edit_prompt("f1")
     assert res is True
     assert entry.domain == "tech"
     assert entry.language == "tr"
-    editor.history_manager._save.assert_called_once()
+    editor.favorites_manager._save.assert_called_once()
 
 
 @patch("rich.prompt.Prompt.ask")
-def test_edit_prompt_tags(mock_ask):
+def test_edit_history_tags(mock_ask, tmp_path, monkeypatch):
+    history_manager = HistoryManager(str(tmp_path / "history.db"))
+    history_manager.save(HistoryEntry(id="h1", prompt_text="hello", metadata={"tags": ["tag1"]}))
+    monkeypatch.setattr("app.quick_edit.get_history_manager", lambda: history_manager)
     editor = QuickEditor()
-    editor.history_manager = MagicMock()
-    editor.favorites_manager = MagicMock()
-
-    entry = MockEntry("h1", "hello", tags=["tag1"])
-    editor.history_manager.get_by_id.return_value = entry
-    editor.history_manager.entries = [entry]
 
     # Choice 3, enter new tags
     mock_ask.side_effect = ["3", "tag1, tag2, tag3"]
 
     res = editor.edit_prompt("h1")
     assert res is True
-    assert entry.tags == ["tag1", "tag2", "tag3"]
-    editor.history_manager._save.assert_called_once()
+    assert history_manager.get_by_id("h1").metadata["tags"] == ["tag1", "tag2", "tag3"]
 
 
 def test_edit_prompt_not_found(capsys):


### PR DESCRIPTION
## Summary
- remove the CLI and Quick Edit history stubs and connect both surfaces to the live SQLite-backed `HistoryManager`
- add the lean query surface needed by current consumers: recent entries, text search, aggregate stats, and JSON-safe entry serialization
- make Quick Edit persist history text/source/tag updates through `HistoryManager.save`
- add real SQLite integration coverage for manager queries, Quick Edit, prompt diff, and `promptc history list/search/show/stats`

## Schema decision
This PR keeps the existing lean history schema instead of adding `domain`, `language`, or migration-only columns. The optimizer already writes `id`, `timestamp`, `prompt_text`, `source`, `parent_id`, `metadata`, and `score`; the repaired CLI now presents those real fields and uses `--source` for optional list filtering. This avoids an unnecessary local SQLite migration and keeps optimizer writes plus prompt-diff reads unchanged.

## Verification
- `python -m pytest tests/test_history_manager.py tests/test_quick_edit_security.py tests/test_prompt_diff.py tests/test_history_integration.py tests/test_history_cli.py -v` — 42 passed
- `python -m ruff check ...` on all changed Python files — passed
- `python -m pytest tests/ -q -k "not test_validate_summary_and_api_schemas"` — 2550 passed, 5 skipped, 1 deselected
- the complete suite produced the same 2550 passes but one environment-dependent failure because another Docker/Uvicorn service already listening on `127.0.0.1:8000` returned 404 for `/schema/ir_v1`; the failing test is unrelated to history

## Manual end-to-end verification
Using an isolated temporary HOME, I saved `HistoryEntry(id="manual-entry", prompt_text="Manual live history proof", source="evolution", score=92.0)` through the real manager, then ran:
- `python -m cli.main history list`
- `python -m cli.main history search live`
- `python -m cli.main history show manual-entry`
- `python -m cli.main history stats`

The commands returned the saved entry, search found one match, show displayed its live details, and stats reported `Total Entries: 1` instead of an empty stub response.

## Boundaries
Only the scoped history model/manager, CLI, Quick Edit, and history-related test files changed. No environment, secret, auth, billing, deploy, dependency, lockfile, provider, LLM prompt, response-format, temperature, or token-setting file was touched.