### PR TITLE
test: add unit coverage for export-adapter private helper functions

### DIFF
--- a/tests/test_claude_code_private_helpers.py
+++ b/tests/test_claude_code_private_helpers.py
@@ -1,0 +1,227 @@
+"""
+Coverage for small, pure, string-shaping helpers that were not directly
+exercised by any existing test:
+
+  * app/adapters/claude_code.py — _to_python_identifier, _strip_markdown_fences,
+    _escape_triple_quotes
+  * app/adapters/agent_ir.py    — _map_sections
+  * app/adapters/agent_packs.py — _preview_order
+
+Note: app/adapters/agent_packs.py's `_classify_kind` is intentionally NOT
+re-tested here — it already has a dedicated, exhaustive test class
+(`TestClassifyKind`) in tests/test_agent_packs_private_helpers.py.
+"""
+
+from __future__ import annotations
+
+from app.adapters.agent_ir import _map_sections
+from app.adapters.agent_packs import _preview_order
+from app.adapters.claude_code import (
+    _escape_triple_quotes,
+    _strip_markdown_fences,
+    _to_python_identifier,
+)
+
+
+# ---------------------------------------------------------------------------
+# _to_python_identifier (claude_code.py's standalone copy)
+# ---------------------------------------------------------------------------
+
+
+class TestToPythonIdentifier:
+    def test_simple_lowercase_name_is_unchanged(self):
+        assert _to_python_identifier("weather") == "weather"
+
+    def test_spaces_and_punctuation_become_single_underscores(self):
+        assert _to_python_identifier("My Skill! Name") == "my_skill_name"
+
+    def test_leading_digit_gets_skill_prefix(self):
+        assert _to_python_identifier("123abc") == "skill_123abc"
+
+    def test_python_keyword_collision_gets_skill_suffix(self):
+        assert _to_python_identifier("class") == "class_skill"
+        assert _to_python_identifier("import") == "import_skill"
+
+    def test_empty_string_falls_back_to_skill(self):
+        assert _to_python_identifier("") == "skill"
+
+    def test_all_symbols_falls_back_to_skill(self):
+        assert _to_python_identifier("!!!") == "skill"
+
+    def test_collapses_repeated_underscores(self):
+        assert _to_python_identifier("a__b___c") == "a_b_c"
+
+    def test_uppercase_is_lowercased(self):
+        assert _to_python_identifier("GetWeather") == "getweather"
+
+    def test_strips_leading_and_trailing_symbols(self):
+        assert _to_python_identifier("__hello__") == "hello"
+
+    def test_leading_digit_and_keyword_do_not_both_apply(self):
+        # "123" alone has no keyword collision after the skill_ prefix is applied.
+        assert _to_python_identifier("123") == "skill_123"
+
+
+# ---------------------------------------------------------------------------
+# _strip_markdown_fences
+# ---------------------------------------------------------------------------
+
+
+class TestStripMarkdownFences:
+    def test_no_fence_returns_stripped_text_unchanged(self):
+        assert _strip_markdown_fences("plain text") == "plain text"
+        assert _strip_markdown_fences("  plain text  ") == "plain text"
+
+    def test_strips_fence_with_language_tag(self):
+        text = "```python\nprint('hi')\n```"
+        assert _strip_markdown_fences(text) == "print('hi')"
+
+    def test_strips_fence_without_language_tag(self):
+        text = "```\nsome content\n```"
+        assert _strip_markdown_fences(text) == "some content"
+
+    def test_mismatched_fence_only_leading_is_stripped(self):
+        # No closing fence at all: only the leading fence is removed.
+        text = "```python\nprint('hi')"
+        assert _strip_markdown_fences(text) == "print('hi')"
+
+    def test_no_trailing_newline_before_closing_fence_is_not_stripped(self):
+        # Trailing-fence regex requires a preceding newline; without it, the
+        # closing ``` is left in place.
+        text = "```\ncode```"
+        assert _strip_markdown_fences(text) == "code```"
+
+    def test_trailing_fence_with_trailing_whitespace_is_stripped(self):
+        text = "```\ncode\n```   \n"
+        assert _strip_markdown_fences(text) == "code"
+
+    def test_multiline_body_preserved_between_fences(self):
+        text = "```markdown\nline one\nline two\n```"
+        assert _strip_markdown_fences(text) == "line one\nline two"
+
+    def test_empty_fenced_block_leaves_closing_backticks(self):
+        # Degenerate case verified against the actual implementation: the
+        # leading-fence regex consumes the single newline shared by both
+        # fences, so the trailing-fence regex (which requires its own
+        # leading "\n") no longer has one to match against, and the closing
+        # "```" is left in the output.
+        text = "```\n```"
+        assert _strip_markdown_fences(text) == "```"
+
+    def test_language_tag_with_digits(self):
+        text = "```html5\n<p>hi</p>\n```"
+        assert _strip_markdown_fences(text) == "<p>hi</p>"
+
+
+# ---------------------------------------------------------------------------
+# _escape_triple_quotes
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeTripleQuotes:
+    def test_no_triple_quotes_unchanged(self):
+        assert _escape_triple_quotes("hello world") == "hello world"
+
+    def test_single_triple_quote_occurrence_escaped(self):
+        assert _escape_triple_quotes('say """hi"""') == 'say \\"\\"\\"hi\\"\\"\\"'
+
+    def test_multiple_triple_quote_occurrences_all_escaped(self):
+        text = '"""first""" and """second"""'
+        result = _escape_triple_quotes(text)
+        assert '"""' not in result
+        assert result.count('\\"\\"\\"') == 4
+
+    def test_lone_double_quotes_are_untouched(self):
+        # Only exact triple-quote runs are targeted; ordinary double quotes
+        # (even multiple, non-adjacent ones) are left alone.
+        assert _escape_triple_quotes('He said "hi" to "you"') == 'He said "hi" to "you"'
+
+    def test_empty_string(self):
+        assert _escape_triple_quotes("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _map_sections
+# ---------------------------------------------------------------------------
+
+
+class TestMapSections:
+    def test_canonical_key_passthrough(self):
+        assert _map_sections({"role": "You are an agent."}) == {"role": "You are an agent."}
+
+    def test_alias_key_maps_to_canonical(self):
+        assert _map_sections({"persona": "You are an agent."}) == {"role": "You are an agent."}
+
+    def test_multiple_aliases_map_to_same_canonical_field(self):
+        assert _map_sections({"goal": "Ship the feature."}) == {"goals": "Ship the feature."}
+        assert _map_sections({"objective": "Ship the feature."}) == {"goals": "Ship the feature."}
+        assert _map_sections({"objectives": "Ship the feature."}) == {"goals": "Ship the feature."}
+
+    def test_unknown_section_key_is_dropped(self):
+        assert _map_sections({"random_header": "irrelevant"}) == {}
+
+    def test_first_occurrence_wins_when_multiple_raw_keys_share_a_canonical(self):
+        # Both "goals" and "goal" alias to the canonical "goals" field; the
+        # first one encountered (dict insertion order) must win.
+        sections = {"goals": "first content", "goal": "second content"}
+        assert _map_sections(sections) == {"goals": "first content"}
+
+    def test_constraints_family_of_aliases(self):
+        for raw_key in ("constraints", "constraint", "rules", "rule", "limitations"):
+            assert _map_sections({raw_key: "x"}) == {"constraints": "x"}
+
+    def test_tech_stack_family_of_aliases(self):
+        for raw_key in (
+            "tech stack",
+            "tech",
+            "technology stack",
+            "tools",
+            "tools & capabilities",
+            "tools and capabilities",
+            "capabilities",
+        ):
+            assert _map_sections({raw_key: "x"}) == {"tech_stack": "x"}
+
+    def test_workflows_family_of_aliases(self):
+        for raw_key in ("workflows", "workflow", "steps"):
+            assert _map_sections({raw_key: "x"}) == {"workflows": "x"}
+
+    def test_empty_input_returns_empty_dict(self):
+        assert _map_sections({}) == {}
+
+    def test_mixed_known_and_unknown_keys(self):
+        sections = {"role": "R", "unknown": "U", "goals": "G"}
+        assert _map_sections(sections) == {"role": "R", "goals": "G"}
+
+
+# ---------------------------------------------------------------------------
+# _preview_order
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewOrder:
+    def test_returns_expected_fixed_order(self):
+        assert _preview_order() == [
+            "claude_md",
+            "settings",
+            "agents",
+            "workflow",
+            "mcp",
+            "readme",
+            "files",
+        ]
+
+    def test_claude_md_is_first_and_files_is_last(self):
+        order = _preview_order()
+        assert order[0] == "claude_md"
+        assert order[-1] == "files"
+
+    def test_is_deterministic_across_calls(self):
+        assert _preview_order() == _preview_order()
+
+    def test_returns_a_new_list_each_time(self):
+        # Callers mutate the result (e.g. list-comprehension filtering); each
+        # call must hand back an independent list, not a shared mutable object.
+        first = _preview_order()
+        first.append("mutated")
+        assert "mutated" not in _preview_order()

--- a/tests/test_skill_adapter_private_helpers.py
+++ b/tests/test_skill_adapter_private_helpers.py
@@ -1,0 +1,295 @@
+"""
+Coverage for small, pure, string-shaping helpers in app/adapters/skill_adapter.py
+that are used by the LangChain / Claude tool_use / Agent Skill exporters but were
+not directly exercised by any existing test.
+"""
+
+from __future__ import annotations
+
+from app.adapters.skill_adapter import (
+    _capitalize_words,
+    _needs_keyword_only_params,
+    _to_kebab,
+    _to_title,
+    _truncate_at_sentence,
+    _unwrap_to_base,
+    _yaml_safe,
+)
+from app.adapters.skill_ir import SkillParam
+
+
+# ---------------------------------------------------------------------------
+# _needs_keyword_only_params
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsKeywordOnlyParams:
+    def test_empty_list_is_false(self):
+        assert _needs_keyword_only_params([]) is False
+
+    def test_all_required_is_false(self):
+        params = [
+            SkillParam(name="a", required=True),
+            SkillParam(name="b", required=True),
+        ]
+        assert _needs_keyword_only_params(params) is False
+
+    def test_all_optional_is_false(self):
+        params = [
+            SkillParam(name="a", required=False),
+            SkillParam(name="b", required=False),
+        ]
+        assert _needs_keyword_only_params(params) is False
+
+    def test_required_then_optional_is_false(self):
+        """Trailing optionals after required params don't need `*`."""
+        params = [
+            SkillParam(name="a", required=True),
+            SkillParam(name="b", required=False),
+        ]
+        assert _needs_keyword_only_params(params) is False
+
+    def test_optional_then_required_is_true(self):
+        """A required param following an optional one forces keyword-only."""
+        params = [
+            SkillParam(name="a", required=False),
+            SkillParam(name="b", required=True),
+        ]
+        assert _needs_keyword_only_params(params) is True
+
+    def test_required_optional_required_is_true(self):
+        params = [
+            SkillParam(name="a", required=True),
+            SkillParam(name="b", required=False),
+            SkillParam(name="c", required=True),
+        ]
+        assert _needs_keyword_only_params(params) is True
+
+    def test_single_required_param_is_false(self):
+        assert _needs_keyword_only_params([SkillParam(name="a", required=True)]) is False
+
+    def test_single_optional_param_is_false(self):
+        assert _needs_keyword_only_params([SkillParam(name="a", required=False)]) is False
+
+
+# ---------------------------------------------------------------------------
+# _yaml_safe
+# ---------------------------------------------------------------------------
+
+
+class TestYamlSafe:
+    def test_plain_word_is_returned_bare(self):
+        assert _yaml_safe("hello world") == "hello world"
+
+    def test_reserved_word_yes_is_quoted(self):
+        assert _yaml_safe("yes") == '"yes"'
+
+    def test_reserved_word_is_case_insensitive_but_preserves_original_case(self):
+        assert _yaml_safe("YES") == '"YES"'
+        assert _yaml_safe("True") == '"True"'
+        assert _yaml_safe("Null") == '"Null"'
+        assert _yaml_safe("~") == '"~"'
+
+    def test_colon_triggers_quoting(self):
+        assert _yaml_safe("a: b") == '"a: b"'
+
+    def test_hash_triggers_quoting(self):
+        assert _yaml_safe("value #note") == '"value #note"'
+
+    def test_embedded_double_quote_is_escaped(self):
+        assert _yaml_safe('He said "hi"') == '"He said \\"hi\\""'
+
+    def test_backslash_is_escaped_when_quoting_is_triggered(self):
+        # A backslash alone isn't a "special char" trigger, but once quoting is
+        # triggered by another special char, existing backslashes must be escaped
+        # so the output round-trips as valid YAML.
+        assert _yaml_safe('C:\\path') == '"C:\\\\path"'
+
+    def test_newline_and_carriage_return_collapsed_to_space(self):
+        assert _yaml_safe("line1\nline2") == "line1 line2"
+        assert _yaml_safe("line1\r\nline2") == "line1  line2"
+
+    def test_surrounding_whitespace_is_stripped(self):
+        assert _yaml_safe("  hello  ") == "hello"
+
+    def test_each_special_char_triggers_quoting(self):
+        for ch in (":", "#", "`", '"', "'", "[", "]", "{", "}", "&", "*", "!", "|", ">", "%", "@"):
+            value = f"a{ch}b"
+            result = _yaml_safe(value)
+            assert result.startswith('"') and result.endswith('"'), (ch, result)
+
+
+# ---------------------------------------------------------------------------
+# _truncate_at_sentence
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateAtSentence:
+    def test_text_shorter_than_max_len_is_unchanged(self):
+        text = "Short text."
+        assert _truncate_at_sentence(text, 200) == text
+
+    def test_text_exactly_max_len_is_unchanged(self):
+        text = "x" * 50
+        assert _truncate_at_sentence(text, 50) == text
+
+    def test_truncates_at_sentence_boundary_when_found_past_halfway(self):
+        # Sentence boundary ". " falls after max_len // 2, so it wins over the
+        # generic word-boundary fallback.
+        text = "A" * 30 + ". " + "B" * 100
+        result = _truncate_at_sentence(text, 60)
+        assert result == "A" * 30 + "."
+        assert not result.endswith("…")
+
+    def test_prefers_exclamation_terminator_past_halfway(self):
+        # "! " sits at index 32, past max_len // 2 == 30, so it wins.
+        text = ("a" * 32) + "! " + ("z" * 100)
+        result = _truncate_at_sentence(text, 60)
+        assert result == ("a" * 32) + "!"
+
+    def test_prefers_question_terminator_past_halfway(self):
+        text = ("a" * 32) + "? " + ("z" * 100)
+        result = _truncate_at_sentence(text, 60)
+        assert result == ("a" * 32) + "?"
+
+    def test_no_sentence_boundary_falls_back_to_word_boundary_with_ellipsis(self):
+        # No ". "/"! "/"? " within the cut at all -> falls back to last space.
+        text = "word " * 40  # no sentence terminators anywhere
+        result = _truncate_at_sentence(text, 60)
+        assert result.endswith("…")
+        assert ". " not in result
+
+    def test_word_boundary_fallback_strips_trailing_punctuation(self):
+        # The only space in range is right after "alpha,"; the trailing comma
+        # must be stripped before the ellipsis is appended.
+        text = "alpha, " + "b" * 100
+        result = _truncate_at_sentence(text, 13)
+        assert result == "alpha…"
+
+    def test_no_boundary_found_early_enough_hard_cuts_with_ellipsis(self):
+        # A single very long unbroken token with no space/sentence terminator
+        # before the halfway point forces a hard cut.
+        text = "x" * 200
+        result = _truncate_at_sentence(text, 50)
+        assert result == "x" * 50 + "…"
+
+    def test_sentence_boundary_before_halfway_is_ignored(self):
+        # ". " occurs at index 2 (well before max_len // 2 == 30), so it must
+        # not be used as the cut point; the word-boundary rule takes over and
+        # the result is far longer than just "Hi.".
+        text = "Hi. " + ("word " * 40)
+        result = _truncate_at_sentence(text, 60)
+        assert result != "Hi."
+        assert result.endswith("…")
+        assert len(result) > len("Hi.")
+
+
+# ---------------------------------------------------------------------------
+# _to_kebab / _to_title / _capitalize_words
+# ---------------------------------------------------------------------------
+
+
+class TestCapitalizeWords:
+    def test_splits_and_capitalizes_each_underscore_word(self):
+        assert _capitalize_words("hello_world") == ["Hello", "World"]
+
+    def test_lowercases_rest_of_already_uppercase_word(self):
+        assert _capitalize_words("HELLO_WORLD") == ["Hello", "World"]
+
+    def test_single_word_no_underscore(self):
+        assert _capitalize_words("single") == ["Single"]
+
+    def test_empty_string_yields_single_empty_element(self):
+        assert _capitalize_words("") == [""]
+
+
+class TestToKebab:
+    def test_simple_snake_case(self):
+        assert _to_kebab("my_skill_name") == "my-skill-name"
+
+    def test_collapses_multiple_underscores_to_one_hyphen(self):
+        assert _to_kebab("my__skill___name") == "my-skill-name"
+
+    def test_strips_leading_and_trailing_underscores(self):
+        assert _to_kebab("_my_skill_") == "my-skill"
+
+    def test_uppercase_is_lowercased(self):
+        assert _to_kebab("My_Skill_Name") == "my-skill-name"
+
+    def test_single_word_no_underscore(self):
+        assert _to_kebab("skill") == "skill"
+
+    def test_all_underscores_yields_empty_string(self):
+        assert _to_kebab("___") == ""
+
+
+class TestToTitle:
+    def test_simple_snake_case(self):
+        assert _to_title("hello_world") == "Hello World"
+
+    def test_single_word(self):
+        assert _to_title("skill") == "Skill"
+
+    def test_all_uppercase_input_normalized(self):
+        assert _to_title("WEATHER_LOOKUP") == "Weather Lookup"
+
+    def test_empty_string(self):
+        assert _to_title("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _unwrap_to_base
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapToBase:
+    def test_non_string_input_returns_empty_string(self):
+        assert _unwrap_to_base(None) == ""
+        assert _unwrap_to_base(123) == ""
+
+    def test_empty_string_returns_empty_string(self):
+        assert _unwrap_to_base("") == ""
+        assert _unwrap_to_base("   ") == ""
+
+    def test_plain_base_type_lowercased(self):
+        assert _unwrap_to_base("Str") == "str"
+        assert _unwrap_to_base("INT") == "int"
+
+    def test_strips_optional_wrapper(self):
+        assert _unwrap_to_base("Optional[int]") == "int"
+        assert _unwrap_to_base("typing.Optional[str]") == "str"
+
+    def test_strips_union_wrapper_taking_first_non_none(self):
+        assert _unwrap_to_base("Union[str, None]") == "str"
+        assert _unwrap_to_base("typing.Union[int, str, None]") == "int"
+
+    def test_union_of_only_none_falls_back_to_any(self):
+        assert _unwrap_to_base("Union[None, NoneType]") == "any"
+
+    def test_strips_pipe_union_taking_first_non_none(self):
+        assert _unwrap_to_base("int | None") == "int"
+        assert _unwrap_to_base("None | float") == "float"
+
+    def test_extracts_generic_base(self):
+        assert _unwrap_to_base("List[str]") == "list"
+        assert _unwrap_to_base("Dict[str, int]") == "dict"
+
+    def test_strips_module_namespace(self):
+        assert _unwrap_to_base("typing.List[str]") == "list"
+        assert _unwrap_to_base("collections.abc.Mapping[str, str]") == "mapping"
+
+    def test_nested_generic_with_optional_and_namespace(self):
+        assert _unwrap_to_base("Optional[typing.List[str]]") == "list"
+
+    def test_whitespace_normalized_around_brackets(self):
+        assert _unwrap_to_base("List [ str ]") == "list"
+
+
+# ---------------------------------------------------------------------------
+# Legacy-bug guard: reserved-word check is genuinely case-insensitive
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_safe_reserved_word_off_variant():
+    assert _yaml_safe("Off") == '"Off"'
+    assert _yaml_safe("no") == '"no"'


### PR DESCRIPTION
## Summary

Adds unit test coverage for pure, previously-untested private helper functions in the export-adapter layer, found during a test-coverage audit. Several of these directly affect generated-code correctness (Python identifier safety, triple-quote escaping, markdown-fence stripping) so leaving them untested carried real regression risk. New test files only — no source, config, or CI changes.

## Changes

- `tests/test_skill_adapter_private_helpers.py` (58 tests) — covers `app/adapters/skill_adapter.py`: `_needs_keyword_only_params`, `_yaml_safe`, `_truncate_at_sentence`, `_capitalize_words`/`_to_kebab`/`_to_title`, `_unwrap_to_base`.
- `tests/test_claude_code_private_helpers.py` (33 tests) — covers `app/adapters/claude_code.py`: `_to_python_identifier`, `_strip_markdown_fences`, `_escape_triple_quotes`; `app/adapters/agent_ir.py`: `_map_sections`; `app/adapters/agent_packs.py`: `_preview_order` (`_classify_kind` in the same module was already covered by the existing `TestClassifyKind` suite, so it wasn't duplicated).

One documented, non-blocking behavioral note: `_strip_markdown_fences("```\n```")` (a fenced block with literally empty content) returns `` ``` `` instead of an empty string, because the leading-fence regex consumes the shared newline before the trailing-fence regex can match. This is asserted as verified real behavior (`test_empty_fenced_block_leaves_closing_backticks`), not silently treated as a bug — it only affects a degenerate empty-fence input and doesn't block this PR, but may be worth a follow-up if fully-empty fenced LLM output needs to be handled.

## Testing

- New suite: `python -m pytest tests/test_skill_adapter_private_helpers.py tests/test_claude_code_private_helpers.py -v` → 91 passed
- Full suite: `python -m pytest tests/ -q` → 2640 passed, 7 skipped (baseline before this change: 2549 passed, 7 skipped — exactly +91, zero regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWn8B6e1jgGuSpdhqVgpF4)_