### PR TITLE
test: add unit tests for heuristics and optimizer pure-function gaps

### DIFF
--- a/tests/test_agent_ir_map_sections_gap.py
+++ b/tests/test_agent_ir_map_sections_gap.py
@@ -1,0 +1,89 @@
+"""Direct unit coverage for app.adapters.agent_ir._map_sections: the pure
+dict alias-normalization step in the agent-markdown parser. It silently
+drops unmapped and duplicate-canonical sections, which is untested in
+isolation today (only exercised indirectly via _build_ir).
+"""
+
+from app.adapters.agent_ir import _map_sections
+
+
+def test_maps_known_aliases_to_canonical_names():
+    sections = {"role": "does X", "goal": "ship Y", "constraints": "no Z"}
+    mapped = _map_sections(sections)
+    assert mapped == {"role": "does X", "goals": "ship Y", "constraints": "no Z"}
+
+
+def test_unmapped_section_is_silently_dropped():
+    sections = {"role": "does X", "random notes": "this has no alias"}
+    mapped = _map_sections(sections)
+    assert mapped == {"role": "does X"}
+    assert "random notes" not in mapped
+
+
+def test_all_unmapped_sections_yields_empty_dict():
+    sections = {"foo": "bar", "misc": "baz"}
+    assert _map_sections(sections) == {}
+
+
+def test_empty_input_yields_empty_dict():
+    assert _map_sections({}) == {}
+
+
+def test_first_occurrence_wins_for_duplicate_canonical_targets():
+    # "goals", "goal", "objective", and "objectives" all map to "goals" —
+    # the first one encountered (in dict/insertion order) must win, and
+    # later ones for the same canonical target are dropped.
+    sections = {
+        "objective": "first content",
+        "goals": "second content",
+        "objectives": "third content",
+    }
+    mapped = _map_sections(sections)
+    assert mapped == {"goals": "first content"}
+
+
+def test_distinct_aliases_for_same_target_do_not_produce_duplicate_key():
+    sections = {"rule": "be nice", "constraint": "no rudeness", "limitations": "keep it short"}
+    mapped = _map_sections(sections)
+    # Only one "constraints" key can exist in the output dict; the first
+    # alias processed (insertion order) determines the surviving value.
+    assert mapped == {"constraints": "be nice"}
+
+
+def test_alias_lookup_is_case_sensitive_and_requires_lowercase_keys():
+    # The alias table only defines lowercase keys; _parse_sections lowercases
+    # raw section headers before calling this, but _map_sections itself does
+    # no normalization, so an uppercase raw key is treated as unmapped.
+    sections = {"Role": "does X"}
+    assert _map_sections(sections) == {}
+
+
+def test_tools_and_tech_stack_aliases_both_map_to_tech_stack():
+    sections = {"tools": "uses pytest", "tech stack": "python, fastapi"}
+    mapped = _map_sections(sections)
+    assert mapped == {"tech_stack": "uses pytest"}
+
+
+def test_multiple_distinct_canonical_targets_all_survive():
+    sections = {
+        "persona": "a helpful bot",
+        "objective": "ship features",
+        "rule": "be concise",
+        "steps": "1. plan 2. build",
+        "capabilities": "python, sql",
+    }
+    mapped = _map_sections(sections)
+    assert mapped == {
+        "role": "a helpful bot",
+        "goals": "ship features",
+        "constraints": "be concise",
+        "workflows": "1. plan 2. build",
+        "tech_stack": "python, sql",
+    }
+
+
+def test_content_value_is_passed_through_unmodified():
+    multiline_content = "line one\nline two\n- bullet"
+    sections = {"goals": multiline_content}
+    mapped = _map_sections(sections)
+    assert mapped["goals"] == multiline_content

--- a/tests/test_heuristics_external_config_gap.py
+++ b/tests/test_heuristics_external_config_gap.py
@@ -1,0 +1,136 @@
+"""Direct unit coverage for app.heuristics._apply_external_config: a pure
+dict merge into module globals (DOMAIN_PATTERNS, AMBIGUOUS_TERMS,
+RISK_KEYWORDS). The I/O (reading the YAML/JSON file) lives in the caller,
+load_external_config; this function only takes an already-parsed dict and
+mutates module state, and has zero direct test of malformed-input handling
+today.
+
+Because the function reassigns module-level globals via `global`, every
+test here restores the original objects afterward so it cannot leak state
+into other test modules that rely on the built-in pattern tables.
+"""
+
+import pytest
+
+import app.heuristics as heuristics
+from app.heuristics import _apply_external_config
+
+
+@pytest.fixture(autouse=True)
+def _restore_config_globals():
+    original_domain_patterns = heuristics.DOMAIN_PATTERNS
+    original_ambiguous_terms = heuristics.AMBIGUOUS_TERMS
+    original_risk_keywords = heuristics.RISK_KEYWORDS
+    yield
+    heuristics.DOMAIN_PATTERNS = original_domain_patterns
+    heuristics.AMBIGUOUS_TERMS = original_ambiguous_terms
+    heuristics.RISK_KEYWORDS = original_risk_keywords
+
+
+def test_empty_dict_leaves_all_globals_unchanged():
+    before_domain = heuristics.DOMAIN_PATTERNS
+    before_ambiguous = heuristics.AMBIGUOUS_TERMS
+    before_risk = heuristics.RISK_KEYWORDS
+
+    _apply_external_config({})
+
+    assert heuristics.DOMAIN_PATTERNS is before_domain
+    assert heuristics.AMBIGUOUS_TERMS is before_ambiguous
+    assert heuristics.RISK_KEYWORDS is before_risk
+
+
+def test_unrelated_keys_are_ignored_without_error():
+    before_domain = heuristics.DOMAIN_PATTERNS
+    _apply_external_config({"some_other_setting": True, "version": 2})
+    assert heuristics.DOMAIN_PATTERNS is before_domain
+
+
+def test_valid_domain_patterns_replaces_global_and_normalizes_to_lists():
+    _apply_external_config({"domain_patterns": {"legal": ("sue", "court"), "medicine": ["clinic"]}})
+    assert heuristics.DOMAIN_PATTERNS == {"legal": ["sue", "court"], "medicine": ["clinic"]}
+    assert isinstance(heuristics.DOMAIN_PATTERNS["legal"], list)
+
+
+def test_domain_patterns_filters_out_non_list_non_tuple_values():
+    _apply_external_config(
+        {
+            "domain_patterns": {
+                "legal": ["sue", "court"],
+                "bad_string_value": "not-a-list",
+                "bad_int_value": 42,
+                "bad_dict_value": {"nested": True},
+            }
+        }
+    )
+    assert heuristics.DOMAIN_PATTERNS == {"legal": ["sue", "court"]}
+    assert "bad_string_value" not in heuristics.DOMAIN_PATTERNS
+    assert "bad_int_value" not in heuristics.DOMAIN_PATTERNS
+    assert "bad_dict_value" not in heuristics.DOMAIN_PATTERNS
+
+
+def test_domain_patterns_with_non_dict_value_is_ignored_entirely():
+    before_domain = heuristics.DOMAIN_PATTERNS
+    _apply_external_config({"domain_patterns": ["legal", "medicine"]})
+    assert heuristics.DOMAIN_PATTERNS is before_domain
+
+
+def test_domain_patterns_with_all_invalid_entries_yields_empty_dict():
+    _apply_external_config({"domain_patterns": {"bad": "nope", "also_bad": 1}})
+    assert heuristics.DOMAIN_PATTERNS == {}
+
+
+def test_valid_ambiguous_terms_replaces_global_verbatim():
+    new_terms = {"scale": {"question": "how big?", "category": "sizing"}}
+    _apply_external_config({"ambiguous_terms": new_terms})
+    assert heuristics.AMBIGUOUS_TERMS == new_terms
+
+
+def test_ambiguous_terms_with_non_dict_value_is_ignored():
+    before_ambiguous = heuristics.AMBIGUOUS_TERMS
+    _apply_external_config({"ambiguous_terms": ["scale", "fast"]})
+    assert heuristics.AMBIGUOUS_TERMS is before_ambiguous
+
+
+def test_valid_risk_keywords_replaces_global_verbatim():
+    new_risk = {"financial": ["yatirim"], "legal": ["dava"]}
+    _apply_external_config({"risk_keywords": new_risk})
+    assert heuristics.RISK_KEYWORDS == new_risk
+
+
+def test_risk_keywords_with_non_dict_value_is_ignored():
+    before_risk = heuristics.RISK_KEYWORDS
+    _apply_external_config({"risk_keywords": "not-a-dict"})
+    assert heuristics.RISK_KEYWORDS is before_risk
+
+
+def test_all_three_sections_applied_together():
+    payload = {
+        "domain_patterns": {"legal": ["sue"]},
+        "ambiguous_terms": {"scale": {"question": "how big?"}},
+        "risk_keywords": {"financial": ["yatirim"]},
+    }
+    _apply_external_config(payload)
+    assert heuristics.DOMAIN_PATTERNS == {"legal": ["sue"]}
+    assert heuristics.AMBIGUOUS_TERMS == {"scale": {"question": "how big?"}}
+    assert heuristics.RISK_KEYWORDS == {"financial": ["yatirim"]}
+
+
+def test_malformed_data_with_none_values_for_known_keys_is_ignored():
+    before_domain = heuristics.DOMAIN_PATTERNS
+    before_ambiguous = heuristics.AMBIGUOUS_TERMS
+    before_risk = heuristics.RISK_KEYWORDS
+
+    _apply_external_config({"domain_patterns": None, "ambiguous_terms": None, "risk_keywords": None})
+
+    assert heuristics.DOMAIN_PATTERNS is before_domain
+    assert heuristics.AMBIGUOUS_TERMS is before_ambiguous
+    assert heuristics.RISK_KEYWORDS is before_risk
+
+
+def test_function_mutates_actual_module_global_not_a_local_copy():
+    # Regression guard for the `global` statement itself: verify the change
+    # is visible through the module object, not just a local return value.
+    _apply_external_config({"risk_keywords": {"sentinel": ["marker"]}})
+    import app.heuristics as reimported
+
+    assert reimported.RISK_KEYWORDS == {"sentinel": ["marker"]}

--- a/tests/test_heuristics_fp_hint_gap.py
+++ b/tests/test_heuristics_fp_hint_gap.py
@@ -1,0 +1,111 @@
+"""Direct unit coverage for app.heuristics._has_fp_hint_around_match: the
+context-window scan that suppresses PII false positives (e.g. SSN/passport
+patterns matched inside documentation examples). It is only exercised
+indirectly today via detect_pii, so its own window-boundary and
+case-sensitivity behavior has no direct assertions. High criticality — this
+gates PII detection accuracy.
+"""
+
+from app.heuristics import _has_fp_hint_around_match
+
+
+def test_hint_immediately_before_match_is_detected():
+    text = "This is a sample 123-45-6789 in the docs"
+    start = text.index("123-45-6789")
+    end = start + len("123-45-6789")
+    assert _has_fp_hint_around_match(text, start, end) is True
+
+
+def test_hint_immediately_after_match_is_detected():
+    text = "Value 123-45-6789 is just a placeholder here"
+    start = text.index("123-45-6789")
+    end = start + len("123-45-6789")
+    assert _has_fp_hint_around_match(text, start, end) is True
+
+
+def test_no_hint_anywhere_returns_false():
+    text = "Contact John at 123-45-6789 for details"
+    start = text.index("123-45-6789")
+    end = start + len("123-45-6789")
+    assert _has_fp_hint_around_match(text, start, end) is False
+
+
+def test_hint_outside_default_window_is_not_detected():
+    # "example" sits 30 chars before the match, past the default window of 24.
+    prefix = "example " + ("x" * 22)
+    match_val = "123-45-6789"
+    text = prefix + " " + match_val
+    start = text.index(match_val)
+    end = start + len(match_val)
+    assert _has_fp_hint_around_match(text, start, end) is False
+
+
+def test_hint_just_inside_default_window_is_detected():
+    # Place "format" exactly window(=24) chars before the match start.
+    match_val = "123-45-6789"
+    filler = "x" * 15
+    prefix = "format " + filler  # len("format ") == 7, total 22 chars before match
+    text = prefix + match_val
+    start = text.index(match_val)
+    end = start + len(match_val)
+    assert start - text.index("format") <= 24
+    assert _has_fp_hint_around_match(text, start, end) is True
+
+
+def test_case_insensitive_hint_detection():
+    text = "SAMPLE VALUE: 123-45-6789"
+    start = text.index("123-45-6789")
+    end = start + len("123-45-6789")
+    assert _has_fp_hint_around_match(text, start, end) is True
+
+
+def test_custom_smaller_window_excludes_distant_hint():
+    text = "This is a dummy value far away 123-45-6789 here"
+    start = text.index("123-45-6789")
+    end = start + len("123-45-6789")
+    # With the default window(24) "dummy" (well outside 24 chars back) is not seen either,
+    # but assert explicitly with a tiny window to make the boundary condition unambiguous.
+    assert _has_fp_hint_around_match(text, start, end, window=2) is False
+
+
+def test_zero_window_checks_only_the_matched_span_itself():
+    # window=0 means lo=start, hi=end, so ctx is exactly the matched substring.
+    text = "fake123456789xx"
+    start = 0
+    end = len(text)
+    assert _has_fp_hint_around_match(text, start, end, window=0) is True
+
+
+def test_zero_window_with_hint_just_outside_span_is_false():
+    text = "fake 123456789xx"
+    start = text.index("123456789xx")
+    end = start + len("123456789xx")
+    assert _has_fp_hint_around_match(text, start, end, window=0) is False
+
+
+def test_hint_matches_as_substring_not_word_boundary():
+    # "format" is substring-matched, so it fires inside "reformatted" too.
+    text = "The reformatted value is 123-45-6789 shown below"
+    start = text.index("123-45-6789")
+    end = start + len("123-45-6789")
+    assert _has_fp_hint_around_match(text, start, end) is True
+
+
+def test_window_clamped_at_start_of_text_does_not_error():
+    text = "123-45-6789 test data follows"
+    start = 0
+    end = len("123-45-6789")
+    # window would push lo below 0; function must clamp to 0 and still find the hint after.
+    assert _has_fp_hint_around_match(text, start, end, window=50) is True
+
+
+def test_window_clamped_at_end_of_text_does_not_error():
+    text = "example 123-45-6789"
+    start = text.index("123-45-6789")
+    end = len(text)
+    # window would push hi past len(text); function must clamp and still find the hint before.
+    assert _has_fp_hint_around_match(text, start, end, window=50) is True
+
+
+def test_empty_text_with_zero_length_match_returns_false():
+    assert _has_fp_hint_around_match("", 0, 0) is False

--- a/tests/test_heuristics_intent_keywords_gap.py
+++ b/tests/test_heuristics_intent_keywords_gap.py
@@ -1,0 +1,104 @@
+"""Direct unit coverage for app.heuristics._contains_any_keyword and the five
+pure intent-detection wrappers built on top of it (detect_creative_intent,
+detect_explanation_intent, detect_proposal_intent, detect_review_intent,
+detect_preparation_intent). These feed downstream intent routing but are
+only exercised indirectly today, so keyword-boundary and case-sensitivity
+behavior has no direct assertions.
+"""
+
+from app.heuristics import (
+    _contains_any_keyword,
+    detect_creative_intent,
+    detect_explanation_intent,
+    detect_preparation_intent,
+    detect_proposal_intent,
+    detect_review_intent,
+)
+
+
+class TestContainsAnyKeyword:
+    def test_returns_true_when_keyword_present(self):
+        assert _contains_any_keyword("please write a short story", ["story", "poem"]) is True
+
+    def test_returns_false_when_no_keyword_present(self):
+        assert _contains_any_keyword("please write some code", ["story", "poem"]) is False
+
+    def test_is_case_insensitive(self):
+        assert _contains_any_keyword("Write me a STORY please", ["story"]) is True
+
+    def test_empty_keyword_list_returns_false(self):
+        assert _contains_any_keyword("anything at all", []) is False
+
+    def test_empty_text_returns_false_for_nonempty_keywords(self):
+        assert _contains_any_keyword("", ["story"]) is False
+
+    def test_matches_as_substring_not_word_boundary(self):
+        # "sue" is a substring of "issue" — _contains_any_keyword has no word
+        # boundary, unlike the risk-keyword regex path elsewhere in this module.
+        assert _contains_any_keyword("please file an issue", ["sue"]) is True
+
+    def test_short_circuits_on_first_match(self):
+        # Even if a later keyword would also match, the first hit is enough
+        # to return True without raising for the remaining keywords.
+        assert _contains_any_keyword("brainstorm names for my startup", ["brainstorm names", "poem"]) is True
+
+
+class TestDetectCreativeIntent:
+    def test_true_for_story_keyword(self):
+        assert detect_creative_intent("write a short story about a dragon") is True
+
+    def test_true_for_multi_word_keyword(self):
+        assert detect_creative_intent("help me brainstorm names for my app") is True
+
+    def test_false_for_unrelated_text(self):
+        assert detect_creative_intent("deploy the app to production") is False
+
+    def test_case_insensitive(self):
+        assert detect_creative_intent("Write me a TAGLINE for launch") is True
+
+
+class TestDetectExplanationIntent:
+    def test_true_for_explain_keyword(self):
+        assert detect_explanation_intent("can you explain how this works") is True
+
+    def test_true_for_multi_word_keyword(self):
+        assert detect_explanation_intent("walk me through the deployment process") is True
+
+    def test_false_for_unrelated_text(self):
+        assert detect_explanation_intent("write a poem about the sea") is False
+
+
+class TestDetectProposalIntent:
+    def test_true_for_proposal_keyword(self):
+        assert detect_proposal_intent("draft a proposal for the new client") is True
+
+    def test_true_for_pitch_keyword(self):
+        assert detect_proposal_intent("help me pitch this idea") is True
+
+    def test_false_for_unrelated_text(self):
+        assert detect_proposal_intent("review my code for bugs") is False
+
+
+class TestDetectReviewIntent:
+    def test_true_for_review_keyword(self):
+        assert detect_review_intent("please review this pull request") is True
+
+    def test_true_for_check_my_keyword(self):
+        assert detect_review_intent("check my essay for grammar mistakes") is True
+
+    def test_false_for_unrelated_text(self):
+        assert detect_review_intent("write a launch post for our product") is False
+
+
+class TestDetectPreparationIntent:
+    def test_true_for_interview_prep_keyword(self):
+        assert detect_preparation_intent("interview prep for a software engineer role") is True
+
+    def test_true_for_study_plan_keyword(self):
+        assert detect_preparation_intent("build me a study plan for finals") is True
+
+    def test_false_for_unrelated_text(self):
+        assert detect_preparation_intent("audit this document for accuracy") is False
+
+    def test_prepare_me_keyword_is_case_insensitive(self):
+        assert detect_preparation_intent("PREPARE ME for the exam next week") is True

--- a/tests/test_language_costs_rates_gap.py
+++ b/tests/test_language_costs_rates_gap.py
@@ -1,0 +1,122 @@
+"""Direct unit coverage for app.optimizer.language_costs.get_openrouter_rates
+and count_estimated_tokens. Both are pure, static-table / offline-tokenizer
+helpers exercised only indirectly today via estimate_prompt_cost, so the
+prefix-matching fallback, the unknown-model $0 branch, and the tiktoken
+except-guarded fallback have no direct assertions.
+"""
+
+import pytest
+
+import app.optimizer.language_costs as language_costs
+from app.optimizer.language_costs import (
+    DEFAULT_OPENROUTER_MODEL,
+    OPENROUTER_RATES,
+    count_estimated_tokens,
+    get_openrouter_rates,
+)
+from app.text_utils import estimate_tokens
+
+
+class TestGetOpenrouterRates:
+    def test_exact_match_returns_configured_rates_with_no_warnings(self):
+        input_rate, output_rate, warnings = get_openrouter_rates("qwen/qwen3-32b")
+        assert input_rate == pytest.approx(0.08)
+        assert output_rate == pytest.approx(0.28)
+        assert warnings == []
+
+    def test_default_model_used_when_empty_string_passed(self):
+        input_rate, output_rate, warnings = get_openrouter_rates("")
+        default_rates = OPENROUTER_RATES[DEFAULT_OPENROUTER_MODEL]
+        assert input_rate == pytest.approx(default_rates["input"])
+        assert output_rate == pytest.approx(default_rates["output"])
+        assert warnings == []
+
+    def test_default_model_used_when_none_passed(self):
+        input_rate, output_rate, warnings = get_openrouter_rates(None)
+        default_rates = OPENROUTER_RATES[DEFAULT_OPENROUTER_MODEL]
+        assert input_rate == pytest.approx(default_rates["input"])
+        assert warnings == []
+
+    def test_prefix_fallback_matches_versioned_suffix(self):
+        # "openai/gpt-oss-20b:free" isn't in the table verbatim but starts with
+        # the known key "openai/gpt-oss-20b".
+        input_rate, output_rate, warnings = get_openrouter_rates("openai/gpt-oss-20b:free")
+        assert input_rate == pytest.approx(0.075)
+        assert output_rate == pytest.approx(0.30)
+        assert warnings == []
+
+    def test_prefix_fallback_prefers_longest_matching_key(self):
+        # "google/gemini-2.5-flash" is itself a prefix of "google/gemini-2.5-flash-lite".
+        # A model id extending the -lite variant must resolve to -lite's rates,
+        # not fall through to the shorter "flash" key.
+        input_rate, output_rate, warnings = get_openrouter_rates(
+            "google/gemini-2.5-flash-lite-preview"
+        )
+        assert input_rate == pytest.approx(0.10)
+        assert output_rate == pytest.approx(0.40)
+        assert warnings == []
+
+    def test_prefix_fallback_does_not_over_match_shorter_sibling_key(self):
+        # A suffix on the base "flash" model must resolve to the base flash
+        # rates, since it does not start with the longer "-lite" key.
+        input_rate, output_rate, warnings = get_openrouter_rates(
+            "google/gemini-2.5-flash:extended-thinking"
+        )
+        assert input_rate == pytest.approx(0.30)
+        assert output_rate == pytest.approx(2.50)
+        assert warnings == []
+
+    def test_unknown_model_returns_zero_rates_with_named_warning(self):
+        input_rate, output_rate, warnings = get_openrouter_rates("totally/unknown-model")
+        assert input_rate == 0.0
+        assert output_rate == 0.0
+        assert len(warnings) == 1
+        assert "totally/unknown-model" in warnings[0]
+
+    def test_whitespace_only_model_normalizes_to_empty_and_warns(self):
+        input_rate, output_rate, warnings = get_openrouter_rates("   ")
+        assert input_rate == 0.0
+        assert output_rate == 0.0
+        assert "''" in warnings[0]
+
+    def test_model_with_surrounding_whitespace_is_stripped_before_lookup(self):
+        input_rate, output_rate, warnings = get_openrouter_rates("  qwen/qwen3-32b  ")
+        assert input_rate == pytest.approx(0.08)
+        assert warnings == []
+
+
+class TestCountEstimatedTokens:
+    def test_empty_text_returns_zero(self):
+        assert count_estimated_tokens("") == 0
+
+    def test_nonempty_text_returns_positive_int_via_tiktoken(self):
+        tokens = count_estimated_tokens("Hello world, this is a test sentence.")
+        assert isinstance(tokens, int)
+        assert tokens > 0
+
+    def test_falls_back_to_estimate_tokens_when_tiktoken_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(language_costs, "tiktoken", None)
+        text = "Bu fonksiyon icin guvenlik kisitlari yaz."
+        assert count_estimated_tokens(text) == estimate_tokens(text)
+
+    def test_falls_back_to_estimate_tokens_when_encoding_raises(self, monkeypatch):
+        class _BoomEncoding:
+            def get_encoding(self, name):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(language_costs, "tiktoken", _BoomEncoding())
+        text = "Some arbitrary prompt text for fallback coverage."
+        assert count_estimated_tokens(text) == estimate_tokens(text)
+
+    def test_falls_back_to_estimate_tokens_when_encode_raises(self, monkeypatch):
+        class _BoomEncoder:
+            def encode(self, text):
+                raise ValueError("encode failure")
+
+        class _FakeTiktoken:
+            def get_encoding(self, name):
+                return _BoomEncoder()
+
+        monkeypatch.setattr(language_costs, "tiktoken", _FakeTiktoken())
+        text = "Another prompt that triggers the except-guarded fallback path."
+        assert count_estimated_tokens(text) == estimate_tokens(text)


### PR DESCRIPTION
## Summary

Adds unit tests for pure-function gaps identified in a test-coverage audit. This repo already has thorough coverage (234 test files); these are private/module-level helpers that were only exercised indirectly via higher-level tests, so specific edge-case branches had no direct assertions.

## Changes

- `tests/test_heuristics_fp_hint_gap.py` — `_has_fp_hint_around_match` (PII false-positive hint detection): window boundary clamping, custom window sizes, `window=0`, case-insensitivity
- `tests/test_heuristics_intent_keywords_gap.py` — `_contains_any_keyword` and the 5 intent-detection wrappers (`detect_creative_intent`, `detect_explanation_intent`, `detect_proposal_intent`, `detect_review_intent`, `detect_preparation_intent`)
- `tests/test_language_costs_rates_gap.py` — `get_openrouter_rates` (exact match, model-name normalization, prefix fallback including longest-key-wins, unknown-model $0+warning branch) and `count_estimated_tokens` (tiktoken path plus 3 distinct except-guarded fallback triggers)
- `tests/test_agent_ir_map_sections_gap.py` — `_map_sections` (alias mapping, unmapped-section dropping, duplicate-canonical first-wins)
- `tests/test_heuristics_external_config_gap.py` — `_apply_external_config` (valid merges, malformed-value filtering, module-global mutation, with an autouse fixture to prevent cross-test state leakage)

No source, config, or existing test files were modified — only new test files were added.

## Testing

- [x] Backend tests: `python -m pytest tests/ -q` — 2556 passed before, 2630 passed after (74 new, all green, 7 pre-existing unrelated skips)
- [x] New tests added

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThkGeGUj3fj9nJj6AR3Z1p)_