### PR TITLE
Fix inverted restrictions, ground a self-check checklist, repair the MCP bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
             tests/test_rag_upload.py \
             tests/test_benchmark_api.py
 
+      # The MCP bridge lives outside tests/ and has its own dependency set, so
+      # the other jobs never exercise it. Without this step an incompatible
+      # `mcp` release breaks the bridge at import time and CI stays green.
+      - name: MCP bridge tests
+        run: |
+          pip install -r integrations/mcp-server/requirements.txt
+          pytest -q integrations/mcp-server/
+
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
+  # Keep in sync with the `ruff` pin in pyproject.toml's [dev] extra, so that
+  # formatting locally and formatting in CI agree.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.14
+    rev: v0.16.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       - id: ruff-format
 

--- a/api/main.py
+++ b/api/main.py
@@ -73,9 +73,9 @@ async def add_security_headers(request, call_next):
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["X-XSS-Protection"] = "1; mode=block"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-    response.headers[
-        "Content-Security-Policy"
-    ] = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
+    )
     return response
 
 

--- a/api/routes/compile.py
+++ b/api/routes/compile.py
@@ -727,8 +727,7 @@ async def optimize_endpoint(
 
         if optimized_cost.tokens > source_cost.tokens > 0:
             warnings.append(
-                "Optimized output uses more tokens than the input; "
-                "consider keeping the original."
+                "Optimized output uses more tokens than the input; consider keeping the original."
             )
 
         english_variant = ""

--- a/app/adapters/agent_packs.py
+++ b/app/adapters/agent_packs.py
@@ -68,8 +68,7 @@ class AgentPackManifest(BaseModel):
 class AgentPackAdapter(Protocol):
     provider: str
 
-    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest:
-        ...
+    def build_manifest(self, req: AgentPackRequest, compiler: Any) -> AgentPackManifest: ...
 
 
 class ClaudeAgentPackAdapter:

--- a/app/adapters/claude_sdk.py
+++ b/app/adapters/claude_sdk.py
@@ -1,6 +1,7 @@
 """
 claude_sdk.py — Generate Claude SDK-compatible Python code and YAML config from AgentExportIR.
 """
+
 from __future__ import annotations
 
 import textwrap

--- a/app/adapters/langchain.py
+++ b/app/adapters/langchain.py
@@ -1,6 +1,7 @@
 """
 langchain.py — Generate LangChain (LCEL) and LangGraph Python code from AgentExportIR.
 """
+
 from __future__ import annotations
 
 import textwrap

--- a/app/agents/context_strategist.py
+++ b/app/agents/context_strategist.py
@@ -2,6 +2,7 @@
 Agent 6: The Context Strategist.
 Responsible for semantic retrieval, query expansion, and context re-ranking.
 """
+
 import json
 import re
 from typing import List, Dict, Any, Optional

--- a/app/compiler.py
+++ b/app/compiler.py
@@ -53,6 +53,7 @@ from .heuristics.handlers.format_enforcer import FormatEnforcerHandler
 from .heuristics.handlers.paradox_resolver import ParadoxResolverHandler
 from .heuristics.handlers.deduplicator import DeduplicatorHandler
 from .heuristics.handlers.exploration import ExplorationHandler
+from .heuristics.handlers.verification import VerificationHandler
 from .heuristics.handlers.schema_sanitizer import SchemaSanitizerHandler
 
 logger = logging.getLogger(__name__)
@@ -307,6 +308,8 @@ def compile_text_v2(
         FormatEnforcerHandler(),
         ParadoxResolverHandler(),
         DeduplicatorHandler(),
+        # After Deduplicator so the checklist is built from settled constraints.
+        VerificationHandler(),
         ExplorationHandler(),  # last: needs final intents + policy
     ]
 

--- a/app/emitters.py
+++ b/app/emitters.py
@@ -5,6 +5,7 @@ import os
 from .models import IR
 from .models_v2 import IRv2, ConstraintV2, StepV2
 from .heuristics import detect_frontend_download_feature
+from .heuristics.handlers.verification import render_verification_block
 
 
 def emit_system_prompt(ir: IR) -> str:
@@ -906,6 +907,13 @@ def emit_system_prompt_v2(ir: IRv2) -> str:
         parts.append("Tone: " + ", ".join(ir.tone))
     if ir.banned:
         parts.append("Avoid: " + ", ".join(ir.banned))
+
+    # Constraint-grounded self-check. Kept with the instructions rather than
+    # after the Context dump below, which is reference material.
+    verification_lines = render_verification_block(ir, ir.language)
+    if verification_lines:
+        parts.append("")
+        parts.extend(verification_lines)
 
     # --- Agent 6: The Strategist (Render Context) ---
     context_snippets = (ir.metadata or {}).get("context_snippets")

--- a/app/heuristics/handlers/verification.py
+++ b/app/heuristics/handlers/verification.py
@@ -1,0 +1,160 @@
+"""
+Verification Handler: constraint-grounded self-check checklist.
+
+Emits a short "before you finish, verify" block built ONLY from constraints the
+compiler already extracted from the user's own words. This is the self-
+verification prompting pattern (ask the model to check its work against explicit
+criteria before finalising), grounded so that it cannot invent a requirement.
+
+Why it earns its place, given `Key Constraints` already exists:
+
+- `emit_system_prompt_v2` renders `_top_constraints_text_v2(..., limit=3)`, so
+  only the three highest-priority constraints ever reach the system prompt. A
+  request like "must not expose user emails and should never log request
+  bodies; exclude soft-deleted rows; do not add new dependencies" produces a
+  dozen constraints, and the email requirement is silently dropped. The
+  checklist covers every hard requirement, so nothing the user said is lost.
+- A stated constraint and an instruction to verify against it do different
+  things. The former is context; the latter is a final pass.
+
+Design rules (mirroring exploration.py):
+- Deterministic: a pure function of constraints already on the IR. No LLM, no
+  network, no clock, no randomness.
+- Conservative: every line is a restatement of an existing constraint. The
+  handler never adds a requirement, metric, or API name of its own.
+- Silent unless it pays for itself: needs at least MIN_ITEMS distinct hard
+  requirements, otherwise `Key Constraints` already says everything and the
+  block would be ceremony.
+- Lossless de-duplication: the compiler records the same restriction twice (a
+  scoped clause from the logic analyser plus the user's full sentence). Items
+  contained within a more complete item are collapsed into it, so the longest
+  faithful phrasing survives.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.heuristics.handlers.base import BaseHandler
+from app.models import IR
+from app.models_v2 import IRv2
+
+# Constraint origins that represent a checkable requirement stated by the user.
+# Everything else is either a clarification request, a description of the data
+# flow, or a rendering directive already handled elsewhere.
+_CHECKABLE_ORIGINS = frozenset(
+    {
+        "heuristic:logic_negation",
+        "restriction",
+        "structure_handler",
+    }
+)
+
+# Constraints below this priority are advisory rather than hard requirements.
+_MIN_PRIORITY = 70
+
+# Below this many distinct requirements, `Key Constraints` already covers them.
+MIN_ITEMS = 2
+
+# Never list more than this — a checklist the model skims is worse than none.
+MAX_ITEMS = 7
+
+# Decoration the emitters add for display; irrelevant when comparing meaning.
+_LABEL_PREFIX_RE = re.compile(
+    r"^\s*(?:[^\w\s]+\s*)?"
+    r"(?:restriction|flow|note|rule)\s*:\s*",
+    re.IGNORECASE,
+)
+
+# The imperative prefix the logic analyser attaches ("Must not: ", "Never: ").
+# Stripped for comparison only, so a scoped clause can be recognised inside the
+# user's original sentence. The displayed text keeps its prefix.
+_IMPERATIVE_PREFIX_RE = re.compile(
+    r"^\s*(?:must not|should not|does not|do not|under no circumstances|"
+    r"refrain from|stay away from|never|avoid|exclude|omit|skip|bypass|ignore|"
+    r"without|except|unless|none of|forbidden|prohibited|disallowed|banned|no)"
+    r"\s*:\s*",
+    re.IGNORECASE,
+)
+
+_NON_WORD_RE = re.compile(r"[^a-z0-9]+")
+
+_HEADINGS = {
+    "en": "Before you finish, verify each of these against your answer:",
+    "tr": "Bitirmeden once yanitini asagidakilerin her biriyle karsilastir:",
+    "es": "Antes de terminar, verifica tu respuesta con cada uno de estos puntos:",
+}
+
+
+def _comparable(text: str) -> str:
+    """Reduce a constraint to a bag of words for containment comparison."""
+    stripped = _LABEL_PREFIX_RE.sub("", text or "")
+    stripped = _IMPERATIVE_PREFIX_RE.sub("", stripped)
+    return _NON_WORD_RE.sub(" ", stripped.lower()).strip()
+
+
+def _display(text: str) -> str:
+    """Strip display decoration so checklist lines read uniformly."""
+    return _LABEL_PREFIX_RE.sub("", text or "").strip()
+
+
+class VerificationHandler(BaseHandler):
+    """Builds ``ir_v2.metadata['verification_checklist']`` from hard constraints."""
+
+    def handle(self, ir_v2: IRv2, ir_v1: IR) -> None:
+        checklist = self.build_checklist(ir_v2)
+        if checklist:
+            ir_v2.metadata["verification_checklist"] = checklist
+
+    def build_checklist(self, ir_v2: IRv2) -> list[str]:
+        candidates: list[tuple[str, str]] = []  # (display, comparable)
+        for constraint in ir_v2.constraints:
+            origin = getattr(constraint, "origin", "") or ""
+            priority = getattr(constraint, "priority", 0) or 0
+            text = getattr(constraint, "text", "") or ""
+            if origin not in _CHECKABLE_ORIGINS or priority < _MIN_PRIORITY:
+                continue
+            # The JSON Schema constraint is a whole code block; it is already
+            # surfaced as "[JSON Schema Enforced]" and would swamp the list.
+            if getattr(constraint, "id", "") == "schema_enforcement" or "```" in text:
+                continue
+            comparable = _comparable(text)
+            if not comparable:
+                continue
+            candidates.append((_display(text), comparable))
+
+        deduped = self._collapse_contained(candidates)
+        if len(deduped) < MIN_ITEMS:
+            return []
+        return deduped[:MAX_ITEMS]
+
+    @staticmethod
+    def _collapse_contained(candidates: list[tuple[str, str]]) -> list[str]:
+        """Drop items whose meaning is fully contained in another item.
+
+        The compiler records a restriction twice — once as a scoped clause
+        ("Never: log request bodies.") and once as the user's whole sentence
+        ("It must not expose user emails and should never log request
+        bodies."). Keeping the longer one preserves the parts of the sentence
+        the scoped clause left behind.
+        """
+        kept: list[str] = []
+        seen: list[str] = []
+        # Longest first, so a container is considered before what it contains.
+        for display, comparable in sorted(candidates, key=lambda c: len(c[1]), reverse=True):
+            if any(comparable in existing for existing in seen):
+                continue
+            seen.append(comparable)
+            kept.append(display)
+        return kept
+
+
+def render_verification_block(ir_v2: IRv2, lang: str) -> list[str]:
+    """Render the checklist as system-prompt lines, or [] when there is none."""
+    checklist = (ir_v2.metadata or {}).get("verification_checklist")
+    if not checklist:
+        return []
+    heading = _HEADINGS.get(lang, _HEADINGS["en"])
+    lines = [heading]
+    lines.extend(f"- [ ] {item}" for item in checklist)
+    return lines

--- a/app/heuristics/handlers/verification.py
+++ b/app/heuristics/handlers/verification.py
@@ -34,10 +34,22 @@ Design rules (mirroring exploration.py):
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 from app.heuristics.handlers.base import BaseHandler
 from app.models import IR
 from app.models_v2 import IRv2
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """A constraint considered for the checklist."""
+
+    display: str  # shown to the user, decoration stripped
+    comparable: str  # normalised, for containment de-duplication
+    priority: int
+    position: int  # index on ir.constraints, to break priority ties stably
+
 
 # Constraint origins that represent a checkable requirement stated by the user.
 # Everything else is either a clarification request, a description of the data
@@ -107,8 +119,8 @@ class VerificationHandler(BaseHandler):
             ir_v2.metadata["verification_checklist"] = checklist
 
     def build_checklist(self, ir_v2: IRv2) -> list[str]:
-        candidates: list[tuple[str, str]] = []  # (display, comparable)
-        for constraint in ir_v2.constraints:
+        candidates: list[_Candidate] = []
+        for position, constraint in enumerate(ir_v2.constraints):
             origin = getattr(constraint, "origin", "") or ""
             priority = getattr(constraint, "priority", 0) or 0
             text = getattr(constraint, "text", "") or ""
@@ -121,15 +133,19 @@ class VerificationHandler(BaseHandler):
             comparable = _comparable(text)
             if not comparable:
                 continue
-            candidates.append((_display(text), comparable))
+            candidates.append(_Candidate(_display(text), comparable, priority, position))
 
         deduped = self._collapse_contained(candidates)
         if len(deduped) < MIN_ITEMS:
             return []
-        return deduped[:MAX_ITEMS]
+        # Rank by priority, then by the order the constraints were recorded, so
+        # truncating to MAX_ITEMS drops the least important requirement rather
+        # than whichever happened to be phrased most briefly.
+        deduped.sort(key=lambda c: (-c.priority, c.position))
+        return [c.display for c in deduped[:MAX_ITEMS]]
 
     @staticmethod
-    def _collapse_contained(candidates: list[tuple[str, str]]) -> list[str]:
+    def _collapse_contained(candidates: list[_Candidate]) -> list[_Candidate]:
         """Drop items whose meaning is fully contained in another item.
 
         The compiler records a restriction twice — once as a scoped clause
@@ -138,14 +154,12 @@ class VerificationHandler(BaseHandler):
         bodies."). Keeping the longer one preserves the parts of the sentence
         the scoped clause left behind.
         """
-        kept: list[str] = []
-        seen: list[str] = []
+        kept: list[_Candidate] = []
         # Longest first, so a container is considered before what it contains.
-        for display, comparable in sorted(candidates, key=lambda c: len(c[1]), reverse=True):
-            if any(comparable in existing for existing in seen):
+        for candidate in sorted(candidates, key=lambda c: len(c.comparable), reverse=True):
+            if any(candidate.comparable in other.comparable for other in kept):
                 continue
-            seen.append(comparable)
-            kept.append(display)
+            kept.append(candidate)
         return kept
 
 

--- a/app/heuristics/handlers/verification.py
+++ b/app/heuristics/handlers/verification.py
@@ -73,8 +73,7 @@ MAX_ITEMS = 7
 
 # Decoration the emitters add for display; irrelevant when comparing meaning.
 _LABEL_PREFIX_RE = re.compile(
-    r"^\s*(?:[^\w\s]+\s*)?"
-    r"(?:restriction|flow|note|rule)\s*:\s*",
+    r"^\s*(?:[^\w\s]+\s*)?(?:restriction|flow|note|rule)\s*:\s*",
     re.IGNORECASE,
 )
 

--- a/app/heuristics/logic_analyzer.py
+++ b/app/heuristics/logic_analyzer.py
@@ -24,7 +24,12 @@ class NegativeConstraint:
     original_text: str
     stripped_text: str  # Without the negation word
     negation_word: str
-    anti_pattern: str  # Positive version (what TO do)
+    # The prohibition restated as an explicit instruction — i.e. the thing the
+    # model must NOT do. This deliberately preserves the user's polarity: the
+    # positive alternative ("what to do instead") is not recoverable from the
+    # text alone, and guessing one would invent a requirement the user never
+    # stated. See _create_anti_pattern.
+    anti_pattern: str
 
 
 @dataclass
@@ -119,6 +124,13 @@ _DEPENDENCY_FAST_PATH_RE = re.compile(
     r"\b(?:because|since|as|due\s+to|so\s+that|in\s+order\s+to|to\s+ensure|for\s+the\s+purpose\s+of|if|when|whenever|which\s+will|that\s+will|so)\b",
     re.IGNORECASE,
 )
+
+# Cleanup for clauses left behind after a negation word is removed from the
+# middle or end of a sentence (see _strip_negation).
+_DANGLING_COPULA_RE = re.compile(r"\s+\b(?:is|are|was|were|be|been|being)\b\s*(?=[.!?;,]|$)")
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([.!?;,])")
+# Where one clause ends and the next begins (see _governed_clause).
+_CLAUSE_BOUNDARY_RE = re.compile(r"[;,]\s+|\s+\b(?:and|or|but)\b\s+", re.IGNORECASE)
 
 _NEGATION_FAST_PATH_RE = re.compile(
     r"\b(?:never|absolutely\s+not|under\s+no\s+circumstances|do\s+not|don't|dont|doesn't|does\s+not|should\s+not|shouldn't|shouldnt|must\s+not|mustn't|mustnt|cannot|can't|can\s+not|avoid|refrain\s+from|stay\s+away\s+from|exclude|omit|skip|bypass|ignore|without|except|unless|none\s+of|forbidden|prohibited|disallowed|banned|\bno\s+\w+)\b",
@@ -294,7 +306,12 @@ class LogicAnalyzer:
 
                     # Strip negation to create anti-pattern
                     stripped = self._strip_negation(sentence, pattern)
-                    anti_pattern = self._create_anti_pattern(stripped, negation_word)
+                    # Scope the restated prohibition to the clause the negation
+                    # actually governs, not the whole sentence — otherwise a
+                    # trailing restriction ("build X ... and must not do Y")
+                    # forbids the request itself.
+                    governed = self._governed_clause(sentence, match) or stripped
+                    anti_pattern = self._create_anti_pattern(governed, negation_word)
 
                     negations.append(
                         NegativeConstraint(
@@ -313,32 +330,123 @@ class LogicAnalyzer:
         # Preserve later negations in the same sentence so anti-pattern guidance
         # only flips the clause that matched this detection (count=1, not all).
         result = pattern.sub(" ", sentence, count=1)
-        return " ".join(result.split())  # Normalize whitespace
+        result = " ".join(result.split())  # Normalize whitespace
+        # Removing a trailing predicate negation ("... is forbidden.") leaves a
+        # dangling copula and a detached full stop. Tidy both so the restated
+        # prohibition reads as a sentence rather than "passwords is .".
+        result = _DANGLING_COPULA_RE.sub("", result)
+        return _SPACE_BEFORE_PUNCT_RE.sub(r"\1", result)
+
+    def _governed_clause(self, sentence: str, match: re.Match) -> str:
+        """Return just the clause the matched negation applies to.
+
+        Negations are detected per sentence, but they scope over a clause. For
+        "Build a rate limiter ... and must not add more than 5ms of latency",
+        restating the whole sentence as a prohibition would forbid building the
+        rate limiter as well. Taking the text after the negation word — up to
+        the next clause boundary — keeps the prohibition on "add more than 5ms
+        of latency".
+
+        A trailing clause that carries its own negation is kept, so
+        "do not use JOIN operations and do not nest subqueries" stays intact
+        rather than losing its second half.
+        """
+        tail = sentence[match.end() :].strip()
+        if not tail.strip(".,;:!? "):
+            # Predicate-final negation ("... is forbidden."): the governed
+            # clause is what came before the negation word.
+            tail = sentence[: match.start()].strip()
+            if not tail:
+                return ""
+            tail = _DANGLING_COPULA_RE.sub("", tail)
+            return _SPACE_BEFORE_PUNCT_RE.sub(r"\1", tail).strip()
+
+        boundary = _CLAUSE_BOUNDARY_RE.search(tail)
+        if boundary:
+            remainder = tail[boundary.end() :]
+            # Keep the remainder when it is itself a prohibition.
+            if not _NEGATION_FAST_PATH_RE.search(remainder):
+                tail = tail[: boundary.start()].strip()
+                if tail and tail[-1] not in ".!?":
+                    tail += "."
+
+        tail = _DANGLING_COPULA_RE.sub("", tail)
+        return _SPACE_BEFORE_PUNCT_RE.sub(r"\1", tail).strip()
 
     def _create_anti_pattern(self, stripped: str, negation_word: str) -> str:
-        """Create a positive recommendation from a negative constraint."""
-        # Map negation types to positive suggestions
-        positive_prefix = {
-            "never": "Always consider:",
-            "do not": "Instead:",
-            "don't": "Instead:",
-            "avoid": "Prefer:",
-            "refrain from": "Prefer:",
-            "should not": "Should:",
-            "shouldn't": "Should:",
-            "must not": "Must:",
-            "mustn't": "Must:",
-            "cannot": "Can:",
-            "can't": "Can:",
-            "exclude": "Include:",
-            "omit": "Include:",
-            "skip": "Do not skip:",
-            "without": "With:",
-            "no": "Include:",
+        """Restate a negative constraint as an explicit prohibition.
+
+        This must PRESERVE the user's polarity. An earlier version mapped each
+        negation onto a positive prefix ("must not" -> "Must:", "never" ->
+        "Always consider:", "cannot" -> "Can:"), then dropped the negation word
+        from the clause. That inverted the requirement: "must not expose user
+        emails" became "Must: expose user emails", and the result was injected
+        at priority 90, so the highest-ranked constraint in the compiled prompt
+        instructed the model to do the exact opposite of what the user asked.
+
+        Deriving a genuine positive alternative ("do X instead") is not possible
+        from the negation alone — the user did not say what to do instead, and
+        inventing one would be exactly the hallucinated requirement conservative
+        mode exists to prevent. So the faithful transformation is to restate the
+        prohibition in imperative form and leave the alternative to the model.
+        """
+        prohibition_prefix = {
+            # strong
+            "never": "Never",
+            "absolutely not": "Never",
+            "under no circumstances": "Under no circumstances",
+            # direct
+            "do not": "Do not",
+            "don't": "Do not",
+            "dont": "Do not",
+            "doesn't": "Does not",
+            "does not": "Does not",
+            # modal
+            "should not": "Should not",
+            "shouldn't": "Should not",
+            "shouldnt": "Should not",
+            "must not": "Must not",
+            "mustn't": "Must not",
+            "mustnt": "Must not",
+            # capability
+            "cannot": "Must not",
+            "can't": "Must not",
+            "can not": "Must not",
+            # avoidance
+            "avoid": "Avoid",
+            "refrain from": "Refrain from",
+            "stay away from": "Stay away from",
+            # exclusion
+            "exclude": "Exclude",
+            "omit": "Omit",
+            "skip": "Skip",
+            "bypass": "Bypass",
+            "ignore": "Ignore",
+            # conditional
+            "without": "Without",
+            "except": "Except",
+            "unless": "Unless",
+            # absolute
+            "none of": "None of",
+            # prohibition
+            "forbidden": "Forbidden",
+            "prohibited": "Prohibited",
+            "disallowed": "Disallowed",
+            "banned": "Banned",
         }
 
-        prefix = positive_prefix.get(negation_word.lower(), "Consider:")
-        return f"{prefix} {stripped}"
+        word = negation_word.lower().strip()
+        prefix = prohibition_prefix.get(word)
+        if prefix is None:
+            # "no <thing>" is matched as a whole phrase by NEGATION_PATTERNS, so
+            # it arrives here as e.g. "no retries" rather than a bare "no".
+            if word.startswith("no ") or word == "no":
+                prefix = "No"
+            else:
+                # Unknown negation: keep the user's own wording rather than
+                # guessing a polarity.
+                prefix = "Do not"
+        return f"{prefix}: {stripped}"
 
     # --------------------------------------------------------------------------
     # DEPENDENCY DETECTION

--- a/app/heuristics/logic_analyzer.py
+++ b/app/heuristics/logic_analyzer.py
@@ -305,12 +305,20 @@ class LogicAnalyzer:
 
                     # Strip negation to create anti-pattern
                     stripped = self._strip_negation(sentence, pattern)
-                    # Scope the restated prohibition to the clause the negation
-                    # actually governs, not the whole sentence — otherwise a
-                    # trailing restriction ("build X ... and must not do Y")
-                    # forbids the request itself.
-                    governed = self._governed_clause(sentence, match) or stripped
-                    anti_pattern = self._create_anti_pattern(governed, negation_word)
+                    if neg_type == "conditional":
+                        # "without" / "except" / "unless" qualify a main clause
+                        # rather than naming an action to forbid. Stripping and
+                        # re-prefixing drops that clause and leaves a fragment
+                        # ("Deploy without running migrations." -> "Without:
+                        # running migrations."), so keep the user's sentence.
+                        anti_pattern = sentence.strip()
+                    else:
+                        # Scope the restated prohibition to the clause the
+                        # negation actually governs, not the whole sentence —
+                        # otherwise a trailing restriction ("build X ... and
+                        # must not do Y") forbids the request itself.
+                        governed = self._governed_clause(sentence, match) or stripped
+                        anti_pattern = self._create_anti_pattern(governed, negation_word)
 
                     negations.append(
                         NegativeConstraint(

--- a/app/heuristics/logic_analyzer.py
+++ b/app/heuristics/logic_analyzer.py
@@ -205,7 +205,6 @@ _NUMBERED_LIST_PAT = re.compile(r"\n\s*\d+[.):]\s*")
 
 
 class LogicAnalyzer:
-
     """
     Advanced logic extractor for prompt analysis.
 

--- a/app/llm_engine/rag.py
+++ b/app/llm_engine/rag.py
@@ -11,8 +11,7 @@ logger = logging.getLogger("promptc.llm.rag")
 
 
 class VectorDBConnection(Protocol):
-    def search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
-        ...
+    def search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]: ...
 
 
 @dataclass

--- a/app/testing/adversarial.py
+++ b/app/testing/adversarial.py
@@ -2,6 +2,7 @@
 
 Uses an LLM to generate tricky test inputs designed to break prompts.
 """
+
 from __future__ import annotations
 import orjson
 

--- a/app/testing/judge.py
+++ b/app/testing/judge.py
@@ -1,4 +1,5 @@
 """LLM-based Judge for evaluating AI outputs against requirements."""
+
 from __future__ import annotations
 import orjson
 

--- a/integrations/mcp-server/requirements.txt
+++ b/integrations/mcp-server/requirements.txt
@@ -1,2 +1,6 @@
-mcp
+# server.py imports `mcp.server.fastmcp.FastMCP`, which is the mcp 1.x API.
+# mcp 2.x renamed FastMCP to MCPServer (mcp.server.mcpserver.MCPServer) and
+# changed other APIs, so an unpinned install breaks the bridge at import time.
+# Keep this pin until server.py is migrated to the 2.x API.
+mcp>=1.0,<2
 httpx

--- a/scripts/evaluate_heuristics.py
+++ b/scripts/evaluate_heuristics.py
@@ -8,7 +8,7 @@ prompts = [
 ]
 
 for i, text in enumerate(prompts, 1):
-    print(f"\n{'='*50}\nTEST {i}: {text}\n{'='*50}")
+    print(f"\n{'=' * 50}\nTEST {i}: {text}\n{'=' * 50}")
     ir2 = compile_text_v2(text)
     system_prompt = emit_system_prompt_v2(ir2)
     user_prompt = emit_user_prompt_v2(ir2)

--- a/scripts/test_benchmark_flow.py
+++ b/scripts/test_benchmark_flow.py
@@ -750,7 +750,7 @@ def run_all() -> int:
     print("  RESULTS SUMMARY")
     print("█" * 60)
 
-    print(f"\n  Offline:  {OfflineResults.passed} passed, " f"{OfflineResults.failed} failed")
+    print(f"\n  Offline:  {OfflineResults.passed} passed, {OfflineResults.failed} failed")
     print(
         f"  Online:   {OnlineResults.passed} passed, "
         f"{OnlineResults.failed} failed, "
@@ -761,7 +761,7 @@ def run_all() -> int:
     total_failed = OfflineResults.failed + OnlineResults.failed
     total = total_passed + total_failed + OnlineResults.skipped
 
-    print(f"\n  Total:    {total_passed}/{total} passed  " f"({elapsed:.1f}s)")
+    print(f"\n  Total:    {total_passed}/{total} passed  ({elapsed:.1f}s)")
 
     if total_failed > 0:
         print(f"\n  ❌  {total_failed} TEST(S) FAILED")

--- a/tests/heuristics/test_domain_expert_analyzers.py
+++ b/tests/heuristics/test_domain_expert_analyzers.py
@@ -144,7 +144,7 @@ def test_detect_story_structure_save_the_cat():
     handler = DomainHandler()
     structures = DOMAIN_RULES["creative_writing"]["structures"]
     text_lower = (
-        "following the save the cat beat sheet, the opening image sets the theme " "stated clearly."
+        "following the save the cat beat sheet, the opening image sets the theme stated clearly."
     )
 
     assert handler._detect_story_structure(text_lower, structures) == "save_the_cat"

--- a/tests/heuristics/test_verification_handler.py
+++ b/tests/heuristics/test_verification_handler.py
@@ -209,6 +209,30 @@ def test_system_prompt_includes_the_checklist_end_to_end():
         assert line.rstrip(".") in constraint_text
 
 
+def test_checklist_is_ordered_by_priority_not_by_phrasing_length(handler):
+    """Truncation must drop the least important item, not the most briefly worded."""
+    ir2 = _ir_v2(
+        _c("A very long but merely advisory sounding requirement about rows.", priority=75),
+        _c("Never: log.", origin="heuristic:logic_negation", priority=95),
+        _c("Do not: cache.", origin="heuristic:logic_negation", priority=85),
+    )
+
+    handler.handle(ir2, _ir_v1())
+
+    assert ir2.metadata["verification_checklist"][0] == "Never: log."
+    assert ir2.metadata["verification_checklist"][-1].startswith("A very long")
+
+
+def test_cap_keeps_the_highest_priority_requirements(handler):
+    low = [_c(f"❌ RESTRICTION: Minor point {i}.", priority=70) for i in range(10)]
+    high = _c("Never: ship secrets.", origin="heuristic:logic_negation", priority=95)
+
+    ir2 = _ir_v2(*low, high)
+    handler.handle(ir2, _ir_v1())
+
+    assert "Never: ship secrets." in ir2.metadata["verification_checklist"]
+
+
 def test_checklist_never_exceeds_the_display_cap(handler):
     many = [_c(f"❌ RESTRICTION: Requirement number {i} must hold.") for i in range(20)]
     ir2 = _ir_v2(*many)

--- a/tests/heuristics/test_verification_handler.py
+++ b/tests/heuristics/test_verification_handler.py
@@ -1,0 +1,218 @@
+import pytest
+
+from app.compiler import compile_text_v2
+from app.emitters import emit_system_prompt_v2
+from app.heuristics.handlers.verification import (
+    MIN_ITEMS,
+    VerificationHandler,
+    render_verification_block,
+)
+from app.models import IR
+from app.models_v2 import ConstraintV2, IRv2
+
+
+@pytest.fixture
+def handler():
+    return VerificationHandler()
+
+
+def _ir_v1() -> IR:
+    return IR(
+        language="en",
+        persona="assistant",
+        role="AI Assistant",
+        domain="general",
+        output_format="markdown",
+        length_hint="medium",
+    )
+
+
+def _ir_v2(*constraints: ConstraintV2, language: str = "en") -> IRv2:
+    return IRv2(language=language, constraints=list(constraints))
+
+
+def _c(
+    text: str, *, origin: str = "restriction", priority: int = 85, cid: str = ""
+) -> ConstraintV2:
+    return ConstraintV2(id=cid, text=text, origin=origin, priority=priority)
+
+
+# --------------------------------------------------------------------------
+# CHECKLIST CONSTRUCTION
+# --------------------------------------------------------------------------
+
+
+def test_checklist_lists_each_hard_requirement(handler):
+    ir2 = _ir_v2(
+        _c("Do not: add new dependencies.", origin="heuristic:logic_negation", priority=90),
+        _c("❌ RESTRICTION: Exclude soft-deleted rows."),
+        _c("Output strict JSON.", origin="structure_handler"),
+    )
+
+    handler.handle(ir2, _ir_v1())
+
+    checklist = ir2.metadata["verification_checklist"]
+    assert len(checklist) == 3
+    assert "Do not: add new dependencies." in checklist
+    # The display decoration is stripped so lines read uniformly.
+    assert "Exclude soft-deleted rows." in checklist
+    assert "Output strict JSON." in checklist
+
+
+def test_checklist_covers_requirements_that_key_constraints_drops(handler):
+    """emit_system_prompt_v2 renders only the top 3 constraints; the rest are lost."""
+    ir2 = _ir_v2(
+        _c("Never: log request bodies.", origin="heuristic:logic_negation", priority=90),
+        _c("Exclude: soft-deleted rows.", origin="heuristic:logic_negation", priority=90),
+        _c("Do not: add new dependencies.", origin="heuristic:logic_negation", priority=90),
+        _c("❌ RESTRICTION: The response must not expose user emails."),
+    )
+
+    handler.handle(ir2, _ir_v1())
+
+    checklist = ir2.metadata["verification_checklist"]
+    assert any("expose user emails" in item for item in checklist)
+
+
+def test_contained_duplicates_collapse_into_the_fuller_sentence(handler):
+    """The compiler records a scoped clause and the user's whole sentence."""
+    ir2 = _ir_v2(
+        _c("Never: log request bodies.", origin="heuristic:logic_negation", priority=90),
+        _c(
+            "❌ RESTRICTION: It must not expose user emails and should never log request bodies.",
+        ),
+        _c("Do not: add new dependencies.", origin="heuristic:logic_negation", priority=90),
+    )
+
+    handler.handle(ir2, _ir_v1())
+
+    checklist = ir2.metadata["verification_checklist"]
+    # The pair collapses to a single line — the one that still mentions both
+    # halves — leaving it plus the unrelated dependency requirement.
+    assert len(checklist) == 2
+    combined = next(item for item in checklist if "expose user emails" in item)
+    assert "log request bodies" in combined
+    assert sum("log request bodies" in item for item in checklist) == 1
+
+
+def test_collapsing_below_the_minimum_stays_silent(handler):
+    """Two records of one requirement are still just one requirement."""
+    ir2 = _ir_v2(
+        _c("Never: log request bodies.", origin="heuristic:logic_negation", priority=90),
+        _c("❌ RESTRICTION: It should never log request bodies."),
+    )
+
+    handler.handle(ir2, _ir_v1())
+
+    assert "verification_checklist" not in ir2.metadata
+
+
+def test_advisory_and_non_checkable_constraints_are_excluded(handler):
+    ir2 = _ir_v2(
+        _c("Do not: add new dependencies.", origin="heuristic:logic_negation", priority=90),
+        _c("❌ RESTRICTION: Exclude soft-deleted rows."),
+        # Clarification request, not something an answer can be checked against.
+        _c("Clarify ambiguous terms: fast", origin="ambiguous_terms", priority=30),
+        # A description of the data flow, not a requirement.
+        _c("🔄 FLOW: Input(csv) → Process(process) → Output(json)", origin="io_flow", priority=50),
+    )
+
+    handler.handle(ir2, _ir_v1())
+
+    checklist = ir2.metadata["verification_checklist"]
+    assert not any("Clarify ambiguous" in item for item in checklist)
+    assert not any("FLOW" in item for item in checklist)
+
+
+def test_json_schema_constraint_is_not_inlined(handler):
+    """The schema block is already surfaced as [JSON Schema Enforced]."""
+    ir2 = _ir_v2(
+        _c("Do not: add new dependencies.", origin="heuristic:logic_negation", priority=90),
+        _c("❌ RESTRICTION: Exclude soft-deleted rows."),
+        _c(
+            'Strictly follow this JSON Schema:\n```json\n{"type": "object"}\n```',
+            origin="structure_handler",
+            priority=90,
+            cid="schema_enforcement",
+        ),
+    )
+
+    handler.handle(ir2, _ir_v1())
+
+    assert not any("```" in item for item in ir2.metadata["verification_checklist"])
+
+
+# --------------------------------------------------------------------------
+# SILENCE
+# --------------------------------------------------------------------------
+
+
+def test_no_checklist_below_the_minimum(handler):
+    """One requirement is already fully covered by Key Constraints."""
+    ir2 = _ir_v2(_c("❌ RESTRICTION: Exclude soft-deleted rows."))
+
+    handler.handle(ir2, _ir_v1())
+
+    assert "verification_checklist" not in ir2.metadata
+    assert render_verification_block(ir2, "en") == []
+
+
+def test_no_checklist_without_constraints(handler):
+    ir2 = _ir_v2()
+
+    handler.handle(ir2, _ir_v1())
+
+    assert "verification_checklist" not in ir2.metadata
+
+
+@pytest.mark.parametrize("text", ["merhaba", "hi", "make it better", "Write a haiku about rain."])
+def test_trivial_and_simple_requests_get_no_checklist(text):
+    """Short or unconstrained requests must not be padded with a checklist."""
+    assert "Before you finish" not in emit_system_prompt_v2(compile_text_v2(text))
+
+
+# --------------------------------------------------------------------------
+# RENDERING
+# --------------------------------------------------------------------------
+
+
+def test_render_uses_the_ir_language():
+    ir2 = _ir_v2(language="tr")
+    ir2.metadata["verification_checklist"] = ["Bagimlilik ekleme.", "Silinmis satirlari disla."]
+
+    lines = render_verification_block(ir2, "tr")
+
+    assert lines[0].startswith("Bitirmeden once")
+    assert lines[1] == "- [ ] Bagimlilik ekleme."
+
+
+def test_render_falls_back_to_english_for_unknown_languages():
+    ir2 = _ir_v2()
+    ir2.metadata["verification_checklist"] = ["A.", "B."]
+
+    assert render_verification_block(ir2, "de")[0] == render_verification_block(ir2, "en")[0]
+
+
+def test_system_prompt_includes_the_checklist_end_to_end():
+    ir = compile_text_v2(
+        "Build a CSV export endpoint. It must not expose user emails and should never "
+        "log request bodies. Exclude soft-deleted rows. Do not add new dependencies."
+    )
+
+    prompt = emit_system_prompt_v2(ir)
+
+    assert "Before you finish, verify each of these against your answer:" in prompt
+    assert "expose user emails" in prompt
+    # Grounding: every checklist line restates a constraint already on the IR.
+    constraint_text = " ".join(c.text for c in ir.constraints)
+    for line in ir.metadata["verification_checklist"]:
+        assert line.rstrip(".") in constraint_text
+
+
+def test_checklist_never_exceeds_the_display_cap(handler):
+    many = [_c(f"❌ RESTRICTION: Requirement number {i} must hold.") for i in range(20)]
+    ir2 = _ir_v2(*many)
+
+    handler.handle(ir2, _ir_v1())
+
+    assert MIN_ITEMS <= len(ir2.metadata["verification_checklist"]) <= 7

--- a/tests/optimizer/test_optimize_live.py
+++ b/tests/optimizer/test_optimize_live.py
@@ -54,9 +54,9 @@ def test_live_turkish_diacritic_input_stays_turkish(client: TestClient) -> None:
     data = _post_optimize(client, text)
 
     assert data["source_language"] == "tr"
-    assert (
-        detect_language(data["text"]) == "tr"
-    ), f"Expected Turkish output but got: {data['text']!r}"
+    assert detect_language(data["text"]) == "tr", (
+        f"Expected Turkish output but got: {data['text']!r}"
+    )
     assert "{{user_level}}" in data["text"], "Placeholder must survive optimization"
     assert data["english_variant"], "English compact variant should be populated for TR input"
     assert data["english_variant_tokens"] > 0

--- a/tests/test_agent_council.py
+++ b/tests/test_agent_council.py
@@ -45,7 +45,7 @@ class TestAgentCouncil(unittest.TestCase):
             # Verify Retrieval
             print(f"Retrieved {len(results)} snippets.")
             for r in results:
-                print(f" - Found: {r['path']} (Score: {r.get('score',0):.2f})")
+                print(f" - Found: {r['path']} (Score: {r.get('score', 0):.2f})")
 
             self.assertTrue(len(results) > 0)
             self.assertEqual(results[0]["path"], "auth.py")

--- a/tests/test_agent_generator.py
+++ b/tests/test_agent_generator.py
@@ -103,8 +103,9 @@ def test_worker_client_generate_agent_timeout_returns_quickly():
         time.sleep(1.0)
         return "# Agent System Prompt"
 
-    with patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01), patch.object(
-        client, "_call_api", side_effect=slow_call_api
+    with (
+        patch("app.llm_engine.client.HARD_TIMEOUT_SECONDS", 0.01),
+        patch.object(client, "_call_api", side_effect=slow_call_api),
     ):
         started_at = time.perf_counter()
         with pytest.raises(RuntimeError, match="Agent generation timed out after 0.01s."):
@@ -262,15 +263,15 @@ def test_single_agent_template_includes_new_sections():
     # Both enabled and disabled example-code modes should include the new sections.
     for include_example_code in (True, False):
         rendered = client._single_agent_prompt(include_example_code)
-        assert (
-            "## Tools & Integrations" in rendered
-        ), f"Missing '## Tools & Integrations' (include_example_code={include_example_code})"
-        assert (
-            "## Stop Conditions" in rendered
-        ), f"Missing '## Stop Conditions' (include_example_code={include_example_code})"
-        assert (
-            "## Self-Verification" in rendered
-        ), f"Missing '## Self-Verification' (include_example_code={include_example_code})"
+        assert "## Tools & Integrations" in rendered, (
+            f"Missing '## Tools & Integrations' (include_example_code={include_example_code})"
+        )
+        assert "## Stop Conditions" in rendered, (
+            f"Missing '## Stop Conditions' (include_example_code={include_example_code})"
+        )
+        assert "## Self-Verification" in rendered, (
+            f"Missing '## Self-Verification' (include_example_code={include_example_code})"
+        )
 
 
 def test_multi_agent_template_includes_topology_and_io():
@@ -280,18 +281,18 @@ def test_multi_agent_template_includes_topology_and_io():
 
     for include_example_code in (True, False):
         rendered = client._multi_agent_prompt(include_example_code)
-        assert (
-            "> **Topology:**" in rendered
-        ), f"Missing '> **Topology:**' declaration guidance (include_example_code={include_example_code})"
-        assert (
-            "## Inputs" in rendered
-        ), f"Missing '## Inputs' (include_example_code={include_example_code})"
-        assert (
-            "## Outputs" in rendered
-        ), f"Missing '## Outputs' (include_example_code={include_example_code})"
-        assert (
-            "## Swarm Stop Conditions" in rendered
-        ), f"Missing '## Swarm Stop Conditions' (include_example_code={include_example_code})"
+        assert "> **Topology:**" in rendered, (
+            f"Missing '> **Topology:**' declaration guidance (include_example_code={include_example_code})"
+        )
+        assert "## Inputs" in rendered, (
+            f"Missing '## Inputs' (include_example_code={include_example_code})"
+        )
+        assert "## Outputs" in rendered, (
+            f"Missing '## Outputs' (include_example_code={include_example_code})"
+        )
+        assert "## Swarm Stop Conditions" in rendered, (
+            f"Missing '## Swarm Stop Conditions' (include_example_code={include_example_code})"
+        )
 
 
 def test_example_code_strip_still_works():

--- a/tests/test_cli_rag_opt_in.py
+++ b/tests/test_cli_rag_opt_in.py
@@ -1,4 +1,5 @@
 """CLI `compile` RAG context retrieval is opt-in (default off) — path-leak guard."""
+
 from unittest.mock import patch
 
 from typer.testing import CliRunner

--- a/tests/test_compile_rag_opt_in_api.py
+++ b/tests/test_compile_rag_opt_in_api.py
@@ -1,4 +1,5 @@
 """POST /compile RAG context retrieval is opt-in (default off) — path-leak guard."""
+
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient

--- a/tests/test_critique_verdict_enforcement.py
+++ b/tests/test_critique_verdict_enforcement.py
@@ -1,4 +1,5 @@
 """Test that critique quality verdicts stay advisory in the compile flow."""
+
 import pytest
 from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
@@ -72,9 +73,10 @@ def test_compile_endpoint_blocks_unsafe_injection_input(client):
     mock_worker_result.optimized_content = "Test optimized content"
 
     # Use patch to mock both the compiler and the CriticAgent
-    with patch("api.routes.compile.CriticAgent", mock_critic_class), patch(
-        "api.routes.compile._get_compiler"
-    ) as mock_get_compiler:
+    with (
+        patch("api.routes.compile.CriticAgent", mock_critic_class),
+        patch("api.routes.compile._get_compiler") as mock_get_compiler,
+    ):
         mock_compiler = MagicMock()
         mock_compiler.compile.return_value = mock_worker_result
         mock_get_compiler.return_value = mock_compiler
@@ -170,9 +172,10 @@ def test_compile_endpoint_enforces_reject_verdict_without_critical_issue(client)
     mock_worker_result.optimized_content = "Write a hello world program in Python"
 
     # Use patch to mock both the compiler and the CriticAgent
-    with patch("api.routes.compile.CriticAgent", mock_critic_class), patch(
-        "api.routes.compile._get_compiler"
-    ) as mock_get_compiler:
+    with (
+        patch("api.routes.compile.CriticAgent", mock_critic_class),
+        patch("api.routes.compile._get_compiler") as mock_get_compiler,
+    ):
         mock_compiler = MagicMock()
         mock_compiler.compile.return_value = mock_worker_result
         mock_get_compiler.return_value = mock_compiler
@@ -254,9 +257,10 @@ def test_compile_endpoint_allows_accept_verdict(client):
     )
 
     # Use patch to mock both the compiler and the CriticAgent
-    with patch("api.routes.compile.CriticAgent", mock_critic_class), patch(
-        "api.routes.compile._get_compiler"
-    ) as mock_get_compiler:
+    with (
+        patch("api.routes.compile.CriticAgent", mock_critic_class),
+        patch("api.routes.compile._get_compiler") as mock_get_compiler,
+    ):
         mock_compiler = MagicMock()
         mock_compiler.compile.return_value = mock_worker_result
         mock_get_compiler.return_value = mock_compiler

--- a/tests/test_emit_user_prompt_v2_gap.py
+++ b/tests/test_emit_user_prompt_v2_gap.py
@@ -56,11 +56,7 @@ def test_sections_render_in_fixed_order_and_are_joined_by_newline():
     )
     result = emit_user_prompt_v2(ir)
     assert result == (
-        "Goals:\n- g1\n"
-        "Tasks:\n- t1\n"
-        "Inputs:\n- k: v\n"
-        "Tools:\n- tool1\n"
-        "Examples:\n---\nex1\n---"
+        "Goals:\n- g1\nTasks:\n- t1\nInputs:\n- k: v\nTools:\n- tool1\nExamples:\n---\nex1\n---"
     )
 
 

--- a/tests/test_emitters_policy_header.py
+++ b/tests/test_emitters_policy_header.py
@@ -6,7 +6,6 @@ ConstraintV2 objects, so they can be tested directly without invoking the
 compiler or any LLM call.
 """
 
-
 import pytest
 
 from app.emitters import (

--- a/tests/test_export_adapters.py
+++ b/tests/test_export_adapters.py
@@ -361,9 +361,9 @@ def test_named_subagent_frontmatter_at_column_zero():
         # Verify frontmatter fields have no leading spaces
         for line in lines[1:closing_idx]:
             if line.strip():
-                assert not line.startswith(
-                    " "
-                ), f"Agent {name}: Frontmatter line has leading spaces: {repr(line)}"
+                assert not line.startswith(" "), (
+                    f"Agent {name}: Frontmatter line has leading spaces: {repr(line)}"
+                )
 
 
 def test_claude_mcp_tool_stub_output():

--- a/tests/test_generator_rag_opt_in_api.py
+++ b/tests/test_generator_rag_opt_in_api.py
@@ -1,4 +1,5 @@
 """Generator RAG context retrieval is opt-in (default off) — session isolation guard."""
+
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient

--- a/tests/test_github_artifacts.py
+++ b/tests/test_github_artifacts.py
@@ -249,9 +249,9 @@ def test_enforcement_checklist_high_risk_no_sanitization_rules_shows_only_gate()
     assert "## Enforcement Checklist" in artifact
     assert "**GATE:** Human review required before merge/deploy" in artifact
     checklist_lines = [line for line in artifact.splitlines() if line.startswith("- [ ]")]
-    assert (
-        len(checklist_lines) == 1
-    ), f"Expected exactly 1 checklist item (GATE only), got: {checklist_lines}"
+    assert len(checklist_lines) == 1, (
+        f"Expected exactly 1 checklist item (GATE only), got: {checklist_lines}"
+    )
 
 
 def test_enforcement_checklist_unknown_rule_uses_fallback_label():

--- a/tests/test_heuristics_pure_functions_gap.py
+++ b/tests/test_heuristics_pure_functions_gap.py
@@ -1,6 +1,7 @@
 """Direct unit tests for pure heuristic helpers that were previously only
 exercised indirectly through compile_text() integration tests.
 """
+
 from app.heuristics import (
     detect_coding_context,
     detect_recency,

--- a/tests/test_jules_api.py
+++ b/tests/test_jules_api.py
@@ -19,9 +19,11 @@ def test_jules_reply_endpoint_uses_latest_agent_message():
         ]
     }
 
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls, patch("app.routers.jules.generate_jules_reply") as mock_reply:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+        patch("app.routers.jules.generate_jules_reply") as mock_reply,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.list_activities.return_value = activities
         mock_client.get_session.return_value = {}
@@ -57,9 +59,10 @@ def test_jules_sources_endpoint_requires_auth():
 
 
 def test_jules_sources_endpoint_closes_client_after_success():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.list_sources.return_value = {"sources": [{"name": "sources/github/acme/repo"}]}
 
@@ -91,9 +94,11 @@ def test_jules_reply_endpoint_supports_plan_generated_activities():
         ]
     }
 
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls, patch("app.routers.jules.generate_jules_reply") as mock_reply:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+        patch("app.routers.jules.generate_jules_reply") as mock_reply,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.list_activities.return_value = activities
         mock_client.get_session.return_value = {}
@@ -127,9 +132,11 @@ def test_jules_reply_endpoint_passes_session_context_into_generation():
         "prompt": "Inspect the repo and answer the current agent question.",
     }
 
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls, patch("app.routers.jules.generate_jules_reply") as mock_reply:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+        patch("app.routers.jules.generate_jules_reply") as mock_reply,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.list_activities.return_value = activities
         mock_client.get_session.return_value = session_data
@@ -165,9 +172,10 @@ def test_jules_reply_endpoint_missing_agent_activity():
         ]
     }
 
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.list_activities.return_value = activities
         mock_client.get_session.return_value = {}
@@ -185,9 +193,10 @@ def test_jules_reply_endpoint_missing_agent_activity():
 
 
 def test_jules_reply_endpoint_client_runtime_error():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.get_session.side_effect = RuntimeError("Failed to connect")
 
@@ -204,9 +213,10 @@ def test_jules_reply_endpoint_client_runtime_error():
 
 
 def test_jules_reply_endpoint_client_generic_error():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.get_session.side_effect = Exception("Unknown failure")
 
@@ -223,9 +233,10 @@ def test_jules_reply_endpoint_client_generic_error():
 
 
 def test_jules_create_session_success():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.create_session.return_value = {"id": "s-new-123"}
 
@@ -260,9 +271,10 @@ def test_jules_create_session_success():
 
 
 def test_jules_create_session_errors():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
 
         # 1. Runtime Error -> 500
@@ -282,9 +294,10 @@ def test_jules_create_session_errors():
 
 
 def test_jules_get_session_success():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.get_session.return_value = {"id": "s1", "title": "my title"}
 
@@ -296,9 +309,10 @@ def test_jules_get_session_success():
 
 
 def test_jules_get_session_errors():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
 
         mock_client.get_session.side_effect = RuntimeError("err")
@@ -310,9 +324,10 @@ def test_jules_get_session_errors():
 
 
 def test_jules_get_session_activities_success():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
         mock_client.list_activities.return_value = {"activities": []}
 
@@ -323,9 +338,10 @@ def test_jules_get_session_activities_success():
 
 
 def test_jules_get_session_activities_errors():
-    with patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False), patch(
-        "app.routers.jules.JulesClient"
-    ) as mock_client_cls:
+    with (
+        patch.dict("os.environ", {"ADMIN_API_KEY": "test-admin-key"}, clear=False),
+        patch("app.routers.jules.JulesClient") as mock_client_cls,
+    ):
         mock_client = mock_client_cls.return_value
 
         mock_client.list_activities.side_effect = RuntimeError("err")
@@ -360,9 +376,10 @@ def test_generate_jules_reply_fallback_mode():
 def test_generate_jules_reply_api_call():
     from app.routers.jules import generate_jules_reply
 
-    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}, clear=False), patch(
-        "app.routers.jules.WorkerClient"
-    ) as mock_worker_cls:
+    with (
+        patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}, clear=False),
+        patch("app.routers.jules.WorkerClient") as mock_worker_cls,
+    ):
         mock_worker = mock_worker_cls.return_value
         mock_worker._call_api.return_value = " LLM generated reply \n"
 

--- a/tests/test_llm_client_openrouter.py
+++ b/tests/test_llm_client_openrouter.py
@@ -9,17 +9,20 @@ from app.llm_engine.client import WorkerClient, _sanitize_skill_definition_plain
 
 
 def test_worker_client_prefers_openrouter_env_defaults():
-    with patch.dict(
-        "os.environ",
-        {
-            "OPENROUTER_API_KEY": "or-key",
-            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
-            "OPENROUTER_MODEL": "openai/gpt-oss-20b",
-            "OPENROUTER_HTTP_REFERER": "https://prcompiler.com",
-            "OPENROUTER_TITLE": "Prompt Compiler",
-        },
-        clear=False,
-    ), patch("app.llm_engine.client.OpenAI") as mock_openai:
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "OPENROUTER_API_KEY": "or-key",
+                "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+                "OPENROUTER_MODEL": "openai/gpt-oss-20b",
+                "OPENROUTER_HTTP_REFERER": "https://prcompiler.com",
+                "OPENROUTER_TITLE": "Prompt Compiler",
+            },
+            clear=False,
+        ),
+        patch("app.llm_engine.client.OpenAI") as mock_openai,
+    ):
         client = WorkerClient()
 
     assert client.api_key == "or-key"

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -167,9 +167,10 @@ class TestOpenAIProvider:
         config = ProviderConfig()
         provider = OpenAIProvider(config)
 
-        with patch.dict(os.environ, {"OPENROUTER_API_KEY": ""}, clear=False), patch.object(
-            provider.client, "post"
-        ) as mock_post:
+        with (
+            patch.dict(os.environ, {"OPENROUTER_API_KEY": ""}, clear=False),
+            patch.object(provider.client, "post") as mock_post,
+        ):
             response = provider.generate("Hello")
 
         assert response.content == "Error: Missing OpenRouter API Key"
@@ -186,15 +187,18 @@ class TestOpenAIProvider:
             "usage": {"prompt_tokens": 21, "completion_tokens": 8},
         }
 
-        with patch.dict(
-            os.environ,
-            {
-                "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
-                "OPENROUTER_HTTP_REFERER": "https://promptc.example",
-                "OPENROUTER_TITLE": "Prompt Compiler",
-            },
-            clear=False,
-        ), patch.object(provider.client, "post", return_value=mock_response) as mock_post:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+                    "OPENROUTER_HTTP_REFERER": "https://promptc.example",
+                    "OPENROUTER_TITLE": "Prompt Compiler",
+                },
+                clear=False,
+            ),
+            patch.object(provider.client, "post", return_value=mock_response) as mock_post,
+        ):
             response = provider.generate(
                 "Hello",
                 system_prompt="Be concise",

--- a/tests/test_logic_analyzer.py
+++ b/tests/test_logic_analyzer.py
@@ -125,9 +125,8 @@ def test_anti_pattern_never_inverts_the_users_requirement():
         # The forbidden action is still named...
         assert forbidden_phrase in anti, f"{forbidden_phrase!r} lost from {anti!r}"
         # ...but it is framed as a prohibition, not an instruction to perform it.
-        assert not anti.lower().startswith(affirmative_openers), (
-            f"{sentence!r} was inverted into an affirmative instruction: {anti!r}"
-        )
+        inverted = anti.lower().startswith(affirmative_openers)
+        assert not inverted, f"inverted into an affirmative: {sentence!r} -> {anti!r}"
 
 
 def test_anti_pattern_is_scoped_to_the_clause_the_negation_governs():

--- a/tests/test_logic_analyzer.py
+++ b/tests/test_logic_analyzer.py
@@ -84,7 +84,9 @@ def test_detect_negations_edge_cases():
         ("you must not use global vars.", "must not", "Must not: use global vars."),
         ("cannot access disk.", "cannot", "Must not: access disk."),
         ("exclude draft results.", "exclude", "Exclude: draft results."),
-        ("without authentication.", "without", "Without: authentication."),
+        # Conditionals keep the sentence verbatim — see
+        # test_conditional_negations_keep_the_whole_sentence below.
+        ("without authentication.", "without", "without authentication."),
     ]
     for sentence, word, expected_anti in words_to_test:
         res = analyzer.detect_negations(sentence)
@@ -159,6 +161,26 @@ def test_anti_pattern_keeps_a_trailing_clause_that_is_itself_negated():
     # ...but an affirmative trailing clause is still trimmed off.
     affirmative = analyzer.detect_negations("Do not use eval and prefer ast.literal_eval.")
     assert affirmative[0].anti_pattern == "Do not: use eval."
+
+
+def test_conditional_negations_keep_the_whole_sentence():
+    """Conditional markers qualify a clause; they do not name a forbidden action.
+
+    Stripping and re-prefixing them dropped the main clause and left a fragment:
+    "Deploy without running migrations." became "Without: running migrations.",
+    which says nothing actionable as a priority-90 constraint.
+    """
+    analyzer = LogicAnalyzer()
+
+    for sentence in [
+        "Deploy without running migrations.",
+        "Run the job without authentication.",
+        "Process all rows except drafts.",
+        "Unless the flag is set, use the cache.",
+    ]:
+        negations = analyzer.detect_negations(sentence)
+        assert negations, f"no negation detected for {sentence!r}"
+        assert negations[0].anti_pattern == sentence
 
 
 def test_anti_pattern_handles_predicate_final_negations():

--- a/tests/test_logic_analyzer.py
+++ b/tests/test_logic_analyzer.py
@@ -16,7 +16,7 @@ def test_detect_negations_preserves_later_negations_in_same_sentence():
     assert len(negations) == 1
     assert negations[0].negation_word == "do not"
     assert negations[0].stripped_text == "use JOIN operations and do not nest subqueries."
-    assert negations[0].anti_pattern == "Instead: use JOIN operations and do not nest subqueries."
+    assert negations[0].anti_pattern == "Do not: use JOIN operations and do not nest subqueries."
 
 
 def test_detect_dependencies_keeps_because_matches_with_fast_path():
@@ -67,7 +67,7 @@ def test_detect_negations_edge_cases():
     negations = analyzer.detect_negations("Never query all columns.")
     assert len(negations) == 1
     assert negations[0].negation_word == "never"
-    assert negations[0].anti_pattern == "Always consider: query all columns."
+    assert negations[0].anti_pattern == "Never: query all columns."
 
     # 2. Duplicate sentences seen
     negations_dup = analyzer.detect_negations(
@@ -76,19 +76,99 @@ def test_detect_negations_edge_cases():
     )
     assert len(negations_dup) == 1
 
-    # 3. Test different negation types / anti-pattern mapping
+    # 3. Test different negation types / anti-pattern mapping.
+    # Every restatement must keep the user's polarity — see
+    # test_anti_pattern_never_inverts_the_users_requirement below.
     words_to_test = [
-        ("avoid nested loops.", "avoid", "Prefer: nested loops."),
-        ("you must not use global vars.", "must not", "Must: you use global vars."),
-        ("cannot access disk.", "cannot", "Can: access disk."),
-        ("exclude draft results.", "exclude", "Include: draft results."),
-        ("without authentication.", "without", "With: authentication."),
+        ("avoid nested loops.", "avoid", "Avoid: nested loops."),
+        ("you must not use global vars.", "must not", "Must not: use global vars."),
+        ("cannot access disk.", "cannot", "Must not: access disk."),
+        ("exclude draft results.", "exclude", "Exclude: draft results."),
+        ("without authentication.", "without", "Without: authentication."),
     ]
     for sentence, word, expected_anti in words_to_test:
         res = analyzer.detect_negations(sentence)
         assert len(res) == 1
         assert res[0].negation_word == word
         assert res[0].anti_pattern == expected_anti
+
+
+def test_anti_pattern_never_inverts_the_users_requirement():
+    """A restated prohibition must never tell the model to do the forbidden thing.
+
+    Regression guard. The prefix table used to map each negation onto a positive
+    ("must not" -> "Must:", "never" -> "Always consider:", "cannot" -> "Can:")
+    and then drop the negation from the clause, so "must not expose user emails"
+    compiled to "Must: expose user emails" — and the ConstraintHandler injects
+    that at priority 90, making the inverted text the top constraint in the
+    emitted system prompt.
+    """
+    analyzer = LogicAnalyzer()
+
+    # (sentence, the verb phrase that must stay forbidden)
+    cases = [
+        ("The API must not expose user emails.", "expose user emails"),
+        ("Never delete the production database.", "delete the production database"),
+        ("You cannot use jQuery in this project.", "use jQuery"),
+        ("Do not add new dependencies.", "add new dependencies"),
+        ("The parser should not crash on malformed input.", "crash on malformed input"),
+        ("Storing plaintext passwords is forbidden.", "Storing plaintext passwords"),
+    ]
+
+    affirmative_openers = ("must:", "can:", "should:", "always", "instead:", "include:", "with:")
+
+    for sentence, forbidden_phrase in cases:
+        negations = analyzer.detect_negations(sentence)
+        assert negations, f"no negation detected for {sentence!r}"
+        anti = negations[0].anti_pattern
+
+        # The forbidden action is still named...
+        assert forbidden_phrase in anti, f"{forbidden_phrase!r} lost from {anti!r}"
+        # ...but it is framed as a prohibition, not an instruction to perform it.
+        assert not anti.lower().startswith(affirmative_openers), (
+            f"{sentence!r} was inverted into an affirmative instruction: {anti!r}"
+        )
+
+
+def test_anti_pattern_is_scoped_to_the_clause_the_negation_governs():
+    """A trailing restriction must not turn the whole request into a prohibition.
+
+    Negations are detected per sentence but scope over a clause. Restating the
+    entire sentence would compile "build X ... and must not do Y" into
+    "Must not: build X ... and do Y", forbidding the very thing being asked for.
+    """
+    analyzer = LogicAnalyzer()
+
+    negations = analyzer.detect_negations(
+        "Build a rate limiter for our FastAPI service and must not add more than 5ms of latency."
+    )
+
+    assert len(negations) == 1
+    assert negations[0].anti_pattern == "Must not: add more than 5ms of latency."
+    # The request itself survives outside the prohibition.
+    assert "Build a rate limiter" not in negations[0].anti_pattern
+
+
+def test_anti_pattern_keeps_a_trailing_clause_that_is_itself_negated():
+    """Clause scoping must not drop a second prohibition joined by "and"."""
+    analyzer = LogicAnalyzer()
+
+    negations = analyzer.detect_negations("Do not use JOIN operations and do not nest subqueries.")
+
+    assert negations[0].anti_pattern == "Do not: use JOIN operations and do not nest subqueries."
+
+    # ...but an affirmative trailing clause is still trimmed off.
+    affirmative = analyzer.detect_negations("Do not use eval and prefer ast.literal_eval.")
+    assert affirmative[0].anti_pattern == "Do not: use eval."
+
+
+def test_anti_pattern_handles_predicate_final_negations():
+    """A predicate-final negation governs the clause before the negation word."""
+    analyzer = LogicAnalyzer()
+
+    negations = analyzer.detect_negations("Storing plaintext passwords is forbidden.")
+
+    assert negations[0].anti_pattern == "Forbidden: Storing plaintext passwords"
 
 
 def test_detect_dependencies_edge_cases():

--- a/tests/test_prompt_diff.py
+++ b/tests/test_prompt_diff.py
@@ -323,8 +323,8 @@ def test_display_comparison(capsys):
     entry1 = MockEntry("id1", "hello\nworld")
     entry2 = MockEntry("id2", "hello\nthere\nworld")
 
-    comp.favorites.get_by_id.side_effect = (
-        lambda x: entry1 if x == "id1" else entry2 if x == "id2" else None
+    comp.favorites.get_by_id.side_effect = lambda x: (
+        entry1 if x == "id1" else entry2 if x == "id2" else None
     )
     comp.favorites.entries = [entry1, entry2]
 

--- a/tests/test_public_endpoints_keyless.py
+++ b/tests/test_public_endpoints_keyless.py
@@ -151,18 +151,18 @@ def test_public_endpoints_have_rate_limiting(client_without_auth_override):
 
     # Check benchmark endpoint
     benchmark_sig = inspect.signature(benchmark_run)
-    assert any(
-        param.name == "_" for param in benchmark_sig.parameters.values()
-    ), "benchmark_run should have rate limit dependency"
+    assert any(param.name == "_" for param in benchmark_sig.parameters.values()), (
+        "benchmark_run should have rate limit dependency"
+    )
 
     # Check skills generator endpoint
     skills_sig = inspect.signature(generate_skill_endpoint)
-    assert any(
-        param.name == "_" for param in skills_sig.parameters.values()
-    ), "generate_skill_endpoint should have rate limit dependency"
+    assert any(param.name == "_" for param in skills_sig.parameters.values()), (
+        "generate_skill_endpoint should have rate limit dependency"
+    )
 
     # Check agent generator endpoint
     agent_sig = inspect.signature(generate_agent_endpoint)
-    assert any(
-        param.name == "_" for param in agent_sig.parameters.values()
-    ), "generate_agent_endpoint should have rate limit dependency"
+    assert any(param.name == "_" for param in agent_sig.parameters.values()), (
+        "generate_agent_endpoint should have rate limit dependency"
+    )

--- a/tests/test_quick_actions.py
+++ b/tests/test_quick_actions.py
@@ -18,10 +18,11 @@ from app.quick_actions import QuickActions, get_quick_actions
 
 
 def test_get_quick_actions_singleton():
-    with patch("app.quick_actions.get_search_history_manager"), patch(
-        "app.quick_actions.get_favorites_manager"
-    ), patch("app.quick_actions.get_templates_manager"), patch(
-        "app.quick_actions.get_snippets_manager"
+    with (
+        patch("app.quick_actions.get_search_history_manager"),
+        patch("app.quick_actions.get_favorites_manager"),
+        patch("app.quick_actions.get_templates_manager"),
+        patch("app.quick_actions.get_snippets_manager"),
     ):
         inst1 = get_quick_actions()
         inst2 = get_quick_actions()
@@ -30,11 +31,12 @@ def test_get_quick_actions_singleton():
 
 @pytest.fixture
 def mock_managers():
-    with patch("app.quick_actions.get_search_history_manager") as m_hist, patch(
-        "app.quick_actions.get_favorites_manager"
-    ) as m_fav, patch("app.quick_actions.get_templates_manager") as m_temp, patch(
-        "app.quick_actions.get_snippets_manager"
-    ) as m_snip:
+    with (
+        patch("app.quick_actions.get_search_history_manager") as m_hist,
+        patch("app.quick_actions.get_favorites_manager") as m_fav,
+        patch("app.quick_actions.get_templates_manager") as m_temp,
+        patch("app.quick_actions.get_snippets_manager") as m_snip,
+    ):
         hist_mgr = MagicMock()
         fav_mgr = MagicMock()
         temp_mgr = MagicMock()

--- a/tests/test_rag_embeddings_cleanup.py
+++ b/tests/test_rag_embeddings_cleanup.py
@@ -58,8 +58,8 @@ def test_delete_chunk_cleans_up_embeddings():
             # Verify the old chunk IDs are gone from embeddings
             for old_id in chunk_ids:
                 if old_id not in new_chunk_ids:
-                    assert (
-                        old_id not in new_emb_chunk_ids
-                    ), f"Orphaned embedding found for deleted chunk {old_id}"
+                    assert old_id not in new_emb_chunk_ids, (
+                        f"Orphaned embedding found for deleted chunk {old_id}"
+                    )
 
             conn.close()

--- a/tests/test_repo_context.py
+++ b/tests/test_repo_context.py
@@ -198,9 +198,9 @@ def test_analyze_public_github_repo_uses_ref_and_subdir_cache_key(monkeypatch):
     assert first == second
     assert third["requested_ref"] == "v4"
     assert "summary_compact" in first and first["summary_compact"]
-    assert (
-        call_log.count("/repos/openai/openai-python") == 2
-    ), f"expected GitHub API to be hit twice for two refs, got call log: {call_log}"
+    assert call_log.count("/repos/openai/openai-python") == 2, (
+        f"expected GitHub API to be hit twice for two refs, got call log: {call_log}"
+    )
     assert call_log.count("/repos/openai/openai-python/contents?ref=main") == 1
     assert call_log.count("/repos/openai/openai-python/contents?ref=v4") == 1
 
@@ -264,9 +264,9 @@ def test_analyze_public_github_repo_uses_in_memory_cache_for_root_url(monkeypatc
     assert first == second
     assert first["requested_ref"] is None
     assert first["requested_subdir"] is None
-    assert (
-        call_log.count("/repos/openai/openai-python") == 1
-    ), f"expected GitHub API to be hit once for root URL, got call log: {call_log}"
+    assert call_log.count("/repos/openai/openai-python") == 1, (
+        f"expected GitHub API to be hit once for root URL, got call log: {call_log}"
+    )
 
     reset_repo_cache_for_tests()
 
@@ -652,8 +652,12 @@ def test_analyze_public_github_repo_authorization_leakage_regression(monkeypatch
     has_auth_client = any(k.lower() == "authorization" for k in captured_client_headers[1])
     has_auth_request = any(k.lower() == "authorization" for k in captured_request_headers[1])
 
-    assert not has_auth_client, f"Leakage detected: Authorization persisted in global client headers! Headers: {captured_client_headers[1]}"
-    assert not has_auth_request, f"Leakage detected: Authorization sent in second request! Headers: {captured_request_headers[1]}"
+    assert not has_auth_client, (
+        f"Leakage detected: Authorization persisted in global client headers! Headers: {captured_client_headers[1]}"
+    )
+    assert not has_auth_request, (
+        f"Leakage detected: Authorization sent in second request! Headers: {captured_request_headers[1]}"
+    )
 
 
 def test_close_github_http_client():

--- a/tests/test_security_injection_detection.py
+++ b/tests/test_security_injection_detection.py
@@ -275,9 +275,9 @@ def test_end_to_end_injection_blocked_in_real_pipeline():
     assert "security" in ir2.metadata, "Security metadata should exist"
     assert ir2.metadata["security"]["is_safe"] is False, "Injection should be marked as unsafe"
     assert len(ir2.metadata["security"]["findings"]) > 0, "Should have security findings"
-    assert any(
-        "injection" in str(f).lower() for f in ir2.metadata["security"]["findings"]
-    ), "Should have injection finding"
+    assert any("injection" in str(f).lower() for f in ir2.metadata["security"]["findings"]), (
+        "Should have injection finding"
+    )
 
     # Verify policy escalation survived the full handler chain
     assert ir2.policy.risk_level == "high", "Risk level should be high after full pipeline"
@@ -285,9 +285,9 @@ def test_end_to_end_injection_blocked_in_real_pipeline():
 
     # Verify the security_injection_attempt flag is in the metadata
     # (This is what makes the refusal gate work)
-    assert (
-        ir2.metadata.get("security", {}).get("is_safe") is False
-    ), "The refusal gate reads metadata.security.is_safe - it must be False"
+    assert ir2.metadata.get("security", {}).get("is_safe") is False, (
+        "The refusal gate reads metadata.security.is_safe - it must be False"
+    )
 
 
 def test_end_to_end_benign_prompt_not_blocked():

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -45,9 +45,9 @@ def test_snapshots_minimal():
         exp = EXPECTED[name]
         assert data["language"] == exp["language"]
         domain = data["domain"]
-        assert (
-            domain in exp["domain_anyof"]
-        ), f"domain {domain} not in allowed {exp['domain_anyof']}"
+        assert domain in exp["domain_anyof"], (
+            f"domain {domain} not in allowed {exp['domain_anyof']}"
+        )
         summary_flag = _get(data, "metadata.summary")
         if "metadata.summary" in exp:
             assert summary_flag == exp["metadata.summary"]

--- a/tests/test_validate_alignment.py
+++ b/tests/test_validate_alignment.py
@@ -32,9 +32,9 @@ def test_validate_weakness_suggestion_alignment():
     weaknesses = body.get("weaknesses", [])
     suggestions = body.get("suggestions", [])
 
-    assert len(weaknesses) == len(
-        suggestions
-    ), f"Length mismatch: {len(weaknesses)} weaknesses vs {len(suggestions)} suggestions"
+    assert len(weaknesses) == len(suggestions), (
+        f"Length mismatch: {len(weaknesses)} weaknesses vs {len(suggestions)} suggestions"
+    )
 
 
 def test_validate_returns_report_shape():

--- a/web/app/agent-generator/components/ExportPanel.tsx
+++ b/web/app/agent-generator/components/ExportPanel.tsx
@@ -127,7 +127,9 @@ export default function ExportPanel({ systemPrompt, isMultiAgent }: ExportPanelP
     return null;
   }, [currentResult, outputMode]);
 
-  const currentFiles = currentResult?.files ?? [];
+  // Memoised so the `?? []` fallback does not allocate a fresh array on every
+  // render and invalidate the downloadFilename memo below.
+  const currentFiles = useMemo(() => currentResult?.files ?? [], [currentResult?.files]);
 
   // Named after the currently selected file's path when the export produced
   // one (e.g. the Claude Subagent markdown file); otherwise a sensible

--- a/web/app/hooks/useContextManager.ts
+++ b/web/app/hooks/useContextManager.ts
@@ -113,7 +113,6 @@ export function useContextManager() {
   }, [refreshStats]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void checkConnection();
   }, [checkConnection]);
 


### PR DESCRIPTION
Started as a triage of the open-PR backlog (21 bot PRs closed, see below), then QA of the repo, which surfaced three problems worth fixing.

## 1. The compiler inverted the user's own restrictions

`_create_anti_pattern` mapped every negation onto a positive prefix and dropped the negation word from the clause, so a restriction compiled into an instruction to do the forbidden thing:

| user wrote | compiler emitted |
|---|---|
| `must not expose user emails` | `Must: expose user emails` |
| `Never delete the production database` | `Always consider: delete the production database` |
| `cannot use jQuery` | `Can: use jQuery` |
| `should not crash on malformed input` | `Should: crash on malformed input` |

`ConstraintHandler` injects these at priority 90, so the inverted text became the **highest-ranked entry in `Key Constraints`** at the top of the emitted system prompt — contradicting the same restriction the compiler had also captured correctly at priority 85, and contradicting conservative mode's promise not to invent requirements.

A genuine positive alternative is not recoverable from a negation: the user never said what to do instead, and guessing one would be exactly the hallucinated requirement the product exists to avoid. So the fix restates the prohibition instead of inverting it, and covers the negation words that previously fell through to a `Consider:` default (`forbidden`, `prohibited`, `banned`, `bypass`, `ignore`, `except`, `unless`, …).

The restatement is also scoped to the clause the negation governs. Negations are detected per sentence but apply to a clause, so `build X … and must not do Y` was restated over the whole sentence and forbade building X as well:

```
before: [90] Must: Build a rate limiter ... and add more than 5ms of latency
after:  [90] Must not: add more than 5ms of latency
```

A trailing clause carrying its own negation is preserved, so `do not use JOIN operations and do not nest subqueries` stays intact.

Two existing tests asserted the inverted strings and are updated. Four regression tests are added, including one that fails if any restatement ever opens with an affirmative again.

## 2. New prompt technique: constraint-grounded self-check

`emit_system_prompt_v2` renders `_top_constraints_text_v2(..., limit=3)`, so **only the three highest-priority constraints ever reach the system prompt**. This request:

> Build a CSV export endpoint. It must not expose user emails and should never log request bodies. Exclude soft-deleted rows. Do not add new dependencies.

compiles to twelve constraints, and `must not expose user emails` — the one with privacy consequences — was silently dropped.

`VerificationHandler` adds a self-verification block built only from constraints already on the IR:

```
Before you finish, verify each of these against your answer:
- [ ] It must not expose user emails and should never log request bodies.
- [ ] Exclude soft-deleted rows.
- [ ] Do not add new dependencies.
```

Design follows `exploration.py`:

- **Deterministic** — a pure function of constraints already extracted. No LLM, network, clock or randomness.
- **Conservative** — every line restates an existing constraint, so no requirement can be invented.
- **Silent unless it pays for itself** — needs at least two distinct hard requirements; below that `Key Constraints` already says everything. Greetings, `make it better`, and unconstrained requests get nothing.
- **Lossless de-duplication** — the compiler records a restriction twice (a scoped clause plus the user's full sentence), so contained items collapse into the fuller one. Ranked by priority so truncation drops the least important requirement, not the most briefly worded.

Advisory constraints, clarification requests, data-flow descriptions and the JSON Schema block are excluded. Runs after `Deduplicator` (settled constraints) and before `Exploration`, which documents that it must stay last.

## 3. The MCP bridge was broken for fresh installs, and CI could not see it

`integrations/mcp-server/requirements.txt` asked for an unpinned `mcp`. `server.py` imports `mcp.server.fastmcp.FastMCP`, which is the 1.x API — mcp 2.x renamed it to `MCPServer`, so a fresh install fails at import time.

CI never caught this: every job runs only `pytest tests/`, so the bridge's own 19 tests were never executed and its dependency set was never installed. Pinned `mcp>=1.0,<2` with a pointer to the 2.x migration, and added an *MCP bridge tests* step to the smoke job.

Also cleared the two standing frontend lint warnings (memoise the `currentFiles` fallback in `ExportPanel`; drop a dead `eslint-disable` in `useContextManager`).

## 4. The two ruff pins disagreed

`.pre-commit-config.yaml` pinned ruff-pre-commit **v0.1.14** while `pyproject.toml`'s dev extra pinned **ruff 0.16.0**, and CI's smoke job runs pre-commit. Installing `.[dev]` and running `ruff format` therefore produced a diff CI rejected — which is exactly what happened on this branch's first push.

The workaround had been documented rather than fixed: several plans under `docs/superpowers/plans/` tell contributors to reach for `uvx ruff@0.1.14` because "local ruff is a different version and will fail CI Smoke".

Bumped the hook repo to v0.16.0 to match, and switched `ruff` to its current id `ruff-check` (v0.16.0 keeps `ruff` only as a legacy alias). Reformatting with the newer formatter touches 36 files.

The reformat is cosmetic only, and that is checked rather than assumed: each of the 36 files parses to an AST identical to its previous version.

Those `docs/superpowers/plans/` and `specs/` files still say `ruff@0.1.14`, but they are dated records of past work, so they are left as-is. `CONTRIBUTING.md` never mentioned ruff, so there was no living guidance to correct.

## Verification

| check | result |
|---|---|
| `pytest tests/` | 2573 passed, 5 skipped (baseline was 2551) |
| `pytest integrations/mcp-server/` | 19 passed (was: collection error) |
| `pre-commit run --all-files` | clean |
| AST equality across the 36 reformatted files | identical |
| `npm run test` | 321 passed, 58 files |
| `npm run lint` | clean (was 2 warnings) |
| `node --test extension/*.test.mjs` | 14 passed |

## PR backlog triage

Closed 21 of the 27 open PRs, each with a reason comment. They were bot-generated duplicates: six PRs changed the same line of `client.py`, three added the same two tests to `test_pr_safety_markdown.py`, two made the same history-filter fix (both red). Three were not merely redundant — #1254 replaced a working conditional tooltip with a hardcoded string that lies when a file is available, #1264 left three consecutive unreachable `except` blocks, and #1268/#1264 deleted chunks of the `.jules/` journals as a side effect.

Kept: #1256, #1258, #1259, #1260, #1262, #1269, #1279.

## Not addressed

`pre-commit` now warns that pre-commit-hooks v4.5.0 uses deprecated stage names (`commit`, `push`). Out of scope for the ruff pins; `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` would clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt5NsteosYyH2eRmDAUeZk