### PR TITLE
🎨 Palette: Add aria-label to compiled prompt toggle button

### DIFF
--- a/web/app/components/BenchmarkResults.tsx
+++ b/web/app/components/BenchmarkResults.tsx
@@ -149,6 +149,7 @@ export default function BenchmarkResults({ data }: BenchmarkResultsProps) {
                     type="button"
                     onClick={() => setPromptOpen(!promptOpen)}
                     aria-expanded={promptOpen}
+                    aria-label="Toggle compiled prompt"
 
                     aria-controls="compiled-prompt-content"
                     className="w-full px-5 py-3 flex items-center justify-between text-left hover:bg-white/[0.02] transition-colors group focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20"

--- a/web/app/hooks/useContextManager.ts
+++ b/web/app/hooks/useContextManager.ts
@@ -113,7 +113,10 @@ export function useContextManager() {
   }, [refreshStats]);
 
   useEffect(() => {
-    void checkConnection();
+    const init = async () => {
+      await checkConnection();
+    };
+    void init();
   }, [checkConnection]);
 
   const uploadFiles = useCallback(


### PR DESCRIPTION
💡 What: Added an explicit `aria-label="Toggle compiled prompt"` to the collapsible Compiled Prompt button in the BenchmarkResults component.
🎯 Why: Previously, the button only had an `aria-expanded` attribute but no descriptive label, leaving screen reader users without clear context on what the button toggles. The chevron icon alone is not accessible to screen readers.
📸 Before/After: (See screenshot)
♿ Accessibility: Improves keyboard navigation and screen reader experience by providing an explicit label for the toggle control.

---
*PR created automatically by Jules for task [10888474079076554714](https://jules.google.com/task/10888474079076554714) started by @madara88645*