### PR TITLE
🎨 Palette: [Add title to RAG insert button]

### DIFF
--- a/web/app/components/context/RagSearchPanel.tsx
+++ b/web/app/components/context/RagSearchPanel.tsx
@@ -100,6 +100,7 @@ export default function RagSearchPanel({
                                 onInsertContext(formatSearchResultForPrompt(result));
                                 toast.success("Snippet inserted into prompt");
                             }}
+                            title={`Insert snippet from ${result.path} into prompt`}
                             aria-label={`Insert snippet from ${result.path} into prompt`}
                             className="mt-1 self-start text-[10px] text-blue-300 hover:text-blue-200 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded transition-all flex items-center gap-1 font-medium"
                         >


### PR DESCRIPTION
💡 What: Added title to RAG insert button
🎯 Why: The insert button was missing a title, which is important for tooltip hover states to provide context for icon-only or shortened buttons.
📸 Before/After: Added `title` to the `button` element
♿ Accessibility: Improves accessibility for screen readers and users who rely on tooltips.

---
*PR created automatically by Jules for task [2171341047891770121](https://jules.google.com/task/2171341047891770121) started by @madara88645*